### PR TITLE
Add a shutdown option

### DIFF
--- a/obolup/README.md
+++ b/obolup/README.md
@@ -21,6 +21,8 @@ Options:
   --clean                           Deletes and recreates the Obol Stack
 ```
 
+To shut down a running instance, run `./oboldown` from this directory. This clears all stack data.
+
 ### Troubleshooting
 
 Adding the `--clean` flag will start your cluster fresh, and may fix issues during alpha usage or version upgrades. This will clear the stored data of your stack.

--- a/obolup/oboldown
+++ b/obolup/oboldown
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# modified from https://github.com/foundry-rs/foundry/blob/master/foundryup/foundryup
+
+# oboldown - Obol Stack shutdown script
+
+set -Eeuo pipefail
+
+# Constants
+readonly STACK_NAME="obol-stack"
+
+# Colors for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Log functions
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing command.
+ensure() {
+  if ! "$@"; then err "command failed: $*"; fi
+}
+
+# Main logic
+main() {
+    banner
+    log_info "Shutting down the Obol Stack..."
+    ensure kind delete cluster --name "$STACK_NAME"
+
+    log_info "Obol Stack shutdown complete."
+    exit 0
+}
+
+
+# Banner Function for Foundry
+banner() {
+  printf '
+
+.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo
+  ___  ____   ___  _
+ / _ \| __ ) / _ \| |                A Kubernetes-based Stack for
+| | | |  _ \| | | | |             deploying Ethereum dApps and infra
+| |_| | |_) | |_| | |___                      using Helm
+ \___/|____/ \___/|_____|
+
+.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo
+
+Repo       : https://github.com/ObolNetwork/obol-stack
+Docs       : https://docs.obol.org/
+
+.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo
+
+'
+}
+
+# Displays help text
+help() {
+	cat <<EOF
+Usage: $0
+
+Shuts down and deletes a running Obol Stack instance. Start a new one with `./obolup`
+EOF
+	exit "${1:-1}"
+}
+
+# Run main
+main "$@"

--- a/obolup/obolup
+++ b/obolup/obolup
@@ -422,7 +422,7 @@ banner() {
 .oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo
   ___  ____   ___  _
  / _ \| __ ) / _ \| |                A Kubernetes-based Stack for
-| | | |  _ \| | | | |               deploying Ethereum based dApps
+| | | |  _ \| | | | |             deploying Ethereum dApps and infra
 | |_| | |_) | |_| | |___                      using Helm
  \___/|____/ \___/|_____|
 


### PR DESCRIPTION
Relates to #15 

Leaving as draft for discussion rather than immediate inclusion, because it might be better to just get obol-cli more out there (and setup with `obolup`), and using an `obol down` type command, to push people to the cli versus hanging in there with scripts to achieve this. 