### PR TITLE
Add standardized pod labels for network discovery

### DIFF
--- a/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
@@ -40,6 +40,18 @@ releases:
       - {{ .Values.executionClient }}:
           enabled: true
           nameOverride: execution-{{ .Values.executionClient }}-{{ .Values.network }}
+          labels:
+            app.kubernetes.io/part-of: obol.stack
+            obol.stack/chain: ethereum
+            obol.stack/network: {{ .Values.network }}
+            obol.stack/type: execution
+            obol.stack/client: {{ .Values.executionClient }}
+          podLabels:
+            app.kubernetes.io/part-of: obol.stack
+            obol.stack/chain: ethereum
+            obol.stack/network: {{ .Values.network }}
+            obol.stack/type: execution
+            obol.stack/client: {{ .Values.executionClient }}
           persistence:
             enabled: true
             size: 500Gi
@@ -50,6 +62,18 @@ releases:
       - {{ .Values.consensusClient }}:
           enabled: true
           nameOverride: consensus-{{ .Values.consensusClient }}-{{ .Values.network }}
+          labels:
+            app.kubernetes.io/part-of: obol.stack
+            obol.stack/chain: ethereum
+            obol.stack/network: {{ .Values.network }}
+            obol.stack/type: consensus
+            obol.stack/client: {{ .Values.consensusClient }}
+          podLabels:
+            app.kubernetes.io/part-of: obol.stack
+            obol.stack/chain: ethereum
+            obol.stack/network: {{ .Values.network }}
+            obol.stack/type: consensus
+            obol.stack/client: {{ .Values.consensusClient }}
           extraArgs:
             - --execution-endpoint=http://ethereum-execution-{{ .Values.executionClient }}-{{ .Values.network }}:8551
             - --network={{ .Values.network }}


### PR DESCRIPTION
## Description
This PR implements the standardized labeling required for the **Dynamic Network Discovery** feature proposed in #114.

It updates the `ethereum` network template (`helmfile.yaml.gotmpl`) to inject the following standard labels into the Execution and Consensus client Pods:

*   `app.kubernetes.io/part-of: obol.stack` (Primary filter)
*   `obol.stack/chain: ethereum`
*   `obol.stack/network: <network>` (e.g., mainnet, hoodi)
*   `obol.stack/type: <type>` (execution/consensus)
*   `obol.stack/client: <client>` (e.g., reth, lighthouse)

## Key Implementation Details
*   **Pod Labels:** The labels are applied via `podLabels`, which is supported by the upstream `ethereum-helm-charts`. This ensures the running Pods carry the metadata needed for discovery.
*   **Service Labels:** Attempts to label the Services directly (via `labels` or `extraLabels`) were unsuccessful because the upstream charts do not currently expose a value to inject custom labels into the Service resource.
*   **Discovery Strategy:** As a result, the frontend discovery logic (to be implemented) should target **Pods** using the `app.kubernetes.io/part-of=obol.stack` selector to find active networks.

Closes #114