### PR TITLE
fix: correct go.mod version format and remove duplicates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,6 @@
 module github.com/ObolNetwork/obol-stack
 
-go 1.25.1
-
-require github.com/urfave/cli/v2 v2.27.7
-
-require (
-	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
-	github.com/google/uuid v1.6.0
-	github.com/urfave/cli/v2 v2.27.7
-)
-
-require (
-	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
-	github.com/google/uuid v1.6.0
-	github.com/urfave/cli/v2 v2.27.7
-)
+go 1.25
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0


### PR DESCRIPTION
- Changed go version from invalid '1.25.1' to valid '1.25' format
- Removed duplicate require blocks that were causing parsing issues
- Go module versions must use 'X.Y' format, not 'X.Y.Z'

Fixes build error: "invalid go version '1.25.1': must match format 1.23"