### PR TITLE
Track llmspy image releases via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,20 @@
         "^internal/openclaw/OPENCLAW_VERSION$"
       ],
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update llmspy image version from ObolNetwork/llms releases",
+      "matchStrings": [
+        "image:\\s*ghcr\\.io/obolnetwork/llms:(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+-obol\\.[0-9]+)"
+      ],
+      "fileMatch": [
+        "^internal/embed/infrastructure/base/templates/llm\\.yaml$"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "ObolNetwork/llms",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-obol\\.(?<build>\\d+)$",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -116,6 +130,22 @@
         "every hour"
       ],
       "groupName": "OpenClaw updates"
+    },
+    {
+      "description": "Group llmspy updates",
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "ObolNetwork/llms"
+      ],
+      "labels": [
+        "renovate/llmspy"
+      ],
+      "schedule": [
+        "every hour"
+      ],
+      "groupName": "llmspy updates"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Renovate custom regex manager to track `ObolNetwork/llms` github-releases
- Auto-bumps the llmspy image tag in `internal/embed/infrastructure/base/templates/llm.yaml` when new obol tags are published
- Add package rule to group updates under `renovate/llmspy` label

## Context
The `ObolNetwork/llms` fork now has automated upstream sync (Renovate + GitHub Actions) that creates `-obol.X` tags and builds multi-arch Docker images. This PR closes the loop by having Renovate in obol-stack detect those new releases and bump the image reference automatically.

## Test plan
- [ ] Verify Renovate picks up the new custom manager on next scan
- [ ] Confirm `v3.0.34-obol.1` is detected as an available update for the current `3.0.33-obol.2` pinned in `llm.yaml`