### PR TITLE
fix: align network naming convention for full nodes with light nodes

### DIFF
--- a/obolup/obolup
+++ b/obolup/obolup
@@ -516,7 +516,7 @@ launch_stack() {
         log_info "Installing an Ethereum full node client synced to $__network..."
         docker pull nethermind/nethermind:latest
         docker pull statusim/nimbus-eth2:multiarch-latest
-        ensure helm upgrade --install --namespace l1 --create-namespace l1-full-node ethereum/ethereum-node -f ../values/ethereum-node.yaml  --set global.main.network=$__network
+        ensure helm upgrade --install --namespace l1 --create-namespace l1-full-node-$__network ethereum/ethereum-node -f ../values/ethereum-node.yaml  --set global.main.network=$__network
         
         # Deploy MEV-boost for supported networks (not hoodi)
         log_info "Installing MEV-boost sidecar for $__network network..."


### PR DESCRIPTION
## Summary
Fixes the inconsistent naming convention between light client nodes and full nodes by including the network name in the full node Helm release name.

## Changes
- Updated `obolup` script line 519 to include network identifier in full node release name
- Full node release name: `l1-full-node` → `l1-full-node-{network}`

## Testing
Tested with hoodi network deployment:

### Before (issue):
- Release name: `l1-full-node`
- Services: `l1-full-node-execution`, `l1-full-node-beacon`

### After (fixed):
- Release name: `l1-full-node-hoodi`
- Services: `l1-full-node-hoodi-execution`, `l1-full-node-hoodi-beacon`

### Verification
```bash
$ helm list -n l1
NAME                NAMESPACE  REVISION  STATUS    CHART
l1-full-node-hoodi  l1         1         deployed  ethereum-node-0.2.4
l1-light-client     l1         1         deployed  helios-0.1.4

$ kubectl get svc -n l1 | grep l1-
l1-full-node-hoodi-beacon      ClusterIP  10.96.48.3      <none>  ...
l1-full-node-hoodi-execution   ClusterIP  10.96.233.143   <none>  ...
l1-light-client-helios          ClusterIP  10.96.132.154   <none>  ...
```

## Benefits
✅ Consistent naming pattern across all node types
✅ Services clearly indicate which network they belong to
✅ Enables running multiple networks in the same namespace
✅ Easier service discovery and identification

Closes #48