### PR TITLE
Add Google API key secret management for Obol Agent

### DIFF
--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ObolNetwork/obol-stack/internal/agent"
 	"github.com/ObolNetwork/obol-stack/internal/app"
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/executor"
@@ -44,6 +45,9 @@ COMMANDS:
      stack up        Start the Obol Stack
      stack down      Stop the Obol Stack
      stack purge     Delete stack config (use --force to also delete data)
+
+   Obol Agent:
+     agent init      Initialize Obol Agent with Google API key
 
    Kubernetes Tools (with auto-configured KUBECONFIG):
      kubectl         Run kubectl with stack kubeconfig (passthrough)
@@ -96,17 +100,8 @@ GLOBAL OPTIONS:
 					{
 						Name:  "up",
 						Usage: "Start the Obol Stack",
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:    "google-api-key",
-								Aliases: []string{"g"},
-								Usage:   "Google API key for Obol Agent (required for AI features)",
-								EnvVars: []string{"GOOGLE_API_KEY"},
-							},
-						},
 						Action: func(c *cli.Context) error {
-							googleAPIKey := c.String("google-api-key")
-							if err := stack.Up(cfg, googleAPIKey); err != nil {
+							if err := stack.Up(cfg); err != nil {
 								stackID := stack.GetStackID(cfg)
 								l, _ := logging.NewSlogLogger(logging.LoggerConfig{
 									StateDir: cfg.StateDir,
@@ -152,6 +147,40 @@ GLOBAL OPTIONS:
 									StackID:  stackID,
 								})
 								l.Error("Failed to purge stack", "error", err.Error())
+								return err
+							}
+							return nil
+						},
+					},
+				},
+			},
+			// ============================================================
+			// Obol Agent Commands
+			// ============================================================
+			{
+				Name:  "agent",
+				Usage: "Manage Obol Agent",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "init",
+						Usage: "Initialize Obol Agent with Google API key",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:    "google-api-key",
+								Aliases: []string{"g"},
+								Usage:   "Google API key for Obol Agent (required for AI features)",
+								EnvVars: []string{"GOOGLE_API_KEY"},
+							},
+						},
+						Action: func(c *cli.Context) error {
+							googleAPIKey := c.String("google-api-key")
+							if err := agent.Init(cfg, googleAPIKey); err != nil {
+								stackID := stack.GetStackID(cfg)
+								l, _ := logging.NewSlogLogger(logging.LoggerConfig{
+									StateDir: cfg.StateDir,
+									StackID:  stackID,
+								})
+								l.Error("Failed to initialize agent", "error", err.Error())
 								return err
 							}
 							return nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/executor"
+	"github.com/ObolNetwork/obol-stack/internal/logging"
+	"github.com/ObolNetwork/obol-stack/internal/stack"
+)
+
+const (
+	kubeconfigFile = "kubeconfig.yaml"
+)
+
+// Init initializes the Obol Agent with required secrets
+func Init(cfg *config.Config, googleAPIKey string) error {
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, kubeconfigFile)
+
+	// Check if kubeconfig exists (stack must be running)
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return fmt.Errorf("stack not running, use 'obol stack up' first")
+	}
+
+	// Get stack ID for logging
+	stackID := stack.GetStackID(cfg)
+	if stackID == "" {
+		return fmt.Errorf("stack ID not found, run 'obol stack init' first")
+	}
+
+	// Create logger and executor
+	l, cleanup := logging.NewSlogLogger(logging.LoggerConfig{
+		StateDir: cfg.StateDir,
+		StackID:  stackID,
+	})
+	defer cleanup()
+
+	exec := executor.New(l.Logger)
+	defer exec.Close()
+
+	// Validate Google API key was provided
+	if googleAPIKey == "" {
+		l.Error("Google API key required")
+		return fmt.Errorf("Google API key required via --google-api-key flag or GOOGLE_API_KEY environment variable")
+	}
+
+	l.Info("Initializing Obol Agent")
+	l.Info("Creating Google API key secret for Obol Agent")
+
+	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+
+	// Create namespace (idempotent)
+	nsCmd := exec.Command(kubectlPath, "--kubeconfig", kubeconfigPath, "create", "namespace", "agent", "--dry-run=client", "-o", "yaml")
+	nsYAML, err := nsCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to generate namespace manifest: %w", err)
+	}
+	applyNs := exec.CommandWithOutput(kubectlPath, "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
+	applyNs.SetStdin(strings.NewReader(string(nsYAML)))
+	if err := applyNs.Run(); err != nil {
+		return fmt.Errorf("failed to create agent namespace: %w", err)
+	}
+
+	// Create secret (idempotent)
+	secretCmd := exec.Command(kubectlPath, "--kubeconfig", kubeconfigPath, "create", "secret", "generic", "obol-agent-google-api-key", "--from-literal=GOOGLE_API_KEY="+googleAPIKey, "--namespace=agent", "--dry-run=client", "-o", "yaml")
+	secretYAML, err := secretCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to generate secret manifest: %w", err)
+	}
+	applySecret := exec.CommandWithOutput(kubectlPath, "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
+	applySecret.SetStdin(strings.NewReader(string(secretYAML)))
+	if err := applySecret.Run(); err != nil {
+		return fmt.Errorf("failed to create Google API key secret: %w", err)
+	}
+
+	l.Success("Google API key secret created")
+	l.Success("Obol Agent initialized successfully")
+	l.Info("The Obol Agent deployment will now have access to Google API services")
+
+	return nil
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -106,7 +106,7 @@ func Init(cfg *config.Config, force bool) error {
 }
 
 // Up starts the k3d cluster
-func Up(cfg *config.Config, googleAPIKey string) error {
+func Up(cfg *config.Config) error {
 	k3dConfigPath := filepath.Join(cfg.ConfigDir, k3dConfigFile)
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, kubeconfigFile)
 
@@ -152,7 +152,7 @@ func Up(cfg *config.Config, googleAPIKey string) error {
 			return fmt.Errorf("failed to start existing cluster: %w", err)
 		}
 
-		if err := syncDefaults(cfg, exec, l, kubeconfigPath, googleAPIKey); err != nil {
+		if err := syncDefaults(cfg, exec, l, kubeconfigPath); err != nil {
 			return err
 		}
 
@@ -200,7 +200,7 @@ func Up(cfg *config.Config, googleAPIKey string) error {
 		return fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
 
-	if err := syncDefaults(cfg, exec, l, kubeconfigPath, googleAPIKey); err != nil {
+	if err := syncDefaults(cfg, exec, l, kubeconfigPath); err != nil {
 		return err
 	}
 
@@ -366,44 +366,8 @@ func GetStackID(cfg *config.Config) string {
 
 // syncDefaults deploys the default infrastructure using helmfile
 // If deployment fails, the cluster is automatically stopped via Down()
-func syncDefaults(cfg *config.Config, exec *executor.Executor, l *logging.Logger, kubeconfigPath string, googleAPIKey string) error {
+func syncDefaults(cfg *config.Config, exec *executor.Executor, l *logging.Logger, kubeconfigPath string) error {
 	l.Info("Deploying default infrastructure with helmfile")
-
-	// Create Google API Key secret if provided
-	if googleAPIKey != "" {
-		l.Info("Creating Google API key secret for Obol Agent")
-
-		kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
-
-		// Create namespace (idempotent)
-		nsCmd := exec.Command(kubectlPath, "--kubeconfig", kubeconfigPath, "create", "namespace", "agent", "--dry-run=client", "-o", "yaml")
-		nsYAML, err := nsCmd.Output()
-		if err != nil {
-			return fmt.Errorf("failed to generate namespace manifest: %w", err)
-		}
-		applyNs := exec.CommandWithOutput(kubectlPath, "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
-		applyNs.SetStdin(strings.NewReader(string(nsYAML)))
-		if err := applyNs.Run(); err != nil {
-			return fmt.Errorf("failed to create agent namespace: %w", err)
-		}
-
-		// Create secret (idempotent)
-		secretCmd := exec.Command(kubectlPath, "--kubeconfig", kubeconfigPath, "create", "secret", "generic", "obol-agent-google-api-key", "--from-literal=GOOGLE_API_KEY="+googleAPIKey, "--namespace=agent", "--dry-run=client", "-o", "yaml")
-		secretYAML, err := secretCmd.Output()
-		if err != nil {
-			return fmt.Errorf("failed to generate secret manifest: %w", err)
-		}
-		applySecret := exec.CommandWithOutput(kubectlPath, "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
-		applySecret.SetStdin(strings.NewReader(string(secretYAML)))
-		if err := applySecret.Run(); err != nil {
-			return fmt.Errorf("failed to create Google API key secret: %w", err)
-		}
-
-		l.Success("Google API key secret created")
-	} else {
-		l.Warn("No Google API key provided - Obol Agent AI features will not work")
-		l.Info("Provide via: obol stack up --google-api-key=<key> or GOOGLE_API_KEY env var")
-	}
 
 	// Sync defaults using helmfile (handles Helm hooks properly)
 	defaultsHelmfilePath := filepath.Join(cfg.ConfigDir, "defaults")


### PR DESCRIPTION
Add support for securely providing the GOOGLE_API_KEY to the Obol Agent via Kubernetes secrets instead of plaintext values in YAML.

Changes:
- Add --google-api-key flag (short: -g) to 'obol stack up' command
- Accept GOOGLE_API_KEY environment variable as alternative input
- Create 'agent' namespace and 'obol-agent-google-api-key' secret automatically
- Update obol-agent.yaml to consume secret via secretKeyRef
- Provide clear warnings when API key is not supplied

The implementation uses kubectl dry-run + apply pattern for idempotent secret creation, matching the error handling style of existing code.

Usage:
  obol stack up --google-api-key="your-key"
  obol stack up -g "your-key"
  GOOGLE_API_KEY="your-key" obol stack up