### PR TITLE
feat(nanobot): add Nanobot AI agent with shared appkit framework

### DIFF
--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -60,6 +60,13 @@ COMMANDS:
      openclaw delete  Remove instance and cluster resources
      openclaw skills  Manage skills (sync from local dir)
 
+   Nanobot (AI Agent):
+     nanobot up       Create and deploy a Nanobot instance
+     nanobot sync     Deploy or update an instance
+     nanobot token    Retrieve gateway token
+     nanobot list     List instances
+     nanobot delete   Remove instance and cluster resources
+
    Inference (x402 Pay-Per-Request):
      inference serve  Start the x402 inference gateway
 
@@ -439,6 +446,7 @@ GLOBAL OPTIONS:
 			},
 			networkCommand(cfg),
 			openclawCommand(cfg),
+			nanobotCommand(cfg),
 			inferenceCommand(cfg),
 			{
 				Name:  "app",

--- a/cmd/obol/nanobot.go
+++ b/cmd/obol/nanobot.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/nanobot"
+	"github.com/urfave/cli/v2"
+)
+
+func nanobotCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "nanobot",
+		Usage: "Manage Nanobot AI agent instances",
+		Subcommands: []*cli.Command{
+			{
+				Name:  "up",
+				Usage: "Create and deploy a Nanobot instance",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "id",
+						Usage: "Instance ID (defaults to generated petname)",
+					},
+					&cli.BoolFlag{
+						Name:    "force",
+						Aliases: []string{"f"},
+						Usage:   "Overwrite existing instance",
+					},
+					&cli.BoolFlag{
+						Name:  "no-sync",
+						Usage: "Only scaffold config, don't deploy to cluster",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					return nanobot.Up(cfg, nanobot.UpOptions{
+						ID:          c.String("id"),
+						Force:       c.Bool("force"),
+						Sync:        !c.Bool("no-sync"),
+						Interactive: true,
+					})
+				},
+			},
+			{
+				Name:      "sync",
+				Usage:     "Deploy or update a Nanobot instance",
+				ArgsUsage: "<id>",
+				Action: func(c *cli.Context) error {
+					if c.NArg() == 0 {
+						return fmt.Errorf("instance ID required (e.g., obol nanobot sync happy-otter)")
+					}
+					return nanobot.Sync(cfg, c.Args().First())
+				},
+			},
+			{
+				Name:      "token",
+				Usage:     "Retrieve gateway token for a Nanobot instance",
+				ArgsUsage: "<id>",
+				Action: func(c *cli.Context) error {
+					if c.NArg() == 0 {
+						return fmt.Errorf("instance ID required (e.g., obol nanobot token happy-otter)")
+					}
+					return nanobot.Token(cfg, c.Args().First())
+				},
+			},
+			{
+				Name:  "list",
+				Usage: "List Nanobot instances",
+				Action: func(c *cli.Context) error {
+					return nanobot.List(cfg)
+				},
+			},
+			{
+				Name:      "delete",
+				Usage:     "Remove a Nanobot instance and its cluster resources",
+				ArgsUsage: "<id>",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:    "force",
+						Aliases: []string{"f"},
+						Usage:   "Skip confirmation prompt",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					if c.NArg() == 0 {
+						return fmt.Errorf("instance ID required (e.g., obol nanobot delete happy-otter)")
+					}
+					return nanobot.Delete(cfg, c.Args().First(), c.Bool("force"))
+				},
+			},
+		},
+	}
+}

--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -33,9 +33,10 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 				},
 				Action: func(c *cli.Context) error {
 					return openclaw.Up(cfg, openclaw.UpOptions{
-						ID:    c.String("id"),
-						Force: c.Bool("force"),
-						Sync:  !c.Bool("no-sync"),
+						ID:          c.String("id"),
+						Force:       c.Bool("force"),
+						Sync:        !c.Bool("no-sync"),
+						Interactive: true,
 					})
 				},
 			},

--- a/internal/appkit/appkit.go
+++ b/internal/appkit/appkit.go
@@ -1,0 +1,97 @@
+package appkit
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	petname "github.com/dustinkirkland/golang-petname"
+)
+
+// DeploymentPaths holds resolved paths for an app deployment instance.
+type DeploymentPaths struct {
+	DeploymentDir string // ~/.config/obol/applications/<app>/<id>/
+	ChartDir      string // <DeploymentDir>/chart/
+	ValuesPath    string // <DeploymentDir>/values.yaml
+	OverlayPath   string // <DeploymentDir>/values-obol.yaml
+	HelmfilePath  string // <DeploymentDir>/helmfile.yaml
+}
+
+// ResolveDeployment returns the full set of paths for a given app/id.
+func ResolveDeployment(cfg *config.Config, appName, id string) DeploymentPaths {
+	dir := filepath.Join(cfg.ConfigDir, "applications", appName, id)
+	return DeploymentPaths{
+		DeploymentDir: dir,
+		ChartDir:      filepath.Join(dir, "chart"),
+		ValuesPath:    filepath.Join(dir, "values.yaml"),
+		OverlayPath:   filepath.Join(dir, "values-obol.yaml"),
+		HelmfilePath:  filepath.Join(dir, "helmfile.yaml"),
+	}
+}
+
+// GenerateID returns the provided ID if non-empty, otherwise generates a petname.
+func GenerateID(provided string) string {
+	if provided != "" {
+		return provided
+	}
+	return petname.Generate(2, "-")
+}
+
+// Hostname builds a hostname like <app>-<id>.<domain>.
+func Hostname(appName, id, domain string) string {
+	return fmt.Sprintf("%s-%s.%s", appName, id, domain)
+}
+
+// Namespace builds a namespace like <app>-<id>.
+func Namespace(appName, id string) string {
+	return fmt.Sprintf("%s-%s", appName, id)
+}
+
+// CopyEmbeddedChart extracts an embedded chart FS to destDir.
+// The chartFS should embed a directory named by root (e.g. "chart").
+// Files are written relative to destDir with the root prefix stripped.
+func CopyEmbeddedChart(chartFS fs.FS, root, destDir string) error {
+	return fs.WalkDir(chartFS, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+
+		relPath := strings.TrimPrefix(path, root+"/")
+		destPath := filepath.Join(destDir, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0755)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return err
+		}
+
+		data, err := fs.ReadFile(chartFS, path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded %s: %w", path, err)
+		}
+		return os.WriteFile(destPath, data, 0644)
+	})
+}
+
+// WriteDefaultValues reads values.yaml from the embedded chart FS and writes it
+// to dest (typically DeploymentPaths.ValuesPath).
+func WriteDefaultValues(chartFS fs.FS, valuesPath, dest string) error {
+	data, err := fs.ReadFile(chartFS, valuesPath)
+	if err != nil {
+		return fmt.Errorf("failed to read chart defaults: %w", err)
+	}
+	return os.WriteFile(dest, data, 0644)
+}
+
+// WriteFile is a convenience wrapper around os.WriteFile with 0644 perms.
+func WriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/appkit/helmfile.go
+++ b/internal/appkit/helmfile.go
@@ -1,0 +1,59 @@
+package appkit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// GenerateHelmfile creates a helmfile.yaml referencing a local chart with
+// two value layers: values.yaml (chart defaults) and values-obol.yaml (overlay).
+func GenerateHelmfile(releaseName, namespace, id string) string {
+	return fmt.Sprintf(`# %s instance: %s
+# Managed by obol %s
+
+releases:
+  - name: %s
+    namespace: %s
+    createNamespace: true
+    chart: ./chart
+    values:
+      - values.yaml
+      - values-obol.yaml
+`, releaseName, id, releaseName, releaseName, namespace)
+}
+
+// SyncHelmfile runs `helmfile sync` in the given deployment directory.
+func SyncHelmfile(cfg *config.Config, deploymentDir string) error {
+	helmfilePath := filepath.Join(deploymentDir, "helmfile.yaml")
+	if _, err := os.Stat(helmfilePath); os.IsNotExist(err) {
+		return fmt.Errorf("helmfile.yaml not found in: %s", deploymentDir)
+	}
+
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	}
+
+	helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
+	if _, err := os.Stat(helmfileBinary); os.IsNotExist(err) {
+		return fmt.Errorf("helmfile not found at %s", helmfileBinary)
+	}
+
+	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
+	cmd.Dir = deploymentDir
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath),
+	)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("helmfile sync failed: %w", err)
+	}
+	return nil
+}

