### PR TITLE
feat(rbac): grant obol-frontend access to OpenClaw namespaces

### DIFF
--- a/internal/embed/infrastructure/base/templates/obol-frontend-rbac.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-frontend-rbac.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.obolFrontend.enabled }}
+---
+#------------------------------------------------------------------------------
+# ClusterRole - Read-only access to namespaces for OpenClaw instance discovery
+# The frontend lists namespaces matching openclaw-* to discover running instances
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: obol-frontend-cluster-reader
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+
+---
+#------------------------------------------------------------------------------
+# ClusterRoleBinding - Grants the obol-frontend ServiceAccount cluster-wide
+# namespace listing so it can discover OpenClaw instances
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: obol-frontend-cluster-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: obol-frontend-cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: obol-frontend
+    namespace: obol-frontend
+{{- end }}

--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -33,6 +33,9 @@ releases:
       # Set obolAgent.enabled=true to deploy it.
       - obolAgent:
           enabled: false
+      # obol-frontend RBAC for OpenClaw instance discovery
+      - obolFrontend:
+          enabled: true
 
   # Monitoring stack (Prometheus operator + Prometheus)
   - name: monitoring

--- a/internal/openclaw/chart/templates/frontend-access.yaml
+++ b/internal/openclaw/chart/templates/frontend-access.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.frontendAccess.enabled -}}
+#------------------------------------------------------------------------------
+# Role - Grants obol-frontend read access to this OpenClaw namespace
+# Required for instance health checks, gateway token retrieval, and model config
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: obol-frontend-access
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+
+---
+#------------------------------------------------------------------------------
+# RoleBinding - Binds the obol-frontend ServiceAccount to the Role above
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: obol-frontend-access
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: obol-frontend-access
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.frontendAccess.serviceAccountName }}
+    namespace: {{ .Values.frontendAccess.namespace }}
+{{- end }}

--- a/internal/openclaw/chart/values.yaml
+++ b/internal/openclaw/chart/values.yaml
@@ -49,6 +49,13 @@ rbac:
   # -- Extra rules to append to the generated Role (list of PolicyRule objects)
   extraRules: []
 
+# -- Grant obol-frontend cross-namespace read access (secrets, configmaps, pods)
+# Required for the dashboard to discover instances, read gateway tokens, and check health
+frontendAccess:
+  enabled: true
+  serviceAccountName: obol-frontend
+  namespace: obol-frontend
+
 # -- One-shot init Job (runs once to bootstrap workspace/personality)
 initJob:
   # -- Enable a one-shot post-install bootstrap Job. Requires persistence.enabled=true.


### PR DESCRIPTION
## Summary

- Add ClusterRole + ClusterRoleBinding in infrastructure base so `obol-frontend` ServiceAccount can list namespaces (required for OpenClaw instance discovery)
- Add per-instance Role + RoleBinding in the OpenClaw chart so each `openclaw-*` namespace grants `obol-frontend` read access to secrets (gateway tokens), configmaps (model config), and pods (health status)
- Follows the same RBAC pattern as `obol-agent` (ClusterRole in base + per-namespace RoleBinding in workload charts)

## Problem

The frontend pod logs show:
```
namespaces is forbidden: User "system:serviceaccount:obol-frontend:obol-frontend"
cannot list resource "namespaces" in API group "" at the cluster scope
```

The `obol-frontend` ServiceAccount exists but has zero RBAC bindings, so the `OpenClawClient` service cannot:
- List namespaces to discover `openclaw-*` instances
- Read secrets to get gateway authentication tokens
- Read configmaps to get model configuration
- List pods to check instance health

## Changes

| File | Change |
|---|---|
| `internal/embed/infrastructure/base/templates/obol-frontend-rbac.yaml` | New: ClusterRole + ClusterRoleBinding (gated by `obolFrontend.enabled`) |
| `internal/embed/infrastructure/helmfile.yaml` | Enable `obolFrontend.enabled: true` in base chart values |
| `internal/openclaw/chart/templates/frontend-access.yaml` | New: Role + RoleBinding per OpenClaw instance (gated by `frontendAccess.enabled`) |
| `internal/openclaw/chart/values.yaml` | Add `frontendAccess` config block (enabled by default) |

## Test plan

- [x] Deploy updated infrastructure base chart and verify ClusterRole/ClusterRoleBinding are created
- [x] Deploy an OpenClaw instance and verify the Role/RoleBinding are created in its namespace
- [x] Verify obol-frontend can list namespaces (`kubectl auth can-i list namespaces --as=system:serviceaccount:obol-frontend:obol-frontend`)
- [x] Verify obol-frontend can read secrets in openclaw-* namespaces
- [x] Verify the dashboard discovers and displays OpenClaw instances
- [ ] Verify chat functionality works (gateway token retrieval + API proxy)

### Test gaps

- **Item 1**: ClusterRole applied via `kubectl apply`, not via `helmfile sync` (base chart has a pre-existing `llm.yaml` lint error)
- **Item 5**: Tested via API endpoint, not via browser UI
- **Item 6**: RBAC chain works end-to-end (gateway token retrieved, request proxied to OpenClaw). Chat fails due to a **pre-existing OpenClaw model routing issue**: model `claude-sonnet-4-5-20250929` lacks a provider prefix so OpenClaw falls back to direct Anthropic API with an invalid API key. Unrelated to this PR.