### PR TITLE
feat: replace nginx-ingress with Traefik and Gateway API

### DIFF
--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -1,17 +1,20 @@
 # Helmfile for Obol Stack default infrastructure
 # Orchestrates core infrastructure components deployed with every stack
+# Uses Traefik with Gateway API for routing (replaces nginx-ingress)
 
 repositories:
-  - name: ingress-nginx
-    url: https://kubernetes.github.io/ingress-nginx
+  - name: traefik
+    url: https://traefik.github.io/charts
   - name: obol
     url: https://obolnetwork.github.io/helm-charts/
   - name: ethereum
     url: https://ethpandaops.github.io/ethereum-helm-charts
+  - name: bedag
+    url: https://bedag.github.io/helm-charts/
 
 # Single source of truth: change this to switch networks
 values:
-  - network: mainnet 
+  - network: mainnet
 
 releases:
   # Local storage provisioner (raw manifests wrapped as chart)
@@ -22,45 +25,149 @@ releases:
       - dataDir: /data
       - network: "{{ .Values.network }}"
 
-  # Nginx ingress controller (upstream chart)
-  - name: ingress-nginx
-    namespace: ingress-nginx
-    chart: ingress-nginx/ingress-nginx
-    version: 4.13.3
+  # Traefik ingress controller with Gateway API support
+  - name: traefik
+    namespace: traefik
+    createNamespace: true
+    chart: traefik/traefik
+    version: 38.0.2
     values:
-      - controller:
-          replicaCount: 1
-          service:
-            type: LoadBalancer
-            externalTrafficPolicy: Local
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          tolerations: []
-          admissionWebhooks:
+      # Gateway API provider configuration
+      - providers:
+          kubernetesGateway:
+            enabled: true
+            namespaces: []  # Watch all namespaces
+          kubernetesCRD:
+            enabled: true
+          kubernetesIngress:
+            enabled: false  # Disable legacy Ingress support
+      # GatewayClass configuration
+      - gatewayClass:
+          enabled: true
+          name: traefik
+      # Gateway configuration (main entry point)
+      - gateway:
+          enabled: true
+          name: traefik-gateway
+          namespace: traefik
+          listeners:
+            web:
+              port: 8000
+              protocol: HTTP
+              namespacePolicy:
+                from: All
+      # Ports configuration
+      - ports:
+          web:
+            port: 8000
+            expose:
+              default: true
+            exposedPort: 80
+            protocol: TCP
+          websecure:
+            port: 8443
+            expose:
+              default: true
+            exposedPort: 443
+            protocol: TCP
+            tls:
+              enabled: false  # TLS termination disabled for local dev
+      # Service configuration
+      - service:
+          type: LoadBalancer
+          externalTrafficPolicy: Local
+      # Resource limits
+      - resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      # Disable dashboard by default
+      - ingressRoute:
+          dashboard:
             enabled: false
 
   # eRPC
   - name: erpc
     namespace: erpc
+    createNamespace: true
     chart: ethereum/erpc
     needs:
       - kube-system/base
-      - ingress-nginx/ingress-nginx
+      - traefik/traefik
     values:
       - ./values/erpc.yaml.gotmpl
+
+  # eRPC HTTPRoute
+  - name: erpc-httproute
+    namespace: erpc
+    chart: bedag/raw
+    needs:
+      - traefik/traefik
+      - erpc/erpc
+    values:
+      - resources:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: erpc
+              namespace: erpc
+            spec:
+              parentRefs:
+                - name: traefik-gateway
+                  namespace: traefik
+                  sectionName: web
+              hostnames:
+                - obol.stack
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /rpc
+                  backendRefs:
+                    - name: erpc
+                      port: 4000
 
   # Obol Stack frontend
   - name: obol-frontend
     namespace: obol-frontend
+    createNamespace: true
     chart: obol/obol-app
     version: 0.1.0
     needs:
-      - ingress-nginx/ingress-nginx
+      - traefik/traefik
       - erpc/erpc
     values:
       - ./values/obol-frontend.yaml.gotmpl
+
+  # Obol Frontend HTTPRoute
+  - name: obol-frontend-httproute
+    namespace: obol-frontend
+    chart: bedag/raw
+    needs:
+      - traefik/traefik
+      - obol-frontend/obol-frontend
+    values:
+      - resources:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: obol-frontend
+              namespace: obol-frontend
+            spec:
+              parentRefs:
+                - name: traefik-gateway
+                  namespace: traefik
+                  sectionName: web
+              hostnames:
+                - obol.stack
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: obol-frontend
+                      port: 3000

--- a/internal/embed/infrastructure/values/erpc.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/erpc.yaml.gotmpl
@@ -87,14 +87,9 @@ extraArgs: []
 # Command replacement for the erpc container
 customCommand: []
 
+# Disable legacy Ingress - using Gateway API HTTPRoute instead
 ingress:
-  enabled: true
-  className: nginx
-  hosts:
-    - host: obol.stack
-      paths:
-        - path: /rpc
-          pathType: Prefix
+  enabled: false
 
 service:
   type: ClusterIP

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -19,11 +19,6 @@ service:
   type: ClusterIP
   port: 3000
 
+# Disable legacy Ingress - using Gateway API HTTPRoute instead
 ingress:
