### PR TITLE
ci: bump Python to 3.12 and update action versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.12.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -40,7 +40,7 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
## Summary

- Fix `lint-test` CI failure: Python 3.9 is EOL and no longer cached on GitHub Actions runners, causing `"candidates is not iterable"` error in `setup-python`
- Bump all action versions to current releases

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v3 | v4 |
| `actions/setup-python` | v4 (Python 3.9) | v5 (Python 3.12) |
| `azure/setup-helm` | v3 | v4 |
| `helm/chart-testing-action` | v2.6.1 | v2.7.0 |
| `helm/kind-action` | v1.5.0 | v1.12.0 |

## Test plan

- [ ] CI `lint-test` job passes on this PR