### PR TITLE
test(openclaw): add import pipeline tests and fix silent failures

### DIFF
--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -102,7 +102,12 @@ func DetectExistingConfig() (*ImportResult, error) {
 	if err != nil {
 		return nil, nil
 	}
+	return detectExistingConfigAt(home)
+}
 
+// detectExistingConfigAt reads and parses openclaw.json from the given home directory.
+// Extracted from DetectExistingConfig for testability.
+func detectExistingConfigAt(home string) (*ImportResult, error) {
 	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -125,14 +130,20 @@ func DetectExistingConfig() (*ImportResult, error) {
 	result.WorkspaceDir = detectWorkspace(home, cfg.Agents.Defaults.Workspace)
 
 	for name, p := range cfg.Models.Providers {
+		sanitized := sanitizeModelAPI(p.API)
+		if p.API != "" && sanitized == "" {
+			fmt.Printf("  Note: unknown API type '%s' for provider '%s', will auto-detect\n", p.API, name)
+		}
 		ip := ImportedProvider{
 			Name:    name,
 			BaseURL: p.BaseURL,
-			API:     sanitizeModelAPI(p.API),
+			API:     sanitized,
 		}
 		// Only import literal API keys, skip env-var references like ${...}
 		if p.APIKey != "" && !isEnvVarRef(p.APIKey) {
 			ip.APIKey = p.APIKey
+		} else if p.APIKey != "" {
+			fmt.Printf("  Note: provider '%s' uses env-var reference %s (will need manual configuration)\n", name, p.APIKey)
 		}
 		for _, m := range p.Models {
 			ip.Models = append(ip.Models, ImportedModel{ID: m.ID, Name: m.Name})
@@ -140,11 +151,19 @@ func DetectExistingConfig() (*ImportResult, error) {
 		result.Providers = append(result.Providers, ip)
 	}
 
-	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.BotToken != "" && !isEnvVarRef(cfg.Channels.Telegram.BotToken) {
-		result.Channels.Telegram = &ImportedTelegram{BotToken: cfg.Channels.Telegram.BotToken}
+	if cfg.Channels.Telegram != nil && cfg.Channels.Telegram.BotToken != "" {
+		if !isEnvVarRef(cfg.Channels.Telegram.BotToken) {
+			result.Channels.Telegram = &ImportedTelegram{BotToken: cfg.Channels.Telegram.BotToken}
+		} else {
+			fmt.Printf("  Note: Telegram bot token uses env-var reference (will need manual configuration)\n")
+		}
 	}
-	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" && !isEnvVarRef(cfg.Channels.Discord.BotToken) {
-		result.Channels.Discord = &ImportedDiscord{BotToken: cfg.Channels.Discord.BotToken}
+	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" {
+		if !isEnvVarRef(cfg.Channels.Discord.BotToken) {
+			result.Channels.Discord = &ImportedDiscord{BotToken: cfg.Channels.Discord.BotToken}
+		} else {
+			fmt.Printf("  Note: Discord bot token uses env-var reference (will need manual configuration)\n")
+		}
 	}
 	if cfg.Channels.Slack != nil {
 		botToken := cfg.Channels.Slack.BotToken
@@ -155,7 +174,11 @@ func DetectExistingConfig() (*ImportResult, error) {
 			}
 			if appToken != "" && !isEnvVarRef(appToken) {
 				result.Channels.Slack.AppToken = appToken
+			} else if appToken != "" {
+				fmt.Printf("  Note: Slack app token uses env-var reference (will need manual configuration)\n")
 			}
+		} else if botToken != "" {
+			fmt.Printf("  Note: Slack bot token uses env-var reference (will need manual configuration)\n")
 		}
 	}
 
@@ -299,6 +322,8 @@ func detectWorkspace(home, configWorkspace string) string {
 		}
 	}
 
+	// Directory exists but has no marker files
+	fmt.Printf("  Note: workspace at %s has no marker files (SOUL.md, AGENTS.md, IDENTITY.md)\n", wsDir)
 	return ""
 }
 

--- a/internal/openclaw/import_test.go
+++ b/internal/openclaw/import_test.go
@@ -1,0 +1,539 @@
+package openclaw
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsEnvVarRef(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"${ANTHROPIC_API_KEY}", true},
+		{"${VAR:default}", true},
+		{"prefix${VAR}suffix", true},
+		{"sk-ant-literal-key", false},
+		{"", false},
+		{"$VAR", false},
+		{"plain-string", false},
+	}
+	for _, tt := range tests {
+		if got := isEnvVarRef(tt.in); got != tt.want {
+			t.Errorf("isEnvVarRef(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSanitizeModelAPI(t *testing.T) {
+	// All valid values should pass through unchanged
+	valid := []string{
+		"openai-completions",
+		"openai-responses",
+		"anthropic-messages",
+		"google-generative-ai",
+		"github-copilot",
+		"bedrock-converse-stream",
+	}
+	for _, api := range valid {
+		if got := sanitizeModelAPI(api); got != api {
+			t.Errorf("sanitizeModelAPI(%q) = %q, want %q", api, got, api)
+		}
+	}
+
+	// Invalid values should return ""
+	invalid := []string{
+		"custom-api",
+		"openai",
+		"",
+		"OpenAI-Completions",
+		"mistral-api",
+	}
+	for _, api := range invalid {
+		if got := sanitizeModelAPI(api); got != "" {
+			t.Errorf("sanitizeModelAPI(%q) = %q, want empty", api, got)
+		}
+	}
+}
+
+func TestDetectWorkspace(t *testing.T) {
+	t.Run("dir with SOUL.md marker", func(t *testing.T) {
+		home := t.TempDir()
+		wsDir := filepath.Join(home, ".openclaw", "workspace")
+		os.MkdirAll(wsDir, 0755)
+		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0644)
+
+		got := detectWorkspace(home, "")
+		if got != wsDir {
+			t.Errorf("detectWorkspace() = %q, want %q", got, wsDir)
+		}
+	})
+
+	t.Run("dir with AGENTS.md marker only", func(t *testing.T) {
+		home := t.TempDir()
+		wsDir := filepath.Join(home, ".openclaw", "workspace")
+		os.MkdirAll(wsDir, 0755)
+		os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("test"), 0644)
+
+		got := detectWorkspace(home, "")
+		if got != wsDir {
+			t.Errorf("detectWorkspace() = %q, want %q", got, wsDir)
+		}
+	})
+
+	t.Run("dir with IDENTITY.md marker only", func(t *testing.T) {
+		home := t.TempDir()
+		wsDir := filepath.Join(home, ".openclaw", "workspace")
+		os.MkdirAll(wsDir, 0755)
+		os.WriteFile(filepath.Join(wsDir, "IDENTITY.md"), []byte("test"), 0644)
+
+		got := detectWorkspace(home, "")
+		if got != wsDir {
+			t.Errorf("detectWorkspace() = %q, want %q", got, wsDir)
+		}
+	})
+
+	t.Run("dir exists but no marker files", func(t *testing.T) {
+		home := t.TempDir()
+		wsDir := filepath.Join(home, ".openclaw", "workspace")
+		os.MkdirAll(wsDir, 0755)
+		os.WriteFile(filepath.Join(wsDir, "readme.txt"), []byte("test"), 0644)
+
+		got := detectWorkspace(home, "")
+		if got != "" {
+			t.Errorf("detectWorkspace() = %q, want empty", got)
+		}
+	})
+
+	t.Run("dir does not exist", func(t *testing.T) {
+		home := t.TempDir()
+		got := detectWorkspace(home, "")
+		if got != "" {
+			t.Errorf("detectWorkspace() = %q, want empty", got)
+		}
+	})
+
+	t.Run("custom workspace path from config", func(t *testing.T) {
+		home := t.TempDir()
+		customWs := filepath.Join(t.TempDir(), "my-workspace")
+		os.MkdirAll(customWs, 0755)
+		os.WriteFile(filepath.Join(customWs, "SOUL.md"), []byte("test"), 0644)
+
+		got := detectWorkspace(home, customWs)
+		if got != customWs {
+			t.Errorf("detectWorkspace() = %q, want %q", got, customWs)
+		}
+	})
+}
+
+func TestDetectWorkspaceFiles(t *testing.T) {
+	t.Run("all files present", func(t *testing.T) {
+		wsDir := t.TempDir()
+		for _, f := range []string{"SOUL.md", "AGENTS.md", "IDENTITY.md", "USER.md", "TOOLS.md", "MEMORY.md"} {
+			os.WriteFile(filepath.Join(wsDir, f), []byte("test"), 0644)
+		}
+		os.Mkdir(filepath.Join(wsDir, "memory"), 0755)
+
+		got := detectWorkspaceFiles(wsDir)
+		if len(got) != 7 {
+			t.Errorf("detectWorkspaceFiles() returned %d items, want 7: %v", len(got), got)
+		}
+	})
+
+	t.Run("only SOUL.md", func(t *testing.T) {
+		wsDir := t.TempDir()
+		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0644)
+
+		got := detectWorkspaceFiles(wsDir)
+		if len(got) != 1 || got[0] != "SOUL.md" {
+			t.Errorf("detectWorkspaceFiles() = %v, want [SOUL.md]", got)
+		}
+	})
+
+	t.Run("memory dir included", func(t *testing.T) {
+		wsDir := t.TempDir()
+		os.Mkdir(filepath.Join(wsDir, "memory"), 0755)
+
+		got := detectWorkspaceFiles(wsDir)
+		if len(got) != 1 || got[0] != "memory/" {
+			t.Errorf("detectWorkspaceFiles() = %v, want [memory/]", got)
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		wsDir := t.TempDir()
+		got := detectWorkspaceFiles(wsDir)
+		if len(got) != 0 {
+			t.Errorf("detectWorkspaceFiles() = %v, want empty", got)
+		}
+	})
+}
+
+func TestTranslateToOverlayYAML_Nil(t *testing.T) {
+	got := TranslateToOverlayYAML(nil)
+	if got != "" {
+		t.Errorf("TranslateToOverlayYAML(nil) = %q, want empty", got)
+	}
+}
+
+func TestTranslateToOverlayYAML_AgentModelOnly(t *testing.T) {
+	result := &ImportResult{
+		AgentModel: "claude-opus-4-6",
+	}
+	got := TranslateToOverlayYAML(result)
+	if !strings.Contains(got, "agentModel: claude-opus-4-6") {
+		t.Errorf("YAML missing agentModel, got:\n%s", got)
+	}
+	if strings.Contains(got, "models:") {
+		t.Errorf("YAML should not contain models section, got:\n%s", got)
+	}
+}
+
+func TestTranslateToOverlayYAML_ProviderWithModels(t *testing.T) {
+	result := &ImportResult{
+		Providers: []ImportedProvider{
+			{
+				Name:    "anthropic",
+				BaseURL: "https://api.anthropic.com/v1",
+				API:     "anthropic-messages",
+				APIKey:  "sk-ant-test",
+				Models: []ImportedModel{
+					{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"},
+				},
+			},
+		},
+	}
+	got := TranslateToOverlayYAML(result)
+
+	checks := []string{
+		"anthropic:\n    enabled: true",
+		"baseUrl: https://api.anthropic.com/v1",
+		"api: anthropic-messages",
+		"apiKeyValue: sk-ant-test",
+		"- id: claude-opus-4-6",
+		"name: Claude Opus 4.6",
+	}
+	for _, check := range checks {
+		if !strings.Contains(got, check) {
+			t.Errorf("YAML missing %q, got:\n%s", check, got)
+		}
+	}
+}
+
+func TestTranslateToOverlayYAML_DisabledProvider(t *testing.T) {
+	result := &ImportResult{
+		Providers: []ImportedProvider{
+			{Name: "openai", Disabled: true},
+		},
+	}
+	got := TranslateToOverlayYAML(result)
+
+	if !strings.Contains(got, "openai:\n    enabled: false") {
+		t.Errorf("YAML missing disabled openai, got:\n%s", got)
+	}
+	if strings.Contains(got, "enabled: true") {
+		t.Errorf("YAML should not contain enabled: true for disabled provider, got:\n%s", got)
+	}
+}
+
+func TestTranslateToOverlayYAML_EmptyAPI(t *testing.T) {
+	result := &ImportResult{
+		Providers: []ImportedProvider{
+			{
+				Name:    "custom",
+				BaseURL: "https://custom.api/v1",
+				API:     "",
+			},
+		},
+	}
+	got := TranslateToOverlayYAML(result)
+
+	if !strings.Contains(got, `api: ""`) {
+		t.Errorf("YAML missing empty api field, got:\n%s", got)
+	}
+}
+
+func TestTranslateToOverlayYAML_Channels(t *testing.T) {
+	result := &ImportResult{
+		Channels: ImportedChannels{
+			Telegram: &ImportedTelegram{BotToken: "123456:ABC"},
+			Discord:  &ImportedDiscord{BotToken: "MTIz..."},
+			Slack:    &ImportedSlack{BotToken: "xoxb-test", AppToken: "xapp-test"},
+		},
+	}
+	got := TranslateToOverlayYAML(result)
+
+	checks := []string{
+		"telegram:\n    enabled: true\n    botToken: 123456:ABC",
+		"discord:\n    enabled: true\n    botToken: MTIz...",
+		"slack:\n    enabled: true\n    botToken: xoxb-test\n    appToken: xapp-test",
+	}
+	for _, check := range checks {
+		if !strings.Contains(got, check) {
+			t.Errorf("YAML missing %q, got:\n%s", check, got)
+		}
+	}
+}
+
+func TestTranslateToOverlayYAML_FullConfig(t *testing.T) {
+	result := &ImportResult{
+		AgentModel: "claude-opus-4-6",
+		Providers: []ImportedProvider{
+			{
+				Name:    "anthropic",
+				BaseURL: "https://api.anthropic.com/v1",
+				API:     "anthropic-messages",
+				APIKey:  "sk-ant-test",
+				Models:  []ImportedModel{{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"}},
+			},
+			{Name: "openai", Disabled: true},
+		},
+		Channels: ImportedChannels{
+			Telegram: &ImportedTelegram{BotToken: "123:ABC"},
+		},
+	}
+	got := TranslateToOverlayYAML(result)
+
+	if !strings.Contains(got, "agentModel: claude-opus-4-6") {
+		t.Errorf("YAML missing agentModel, got:\n%s", got)
+	}
+	if !strings.Contains(got, "anthropic:\n    enabled: true") {
+		t.Errorf("YAML missing enabled anthropic, got:\n%s", got)
+	}
+	if !strings.Contains(got, "openai:\n    enabled: false") {
+		t.Errorf("YAML missing disabled openai, got:\n%s", got)
+	}
+	if !strings.Contains(got, "telegram:\n    enabled: true") {
+		t.Errorf("YAML missing telegram channel, got:\n%s", got)
+	}
+}
+
+// writeTestOpenclawConfig creates a test openclaw.json at the expected path
+func writeTestOpenclawConfig(t *testing.T, home string, cfg *openclawConfig) {
+	t.Helper()
+	dir := filepath.Join(home, ".openclaw")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectExistingConfigAt_FileNotFound(t *testing.T) {
+	home := t.TempDir()
+	result, err := detectExistingConfigAt(home)
+	if result != nil || err != nil {
+		t.Errorf("expected (nil, nil), got (%v, %v)", result, err)
+	}
+}
+
+func TestDetectExistingConfigAt_InvalidJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".openclaw")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "openclaw.json"), []byte("{invalid json"), 0644)
+
+	result, err := detectExistingConfigAt(home)
+	if result != nil {
+		t.Errorf("expected nil result, got %v", result)
+	}
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Errorf("error should mention parsing, got: %v", err)
+	}
+}
+
+func TestDetectExistingConfigAt_ValidConfig(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	cfg.Models.Providers = map[string]openclawProvider{
+		"anthropic": {
+			BaseURL: "https://api.anthropic.com/v1",
+			API:     "anthropic-messages",
+			APIKey:  "sk-ant-test-key",
+			Models:  []openclawModel{{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"}},
+		},
+	}
+	cfg.Agents.Defaults.Model.Primary = "claude-opus-4-6"
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AgentModel != "claude-opus-4-6" {
+		t.Errorf("AgentModel = %q, want %q", result.AgentModel, "claude-opus-4-6")
+	}
+	if len(result.Providers) != 1 {
+		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
+	}
+	p := result.Providers[0]
+	if p.Name != "anthropic" {
+		t.Errorf("Provider.Name = %q, want %q", p.Name, "anthropic")
+	}
+	if p.APIKey != "sk-ant-test-key" {
+		t.Errorf("Provider.APIKey = %q, want %q", p.APIKey, "sk-ant-test-key")
+	}
+	if p.API != "anthropic-messages" {
+		t.Errorf("Provider.API = %q, want %q", p.API, "anthropic-messages")
+	}
+	if len(p.Models) != 1 || p.Models[0].ID != "claude-opus-4-6" {
+		t.Errorf("Provider.Models = %v", p.Models)
+	}
+}
+
+func TestDetectExistingConfigAt_EnvVarKeySkipped(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	cfg.Models.Providers = map[string]openclawProvider{
+		"openai": {
+			BaseURL: "https://api.openai.com/v1",
+			API:     "openai-completions",
+			APIKey:  "${OPENAI_API_KEY}",
+			Models:  []openclawModel{{ID: "gpt-5.2", Name: "GPT-5.2"}},
+		},
+	}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if len(result.Providers) != 1 {
+		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
+	}
+	if result.Providers[0].APIKey != "" {
+		t.Errorf("Provider.APIKey = %q, want empty (env-var should be skipped)", result.Providers[0].APIKey)
+	}
+}
+
+func TestDetectExistingConfigAt_ChannelImport(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	cfg.Channels.Telegram = &struct {
+		BotToken string `json:"botToken"`
+	}{BotToken: "123456:ABCDEF"}
+	cfg.Channels.Discord = &struct {
+		BotToken string `json:"botToken"`
+	}{BotToken: "MTIzNDU2"}
+	cfg.Channels.Slack = &struct {
+		BotToken string `json:"botToken"`
+		AppToken string `json:"appToken"`
+	}{BotToken: "xoxb-test", AppToken: "xapp-test"}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Channels.Telegram == nil || result.Channels.Telegram.BotToken != "123456:ABCDEF" {
+		t.Errorf("Telegram = %v", result.Channels.Telegram)
+	}
+	if result.Channels.Discord == nil || result.Channels.Discord.BotToken != "MTIzNDU2" {
+		t.Errorf("Discord = %v", result.Channels.Discord)
+	}
+	if result.Channels.Slack == nil || result.Channels.Slack.BotToken != "xoxb-test" || result.Channels.Slack.AppToken != "xapp-test" {
+		t.Errorf("Slack = %v", result.Channels.Slack)
+	}
+}
+
+func TestDetectExistingConfigAt_ChannelEnvVarSkipped(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	cfg.Channels.Telegram = &struct {
+		BotToken string `json:"botToken"`
+	}{BotToken: "${TELEGRAM_TOKEN}"}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Channels.Telegram != nil {
+		t.Errorf("Telegram should be nil when token is env-var, got %v", result.Channels.Telegram)
+	}
+}
+
+func TestDetectExistingConfigAt_WorkspaceDetection(t *testing.T) {
+	home := t.TempDir()
+	wsDir := filepath.Join(home, ".openclaw", "workspace")
+	os.MkdirAll(wsDir, 0755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("I am an agent"), 0644)
+
+	cfg := &openclawConfig{}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.WorkspaceDir != wsDir {
+		t.Errorf("WorkspaceDir = %q, want %q", result.WorkspaceDir, wsDir)
+	}
+}
+
+func TestDetectExistingConfigAt_UnknownAPISanitized(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	cfg.Models.Providers = map[string]openclawProvider{
+		"custom": {
+			BaseURL: "https://custom.api/v1",
+			API:     "custom-protocol",
+			APIKey:  "key123",
+		},
+	}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Providers) != 1 {
+		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
+	}
+	if result.Providers[0].API != "" {
+		t.Errorf("Provider.API = %q, want empty (unknown API should be sanitized)", result.Providers[0].API)
+	}
+}
+
+func TestDetectExistingConfigAt_EmptyConfig(t *testing.T) {
+	home := t.TempDir()
+	cfg := &openclawConfig{}
+	writeTestOpenclawConfig(t, home, cfg)
+
+	result, err := detectExistingConfigAt(home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result for valid but empty config")
+	}
+	if len(result.Providers) != 0 {
+		t.Errorf("len(Providers) = %d, want 0", len(result.Providers))
+	}
+	if result.AgentModel != "" {
+		t.Errorf("AgentModel = %q, want empty", result.AgentModel)
+	}
+}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -75,7 +75,10 @@ func SetupDefault(cfg *config.Config) error {
 	}
 
 	// Check if there is an existing ~/.openclaw config with providers
-	imported, _ := DetectExistingConfig()
+	imported, importErr := DetectExistingConfig()
+	if importErr != nil {
+		fmt.Printf("  Warning: could not read existing config: %v\n", importErr)
+	}
 	hasImportedProviders := imported != nil && len(imported.Providers) > 0
 
 	// If no imported providers, check Ollama availability for the default overlay
@@ -122,7 +125,10 @@ func Onboard(cfg *config.Config, opts OnboardOptions) error {
 					return err
 				}
 				// Import workspace on re-sync too
-				imported, _ := DetectExistingConfig()
+				imported, importErr := DetectExistingConfig()
+				if importErr != nil {
+					fmt.Printf("Warning: could not read existing config: %v\n", importErr)
+				}
 				if imported != nil && imported.WorkspaceDir != "" {
 					copyWorkspaceToPod(cfg, id, imported.WorkspaceDir)
 				}


### PR DESCRIPTION
## Summary
- Add 25 unit tests for the OpenClaw config import pipeline (`import_test.go`) covering `DetectExistingConfig`, `TranslateToOverlayYAML`, workspace detection, env-var handling, API sanitization, and channel import
- Refactor `DetectExistingConfig` for testability by extracting `detectExistingConfigAt(home)` inner function
- Fix silent failures: warn users when env-var API keys are skipped, unknown API types are sanitized away, workspace directories have no marker files, and `DetectExistingConfig` returns errors

## Test plan
- [x] All 25 new tests pass (`go test ./internal/openclaw/ -v`)
- [x] All 5 existing overlay tests still pass (no regressions)
- [x] `go build ./cmd/obol` succeeds