-  enabled: true
-  className: "nginx"
-  hosts:
-    - host: obol.stack
-      paths:
-        - path: /
-          pathType: Prefix
+  enabled: false

--- a/internal/embed/k3d-config.yaml
+++ b/internal/embed/k3d-config.yaml
@@ -35,10 +35,6 @@ options:
       - arg: --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true
         nodeFilters:
           - server:*
-      # Disable Traefik to use nginx instead
-      - arg: --disable=traefik
-        nodeFilters:
-          - server:*
       # Disable local-storage addon (we provide our own config)
       - arg: --disable=local-storage
         nodeFilters:

--- a/internal/embed/networks/aztec/templates/ingress.yaml
+++ b/internal/embed/networks/aztec/templates/ingress.yaml
@@ -1,23 +1,29 @@
 {{- if eq .Release.Name "aztec-ingress" }}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+# HTTPRoute for Aztec sequencer node RPC
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: aztec
   namespace: {{ .Release.Namespace }}
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
-  ingressClassName: nginx
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  hostnames:
+    - obol.stack
   rules:
-  - host: obol.stack
-    http:
-      paths:
-      - path: /{{ .Release.Namespace }}(/|$)(.*)
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: l2-sequencer-node-{{ .Values.id }}-node
-            port:
-              number: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: l2-sequencer-node-{{ .Values.id }}-node
+          port: 8080
 {{- end }}

--- a/internal/embed/networks/ethereum/templates/ingress.yaml
+++ b/internal/embed/networks/ethereum/templates/ingress.yaml
@@ -1,30 +1,57 @@
 {{- if eq .Release.Name "ethereum-ingress" }}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+# HTTPRoute for Ethereum execution client RPC
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
-  name: ethereum
+  name: ethereum-execution
   namespace: {{ .Release.Namespace }}
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
-  ingressClassName: nginx
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  hostnames:
+    - obol.stack
   rules:
-  - host: obol.stack
-    http:
-      paths:
-      - path: /{{ .Release.Namespace }}/execution(/|$)(.*)
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: ethereum-execution
-            port:
-              number: 8545
-      - path: /{{ .Release.Namespace }}/beacon(/|$)(.*)
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: ethereum-beacon
-            port:
-              number: 5052
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}/execution
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: ethereum-execution
+          port: 8545
+---
+# HTTPRoute for Ethereum beacon client RPC
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ethereum-beacon
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  hostnames:
+    - obol.stack
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}/beacon
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: ethereum-beacon
+          port: 5052
 {{- end }}

--- a/internal/embed/networks/helios/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/helios/helmfile.yaml.gotmpl
@@ -28,17 +28,42 @@ releases:
           size: 10Gi
           storageClass: local-path
 
+      # Disable legacy Ingress - using Gateway API HTTPRoute instead
       - ingress:
-          enabled: true
-          className: nginx
-          annotations:
-            nginx.ingress.kubernetes.io/rewrite-target: /$2
-            nginx.ingress.kubernetes.io/use-regex: "true"
-          hosts:
-            - host: obol.stack
-              paths:
-                - path: /helios-{{ .Values.id }}(/|$)(.*)
-                  pathType: ImplementationSpecific
+          enabled: false
+
+  # HTTPRoute for Helios RPC endpoint
+  - name: helios-httproute
+    namespace: helios-{{ .Values.id }}
+    chart: bedag/raw
+    values:
+      - resources:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: helios
+              namespace: helios-{{ .Values.id }}
+            spec:
+              parentRefs:
+                - name: traefik-gateway
+                  namespace: traefik
+                  sectionName: web
+              hostnames:
+                - obol.stack
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /helios-{{ .Values.id }}
+                  filters:
+                    - type: URLRewrite
+                      urlRewrite:
+                        path:
+                          type: ReplacePrefixMatch
+                          replacePrefixMatch: /
+                  backendRefs:
+                    - name: helios-{{ .Values.network }}
+                      port: 8545
 
   # Metadata ConfigMap for frontend discovery
   - name: helios-metadata


### PR DESCRIPTION
## Summary

- Replace nginx-ingress controller with Traefik 38.0.2 using Kubernetes Gateway API
- Address nginx-ingress deprecation (end of maintenance March 2026)
- Migrate all Ingress resources to HTTPRoute format

## Changes

- Remove `--disable=traefik` from k3d config to use k3s built-in Traefik
- Replace nginx-ingress helm release with Traefik 38.0.2 in infrastructure helmfile
- Configure Gateway API provider with cross-namespace routing support
- Add GatewayClass and Gateway resources via Traefik helm chart
- Convert all Ingress resources to HTTPRoute format:
  - eRPC: `/rpc` path routing
  - obol-frontend: `/` path routing
  - ethereum: `/execution` and `/beacon` path routing with URL rewrite
  - aztec: namespace-based path routing with URL rewrite
  - helios: namespace-based path routing with URL rewrite
- Disable legacy Ingress in service helm values

## Test plan

- [x] Stack init and up with new Traefik configuration
- [x] Verify GatewayClass is accepted
- [x] Verify Gateway is programmed with correct listeners
- [x] Verify HTTPRoutes are accepted and refs resolved
- [ ] Test frontend routing via `http://obol.stack/`
- [ ] Test eRPC routing via `http://obol.stack/rpc`
- [ ] Test network-specific routes after network install

Closes #125