### PR TITLE
fix(infra): disable obol-agent from default stack deployment

### DIFF
--- a/internal/embed/infrastructure/base/templates/obol-agent.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-agent.yaml
@@ -1,8 +1,12 @@
+{{- if .Values.obolAgent.enabled }}
 ---
 # Obol Agent Kubernetes Manifest
 # This manifest deploys the Obol AI Agent with namespace-scoped RBAC permissions
 # The agent can read cluster-wide resources (nodes, namespaces) but can only modify
 # resources in specific namespaces: agent (and others via dynamic bindings)
+#
+# To enable the obol-agent, set obolAgent.enabled=true in the base chart values
+# (infrastructure helmfile.yaml → base release → values).
 
 #------------------------------------------------------------------------------
 # Namespace - Ensure the agent namespace exists
@@ -198,3 +202,4 @@ spec:
       name: http
   selector:
     app: obol-agent  # Routes traffic to pods with this label
+{{- end }}

--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -29,6 +29,10 @@ releases:
     values:
       - dataDir: /data
       - network: "{{ .Values.network }}"
+      # obol-agent is disabled by default (image not publicly available).
+      # Set obolAgent.enabled=true to deploy it.
+      - obolAgent:
+          enabled: false
 
   # Monitoring stack (Prometheus operator + Prometheus)
   - name: monitoring


### PR DESCRIPTION
## Summary

- The `obol-agent` deployment fails with **ImagePullBackOff** because the container image is not publicly accessible from k3d.
- Wraps the entire `obol-agent.yaml` template in a Helm conditional and sets `obolAgent.enabled: false` in the helmfile.
- The manifest file is preserved -- set `obolAgent.enabled: true` to re-enable.

## Changes

| File | Change |
|------|--------|
| `obol-agent.yaml` | Wrapped all resources in Helm `enabled` conditional |
| `helmfile.yaml` | Added `obolAgent.enabled: false` to base release values |

## Test plan

- [x] Copied worktree changes into running stack defaults and re-synced helmfile (base revision 2)
- [x] `kubectl get all -n agent` returns no resources (deployment, service, RBAC all removed)
- [x] `kubectl get pods -A --field-selector=status.phase!=Running` returns no unhealthy pods cluster-wide
- [x] Agent namespace still exists but is empty (Helm does not delete namespaces)