### PR TITLE
feat(erpc): switch upstream to erpc.gcp.obol.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ obol network install ethereum --network=hoodi
 ```
 
 **Ethereum configuration options:**
-- `--network`: Choose network (mainnet, sepolia, hoodi)
+- `--network`: Choose network (mainnet, hoodi)
 - `--execution-client`: Choose execution client (reth, geth, nethermind, besu, erigon, ethereumjs)
 - `--consensus-client`: Choose consensus client (lighthouse, prysm, teku, nimbus, lodestar, grandine)
 
@@ -669,7 +669,7 @@ Networks are embedded in the binary at `internal/embed/networks/`. Each network 
 ```yaml
 # internal/embed/networks/ethereum/helmfile.yaml.gotmpl
 values:
-  # @enum mainnet,sepolia,holesky,hoodi
+  # @enum mainnet,hoodi
   # @default mainnet
   # @description Blockchain network to deploy
   - network: {{.Network}}

--- a/internal/embed/infrastructure/values/erpc.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/erpc.yaml.gotmpl
@@ -3,11 +3,16 @@
 {{- $chainId := 1 -}}  {{/* Default: mainnet */}}
 {{- if eq $network "hoodi" -}}
   {{- $chainId = 560048 -}}
-{{- else if eq $network "sepolia" -}}
-  {{- $chainId = 11155111 -}}
 {{- else if ne $network "mainnet" -}}
-  {{- fail (printf "Unknown network: %s. Supported networks: mainnet, hoodi, sepolia" $network) -}}
+  {{- fail (printf "Unknown network: %s. Supported networks: mainnet, hoodi" $network) -}}
 {{- end -}}
+{{/*
+  erpc.gcp.obol.tech — internal, rate-limited eRPC gateway hosted by Obol.
+  The Basic Auth credential below is knowingly included in the obol-stack source.
+  This endpoint is rate-limited and serves only as a convenience RPC proxy for
+  local stack users; exposing it carries less risk than running fully unprotected.
+*/}}
+{{- $erpcGcpAuth := "obol:svXELzJDXQPrmgA3AopiWZWm" -}} {{/* gitleaks:allow */}}
 
 # Number of replicas
 replicas: 1
@@ -50,13 +55,10 @@ config: |-
   projects:
     - id: rpc
       upstreams:
-        - id: nodecore
-          endpoint: https://rpc.nodecore.io
+        - id: erpc-gcp
+          endpoint: https://{{ $erpcGcpAuth }}@erpc.gcp.obol.tech/{{ $network }}/evm/{{ $chainId }}
           evm:
             chainId: {{ $chainId }}
-          jsonRpc:
-            headers:
-              X-Nodecore-Token: "${OBOL_OAUTH_TOKEN}"
       networks:
         - architecture: evm
           evm:
@@ -90,14 +92,8 @@ config: |-
 # Secret env variables (chart-managed secret for inline values)
 secretEnv: {}
 
-# Extra env variables (reference external obol-oauth-token secret)
-extraEnv:
-  - name: OBOL_OAUTH_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: obol-oauth-token
-        key: token
-        optional: true
+# Extra env variables
+extraEnv: []
 
 # Extra args for the erpc container
 extraArgs: []
@@ -119,8 +115,7 @@ affinity: {}
 imagePullSecrets: []
 
 # Annotations for the Deployment
-annotations:
-  secret.reloader.stakater.com/reload: "obol-oauth-token"
+annotations: {}
 
 # Liveness probe
 livenessProbe:
@@ -145,8 +140,7 @@ nodeSelector: {}
 podLabels: {}
 
 # Pod annotations
-podAnnotations:
-  secret.reloader.stakater.com/reload: "obol-oauth-token"
+podAnnotations: {}
 
 # Pod management policy
 podManagementPolicy: OrderedReady
@@ -203,7 +197,7 @@ extraVolumeMounts: []
 # Additional ports
 extraPorts: []
 
-# Additional env variables (defined above with OBOL_OAUTH_TOKEN)
+# Additional env variables
 
 serviceMonitor:
   enabled: false

--- a/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
@@ -34,7 +34,6 @@ releases:
             enabled: true
             addresses:
               mainnet: https://mainnet-checkpoint-sync.attestant.io
-              sepolia: https://checkpoint-sync.sepolia.ethpandaops.io
               hoodi: https://checkpoint-sync.hoodi.ethpandaops.io
 
       # Execution client

--- a/internal/embed/networks/ethereum/values.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/values.yaml.gotmpl
@@ -1,7 +1,7 @@
 # Configuration via CLI flags
 # Template fields populated by obol CLI during network installation
 
-# @enum mainnet,sepolia,hoodi
+# @enum mainnet,hoodi
 # @default mainnet
 # @description Blockchain network to deploy
 network: {{.Network}}


### PR DESCRIPTION
## Summary

- Replace nodecore RPC upstream with Obol's internal rate-limited eRPC gateway (`erpc.gcp.obol.tech`)
- Remove sepolia support (upstream only serves mainnet and hoodi)
- Basic Auth credential intentionally embedded per CTO approval — extracted to template variable with `gitleaks:allow` suppression

## Upstream Validation

| Check | Result |
|-------|--------|
| Server | `34.91.21.241`, TLSv1.3, Let's Encrypt |
| Mainnet (evm:1) | Block 24,510,988 |
| Hoodi (evm:560048) | Block 2,227,487 |
| Sepolia | Not available |

## Files Changed

| File | Change |
|------|--------|
| `internal/embed/infrastructure/values/erpc.yaml.gotmpl` | Upstream → `erpc-gcp`, Basic Auth, drop nodecore OAuth refs |
| `internal/embed/networks/ethereum/values.yaml.gotmpl` | `@enum mainnet,hoodi` |
| `internal/embed/networks/ethereum/helmfile.yaml.gotmpl` | Remove sepolia checkpoint sync |
| `README.md` | Update network options docs |

## Test plan

- [ ] Deploy stack with `--network=mainnet` and verify eRPC proxies RPC requests through `erpc.gcp.obol.tech`
- [ ] Deploy stack with `--network=hoodi` and verify eRPC proxies RPC requests through `erpc.gcp.obol.tech`
- [ ] Verify `obol network install ethereum --help` no longer shows sepolia
- [ ] Confirm no security scan false positives on the embedded credential