### PR TITLE
Add monitoring stack for Prometheus endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ The Obol Stack is a local Kubernetes-based framework for running blockchain netw
 5. **Two-stage templating**: CLI flags → Go templates → Helmfile → Kubernetes resources
 6. **Development mode**: Local `.workspace/` directory with `go run` wrapper for rapid development
 
+### Routing and Gateway API
+
+Obol Stack uses Traefik with the Kubernetes Gateway API for HTTP routing.
+
+- Controller: Traefik Helm chart (`traefik` namespace)
+- GatewayClass: `traefik`
+- Gateway: `traefik-gateway` in `traefik` namespace
+- HTTPRoute patterns:
+  - `/` → `obol-frontend`
+  - `/rpc` → `erpc`
+  - `/ethereum-<id>/execution` and `/ethereum-<id>/beacon`
+  - `/aztec-<id>` and `/helios-<id>`
+
 ## Bootstrap Installer: obolup.sh
 
 ### Purpose

--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -5,6 +5,8 @@
 repositories:
   - name: traefik
     url: https://traefik.github.io/charts
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
   - name: obol
     url: https://obolnetwork.github.io/helm-charts/
   - name: ethereum
@@ -15,6 +17,7 @@ repositories:
 # Single source of truth: change this to switch networks
 values:
   - network: mainnet
+  - gatewayApiVersion: v1.4.1
 
 releases:
   # Local storage provisioner (raw manifests wrapped as chart)
@@ -25,12 +28,39 @@ releases:
       - dataDir: /data
       - network: "{{ .Values.network }}"
 
+  # Monitoring stack (Prometheus operator + Prometheus)
+  - name: monitoring
+    namespace: monitoring
+    createNamespace: true
+    chart: prometheus-community/kube-prometheus-stack
+    version: 79.5.0
+    values:
+      - ./values/monitoring.yaml.gotmpl
+
+  # Gateway API CRDs (applied from upstream release)
+  - name: gateway-api-crds
+    namespace: gateway-system
+    createNamespace: true
+    chart: bedag/raw
+    values:
+      - resources: []
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: kubectl
+        args:
+          - apply
+          - -f
+          - https://github.com/kubernetes-sigs/gateway-api/releases/download/{{ .Values.gatewayApiVersion }}/standard-install.yaml
+
   # Traefik ingress controller with Gateway API support
   - name: traefik
     namespace: traefik
     createNamespace: true
     chart: traefik/traefik
     version: 38.0.2
+    needs:
+      - gateway-system/gateway-api-crds
     values:
       # Gateway API provider configuration
       - providers:
@@ -169,5 +199,5 @@ releases:
                         type: PathPrefix
                         value: /
                   backendRefs:
-                    - name: obol-frontend
+                    - name: obol-frontend-obol-app
                       port: 3000

--- a/internal/embed/infrastructure/values/monitoring.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/monitoring.yaml.gotmpl
@@ -1,0 +1,33 @@
+prometheus:
+  enabled: true
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector:
+      matchLabels:
+        release: monitoring
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector:
+      matchLabels:
+        release: monitoring
+    podMonitorNamespaceSelector: {}
+    retention: 6h
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+
+grafana:
+  enabled: false  # Enable when we want UI access
+
+alertmanager:
+  enabled: false  # Disable to keep the local stack lean
+
+kubeStateMetrics:
+  enabled: true
+
+nodeExporter:
+  enabled: true

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -13,7 +13,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: Always
-  tag: "v0.1.1"
+  tag: "latest"
 
 service:
   type: ClusterIP

--- a/internal/embed/k3d-config.yaml
+++ b/internal/embed/k3d-config.yaml
@@ -35,6 +35,10 @@ options:
       - arg: --kube-apiserver-arg=feature-gates=KubeletInUserNamespace=true
         nodeFilters:
           - server:*
+      # Disable bundled Traefik (we install Traefik via Helm)
+      - arg: --disable=traefik
+        nodeFilters:
+          - server:*
       # Disable local-storage addon (we provide our own config)
       - arg: --disable=local-storage
         nodeFilters:

--- a/internal/embed/networks/aztec/templates/ingress.yaml
+++ b/internal/embed/networks/aztec/templates/ingress.yaml
@@ -15,8 +15,11 @@ spec:
   rules:
     - matches:
         - path:
-            type: PathPrefix
+            type: Exact
             value: /{{ .Release.Namespace }}
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}/
       filters:
         - type: URLRewrite
           urlRewrite:

--- a/internal/embed/networks/ethereum/templates/ingress.yaml
+++ b/internal/embed/networks/ethereum/templates/ingress.yaml
@@ -15,8 +15,11 @@ spec:
   rules:
     - matches:
         - path:
-            type: PathPrefix
+            type: Exact
             value: /{{ .Release.Namespace }}/execution
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}/execution/
       filters:
         - type: URLRewrite
           urlRewrite:
@@ -43,8 +46,11 @@ spec:
   rules:
     - matches:
         - path:
-            type: PathPrefix
+            type: Exact
             value: /{{ .Release.Namespace }}/beacon
+        - path:
+            type: PathPrefix
+            value: /{{ .Release.Namespace }}/beacon/
       filters:
         - type: URLRewrite
           urlRewrite:

--- a/internal/embed/networks/helios/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/helios/helmfile.yaml.gotmpl
@@ -53,8 +53,11 @@ releases:
               rules:
                 - matches:
                     - path:
-                        type: PathPrefix
+                        type: Exact
                         value: /helios-{{ .Values.id }}
+                    - path:
+                        type: PathPrefix
+                        value: /helios-{{ .Values.id }}/
                   filters:
                     - type: URLRewrite
                       urlRewrite:

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,19 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "ObolNetwork/obol-stack-front-end",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Gateway API release version",
+      "matchStrings": [
+        "gatewayApiVersion:\\s*[\"']?(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)[\"']?"
+      ],
+      "fileMatch": [
+        "^internal/embed/infrastructure/helmfile\\.yaml$"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "kubernetes-sigs/gateway-api",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary
- add kube-prometheus-stack in the `monitoring` namespace with lightweight defaults
- ensure Prometheus service exists for frontend dashboard metrics
- keep Grafana/Alertmanager disabled by default

## Testing
- `obol stack up` (dev wrapper)

Refs ObolNetwork/obol-stack-front-end#174
