### PR TITLE
fix: only install light client for selected network

### DIFF
--- a/obolup/obolup
+++ b/obolup/obolup
@@ -508,10 +508,8 @@ launch_stack() {
     # Deploy a Helm Release named "kubernetes-dashboard" using the kubernetes-dashboard chart
     #helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
 
-    log_info "Installing the Obol Stack Ethereum light clients..."
-    ensure helm upgrade  --namespace l1 --create-namespace --hide-notes --force --install l1-light-client-mainnet obol/helios -f ../values/mainnet/helios.yaml
-    ensure helm upgrade  --namespace l1 --create-namespace --hide-notes --force --install l1-light-client-hoodi obol/helios -f ../values/hoodi/helios.yaml
-    ensure helm upgrade  --namespace l1 --create-namespace --hide-notes --force --install l1-light-client-sepolia obol/helios -f ../values/sepolia/helios.yaml
+    log_info "Installing the Obol Stack Ethereum light client for $__network..."
+    ensure helm upgrade  --namespace l1 --create-namespace --hide-notes --force --install l1-light-client obol/helios -f ../values/$__network/helios.yaml
 
     # If mode="full", also sync a full node
     if [[ "$__mode" = "full" ]]; then


### PR DESCRIPTION
## Summary
Fixes the obolup script to only install the light client for the selected network instead of installing all three networks (mainnet, hoodi, sepolia) every time.

## Problem Solved
Previously, when running `./obolup --network hoodi`, the script would install light clients for ALL networks:
- l1-light-client-mainnet
- l1-light-client-hoodi  
- l1-light-client-sepolia

This caused:
- 🔴 Unnecessary resource usage in the Kubernetes cluster
- 🔴 Longer deployment times
- 🔴 Confusion about which network is actually being used
- 🔴 The `--network` flag didn't fully control what was deployed

## Solution
Changed the script to only install the light client for the selected network using the `$__network` variable.

### Before:
```bash
log_info "Installing the Obol Stack Ethereum light clients..."
ensure helm upgrade ... --install l1-light-client-mainnet obol/helios -f ../values/mainnet/helios.yaml
ensure helm upgrade ... --install l1-light-client-hoodi obol/helios -f ../values/hoodi/helios.yaml
ensure helm upgrade ... --install l1-light-client-sepolia obol/helios -f ../values/sepolia/helios.yaml
```

### After:
```bash
log_info "Installing the Obol Stack Ethereum light client for $__network..."
ensure helm upgrade ... --install l1-light-client obol/helios -f ../values/$__network/helios.yaml
```

## Impact
- ✅ Only deploys the light client for the selected network
- ✅ Reduces resource usage by ~66% (1 client instead of 3)
- ✅ Faster deployment times
- ✅ Clear 1:1 mapping between `--network` flag and what gets deployed
- ✅ Cleaner `kubectl get pods -n l1` output

## Testing
```bash
# Test with different networks
./obolup --network mainnet   # Should only install l1-light-client for mainnet
./obolup --network hoodi     # Should only install l1-light-client for hoodi
./obolup --network sepolia   # Should only install l1-light-client for sepolia

# Verify only one light client is installed
kubectl get pods -n l1
```

## Breaking Changes
None - this makes the behavior match what users expect from the `--network` flag.