--- a/internal/appkit/lifecycle.go
+++ b/internal/appkit/lifecycle.go
@@ -1,0 +1,185 @@
+package appkit
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// DeleteDeployment removes a deployment's namespace and local config directory.
+// If force is false, prompts the user for confirmation.
+func DeleteDeployment(cfg *config.Config, appName, id string, force bool) error {
+	namespace := Namespace(appName, id)
+	paths := ResolveDeployment(cfg, appName, id)
+
+	fmt.Printf("Deleting %s: %s/%s\n", appName, appName, id)
+	fmt.Printf("Namespace: %s\n", namespace)
+
+	configExists := false
+	if _, err := os.Stat(paths.DeploymentDir); err == nil {
+		configExists = true
+	}
+
+	namespaceExists := false
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); err == nil {
+		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+		cmd := exec.Command(kubectlBinary, "get", "namespace", namespace)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+		if err := cmd.Run(); err == nil {
+			namespaceExists = true
+		}
+	}
+
+	if !namespaceExists && !configExists {
+		return fmt.Errorf("instance not found: %s", id)
+	}
+
+	fmt.Println("\nResources to be deleted:")
+	if namespaceExists {
+		fmt.Printf("  [x] Kubernetes namespace: %s\n", namespace)
+	} else {
+		fmt.Printf("  [ ] Kubernetes namespace: %s (not found)\n", namespace)
+	}
+	if configExists {
+		fmt.Printf("  [x] Configuration: %s\n", paths.DeploymentDir)
+	}
+
+	if !force {
+		fmt.Print("\nProceed with deletion? [y/N]: ")
+		var response string
+		fmt.Scanln(&response)
+		if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
+			fmt.Println("Deletion cancelled")
+			return nil
+		}
+	}
+
+	if namespaceExists {
+		fmt.Printf("\nDeleting namespace %s...\n", namespace)
+		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+		cmd := exec.Command(kubectlBinary, "delete", "namespace", namespace,
+			"--force", "--grace-period=0")
+		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to delete namespace: %w", err)
+		}
+		fmt.Println("Namespace deleted")
+	}
+
+	if configExists {
+		fmt.Printf("Deleting configuration...\n")
+		if err := os.RemoveAll(paths.DeploymentDir); err != nil {
+			return fmt.Errorf("failed to delete config directory: %w", err)
+		}
+		fmt.Println("Configuration deleted")
+
+		parentDir := filepath.Join(cfg.ConfigDir, "applications", appName)
+		entries, err := os.ReadDir(parentDir)
+		if err == nil && len(entries) == 0 {
+			os.Remove(parentDir)
+		}
+	}
+
+	fmt.Printf("\n%s %s deleted successfully!\n", appName, id)
+	return nil
+}
+
+// ListDeployments displays installed instances for a given app.
+func ListDeployments(cfg *config.Config, appName, domain string) error {
+	appsDir := filepath.Join(cfg.ConfigDir, "applications", appName)
+
+	if _, err := os.Stat(appsDir); os.IsNotExist(err) {
+		fmt.Printf("No %s instances installed\n", appName)
+		fmt.Printf("\nTo create one: obol %s up\n", appName)
+		return nil
+	}
+
+	entries, err := os.ReadDir(appsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Printf("No %s instances installed\n", appName)
+		return nil
+	}
+
+	displayName := strings.ToUpper(appName[:1]) + appName[1:]
+	fmt.Printf("%s instances:\n\n", displayName)
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		namespace := Namespace(appName, id)
+		hostname := Hostname(appName, id, domain)
+		fmt.Printf("  %s\n", id)
+		fmt.Printf("    Namespace: %s\n", namespace)
+		fmt.Printf("    URL:       http://%s\n", hostname)
+		fmt.Println()
+		count++
+	}
+
+	fmt.Printf("Total: %d instance(s)\n", count)
+	return nil
+}
+
+// GetSecretValue retrieves a specific key from a Kubernetes Secret matching
+// a label selector in the given namespace.
+func GetSecretValue(cfg *config.Config, namespace, labelSelector, key string) (string, error) {
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	}
+
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+
+	cmd := exec.Command(kubectlBinary, "get", "secret", "-n", namespace,
+		"-l", labelSelector,
+		"-o", "json")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to get secret: %w\n%s", err, stderr.String())
+	}
+
+	var secretList struct {
+		Items []struct {
+			Data map[string]string `json:"data"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &secretList); err != nil {
+		return "", fmt.Errorf("failed to parse secret: %w", err)
+	}
+
+	if len(secretList.Items) == 0 {
+		return "", fmt.Errorf("no secrets found in namespace %s", namespace)
+	}
+
+	for _, item := range secretList.Items {
+		if encoded, ok := item.Data[key]; ok {
+			decoded, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return "", fmt.Errorf("failed to decode secret value: %w", err)
+			}
+			return string(decoded), nil
+		}
+	}
+
+	return "", fmt.Errorf("%s not found in namespace %s secrets", key, namespace)
+}

--- a/internal/nanobot/chart/Chart.yaml
+++ b/internal/nanobot/chart/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: nanobot
+description: Nanobot AI agent deployment for Kubernetes.
+type: application
+version: 0.1.0
+appVersion: "latest"
+kubeVersion: ">=1.26.0-0"
+
+home: https://github.com/obolnetwork/nanobot
+maintainers:
+  - name: Obol Platform Team
+    email: platform@obol.tech
+keywords:
+  - nanobot
+  - agent
+  - ai
+  - gateway
+  - obol

--- a/internal/nanobot/chart/templates/NOTES.txt
+++ b/internal/nanobot/chart/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Nanobot is now installed.
+
+Namespace: {{ .Release.Namespace }}
+Service: {{ include "nanobot.fullname" . }}
+Port: {{ .Values.service.port }}
+
+Gateway token:
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "nanobot.secretsName" . }} -o jsonpath='{.data.{{ .Values.secrets.gatewayToken.key }}}' | base64 --decode
+
+{{- if .Values.httpRoute.enabled }}
+
+HTTPRoute is enabled. Access Nanobot at:
+{{- range .Values.httpRoute.hostnames }}
+  http://{{ . }}
+{{- end }}
+
+{{- else if .Values.ingress.enabled }}
+
+Ingress is enabled. Access Nanobot at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+
+{{- else }}
+
+Port-forward for local access:
+  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nanobot.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 18790:{{ .Values.service.port }}
+  open http://127.0.0.1:18790
+
+{{- end }}

--- a/internal/nanobot/chart/templates/_helpers.tpl
+++ b/internal/nanobot/chart/templates/_helpers.tpl
@@ -1,0 +1,182 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nanobot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "nanobot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nanobot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "nanobot.labels" -}}
+helm.sh/chart: {{ include "nanobot.chart" . }}
+{{ include "nanobot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "nanobot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nanobot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "nanobot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nanobot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Compute the full image reference.
+*/}}
+{{- define "nanobot.image" -}}
+{{- $tag := .Values.image.tag -}}
+{{- if not $tag -}}
+{{- $tag = .Chart.AppVersion -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+Name of the Secret used for envFrom.
+*/}}
+{{- define "nanobot.secretsName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else if .Values.secrets.name -}}
+{{- .Values.secrets.name -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "nanobot.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the ConfigMap containing config.json.
+*/}}
+{{- define "nanobot.configMapName" -}}
+{{- if .Values.config.existingConfigMap -}}
+{{- .Values.config.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-config" (include "nanobot.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the PVC used for state storage.
+*/}}
+{{- define "nanobot.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "nanobot.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Compute (or reuse) the gateway token value.
+*/}}
+{{- define "nanobot.gatewayTokenValue" -}}
+{{- if .Values.secrets.gatewayToken.value -}}
+{{- .Values.secrets.gatewayToken.value -}}
+{{- else -}}
+{{- $secretName := include "nanobot.secretsName" . -}}
+{{- $key := .Values.secrets.gatewayToken.key -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- if $existing -}}
+  {{- $data := index $existing "data" -}}
+  {{- if and $data (hasKey $data $key) -}}
+    {{- index $data $key | b64dec -}}
+  {{- else -}}
+    {{- randAlphaNum 48 -}}
+  {{- end -}}
+{{- else -}}
+  {{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render config.json for Nanobot. If config.content is provided, it is used verbatim.
+*/}}
+{{- define "nanobot.configJson" -}}
+{{- if .Values.config.content -}}
+{{- .Values.config.content -}}
+{{- else -}}
+{{- $cfg := dict
+  "gateway" (dict
+    "host" .Values.nanobot.gateway.host
+    "port" (.Values.nanobot.gateway.port | int)
+    "auth" (dict "token" (printf "${%s}" .Values.secrets.gatewayToken.key))
+  )
+  "stateDir" .Values.nanobot.stateDir
+  "workspaceDir" .Values.nanobot.workspaceDir
+-}}
+
+{{- if .Values.nanobot.agentModel -}}
+{{- $_ := set $cfg "agentModel" .Values.nanobot.agentModel -}}
+{{- end -}}
+
+{{- /* Build providers map from all enabled providers */ -}}
+{{- $providers := dict -}}
+{{- range $name := list "anthropic" "openai" "openrouter" "ollama" -}}
+{{- $p := index $.Values.providers $name -}}
+{{- if $p.enabled -}}
+{{- $entry := dict
+  "baseUrl" $p.baseUrl
+  "apiKey" (printf "${%s}" $p.apiKeyEnvVar)
+-}}
+{{- $_ := set $providers $name $entry -}}
+{{- end -}}
+{{- end -}}
+{{- if $providers -}}
+{{- $_ := set $cfg "providers" $providers -}}
+{{- end -}}
+
+{{- /* Build channels config from enabled integrations */ -}}
+{{- $channels := dict -}}
+{{- if .Values.channels.telegram.enabled -}}
+{{- $_ := set $channels "telegram" (dict "token" "${TELEGRAM_BOT_TOKEN}") -}}
+{{- end -}}
+{{- if .Values.channels.discord.enabled -}}
+{{- $_ := set $channels "discord" (dict "token" "${DISCORD_BOT_TOKEN}") -}}
+{{- end -}}
+{{- if $channels -}}
+{{- $_ := set $cfg "channels" $channels -}}
+{{- end -}}
+
+{{- $cfg | toPrettyJson -}}
+{{- end -}}
+{{- end }}

--- a/internal/nanobot/chart/templates/configmap.yaml
+++ b/internal/nanobot/chart/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.config.existingConfigMap -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nanobot.configMapName" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.key }}: |-
+    {{- include "nanobot.configJson" . | nindent 4 }}
+{{- end }}

--- a/internal/nanobot/chart/templates/deployment.yaml
+++ b/internal/nanobot/chart/templates/deployment.yaml
@@ -1,0 +1,150 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nanobot.fullname" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "nanobot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "nanobot.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "nanobot.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: nanobot
+          image: "{{ include "nanobot.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.image.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.image.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: NANOBOT_CONFIG_PATH
+              value: "/etc/nanobot/{{ .Values.config.key }}"
+            - name: NANOBOT_STATE_DIR
+              value: {{ .Values.nanobot.stateDir | quote }}
+            {{- /* Inject non-secret provider API key values (e.g. Ollama placeholder) */ -}}
+            {{- range $name := list "anthropic" "openai" "openrouter" "ollama" }}
+            {{- $p := index $.Values.providers $name }}
+            {{- if and $p.enabled $p.apiKeyValue (not (has $name (list "anthropic" "openai" "openrouter"))) }}
+            - name: {{ $p.apiKeyEnvVar }}
+              value: {{ $p.apiKeyValue | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.image.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "nanobot.secretsName" . }}
+            {{- range .Values.secrets.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nanobot
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "nanobot.configMapName" . }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "nanobot.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/internal/nanobot/chart/templates/httproute.yaml
+++ b/internal/nanobot/chart/templates/httproute.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "nanobot.fullname" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.pathPrefix | quote }}
+      backendRefs:
+        - name: {{ include "nanobot.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/internal/nanobot/chart/templates/ingress.yaml
+++ b/internal/nanobot/chart/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "nanobot.fullname" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "nanobot.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/internal/nanobot/chart/templates/pvc.yaml
+++ b/internal/nanobot/chart/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nanobot.pvcName" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/internal/nanobot/chart/templates/secret.yaml
+++ b/internal/nanobot/chart/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nanobot.secretsName" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.secrets.gatewayToken.key }}: {{ include "nanobot.gatewayTokenValue" . | quote }}
+  {{- if and .Values.providers.anthropic.enabled .Values.providers.anthropic.apiKeyValue }}
+  {{ .Values.providers.anthropic.apiKeyEnvVar }}: {{ .Values.providers.anthropic.apiKeyValue | quote }}
+  {{- end }}
+  {{- if and .Values.providers.openai.enabled .Values.providers.openai.apiKeyValue }}
+  {{ .Values.providers.openai.apiKeyEnvVar }}: {{ .Values.providers.openai.apiKeyValue | quote }}
+  {{- end }}
+  {{- if and .Values.providers.openrouter.enabled .Values.providers.openrouter.apiKeyValue }}
+  {{ .Values.providers.openrouter.apiKeyEnvVar }}: {{ .Values.providers.openrouter.apiKeyValue | quote }}
+  {{- end }}
+  {{- if and .Values.channels.telegram.enabled .Values.channels.telegram.token }}
+  TELEGRAM_BOT_TOKEN: {{ .Values.channels.telegram.token | quote }}
+  {{- end }}
+  {{- if and .Values.channels.discord.enabled .Values.channels.discord.token }}
+  DISCORD_BOT_TOKEN: {{ .Values.channels.discord.token | quote }}
+  {{- end }}
+{{- end }}

--- a/internal/nanobot/chart/templates/service.yaml
+++ b/internal/nanobot/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nanobot.fullname" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nanobot.selectorLabels" . | nindent 4 }}

--- a/internal/nanobot/chart/templates/serviceaccount.yaml
+++ b/internal/nanobot/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nanobot.serviceAccountName" . }}
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/internal/nanobot/chart/templates/tests/test-connection.yaml
+++ b/internal/nanobot/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "nanobot.fullname" . }}-test-connection
+  labels:
+    {{- include "nanobot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: tcp-check
+      image: busybox:1.36.1
+      command:
+        - sh
+        - -c
+        - |
+          echo "Testing TCP connection to {{ include "nanobot.fullname" . }}:{{ .Values.service.port }}..."
+          for i in $(seq 1 10); do
+            if nc -z {{ include "nanobot.fullname" . }} {{ .Values.service.port }} 2>/dev/null; then
+              echo "Connection successful!"
+              exit 0
+            fi
+            echo "Attempt $i/10 failed, retrying in 3s..."
+            sleep 3
+          done
+          echo "Connection failed after 10 attempts"
+          exit 1

--- a/internal/nanobot/chart/templates/validate.yaml
+++ b/internal/nanobot/chart/templates/validate.yaml
@@ -1,0 +1,15 @@
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "nanobot: replicaCount must be 1 (Nanobot stores state on disk and should not be scaled horizontally)" -}}
+{{- end -}}
+
+{{- if and .Values.secrets.existingSecret .Values.secrets.create -}}
+{{- fail "nanobot: secrets.existingSecret is set; set secrets.create=false" -}}
+{{- end -}}
+
+{{- if and (not .Values.secrets.existingSecret) (not .Values.secrets.create) -}}
+{{- fail "nanobot: set secrets.existingSecret or enable secrets.create" -}}
+{{- end -}}
+
+{{- if and .Values.httpRoute.enabled (eq (len .Values.httpRoute.hostnames) 0) -}}
+{{- fail "nanobot: httpRoute.enabled is true but httpRoute.hostnames is empty" -}}
+{{- end -}}

--- a/internal/nanobot/chart/values.yaml
+++ b/internal/nanobot/chart/values.yaml
@@ -1,0 +1,215 @@
+# Default values for nanobot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of replicas (Nanobot should run as a single instance)
+replicaCount: 1
+
+# -- Nanobot image repository, pull policy, and tag version
+image:
+  repository: ghcr.io/obolnetwork/nanobot
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+  # -- Override the container command (ENTRYPOINT)
+  command: []
+  # -- Override the container args (CMD)
+  args:
+    - gateway
+
+  # -- Additional environment variables for the container
+  env: []
+  # - name: FOO
+  #   value: bar
+
+# -- Credentials to fetch images from private registry
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full resource name
+fullnameOverride: ""
+
+# -- Create a ServiceAccount for Nanobot
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+# -- Pod labels
+podLabels: {}
+
+# -- Pod security context
+podSecurityContext:
+  fsGroup: 1000
+
+# -- Container security context
+containerSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Service configuration
+service:
+  type: ClusterIP
+  port: 18790
+
+# -- Kubernetes Ingress (optional; not used in Obol Stack which uses Gateway API)
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# -- Gateway API HTTPRoute (recommended for Obol Stack / Traefik Gateway API)
+httpRoute:
+  enabled: false
+  annotations: {}
+  # -- Hostnames for routing (required when enabled)
+  hostnames: []
+  # - nanobot-myid.obol.stack
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  pathPrefix: /
+
+# -- Persistence settings for Nanobot state directory
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  mountPath: /data
+
+# -- Nanobot state/workspace settings (paths should be inside persistence.mountPath)
+nanobot:
+  stateDir: /data/.nanobot
+  workspaceDir: /data/.nanobot/workspace
+  # -- Default agent model (provider/model). Set to route agent traffic to a specific provider.
+  agentModel: ""
+
+  gateway:
+    host: "0.0.0.0"
+    port: 18790
+
+# -- Model provider configuration
+# Each provider is independently toggled. At least one must be enabled.
+# API keys are stored in the chart Secret and injected as env vars.
+providers:
+  anthropic:
+    enabled: false
+    baseUrl: https://api.anthropic.com/v1
+    apiKeyEnvVar: ANTHROPIC_API_KEY
+    apiKeyValue: ""
+  openai:
+    enabled: false
+    baseUrl: https://api.openai.com/v1
+    apiKeyEnvVar: OPENAI_API_KEY
+    apiKeyValue: ""
+  openrouter:
+    enabled: false
+    baseUrl: https://openrouter.ai/api/v1
+    apiKeyEnvVar: OPENROUTER_API_KEY
+    apiKeyValue: ""
+  ollama:
+    enabled: true
+    baseUrl: http://ollama.llm.svc.cluster.local:11434/v1
+    apiKeyEnvVar: OLLAMA_API_KEY
+    apiKeyValue: ollama-local
+
+# -- Chat channel integrations
+# Tokens are stored in the chart Secret and injected as env vars.
+channels:
+  telegram:
+    enabled: false
+    token: ""
+  discord:
+    enabled: false
+    token: ""
+
+# -- Configuration for the Nanobot config file (config.json)
+config:
+  # -- Use an existing ConfigMap instead of creating one
+  existingConfigMap: ""
+  # -- ConfigMap key / filename
+  key: config.json
+  # -- Optional raw JSON configuration (overrides generated config when set)
+  content: ""
+
+# -- Nanobot secrets (one Secret per instance)
+secrets:
+  # -- Use an existing secret instead of creating one
+  existingSecret: ""
+  # -- Create the secret when existingSecret is not set
+  create: true
+  # -- Override the created Secret name
+  name: ""
+
+  gatewayToken:
+    # -- Secret key name + env var name for gateway token
+    key: NANOBOT_GATEWAY_TOKEN
+    # -- Explicit token value. If empty, a token is generated and persisted across upgrades.
+    value: ""
+
+  # -- Extra Secret names to load via envFrom
+  extraEnvFromSecrets: []
+
+# -- Resource requests and limits
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+# -- Startup probe (tcpSocket)
+startupProbe:
+  enabled: true
+  periodSeconds: 5
+  failureThreshold: 30
+  timeoutSeconds: 3
+
+# -- Liveness probe (tcpSocket)
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Readiness probe (tcpSocket)
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# -- Additional volumes
+extraVolumes: []
+# -- Additional volume mounts
+extraVolumeMounts: []
+# -- Additional environment variables
+extraEnv: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+priorityClassName: ""

--- a/internal/nanobot/import.go
+++ b/internal/nanobot/import.go
@@ -1,0 +1,55 @@
+package nanobot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/providers"
+)
+
+// TranslateToOverlayYAML converts detected config to Nanobot chart values format.
+func TranslateToOverlayYAML(result *providers.DetectedConfig) string {
+	if result == nil {
+		return ""
+	}
+
+	var b strings.Builder
+
+	if result.AgentModel != "" {
+		b.WriteString(fmt.Sprintf("nanobot:\n  agentModel: %s\n\n", result.AgentModel))
+	}
+
+	if len(result.Providers) > 0 {
+		b.WriteString("providers:\n")
+		for _, p := range result.Providers {
+			b.WriteString(fmt.Sprintf("  %s:\n", p.Name))
+			b.WriteString("    enabled: true\n")
+			if p.BaseURL != "" {
+				b.WriteString(fmt.Sprintf("    baseUrl: %s\n", p.BaseURL))
+			}
+			if p.APIKey != "" {
+				b.WriteString(fmt.Sprintf("    apiKeyValue: %s\n", p.APIKey))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// Channels
+	hasChannels := result.Channels.Telegram != nil || result.Channels.Discord != nil
+	if hasChannels {
+		b.WriteString("channels:\n")
+		if result.Channels.Telegram != nil {
+			b.WriteString("  telegram:\n")
+			b.WriteString("    enabled: true\n")
+			b.WriteString(fmt.Sprintf("    token: %s\n", result.Channels.Telegram.BotToken))
+		}
+		if result.Channels.Discord != nil {
+			b.WriteString("  discord:\n")
+			b.WriteString("    enabled: true\n")
+			b.WriteString(fmt.Sprintf("    token: %s\n", result.Channels.Discord.BotToken))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/nanobot/nanobot.go
+++ b/internal/nanobot/nanobot.go
@@ -1,41 +1,35 @@
-package openclaw
+package nanobot
 
 import (
 	"bufio"
-	"bytes"
 	"embed"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/appkit"
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/providers"
 )
 
 const (
-	appName       = "openclaw"
+	appName       = "nanobot"
 	defaultDomain = "obol.stack"
 )
 
-// Embed the OpenClaw Helm chart from the shared charts directory.
-// The chart source lives in internal/embed/charts/openclaw/ and is
-// referenced here so the openclaw package owns its own chart lifecycle.
-//
 //go:embed all:chart
 var chartFS embed.FS
 
 // UpOptions contains options for the up command
 type UpOptions struct {
-	ID          string // Deployment ID (empty = generate petname)
-	Force       bool   // Overwrite existing deployment
-	Sync        bool   // Also run helmfile sync after install
-	Interactive bool   // true = prompt for provider choice; false = silent defaults
-	IsDefault   bool   // true = use fixed ID "default", idempotent on re-run
+	ID          string
+	Force       bool
+	Sync        bool
+	Interactive bool
+	IsDefault   bool
 }
 
-// SetupDefault deploys a default OpenClaw instance as part of stack setup.
+// SetupDefault deploys a default Nanobot instance as part of stack setup.
 // It is idempotent: if a "default" deployment already exists, it re-syncs.
 func SetupDefault(cfg *config.Config) error {
 	return Up(cfg, UpOptions{
@@ -45,7 +39,7 @@ func SetupDefault(cfg *config.Config) error {
 	})
 }
 
-// Up creates and optionally deploys an OpenClaw instance
+// Up creates and optionally deploys a Nanobot instance
 func Up(cfg *config.Config, opts UpOptions) error {
 	id := opts.ID
 	if opts.IsDefault {
@@ -63,7 +57,7 @@ func Up(cfg *config.Config, opts UpOptions) error {
 	// Idempotent re-run for default deployment: just re-sync
 	if opts.IsDefault && !opts.Force {
 		if _, err := os.Stat(paths.DeploymentDir); err == nil {
-			fmt.Println("Default OpenClaw instance already configured, re-syncing...")
+			fmt.Println("Default Nanobot instance already configured, re-syncing...")
 			if opts.Sync {
 				return doSync(cfg, id)
 			}
@@ -80,13 +74,13 @@ func Up(cfg *config.Config, opts UpOptions) error {
 		fmt.Printf("WARNING: Overwriting existing deployment at %s\n", paths.DeploymentDir)
 	}
 
-	// Detect existing ~/.openclaw config
-	imported, err := DetectExistingConfig()
+	// Detect existing config from all sources
+	imported, err := providers.DetectAll()
 	if err != nil {
 		fmt.Printf("Warning: failed to read existing config: %v\n", err)
 	}
 	if imported != nil {
-		PrintImportSummary(imported)
+		providers.PrintSummary("~/.openclaw, ~/.nanobot, env", imported)
 	}
 
 	// Interactive setup: prompt for provider choice
@@ -113,7 +107,7 @@ func Up(cfg *config.Config, opts UpOptions) error {
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
 
-	// Write Obol Stack overlay values (httpRoute, provider config, eRPC, skills)
+	// Write Obol Stack overlay values
 	hostname := appkit.Hostname(appName, id, defaultDomain)
 	namespace := appkit.Namespace(appName, id)
 	overlay := generateOverlayValues(hostname, imported)
@@ -129,15 +123,15 @@ func Up(cfg *config.Config, opts UpOptions) error {
 		return fmt.Errorf("failed to write helmfile.yaml: %w", err)
 	}
 
-	fmt.Printf("\n✓ OpenClaw instance configured!\n")
+	fmt.Printf("\n✓ Nanobot instance configured!\n")
 	fmt.Printf("  Deployment: %s/%s\n", appName, id)
 	fmt.Printf("  Namespace:  %s\n", namespace)
 	fmt.Printf("  Hostname:   %s\n", hostname)
 	fmt.Printf("  Location:   %s\n", paths.DeploymentDir)
 	fmt.Printf("\nFiles created:\n")
-	fmt.Printf("  - chart/            Embedded OpenClaw Helm chart\n")
+	fmt.Printf("  - chart/            Embedded Nanobot Helm chart\n")
 	fmt.Printf("  - values.yaml       Chart defaults (edit to customize)\n")
-	fmt.Printf("  - values-obol.yaml  Obol Stack defaults (httpRoute, providers, eRPC)\n")
+	fmt.Printf("  - values-obol.yaml  Obol Stack defaults (httpRoute, providers)\n")
 	fmt.Printf("  - helmfile.yaml     Deployment configuration\n")
 
 	if opts.Sync {
@@ -145,11 +139,11 @@ func Up(cfg *config.Config, opts UpOptions) error {
 		return doSync(cfg, id)
 	}
 
-	fmt.Printf("\nTo deploy: obol openclaw sync %s\n", id)
+	fmt.Printf("\nTo deploy: obol nanobot sync %s\n", id)
 	return nil
 }
 
-// Sync deploys or updates an OpenClaw instance
+// Sync deploys or updates a Nanobot instance
 func Sync(cfg *config.Config, id string) error {
 	return doSync(cfg, id)
 }
@@ -160,7 +154,7 @@ func doSync(cfg *config.Config, id string) error {
 		return fmt.Errorf("deployment not found: %s/%s\nDirectory: %s", appName, id, paths.DeploymentDir)
 	}
 
-	fmt.Printf("Syncing OpenClaw: %s/%s\n", appName, id)
+	fmt.Printf("Syncing Nanobot: %s/%s\n", appName, id)
 	fmt.Printf("Deployment directory: %s\n", paths.DeploymentDir)
 	fmt.Printf("Running helmfile sync...\n\n")
 
@@ -170,23 +164,23 @@ func doSync(cfg *config.Config, id string) error {
 
 	namespace := appkit.Namespace(appName, id)
 	hostname := appkit.Hostname(appName, id, defaultDomain)
-	fmt.Printf("\n✓ OpenClaw synced successfully!\n")
+	fmt.Printf("\n✓ Nanobot synced successfully!\n")
 	fmt.Printf("  Namespace: %s\n", namespace)
 	fmt.Printf("  URL:       http://%s\n", hostname)
 	fmt.Printf("\nRetrieve gateway token:\n")
-	fmt.Printf("  obol openclaw token %s\n", id)
+	fmt.Printf("  obol nanobot token %s\n", id)
 	fmt.Printf("\nPort-forward fallback:\n")
-	fmt.Printf("  obol kubectl -n %s port-forward svc/openclaw 18789:18789\n", namespace)
+	fmt.Printf("  obol kubectl -n %s port-forward svc/nanobot 18790:18790\n", namespace)
 
 	return nil
 }
 
-// Token retrieves the gateway token for an OpenClaw instance from the cluster
+// Token retrieves the gateway token for a Nanobot instance from the cluster
 func Token(cfg *config.Config, id string) error {
 	namespace := appkit.Namespace(appName, id)
 	labelSelector := fmt.Sprintf("app.kubernetes.io/name=%s", appName)
 
-	token, err := appkit.GetSecretValue(cfg, namespace, labelSelector, "OPENCLAW_GATEWAY_TOKEN")
+	token, err := appkit.GetSecretValue(cfg, namespace, labelSelector, "NANOBOT_GATEWAY_TOKEN")
 	if err != nil {
 		return err
 	}
@@ -194,85 +188,21 @@ func Token(cfg *config.Config, id string) error {
 	return nil
 }
 
-// List displays installed OpenClaw instances
+// List displays installed Nanobot instances
 func List(cfg *config.Config) error {
 	return appkit.ListDeployments(cfg, appName, defaultDomain)
 }
 
-// Delete removes an OpenClaw instance
+// Delete removes a Nanobot instance
 func Delete(cfg *config.Config, id string, force bool) error {
 	return appkit.DeleteDeployment(cfg, appName, id, force)
 }
 
-// SkillsSync packages a local skills directory into a ConfigMap and rolls the deployment
-func SkillsSync(cfg *config.Config, id, skillsDir string) error {
-	namespace := appkit.Namespace(appName, id)
-
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
-	}
-
-	if _, err := os.Stat(skillsDir); os.IsNotExist(err) {
-		return fmt.Errorf("skills directory not found: %s", skillsDir)
-	}
-
-	configMapName := fmt.Sprintf("openclaw-%s-skills", id)
-	archiveKey := "skills.tgz"
-
-	fmt.Printf("Packaging skills from %s...\n", skillsDir)
-
-	var archiveBuf bytes.Buffer
-	tarCmd := exec.Command("tar", "-czf", "-", "-C", skillsDir, ".")
-	tarCmd.Stdout = &archiveBuf
-	var tarStderr bytes.Buffer
-	tarCmd.Stderr = &tarStderr
-	if err := tarCmd.Run(); err != nil {
-		return fmt.Errorf("failed to create skills archive: %w\n%s", err, tarStderr.String())
-	}
-
-	tmpFile, err := os.CreateTemp("", "openclaw-skills-*.tgz")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.Write(archiveBuf.Bytes()); err != nil {
-		tmpFile.Close()
-		return fmt.Errorf("failed to write archive: %w", err)
-	}
-	tmpFile.Close()
-
-	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
-
-	delCmd := exec.Command(kubectlBinary, "delete", "configmap", configMapName,
-		"-n", namespace, "--ignore-not-found")
-	delCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	delCmd.Run()
-
-	fmt.Printf("Creating ConfigMap %s in namespace %s...\n", configMapName, namespace)
-	createCmd := exec.Command(kubectlBinary, "create", "configmap", configMapName,
-		"-n", namespace,
-		fmt.Sprintf("--from-file=%s=%s", archiveKey, tmpFile.Name()))
-	createCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	var createStderr bytes.Buffer
-	createCmd.Stderr = &createStderr
-	if err := createCmd.Run(); err != nil {
-		return fmt.Errorf("failed to create ConfigMap: %w\n%s", err, createStderr.String())
-	}
-
-	fmt.Printf("✓ Skills ConfigMap updated: %s\n", configMapName)
-	fmt.Printf("\nTo apply, re-sync: obol openclaw sync %s\n", id)
-	return nil
-}
-
-// generateOverlayValues creates the Obol Stack-specific values overlay.
-// If imported is non-nil, provider/channel config from the import is used
-// instead of the default Ollama configuration.
-func generateOverlayValues(hostname string, imported *ImportResult) string {
+// generateOverlayValues creates the Obol Stack-specific values overlay for Nanobot.
+func generateOverlayValues(hostname string, imported *providers.DetectedConfig) string {
 	var b strings.Builder
 
-	b.WriteString(`# Obol Stack overlay values for OpenClaw
+	b.WriteString(`# Obol Stack overlay values for Nanobot
 # This file contains stack-specific defaults. Edit to customize.
 
 # Enable Gateway API HTTPRoute for stack routing
@@ -286,61 +216,29 @@ httpRoute:
       namespace: traefik
       sectionName: web
 
-# SA needs API token mount for K8s read access
-serviceAccount:
-  automount: true
-
-# Read-only RBAC for K8s API (pods, services, deployments, etc.)
-rbac:
-  create: true
-
 `)
 
 	// Provider and agent model configuration
 	importedOverlay := TranslateToOverlayYAML(imported)
 	if importedOverlay != "" {
-		b.WriteString("# Imported from ~/.openclaw/openclaw.json\n")
+		b.WriteString("# Imported from detected configuration\n")
 		b.WriteString(importedOverlay)
 	} else {
-		b.WriteString(`# Route agent traffic to in-cluster Ollama
-openclaw:
-  agentModel: ollama/glm-4.7-flash
-
-# Default model provider: in-cluster Ollama
-models:
+		b.WriteString(`# Default model provider: in-cluster Ollama
+providers:
   ollama:
     enabled: true
     baseUrl: http://ollama.llm.svc.cluster.local:11434/v1
-    api: openai-completions
-    apiKeyEnvVar: OLLAMA_API_KEY
     apiKeyValue: ollama-local
-    models:
-      - id: glm-4.7-flash
-        name: GLM-4.7 Flash
 
 `)
 	}
-
-	b.WriteString(`# eRPC integration
-erpc:
-  url: http://erpc.erpc.svc.cluster.local:4000/rpc
-
-# Skills: chart creates a default empty ConfigMap; populate with obol openclaw skills sync
-skills:
-  enabled: true
-  createDefault: true
-
-# Agent init Job (enable to bootstrap workspace on first deploy)
-initJob:
-  enabled: false
-`)
 
 	return b.String()
 }
 
 // interactiveSetup prompts the user for provider configuration.
-// If imported is non-nil, offers to use the detected config.
-func interactiveSetup(imported *ImportResult) (*ImportResult, error) {
+func interactiveSetup(imported *providers.DetectedConfig) (*providers.DetectedConfig, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	if imported != nil {
@@ -357,6 +255,7 @@ func interactiveSetup(imported *ImportResult) (*ImportResult, error) {
 	fmt.Println("  [1] Ollama (default, runs in-cluster)")
 	fmt.Println("  [2] OpenAI")
 	fmt.Println("  [3] Anthropic")
+	fmt.Println("  [4] OpenRouter")
 	fmt.Print("\nChoice [1]: ")
 
 	line, _ := reader.ReadString('\n')
@@ -367,21 +266,21 @@ func interactiveSetup(imported *ImportResult) (*ImportResult, error) {
 
 	switch choice {
 	case "1":
-		// Ollama defaults — return nil so generateOverlayValues uses built-in defaults
 		fmt.Println("Using Ollama (in-cluster) as default provider.")
 		return nil, nil
 	case "2":
-		return promptForProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "", "gpt-4o", "GPT-4o")
+		return promptForProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1")
 	case "3":
-		return promptForProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com/v1", "anthropic", "claude-sonnet-4-5-20250929", "Claude Sonnet 4.5")
+		return promptForProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com/v1")
+	case "4":
+		return promptForProvider(reader, "openrouter", "OpenRouter", "https://openrouter.ai/api/v1")
 	default:
 		fmt.Printf("Unknown choice '%s', using Ollama defaults.\n", choice)
 		return nil, nil
 	}
 }
 
-// promptForProvider asks for an API key and builds an ImportResult for a single provider
-func promptForProvider(reader *bufio.Reader, name, display, baseURL, api, modelID, modelName string) (*ImportResult, error) {
+func promptForProvider(reader *bufio.Reader, name, display, baseURL string) (*providers.DetectedConfig, error) {
 	fmt.Printf("\n%s API key: ", display)
 	apiKey, _ := reader.ReadString('\n')
 	apiKey = strings.TrimSpace(apiKey)
@@ -389,19 +288,12 @@ func promptForProvider(reader *bufio.Reader, name, display, baseURL, api, modelI
 		return nil, fmt.Errorf("%s API key is required", display)
 	}
 
-	agentModel := fmt.Sprintf("%s/%s", name, modelID)
-
-	return &ImportResult{
-		AgentModel: agentModel,
-		Providers: []ImportedProvider{
+	return &providers.DetectedConfig{
+		Providers: []providers.ProviderConfig{
 			{
 				Name:    name,
 				BaseURL: baseURL,
-				API:     api,
 				APIKey:  apiKey,
-				Models: []ImportedModel{
-					{ID: modelID, Name: modelName},
-				},
 			},
 		},
 	}, nil

--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -1,27 +1,27 @@
 package openclaw
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/providers"
 )
 
-// ImportResult holds the parsed configuration from ~/.openclaw/openclaw.json
+// ImportResult holds the parsed configuration from ~/.openclaw/openclaw.json.
+// This is an OpenClaw-specific wrapper around providers.DetectedConfig.
 type ImportResult struct {
-	Providers []ImportedProvider
+	Providers  []ImportedProvider
 	AgentModel string
-	Channels  ImportedChannels
+	Channels   ImportedChannels
 }
 
 // ImportedProvider represents a model provider extracted from openclaw.json
 type ImportedProvider struct {
-	Name       string
-	BaseURL    string
-	API        string
-	APIKey     string // literal only; empty if env-var reference
-	Models     []ImportedModel
+	Name    string
+	BaseURL string
+	API     string
+	APIKey  string // literal only; empty if env-var reference
+	Models  []ImportedModel
 }
 
 // ImportedModel represents a model entry
@@ -53,79 +53,32 @@ type ImportedSlack struct {
 	AppToken string
 }
 
-// openclawConfig mirrors the relevant parts of ~/.openclaw/openclaw.json
-type openclawConfig struct {
-	Models struct {
-		Providers map[string]openclawProvider `json:"providers"`
-	} `json:"models"`
-	Agents struct {
-		Defaults struct {
-			Model struct {
-				Primary string `json:"primary"`
-			} `json:"model"`
-		} `json:"defaults"`
-	} `json:"agents"`
-	Channels struct {
-		Telegram *struct {
-			BotToken string `json:"botToken"`
-		} `json:"telegram"`
-		Discord *struct {
-			BotToken string `json:"botToken"`
-		} `json:"discord"`
-		Slack *struct {
-			BotToken string `json:"botToken"`
-			AppToken string `json:"appToken"`
-		} `json:"slack"`
-	} `json:"channels"`
-}
-
-type openclawProvider struct {
-	BaseURL string           `json:"baseUrl"`
-	API     string           `json:"api"`
-	APIKey  string           `json:"apiKey"`
-	Models  []openclawModel  `json:"models"`
-}
-
-type openclawModel struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-// DetectExistingConfig checks for ~/.openclaw/openclaw.json and parses it.
-// Returns nil (not an error) if the file does not exist.
+// DetectExistingConfig checks for configuration from all known sources.
+// Uses providers.DetectAll() to merge ~/.openclaw, ~/.nanobot, and env vars.
+// Returns nil (not an error) if no config is found.
 func DetectExistingConfig() (*ImportResult, error) {
-	home, err := os.UserHomeDir()
+	detected, err := providers.DetectAll()
 	if err != nil {
+		return nil, err
+	}
+	if detected == nil {
 		return nil, nil
 	}
+	return fromDetectedConfig(detected), nil
+}
 
-	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
-	}
-
-	var cfg openclawConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
-	}
-
+// fromDetectedConfig converts providers.DetectedConfig to ImportResult.
+func fromDetectedConfig(cfg *providers.DetectedConfig) *ImportResult {
 	result := &ImportResult{
-		AgentModel: cfg.Agents.Defaults.Model.Primary,
+		AgentModel: cfg.AgentModel,
 	}
 
-	for name, p := range cfg.Models.Providers {
+	for _, p := range cfg.Providers {
 		ip := ImportedProvider{
-			Name:    name,
+			Name:    p.Name,
 			BaseURL: p.BaseURL,
 			API:     p.API,
-		}
-		// Only import literal API keys, skip env-var references like ${...}
-		if p.APIKey != "" && !isEnvVarRef(p.APIKey) {
-			ip.APIKey = p.APIKey
+			APIKey:  p.APIKey,
 		}
 		for _, m := range p.Models {
 			ip.Models = append(ip.Models, ImportedModel{ID: m.ID, Name: m.Name})
@@ -133,26 +86,20 @@ func DetectExistingConfig() (*ImportResult, error) {
 		result.Providers = append(result.Providers, ip)
 	}
 
-	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.BotToken != "" && !isEnvVarRef(cfg.Channels.Telegram.BotToken) {
+	if cfg.Channels.Telegram != nil {
 		result.Channels.Telegram = &ImportedTelegram{BotToken: cfg.Channels.Telegram.BotToken}
 	}
-	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" && !isEnvVarRef(cfg.Channels.Discord.BotToken) {
+	if cfg.Channels.Discord != nil {
 		result.Channels.Discord = &ImportedDiscord{BotToken: cfg.Channels.Discord.BotToken}
 	}
 	if cfg.Channels.Slack != nil {
-		botToken := cfg.Channels.Slack.BotToken
-		appToken := cfg.Channels.Slack.AppToken
-		if botToken != "" && !isEnvVarRef(botToken) {
-			result.Channels.Slack = &ImportedSlack{
-				BotToken: botToken,
-			}
-			if appToken != "" && !isEnvVarRef(appToken) {
-				result.Channels.Slack.AppToken = appToken
-			}
+		result.Channels.Slack = &ImportedSlack{
+			BotToken: cfg.Channels.Slack.BotToken,
+			AppToken: cfg.Channels.Slack.AppToken,
 		}
 	}
 
-	return result, nil
+	return result
 }
 
 // TranslateToOverlayYAML maps imported config fields to chart values YAML fragment.
@@ -229,7 +176,7 @@ func PrintImportSummary(result *ImportResult) {
 		return
 	}
 
-	fmt.Println("Detected existing OpenClaw configuration (~/.openclaw/openclaw.json):")
+	fmt.Println("Detected existing configuration:")
 	if len(result.Providers) > 0 {
 		fmt.Printf("  Providers: ")
 		names := make([]string, 0, len(result.Providers))
@@ -250,9 +197,4 @@ func PrintImportSummary(result *ImportResult) {
 	if result.Channels.Slack != nil {
 		fmt.Println("  Slack: configured")
 	}
-}
-
-// isEnvVarRef returns true if the value looks like an environment variable reference (${...})
-func isEnvVarRef(s string) bool {
-	return strings.Contains(s, "${")
 }

--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -1,0 +1,258 @@
+package openclaw
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ImportResult holds the parsed configuration from ~/.openclaw/openclaw.json
+type ImportResult struct {
+	Providers []ImportedProvider
+	AgentModel string
+	Channels  ImportedChannels
+}
+
+// ImportedProvider represents a model provider extracted from openclaw.json
+type ImportedProvider struct {
+	Name       string
+	BaseURL    string
+	API        string
+	APIKey     string // literal only; empty if env-var reference
+	Models     []ImportedModel
+}
+
+// ImportedModel represents a model entry
+type ImportedModel struct {
+	ID   string
+	Name string
+}
+
+// ImportedChannels holds detected channel configurations
+type ImportedChannels struct {
+	Telegram *ImportedTelegram
+	Discord  *ImportedDiscord
+	Slack    *ImportedSlack
+}
+
+// ImportedTelegram holds Telegram bot config
+type ImportedTelegram struct {
+	BotToken string
+}
+
+// ImportedDiscord holds Discord bot config
+type ImportedDiscord struct {
+	BotToken string
+}
+
+// ImportedSlack holds Slack bot config
+type ImportedSlack struct {
+	BotToken string
+	AppToken string
+}
+
+// openclawConfig mirrors the relevant parts of ~/.openclaw/openclaw.json
+type openclawConfig struct {
+	Models struct {
+		Providers map[string]openclawProvider `json:"providers"`
+	} `json:"models"`
+	Agents struct {
+		Defaults struct {
+			Model struct {
+				Primary string `json:"primary"`
+			} `json:"model"`
+		} `json:"defaults"`
+	} `json:"agents"`
+	Channels struct {
+		Telegram *struct {
+			BotToken string `json:"botToken"`
+		} `json:"telegram"`
+		Discord *struct {
+			BotToken string `json:"botToken"`
+		} `json:"discord"`
+		Slack *struct {
+			BotToken string `json:"botToken"`
+			AppToken string `json:"appToken"`
+		} `json:"slack"`
+	} `json:"channels"`
+}
+
+type openclawProvider struct {
+	BaseURL string           `json:"baseUrl"`
+	API     string           `json:"api"`
+	APIKey  string           `json:"apiKey"`
+	Models  []openclawModel  `json:"models"`
+}
+
+type openclawModel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// DetectExistingConfig checks for ~/.openclaw/openclaw.json and parses it.
+// Returns nil (not an error) if the file does not exist.
+func DetectExistingConfig() (*ImportResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil
+	}
+
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
+	}
+
+	var cfg openclawConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	result := &ImportResult{
+		AgentModel: cfg.Agents.Defaults.Model.Primary,
+	}
+
+	for name, p := range cfg.Models.Providers {
+		ip := ImportedProvider{
+			Name:    name,
+			BaseURL: p.BaseURL,
+			API:     p.API,
+		}
+		// Only import literal API keys, skip env-var references like ${...}
+		if p.APIKey != "" && !isEnvVarRef(p.APIKey) {
+			ip.APIKey = p.APIKey
+		}
+		for _, m := range p.Models {
+			ip.Models = append(ip.Models, ImportedModel{ID: m.ID, Name: m.Name})
+		}
+		result.Providers = append(result.Providers, ip)
+	}
+
+	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.BotToken != "" && !isEnvVarRef(cfg.Channels.Telegram.BotToken) {
+		result.Channels.Telegram = &ImportedTelegram{BotToken: cfg.Channels.Telegram.BotToken}
+	}
+	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" && !isEnvVarRef(cfg.Channels.Discord.BotToken) {
+		result.Channels.Discord = &ImportedDiscord{BotToken: cfg.Channels.Discord.BotToken}
+	}
+	if cfg.Channels.Slack != nil {
+		botToken := cfg.Channels.Slack.BotToken
+		appToken := cfg.Channels.Slack.AppToken
+		if botToken != "" && !isEnvVarRef(botToken) {
+			result.Channels.Slack = &ImportedSlack{
+				BotToken: botToken,
+			}
+			if appToken != "" && !isEnvVarRef(appToken) {
+				result.Channels.Slack.AppToken = appToken
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// TranslateToOverlayYAML maps imported config fields to chart values YAML fragment.
+// The returned string is appended to the base overlay.
+func TranslateToOverlayYAML(result *ImportResult) string {
+	if result == nil {
+		return ""
+	}
+
+	var b strings.Builder
+
+	if result.AgentModel != "" {
+		b.WriteString(fmt.Sprintf("openclaw:\n  agentModel: %s\n\n", result.AgentModel))
+	}
+
+	if len(result.Providers) > 0 {
+		b.WriteString("models:\n")
+		for _, p := range result.Providers {
+			b.WriteString(fmt.Sprintf("  %s:\n", p.Name))
+			b.WriteString("    enabled: true\n")
+			if p.BaseURL != "" {
+				b.WriteString(fmt.Sprintf("    baseUrl: %s\n", p.BaseURL))
+			}
+			if p.API != "" {
+				b.WriteString(fmt.Sprintf("    api: %s\n", p.API))
+			}
+			if p.APIKey != "" {
+				b.WriteString(fmt.Sprintf("    apiKeyValue: %s\n", p.APIKey))
+			}
+			if len(p.Models) > 0 {
+				b.WriteString("    models:\n")
+				for _, m := range p.Models {
+					b.WriteString(fmt.Sprintf("      - id: %s\n", m.ID))
+					if m.Name != "" {
+						b.WriteString(fmt.Sprintf("        name: %s\n", m.Name))
+					}
+				}
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// Channels
+	hasChannels := result.Channels.Telegram != nil || result.Channels.Discord != nil || result.Channels.Slack != nil
+	if hasChannels {
+		b.WriteString("channels:\n")
+		if result.Channels.Telegram != nil {
+			b.WriteString("  telegram:\n")
+			b.WriteString("    enabled: true\n")
+			b.WriteString(fmt.Sprintf("    botToken: %s\n", result.Channels.Telegram.BotToken))
+		}
+		if result.Channels.Discord != nil {
+			b.WriteString("  discord:\n")
+			b.WriteString("    enabled: true\n")
+			b.WriteString(fmt.Sprintf("    botToken: %s\n", result.Channels.Discord.BotToken))
+		}
+		if result.Channels.Slack != nil {
+			b.WriteString("  slack:\n")
+			b.WriteString("    enabled: true\n")
+			b.WriteString(fmt.Sprintf("    botToken: %s\n", result.Channels.Slack.BotToken))
+			if result.Channels.Slack.AppToken != "" {
+				b.WriteString(fmt.Sprintf("    appToken: %s\n", result.Channels.Slack.AppToken))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// PrintImportSummary prints a human-readable summary of detected config
+func PrintImportSummary(result *ImportResult) {
+	if result == nil {
+		return
+	}
+
+	fmt.Println("Detected existing OpenClaw configuration (~/.openclaw/openclaw.json):")
+	if len(result.Providers) > 0 {
+		fmt.Printf("  Providers: ")
+		names := make([]string, 0, len(result.Providers))
+		for _, p := range result.Providers {
+			names = append(names, p.Name)
+		}
+		fmt.Println(strings.Join(names, ", "))
+	}
+	if result.AgentModel != "" {
+		fmt.Printf("  Agent model: %s\n", result.AgentModel)
+	}
+	if result.Channels.Telegram != nil {
+		fmt.Println("  Telegram: configured")
+	}
+	if result.Channels.Discord != nil {
+		fmt.Println("  Discord: configured")
+	}
+	if result.Channels.Slack != nil {
+		fmt.Println("  Slack: configured")
+	}
+}
+
+// isEnvVarRef returns true if the value looks like an environment variable reference (${...})
+func isEnvVarRef(s string) bool {
+	return strings.Contains(s, "${")
+}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -1,6 +1,7 @@
 package openclaw
 
 import (
+	"bufio"
 	"bytes"
 	"embed"
 	"encoding/base64"
@@ -30,14 +31,29 @@ var chartFS embed.FS
 
 // UpOptions contains options for the up command
 type UpOptions struct {
-	ID    string // Deployment ID (empty = generate petname)
-	Force bool   // Overwrite existing deployment
-	Sync  bool   // Also run helmfile sync after install
+	ID          string // Deployment ID (empty = generate petname)
+	Force       bool   // Overwrite existing deployment
+	Sync        bool   // Also run helmfile sync after install
+	Interactive bool   // true = prompt for provider choice; false = silent defaults
+	IsDefault   bool   // true = use fixed ID "default", idempotent on re-run
+}
+
+// SetupDefault deploys a default OpenClaw instance as part of stack setup.
+// It is idempotent: if a "default" deployment already exists, it re-syncs.
+func SetupDefault(cfg *config.Config) error {
+	return Up(cfg, UpOptions{
+		ID:        "default",
+		Sync:      true,
+		IsDefault: true,
+	})
 }
 
 // Up creates and optionally deploys an OpenClaw instance
 func Up(cfg *config.Config, opts UpOptions) error {
 	id := opts.ID
+	if opts.IsDefault {
+		id = "default"
+	}
 	if id == "" {
 		id = petname.Generate(2, "-")
 		fmt.Printf("Generated deployment ID: %s\n", id)
@@ -46,13 +62,42 @@ func Up(cfg *config.Config, opts UpOptions) error {
 	}
 
 	deploymentDir := deploymentPath(cfg, id)
+
+	// Idempotent re-run for default deployment: just re-sync
+	if opts.IsDefault && !opts.Force {
+		if _, err := os.Stat(deploymentDir); err == nil {
+			fmt.Println("Default OpenClaw instance already configured, re-syncing...")
+			if opts.Sync {
+				return doSync(cfg, id)
+			}
+			return nil
+		}
+	}
+
 	if _, err := os.Stat(deploymentDir); err == nil {
-		if !opts.Force {
+		if !opts.Force && !opts.IsDefault {
 			return fmt.Errorf("deployment already exists: %s/%s\n"+
 				"Directory: %s\n"+
 				"Use --force or -f to overwrite", appName, id, deploymentDir)
 		}
 		fmt.Printf("WARNING: Overwriting existing deployment at %s\n", deploymentDir)
+	}
+
+	// Detect existing ~/.openclaw config
+	imported, err := DetectExistingConfig()
+	if err != nil {
+		fmt.Printf("Warning: failed to read existing config: %v\n", err)
+	}
+	if imported != nil {
+		PrintImportSummary(imported)
+	}
+
+	// Interactive setup: prompt for provider choice
+	if opts.Interactive {
+		imported, err = interactiveSetup(imported)
+		if err != nil {
+			return fmt.Errorf("interactive setup failed: %w", err)
+		}
 	}
 
 	if err := os.MkdirAll(deploymentDir, 0755); err != nil {
@@ -77,10 +122,10 @@ func Up(cfg *config.Config, opts UpOptions) error {
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
 
-	// Write Obol Stack overlay values (httpRoute, Ollama, eRPC, skills)
+	// Write Obol Stack overlay values (httpRoute, provider config, eRPC, skills)
 	hostname := fmt.Sprintf("openclaw-%s.%s", id, defaultDomain)
 	namespace := fmt.Sprintf("%s-%s", appName, id)
-	overlay := generateOverlayValues(hostname)
+	overlay := generateOverlayValues(hostname, imported)
 	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0644); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write overlay values: %w", err)
@@ -101,7 +146,7 @@ func Up(cfg *config.Config, opts UpOptions) error {
 	fmt.Printf("\nFiles created:\n")
 	fmt.Printf("  - chart/            Embedded OpenClaw Helm chart\n")
 	fmt.Printf("  - values.yaml       Chart defaults (edit to customize)\n")
-	fmt.Printf("  - values-obol.yaml  Obol Stack defaults (httpRoute, Ollama, eRPC)\n")
+	fmt.Printf("  - values-obol.yaml  Obol Stack defaults (httpRoute, providers, eRPC)\n")
 	fmt.Printf("  - helmfile.yaml     Deployment configuration\n")
 
 	if opts.Sync {
@@ -437,17 +482,22 @@ func copyEmbeddedChart(destDir string) error {
 	})
 }
 
-// generateOverlayValues creates the Obol Stack-specific values overlay
-func generateOverlayValues(hostname string) string {
-	return fmt.Sprintf(`# Obol Stack overlay values for OpenClaw
+// generateOverlayValues creates the Obol Stack-specific values overlay.
+// If imported is non-nil, provider/channel config from the import is used
+// instead of the default Ollama configuration.
+func generateOverlayValues(hostname string, imported *ImportResult) string {
+	var b strings.Builder
+
+	b.WriteString(`# Obol Stack overlay values for OpenClaw
 # This file contains stack-specific defaults. Edit to customize.
 
 # Enable Gateway API HTTPRoute for stack routing
 httpRoute:
   enabled: true
   hostnames:
-    - %s
-  parentRefs:
+`)
+	b.WriteString(fmt.Sprintf("    - %s\n", hostname))
+	b.WriteString(`  parentRefs:
     - name: traefik-gateway
       namespace: traefik
       sectionName: web
@@ -460,18 +510,34 @@ serviceAccount:
 rbac:
   create: true
 
+`)
+
+	// Provider and agent model configuration
+	importedOverlay := TranslateToOverlayYAML(imported)
+	if importedOverlay != "" {
+		b.WriteString("# Imported from ~/.openclaw/openclaw.json\n")
+		b.WriteString(importedOverlay)
+	} else {
+		b.WriteString(`# Route agent traffic to in-cluster Ollama
+openclaw:
+  agentModel: ollama/glm-4.7-flash
+
 # Default model provider: in-cluster Ollama
 models:
   ollama:
     enabled: true
     baseUrl: http://ollama.llm.svc.cluster.local:11434/v1
+    api: openai-completions
     apiKeyEnvVar: OLLAMA_API_KEY
     apiKeyValue: ollama-local
     models:
       - id: glm-4.7-flash
-        name: glm-4.7-flash
+        name: GLM-4.7 Flash
 
-# eRPC integration
+`)
+	}
+
+	b.WriteString(`# eRPC integration
 erpc:
   url: http://erpc.erpc.svc.cluster.local:4000/rpc
 
@@ -483,7 +549,78 @@ skills:
 # Agent init Job (enable to bootstrap workspace on first deploy)
 initJob:
   enabled: false
-`, hostname)
+`)
+
+	return b.String()
+}
+
+// interactiveSetup prompts the user for provider configuration.
+// If imported is non-nil, offers to use the detected config.
+func interactiveSetup(imported *ImportResult) (*ImportResult, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	if imported != nil {
+		fmt.Print("\nUse detected configuration? [Y/n]: ")
+		line, _ := reader.ReadString('\n')
+		line = strings.TrimSpace(strings.ToLower(line))
+		if line == "" || line == "y" || line == "yes" {
+			fmt.Println("Using detected configuration.")
+			return imported, nil
+		}
+	}
+
+	fmt.Println("\nSelect a model provider:")
+	fmt.Println("  [1] Ollama (default, runs in-cluster)")
+	fmt.Println("  [2] OpenAI")
+	fmt.Println("  [3] Anthropic")
+	fmt.Print("\nChoice [1]: ")
+
+	line, _ := reader.ReadString('\n')
+	choice := strings.TrimSpace(line)
+	if choice == "" {
+		choice = "1"
+	}
+
+	switch choice {
+	case "1":
+		// Ollama defaults — return nil so generateOverlayValues uses built-in defaults
+		fmt.Println("Using Ollama (in-cluster) as default provider.")
+		return nil, nil
+	case "2":
+		return promptForProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "", "gpt-4o", "GPT-4o")
+	case "3":
+		return promptForProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com/v1", "anthropic", "claude-sonnet-4-5-20250929", "Claude Sonnet 4.5")
+	default:
+		fmt.Printf("Unknown choice '%s', using Ollama defaults.\n", choice)
+		return nil, nil
+	}
+}
+
+// promptForProvider asks for an API key and builds an ImportResult for a single provider
+func promptForProvider(reader *bufio.Reader, name, display, baseURL, api, modelID, modelName string) (*ImportResult, error) {
+	fmt.Printf("\n%s API key: ", display)
+	apiKey, _ := reader.ReadString('\n')
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("%s API key is required", display)
+	}
+
+	agentModel := fmt.Sprintf("%s/%s", name, modelID)
+
+	return &ImportResult{
+		AgentModel: agentModel,
+		Providers: []ImportedProvider{
+			{
+				Name:    name,
+				BaseURL: baseURL,
+				API:     api,
+				APIKey:  apiKey,
+				Models: []ImportedModel{
+					{ID: modelID, Name: modelName},
+				},
+			},
+		},
+	}, nil
 }
 
 // generateHelmfile creates a helmfile.yaml referencing the local chart

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,0 +1,337 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DetectedConfig holds the merged configuration detected from all sources.
+type DetectedConfig struct {
+	Providers  []ProviderConfig
+	Channels   ChannelConfig
+	AgentModel string
+}
+
+// ProviderConfig represents a model provider.
+type ProviderConfig struct {
+	Name    string
+	BaseURL string
+	API     string
+	APIKey  string
+	Models  []ModelConfig
+}
+
+// ModelConfig represents a model entry.
+type ModelConfig struct {
+	ID   string
+	Name string
+}
+
+// ChannelConfig holds detected channel configurations.
+type ChannelConfig struct {
+	Telegram *TelegramConfig
+	Discord  *DiscordConfig
+	Slack    *SlackConfig
+}
+
+// TelegramConfig holds Telegram bot config.
+type TelegramConfig struct {
+	BotToken string
+}
+
+// DiscordConfig holds Discord bot config.
+type DiscordConfig struct {
+	BotToken string
+}
+
+// SlackConfig holds Slack bot config.
+type SlackConfig struct {
+	BotToken string
+	AppToken string
+}
+
+// DetectAll merges config from all known sources.
+// Order: OpenClaw, Nanobot, environment variables. First-found wins per provider.
+func DetectAll() (*DetectedConfig, error) {
+	sources := []func() (*DetectedConfig, error){
+		DetectFromOpenClaw,
+		DetectFromNanobot,
+		DetectFromEnv,
+	}
+
+	var merged DetectedConfig
+	seenProviders := make(map[string]bool)
+
+	for _, detect := range sources {
+		cfg, err := detect()
+		if err != nil || cfg == nil {
+			continue
+		}
+
+		// Merge agent model (first-found wins)
+		if merged.AgentModel == "" && cfg.AgentModel != "" {
+			merged.AgentModel = cfg.AgentModel
+		}
+
+		// Merge providers (first-found per name wins)
+		for _, p := range cfg.Providers {
+			if !seenProviders[p.Name] {
+				merged.Providers = append(merged.Providers, p)
+				seenProviders[p.Name] = true
+			}
+		}
+
+		// Merge channels (first-found per channel wins)
+		if merged.Channels.Telegram == nil && cfg.Channels.Telegram != nil {
+			merged.Channels.Telegram = cfg.Channels.Telegram
+		}
+		if merged.Channels.Discord == nil && cfg.Channels.Discord != nil {
+			merged.Channels.Discord = cfg.Channels.Discord
+		}
+		if merged.Channels.Slack == nil && cfg.Channels.Slack != nil {
+			merged.Channels.Slack = cfg.Channels.Slack
+		}
+	}
+
+	if len(merged.Providers) == 0 && merged.AgentModel == "" &&
+		merged.Channels.Telegram == nil && merged.Channels.Discord == nil && merged.Channels.Slack == nil {
+		return nil, nil
+	}
+
+	return &merged, nil
+}
+
+// DetectFromOpenClaw reads ~/.openclaw/openclaw.json.
+func DetectFromOpenClaw() (*DetectedConfig, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil
+	}
+
+	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
+	}
+
+	var cfg openclawConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	result := &DetectedConfig{
+		AgentModel: cfg.Agents.Defaults.Model.Primary,
+	}
+
+	for name, p := range cfg.Models.Providers {
+		pc := ProviderConfig{
+			Name:    name,
+			BaseURL: p.BaseURL,
+			API:     p.API,
+		}
+		if p.APIKey != "" && !isEnvVarRef(p.APIKey) {
+			pc.APIKey = p.APIKey
+		}
+		for _, m := range p.Models {
+			pc.Models = append(pc.Models, ModelConfig{ID: m.ID, Name: m.Name})
+		}
+		result.Providers = append(result.Providers, pc)
+	}
+
+	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.BotToken != "" && !isEnvVarRef(cfg.Channels.Telegram.BotToken) {
+		result.Channels.Telegram = &TelegramConfig{BotToken: cfg.Channels.Telegram.BotToken}
+	}
+	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" && !isEnvVarRef(cfg.Channels.Discord.BotToken) {
+		result.Channels.Discord = &DiscordConfig{BotToken: cfg.Channels.Discord.BotToken}
+	}
+	if cfg.Channels.Slack != nil {
+		botToken := cfg.Channels.Slack.BotToken
+		appToken := cfg.Channels.Slack.AppToken
+		if botToken != "" && !isEnvVarRef(botToken) {
+			sc := &SlackConfig{BotToken: botToken}
+			if appToken != "" && !isEnvVarRef(appToken) {
+				sc.AppToken = appToken
+			}
+			result.Channels.Slack = sc
+		}
+	}
+
+	return result, nil
+}
+
+// DetectFromNanobot reads ~/.nanobot/config.json.
+func DetectFromNanobot() (*DetectedConfig, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil
+	}
+
+	configPath := filepath.Join(home, ".nanobot", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
+	}
+
+	var cfg nanobotConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	result := &DetectedConfig{
+		AgentModel: cfg.AgentModel,
+	}
+
+	for name, p := range cfg.Providers {
+		pc := ProviderConfig{
+			Name:    name,
+			BaseURL: p.BaseURL,
+		}
+		if p.APIKey != "" && !isEnvVarRef(p.APIKey) {
+			pc.APIKey = p.APIKey
+		}
+		result.Providers = append(result.Providers, pc)
+	}
+
+	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.Token != "" && !isEnvVarRef(cfg.Channels.Telegram.Token) {
+		result.Channels.Telegram = &TelegramConfig{BotToken: cfg.Channels.Telegram.Token}
+	}
+	if cfg.Channels.Discord != nil && cfg.Channels.Discord.Token != "" && !isEnvVarRef(cfg.Channels.Discord.Token) {
+		result.Channels.Discord = &DiscordConfig{BotToken: cfg.Channels.Discord.Token}
+	}
+
+	return result, nil
+}
+
+// DetectFromEnv reads well-known environment variables for API keys.
+func DetectFromEnv() (*DetectedConfig, error) {
+	result := &DetectedConfig{}
+
+	envProviders := []struct {
+		envVar  string
+		name    string
+		baseURL string
+		api     string
+	}{
+		{"OPENAI_API_KEY", "openai", "https://api.openai.com/v1", ""},
+		{"ANTHROPIC_API_KEY", "anthropic", "https://api.anthropic.com/v1", "anthropic"},
+		{"OPENROUTER_API_KEY", "openrouter", "https://openrouter.ai/api/v1", ""},
+	}
+
+	for _, ep := range envProviders {
+		if key := os.Getenv(ep.envVar); key != "" {
+			result.Providers = append(result.Providers, ProviderConfig{
+				Name:    ep.name,
+				BaseURL: ep.baseURL,
+				API:     ep.api,
+				APIKey:  key,
+			})
+		}
+	}
+
+	if len(result.Providers) == 0 {
+		return nil, nil
+	}
+
+	return result, nil
+}
+
+// PrintSummary prints a human-readable summary of detected config.
+func PrintSummary(source string, result *DetectedConfig) {
+	if result == nil {
+		return
+	}
+
+	fmt.Printf("Detected configuration (%s):\n", source)
+	if len(result.Providers) > 0 {
+		fmt.Printf("  Providers: ")
+		names := make([]string, 0, len(result.Providers))
+		for _, p := range result.Providers {
+			names = append(names, p.Name)
+		}
+		fmt.Println(strings.Join(names, ", "))
+	}
+	if result.AgentModel != "" {
+		fmt.Printf("  Agent model: %s\n", result.AgentModel)
+	}
+	if result.Channels.Telegram != nil {
+		fmt.Println("  Telegram: configured")
+	}
+	if result.Channels.Discord != nil {
+		fmt.Println("  Discord: configured")
+	}
+	if result.Channels.Slack != nil {
+		fmt.Println("  Slack: configured")
+	}
+}
+
+// --- Internal types for JSON parsing ---
+
+// openclawConfig mirrors relevant parts of ~/.openclaw/openclaw.json
+type openclawConfig struct {
+	Models struct {
+		Providers map[string]openclawProvider `json:"providers"`
+	} `json:"models"`
+	Agents struct {
+		Defaults struct {
+			Model struct {
+				Primary string `json:"primary"`
+			} `json:"model"`
+		} `json:"defaults"`
+	} `json:"agents"`
+	Channels struct {
+		Telegram *struct {
+			BotToken string `json:"botToken"`
+		} `json:"telegram"`
+		Discord *struct {
+			BotToken string `json:"botToken"`
+		} `json:"discord"`
+		Slack *struct {
+			BotToken string `json:"botToken"`
+			AppToken string `json:"appToken"`
+		} `json:"slack"`
+	} `json:"channels"`
+}
+
+type openclawProvider struct {
+	BaseURL string          `json:"baseUrl"`
+	API     string          `json:"api"`
+	APIKey  string          `json:"apiKey"`
+	Models  []openclawModel `json:"models"`
+}
+
+type openclawModel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// nanobotConfig mirrors relevant parts of ~/.nanobot/config.json
+type nanobotConfig struct {
+	AgentModel string                       `json:"agentModel"`
+	Providers  map[string]nanobotProvider   `json:"providers"`
+	Channels   struct {
+		Telegram *struct {
+			Token string `json:"token"`
+		} `json:"telegram"`
+		Discord *struct {
+			Token string `json:"token"`
+		} `json:"discord"`
+	} `json:"channels"`
+}
+
+type nanobotProvider struct {
+	BaseURL string `json:"baseUrl"`
+	APIKey  string `json:"apiKey"`
+}
+
+func isEnvVarRef(s string) bool {
+	return strings.Contains(s, "${")
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/embed"
+	"github.com/ObolNetwork/obol-stack/internal/openclaw"
 	petname "github.com/dustinkirkland/golang-petname"
 )
 
@@ -352,6 +353,14 @@ func syncDefaults(cfg *config.Config, kubeconfigPath string) error {
 	}
 
 	fmt.Println("Default infrastructure deployed")
+
+	// Deploy default OpenClaw instance (non-fatal on failure)
+	fmt.Println("Setting up default OpenClaw instance...")
+	if err := openclaw.SetupDefault(cfg); err != nil {
+		fmt.Printf("Warning: failed to set up default OpenClaw: %v\n", err)
+		fmt.Println("You can manually set up OpenClaw later with: obol openclaw up")
+	}
+
 	return nil
 }
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/embed"
+	"github.com/ObolNetwork/obol-stack/internal/nanobot"
 	"github.com/ObolNetwork/obol-stack/internal/openclaw"
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -354,11 +355,20 @@ func syncDefaults(cfg *config.Config, kubeconfigPath string) error {
 
 	fmt.Println("Default infrastructure deployed")
 
-	// Deploy default OpenClaw instance (non-fatal on failure)
-	fmt.Println("Setting up default OpenClaw instance...")
-	if err := openclaw.SetupDefault(cfg); err != nil {
-		fmt.Printf("Warning: failed to set up default OpenClaw: %v\n", err)
-		fmt.Println("You can manually set up OpenClaw later with: obol openclaw up")
+	// Deploy default application instances (non-fatal on failure)
+	for _, setup := range []struct {
+		name string
+		fn   func(*config.Config) error
+		cmd  string
+	}{
+		{"OpenClaw", openclaw.SetupDefault, "obol openclaw up"},
+		{"Nanobot", nanobot.SetupDefault, "obol nanobot up"},
+	} {
+		fmt.Printf("Setting up default %s instance...\n", setup.name)
+		if err := setup.fn(cfg); err != nil {
+			fmt.Printf("Warning: failed to set up default %s: %v\n", setup.name, err)
+			fmt.Printf("You can manually set up %s later with: %s\n", setup.name, setup.cmd)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **Extract shared `internal/appkit/` utilities** from OpenClaw's lifecycle code — path resolution, chart embedding, helmfile generation/sync, delete, list, and secret retrieval — reducing ~200 lines of duplication
- **Create shared `internal/providers/` package** for multi-source LLM provider and chat channel detection (merges config from `~/.openclaw/`, `~/.nanobot/`, and environment variables with first-found-wins semantics)
- **Add complete Nanobot Helm chart and Go package** (`internal/nanobot/`) with full lifecycle: `up`, `sync`, `token`, `list`, `delete` — using appkit for all shared operations
- **Integrate Nanobot into CLI and stack** — `obol nanobot *` commands and automatic default instance deployment during `obol stack up`

## Architecture

```
internal/
├── appkit/           # NEW — shared lifecycle utilities (no state, no embed)
│   ├── appkit.go     #   paths, ID gen, chart copy, hostname/namespace
│   ├── helmfile.go   #   helmfile generation + sync
│   └── lifecycle.go  #   delete, list, secret retrieval
├── providers/        # NEW — shared provider/channel detection
│   └── providers.go  #   DetectAll() merges OpenClaw + Nanobot + env sources
├── nanobot/          # NEW — Nanobot app package
│   ├── nanobot.go    #   lifecycle using appkit (Up, Sync, Delete, List, Token)
│   ├── import.go     #   config → overlay YAML translation
│   └── chart/        #   embedded Helm chart (12 templates + values)
├── openclaw/         # MODIFIED — refactored to use appkit (~200 lines removed)
│   ├── openclaw.go   #   public API unchanged, internals delegate to appkit
│   └── import.go     #   uses providers.DetectAll() instead of inline parsing
└── stack/
    └── stack.go      # MODIFIED — deploys both OpenClaw + Nanobot defaults
```

## Key design decisions

- **Utilities, not a framework** — `appkit` is pure functions with no state or `go:embed`. Each app owns its chart, overlays, and import logic.
- **Provider keys copied to each app** — No shared K8s Secret or cross-namespace RBAC. Simple and isolated.
- **No interface/registry** — Explicit function calls. Adding a third app means ~3 lines.

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes (verified)
- [ ] `obol openclaw up/list/delete/token` still works (refactor is transparent)
- [ ] `obol nanobot up` creates deployment at `~/.config/obol/applications/nanobot/<id>/`
- [ ] `obol nanobot list` shows instances
- [ ] `obol stack up` deploys both default OpenClaw and Nanobot instances
- [ ] Provider keys from `~/.openclaw/` are available when setting up Nanobot