### PR TITLE
feat: add GitHub Actions workflow for obolup releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release obolup
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            ## Installation
+
+            Install the latest version of obolup:
+            ```bash
+            curl -L https://github.com/ObolNetwork/obol-stack/releases/latest/download/obolup | bash
+            ```
+
+            Or install this specific version:
+            ```bash
+            curl -L https://github.com/ObolNetwork/obol-stack/releases/download/${{ github.ref_name }}/obolup | bash
+            ```
+
+            ## What's Changed
+            See the [commit history](https://github.com/ObolNetwork/obol-stack/compare/${{ github.event.before }}...${{ github.ref_name }}) for details.
+          draft: false
+          prerelease: false
+
+      - name: Upload obolup script
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./obolup/obolup
+          asset_name: obolup
+          asset_content_type: text/plain


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automate releases of the obolup script
- Enables direct installation via curl from GitHub Releases

## Implementation
- Created `.github/workflows/release.yml` that triggers on version tags (v*.*.*)
- Workflow creates GitHub Release and uploads obolup script as release asset
- No bundling or modifications to the script - simple, direct download

## Usage After Merge
```bash
# Latest release
curl -L https://github.com/ObolNetwork/obol-stack/releases/latest/download/obolup | bash

# Specific version
curl -L https://github.com/ObolNetwork/obol-stack/releases/download/v1.0.0/obolup | bash
```

## Testing
To test this workflow after merge:
1. Create and push a version tag: `git tag v0.1.0 && git push --tags`
2. Check that the release is created at https://github.com/ObolNetwork/obol-stack/releases
3. Test the curl installation command

Closes #44