### PR TITLE
Extend initialisation timeout to 5mins

### DIFF
--- a/internal/embed/k3d-config.yaml
+++ b/internal/embed/k3d-config.yaml
@@ -25,7 +25,7 @@ ports:
 options:
   k3d:
     wait: true
-    timeout: "100s"
+    timeout: "300s"
     disableLoadbalancer: false
   k3s:
     extraArgs:


### PR DESCRIPTION
Initial spin up may take a while on first launch and trigger cancellation, extending timeout may fix that