### PR TITLE
fix(openclaw): bump llmspy image and fix Anthropic baseUrl

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -132,7 +132,7 @@ spec:
         # providers.json is taken from the llmspy package (has full model definitions)
         # and then merged with ConfigMap overrides (Ollama endpoint, API key refs).
         - name: seed-config
-          image: ghcr.io/obolnetwork/llms:3.0.33-obol.1
+          image: ghcr.io/obolnetwork/llms:3.0.33-obol.2
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -169,7 +169,7 @@ spec:
         - name: llmspy
           # Obol fork of LLMSpy with smart routing extension.
           # Pin a specific version for reproducibility.
-          image: ghcr.io/obolnetwork/llms:3.0.33-obol.1
+          image: ghcr.io/obolnetwork/llms:3.0.33-obol.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/internal/openclaw/import_test.go
+++ b/internal/openclaw/import_test.go
@@ -235,7 +235,7 @@ func TestTranslateToOverlayYAML_ProviderWithModels(t *testing.T) {
 		Providers: []ImportedProvider{
 			{
 				Name:    "anthropic",
-				BaseURL: "https://api.anthropic.com/v1",
+				BaseURL: "https://api.anthropic.com",
 				API:     "anthropic-messages",
 				APIKey:  "sk-ant-test",
 				Models: []ImportedModel{
@@ -248,7 +248,7 @@ func TestTranslateToOverlayYAML_ProviderWithModels(t *testing.T) {
 
 	checks := []string{
 		"anthropic:\n    enabled: true",
-		"baseUrl: https://api.anthropic.com/v1",
+		"baseUrl: https://api.anthropic.com",
 		"api: anthropic-messages",
 		"- id: claude-opus-4-6",
 		"name: Claude Opus 4.6",
@@ -326,7 +326,7 @@ func TestTranslateToOverlayYAML_FullConfig(t *testing.T) {
 		Providers: []ImportedProvider{
 			{
 				Name:    "anthropic",
-				BaseURL: "https://api.anthropic.com/v1",
+				BaseURL: "https://api.anthropic.com",
 				API:     "anthropic-messages",
 				APIKey:  "sk-ant-test",
 				Models:  []ImportedModel{{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"}},
@@ -400,7 +400,7 @@ func TestDetectExistingConfigAt_ValidConfig(t *testing.T) {
 	cfg := &openclawConfig{}
 	cfg.Models.Providers = map[string]openclawProvider{
 		"anthropic": {
-			BaseURL: "https://api.anthropic.com/v1",
+			BaseURL: "https://api.anthropic.com",
 			API:     "anthropic-messages",
 			APIKey:  "sk-ant-test-key",
 			Models:  []openclawModel{{ID: "claude-opus-4-6", Name: "Claude Opus 4.6"}},

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -1238,7 +1238,7 @@ func interactiveSetup(imported *ImportResult) (*ImportResult, *CloudProviderInfo
 			}
 			return result, nil, nil
 		case "5":
-			result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com/v1", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-opus-4-6", "Claude Opus 4.6")
+			result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-opus-4-6", "Claude Opus 4.6")
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1292,7 +1292,7 @@ func interactiveSetup(imported *ImportResult) (*ImportResult, *CloudProviderInfo
 		}
 		return result, nil, nil
 	case "4":
-		result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com/v1", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-opus-4-6", "Claude Opus 4.6")
+		result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-opus-4-6", "Claude Opus 4.6")
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
## Summary

- Bump llmspy to `v3.0.33-obol.2` which fixes the SQLite "database is locked" startup race condition in the writer thread (retry with exponential backoff)
- Fix Anthropic Direct provider `baseUrl`: remove `/v1` suffix since LiteLLM appends `/v1/messages` itself, causing double-path (`/v1/v1/messages`) 404 errors

## Test plan

- [x] `go test ./internal/openclaw/` passes
- [x] Verified llmspy pod starts without SQLite errors on live cluster
- [x] Verified Anthropic Direct provider inference succeeds (claude-sonnet-4-5-20250929)