### PR TITLE
chore(llm): bump LLMSpy to v3.0.33-obol.1

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -132,7 +132,7 @@ spec:
         # providers.json is taken from the llmspy package (has full model definitions)
         # and then merged with ConfigMap overrides (Ollama endpoint, API key refs).
         - name: seed-config
-          image: ghcr.io/obolnetwork/llms:3.0.32-obol.1-rc.4
+          image: ghcr.io/obolnetwork/llms:3.0.33-obol.1
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -169,7 +169,7 @@ spec:
         - name: llmspy
           # Obol fork of LLMSpy with smart routing extension.
           # Pin a specific version for reproducibility.
-          image: ghcr.io/obolnetwork/llms:3.0.32-obol.1-rc.4
+          image: ghcr.io/obolnetwork/llms:3.0.33-obol.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- Bump LLMSpy image from `3.0.32-obol.1-rc.4` to `3.0.33-obol.1` (both init container and main container)
- Syncs upstream ServiceStack/llms v3.0.33 changes: version bump, nostore feature, response_format fix, provider updates

## Test plan
- [ ] Verify `ghcr.io/obolnetwork/llms:3.0.33-obol.1` image is available
- [ ] Deploy to k3s cluster and confirm LLMSpy pod starts successfully
- [ ] Validate smart routing and streaming SSE passthrough still work