### PR TITLE
fix(openclaw): add controlUi gateway settings for Traefik HTTP proxy

### DIFF
--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -200,3 +200,39 @@ releases:
                   backendRefs:
                     - name: obol-frontend-obol-app
                       port: 3000
+
+  # Obol Frontend RBAC (OpenClaw instance discovery via Kubernetes API)
+  - name: obol-frontend-rbac
+    namespace: obol-frontend
+    chart: bedag/raw
+    needs:
+      - obol-frontend/obol-frontend
+    values:
+      - resources:
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: obol-frontend-openclaw-discovery
+              labels:
+                app.kubernetes.io/name: obol-frontend
+            rules:
+              - apiGroups: [""]
+                resources: ["namespaces"]
+                verbs: ["get", "list"]
+              - apiGroups: [""]
+                resources: ["pods", "configmaps", "secrets"]
+                verbs: ["get", "list"]
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: obol-frontend-openclaw-discovery
+              labels:
+                app.kubernetes.io/name: obol-frontend
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: obol-frontend-openclaw-discovery
+            subjects:
+              - kind: ServiceAccount
+                name: obol-frontend
+                namespace: obol-frontend

--- a/internal/openclaw/chart/templates/_helpers.tpl
+++ b/internal/openclaw/chart/templates/_helpers.tpl
@@ -143,6 +143,19 @@ Render openclaw.json as strict JSON. If config.content is provided, it is used v
   "auth" $gatewayAuth
   "http" (dict "endpoints" (dict "chatCompletions" (dict "enabled" .Values.openclaw.gateway.http.endpoints.chatCompletions.enabled)))
 -}}
+{{- if .Values.openclaw.gateway.trustedProxies -}}
+{{- $_ := set $gateway "trustedProxies" .Values.openclaw.gateway.trustedProxies -}}
+{{- end -}}
+{{- if or .Values.openclaw.gateway.controlUi.allowInsecureAuth .Values.openclaw.gateway.controlUi.dangerouslyDisableDeviceAuth -}}
+{{- $controlUi := dict -}}
+{{- if .Values.openclaw.gateway.controlUi.allowInsecureAuth -}}
+{{- $_ := set $controlUi "allowInsecureAuth" true -}}
+{{- end -}}
+{{- if .Values.openclaw.gateway.controlUi.dangerouslyDisableDeviceAuth -}}
+{{- $_ := set $controlUi "dangerouslyDisableDeviceAuth" true -}}
+{{- end -}}
+{{- $_ := set $gateway "controlUi" $controlUi -}}
+{{- end -}}
 
 {{- $agentDefaults := dict "workspace" .Values.openclaw.workspaceDir -}}
 {{- if .Values.openclaw.agentModel -}}

--- a/internal/openclaw/chart/values.yaml
+++ b/internal/openclaw/chart/values.yaml
@@ -153,6 +153,15 @@ openclaw:
   gateway:
     mode: local
     bind: lan
+    # -- Trusted proxy IPs for secure context detection behind a reverse proxy (e.g. Traefik).
+    # OpenClaw uses exact IP matching (no CIDR support).
+    trustedProxies: []
+    # -- Control UI settings for running behind a reverse proxy
+    controlUi:
+      # -- Allow control UI over HTTP (required when behind a non-TLS proxy like Traefik in dev)
+      allowInsecureAuth: false
+      # -- Disable device authentication for control UI (not recommended)
+      dangerouslyDisableDeviceAuth: false
     auth:
       mode: token
 

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -1024,11 +1024,22 @@ rbac:
 	importedOverlay := TranslateToOverlayYAML(imported)
 	if importedOverlay != "" {
 		b.WriteString("# Imported from ~/.openclaw/openclaw.json\n")
+		// Inject gateway proxy settings into the openclaw: section for Traefik.
+		if strings.Contains(importedOverlay, "openclaw:\n") {
+			importedOverlay = strings.Replace(importedOverlay, "openclaw:\n", "openclaw:\n  gateway:\n    controlUi:\n      allowInsecureAuth: true\n      dangerouslyDisableDeviceAuth: true\n", 1)
+		} else {
+			b.WriteString("openclaw:\n  gateway:\n    controlUi:\n      allowInsecureAuth: true\n      dangerouslyDisableDeviceAuth: true\n\n")
+		}
 		b.WriteString(importedOverlay)
 	} else {
 		b.WriteString(`# Route agent traffic to in-cluster Ollama via llmspy proxy
 openclaw:
   agentModel: ollama/glm-4.7-flash
+  gateway:
+    # Allow control UI over HTTP behind Traefik (local dev stack)
+    controlUi:
+      allowInsecureAuth: true
+      dangerouslyDisableDeviceAuth: true
 
 # Default model provider: in-cluster Ollama (routed through llmspy)
 models:


### PR DESCRIPTION
## Summary

- Adds `controlUi.allowInsecureAuth` and `controlUi.dangerouslyDisableDeviceAuth` gateway settings to the OpenClaw Helm chart, enabling the control UI to work behind Traefik over HTTP (non-TLS)
- Adds `trustedProxies` chart value for reverse proxy IP allowlisting
- Injects controlUi settings during overlay generation (both imported config and fresh install paths)
- Adds RBAC ClusterRole/ClusterRoleBinding for the frontend to discover OpenClaw instances via Kubernetes API (namespaces, pods, configmaps, secrets)

## Context

OpenClaw's control UI rejects WebSocket connections with error code 1008 ("control ui requires HTTPS or localhost") when running behind Traefik over HTTP. This was discovered when deploying a second OpenClaw instance (`staging`) alongside the existing `demo` instance — the staging dashboard was unreachable until these gateway settings were added.

## Test plan

- [x] Validated with both `demo` and `staging` OpenClaw instances behind Traefik
- [x] WebSocket connections succeed with `allowInsecureAuth: true` + `dangerouslyDisableDeviceAuth: true`
- [ ] `helm lint` passes on updated chart
- [ ] Fresh `obol openclaw onboard` generates overlay with controlUi settings
- [ ] Import path (`DetectExistingConfig`) injects controlUi settings into overlay