### PR TITLE
Replace hardcoded default model with dynamic Ollama detection

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -40,7 +40,7 @@ spec:
 # llms.py v3 configuration for Obol Stack:
 # - Ollama provider enabled by default (host machine via ollama Service)
 # - Anthropic and OpenAI providers available (disabled by default; enabled via `obol model setup`)
-# - Default model is gpt-oss:120b-cloud (Ollama cloud)
+# - No default model; users configure via `obol model setup`
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,7 +56,7 @@ data:
           "User-Agent": "llmspy.org/3.0"
         },
         "text": {
-          "model": "gpt-oss:120b-cloud",
+          "model": "",
           "messages": [
             { "role": "user", "content": [{ "type": "text", "text": "" }] }
           ]

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -45,11 +45,12 @@ const (
 
 // OnboardOptions contains options for the onboard command
 type OnboardOptions struct {
-	ID          string // Deployment ID (empty = generate petname)
-	Force       bool   // Overwrite existing deployment
-	Sync        bool   // Also run helmfile sync after install
-	Interactive bool   // true = prompt for provider choice; false = silent defaults
-	IsDefault   bool   // true = use fixed ID "default", idempotent on re-run
+	ID           string   // Deployment ID (empty = generate petname)
+	Force        bool     // Overwrite existing deployment
+	Sync         bool     // Also run helmfile sync after install
+	Interactive  bool     // true = prompt for provider choice; false = silent defaults
+	IsDefault    bool     // true = use fixed ID "default", idempotent on re-run
+	OllamaModels []string // Available Ollama models detected on host (nil = not queried)
 }
 
 // SetupDefault deploys a default OpenClaw instance as part of stack setup.
@@ -77,23 +78,31 @@ func SetupDefault(cfg *config.Config) error {
 	}
 	hasImportedProviders := imported != nil && len(imported.Providers) > 0
 
-	// If no imported providers, check Ollama availability for the default overlay
+	// If no imported providers, query Ollama for available models
+	var ollamaModels []string
 	if !hasImportedProviders {
-		ollamaAvailable := detectOllama()
-		if ollamaAvailable {
-			fmt.Printf("  ✓ Local Ollama detected at %s\n", ollamaEndpoint())
+		ollamaModels = listOllamaModels()
+		if ollamaModels != nil {
+			if len(ollamaModels) > 0 {
+				fmt.Printf("  ✓ Local Ollama detected with %d model(s) at %s\n", len(ollamaModels), ollamaEndpoint())
+			} else {
+				fmt.Printf("  ✓ Local Ollama detected at %s (no models pulled)\n", ollamaEndpoint())
+				fmt.Println("  Run 'obol model setup' to configure a cloud provider,")
+				fmt.Println("  or pull a model with: ollama pull llama3.2:3b")
+			}
 		} else {
 			fmt.Printf("  ⚠ Local Ollama not detected on host (%s)\n", ollamaEndpoint())
 			fmt.Println("  Skipping default OpenClaw model provider setup.")
-			fmt.Println("  Run 'obol agent init' to configure a provider later.")
+			fmt.Println("  Run 'obol model setup' to configure a provider later.")
 			return nil
 		}
 	}
 
 	return Onboard(cfg, OnboardOptions{
-		ID:        "default",
-		Sync:      true,
-		IsDefault: true,
+		ID:           "default",
+		Sync:         true,
+		IsDefault:    true,
+		OllamaModels: ollamaModels,
 	})
 }
 
@@ -183,7 +192,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions) error {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write OpenClaw secrets metadata: %w", err)
 	}
-	overlay := generateOverlayValues(hostname, imported, len(secretData) > 0)
+	overlay := generateOverlayValues(hostname, imported, len(secretData) > 0, opts.OllamaModels)
 	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0644); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write overlay values: %w", err)
@@ -654,7 +663,7 @@ func Setup(cfg *config.Config, id string, _ SetupOptions) error {
 	if err := writeUserSecretsFile(deploymentDir, secretData); err != nil {
 		return fmt.Errorf("failed to write OpenClaw secrets metadata: %w", err)
 	}
-	overlay := generateOverlayValues(hostname, imported, len(secretData) > 0)
+	overlay := generateOverlayValues(hostname, imported, len(secretData) > 0, nil)
 	overlayPath := filepath.Join(deploymentDir, "values-obol.yaml")
 	if err := os.WriteFile(overlayPath, []byte(overlay), 0644); err != nil {
 		return fmt.Errorf("failed to write overlay values: %w", err)
@@ -1046,7 +1055,7 @@ func deploymentPath(cfg *config.Config, id string) string {
 // generateOverlayValues creates the Obol Stack-specific values overlay.
 // If imported is non-nil, provider/channel config from the import is used
 // instead of the default Ollama configuration.
-func generateOverlayValues(hostname string, imported *ImportResult, useExternalSecrets bool) string {
+func generateOverlayValues(hostname string, imported *ImportResult, useExternalSecrets bool, ollamaModels []string) string {
 	var b strings.Builder
 
 	b.WriteString(`# Obol Stack overlay values for OpenClaw
@@ -1089,17 +1098,19 @@ rbac:
 		}
 		b.WriteString(importedOverlay)
 	} else {
-		b.WriteString(`# Route agent traffic to in-cluster Ollama via llmspy proxy
-openclaw:
-  agentModel: ollama/gpt-oss:120b-cloud
-  gateway:
+		// Default provider: in-cluster Ollama via llmspy proxy.
+		// Model list is populated from the host's Ollama instance (if available).
+		b.WriteString("# Default model provider: in-cluster Ollama (routed through llmspy)\nopenclaw:\n")
+		if len(ollamaModels) > 0 {
+			b.WriteString(fmt.Sprintf("  agentModel: ollama/%s\n", ollamaModels[0]))
+		}
+		b.WriteString(`  gateway:
     # Allow control UI over HTTP behind Traefik (local dev stack).
     # Required: browser on non-localhost HTTP has no crypto.subtle,
     # so device identity is unavailable. Token auth is still enforced.
     controlUi:
       allowInsecureAuth: true
 
-# Default model provider: in-cluster Ollama (routed through llmspy)
 # apiKeyValue is a dummy placeholder — Ollama does not require auth.
 # It is safe to inline here (unlike real cloud keys, which go to secrets).
 models:
@@ -1109,11 +1120,16 @@ models:
     api: openai-completions
     apiKeyEnvVar: OLLAMA_API_KEY
     apiKeyValue: ollama-local
-    models:
-      - id: gpt-oss:120b-cloud
-        name: GPT-OSS 120B Cloud
-
 `)
+		if len(ollamaModels) > 0 {
+			b.WriteString("    models:\n")
+			for _, m := range ollamaModels {
+				b.WriteString(fmt.Sprintf("      - id: %s\n        name: %s\n", m, ollamaModelDisplayName(m)))
+			}
+		} else {
+			b.WriteString("    models: []\n")
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString(`# eRPC integration
@@ -1172,6 +1188,53 @@ func detectOllama() bool {
 	}
 	resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+// listOllamaModels queries the local Ollama server for pulled models.
+// Returns nil if Ollama is not reachable, empty slice if reachable but no models pulled.
+func listOllamaModels() []string {
+	endpoint := ollamaEndpoint()
+	tagsURL, err := url.JoinPath(endpoint, "api", "tags")
+	if err != nil {
+		return nil
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(tagsURL)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var result struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(result.Models))
+	for _, m := range result.Models {
+		name := strings.TrimSuffix(m.Name, ":latest")
+		names = append(names, name)
+	}
+	return names
+}
+
+// ollamaModelDisplayName converts an Ollama model name (e.g. "llama3.2:3b")
+// into a human-friendly display name (e.g. "Llama3.2 3b").
+func ollamaModelDisplayName(name string) string {
+	parts := strings.SplitN(name, ":", 2)
+	display := parts[0]
+	if len(display) > 0 {
+		display = strings.ToUpper(display[:1]) + display[1:]
+	}
+	if len(parts) > 1 {
+		display += " " + parts[1]
+	}
+	return display
 }
 
 // interactiveSetup prompts the user for provider configuration.

--- a/internal/openclaw/overlay_test.go
+++ b/internal/openclaw/overlay_test.go
@@ -132,12 +132,34 @@ func TestOverlayYAML_LLMSpyRouted(t *testing.T) {
 	}
 }
 
-func TestGenerateOverlayValues_OllamaDefault(t *testing.T) {
-	// When imported is nil, generateOverlayValues should use Ollama defaults
-	yaml := generateOverlayValues("openclaw-default.obol.stack", nil, false)
+func TestGenerateOverlayValues_OllamaDefaultWithModels(t *testing.T) {
+	// When Ollama models are available, overlay should use them
+	models := []string{"llama3.2:3b", "mistral:7b"}
+	yaml := generateOverlayValues("openclaw-default.obol.stack", nil, false, models)
 
-	if !strings.Contains(yaml, "agentModel: ollama/gpt-oss:120b-cloud") {
+	if !strings.Contains(yaml, "agentModel: ollama/llama3.2:3b") {
 		t.Errorf("default overlay missing ollama agentModel, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "baseUrl: http://llmspy.llm.svc.cluster.local:8000/v1") {
+		t.Errorf("default overlay missing llmspy baseUrl, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "id: llama3.2:3b") {
+		t.Errorf("default overlay missing first model, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "id: mistral:7b") {
+		t.Errorf("default overlay missing second model, got:\n%s", yaml)
+	}
+}
+
+func TestGenerateOverlayValues_OllamaDefaultNoModels(t *testing.T) {
+	// When no Ollama models are available, overlay should have empty model list
+	yaml := generateOverlayValues("openclaw-default.obol.stack", nil, false, nil)
+
+	if strings.Contains(yaml, "agentModel:") {
+		t.Errorf("default overlay should not set agentModel when no models available, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "models: []") {
+		t.Errorf("default overlay should have empty models list, got:\n%s", yaml)
 	}
 	if !strings.Contains(yaml, "baseUrl: http://llmspy.llm.svc.cluster.local:8000/v1") {
 		t.Errorf("default overlay missing llmspy baseUrl, got:\n%s", yaml)
@@ -145,7 +167,7 @@ func TestGenerateOverlayValues_OllamaDefault(t *testing.T) {
 }
 
 func TestGenerateOverlayValues_ExternalSecrets(t *testing.T) {
-	yaml := generateOverlayValues("openclaw-default.obol.stack", nil, true)
+	yaml := generateOverlayValues("openclaw-default.obol.stack", nil, true, nil)
 	if !strings.Contains(yaml, "extraEnvFromSecrets") {
 		t.Errorf("overlay missing extraEnvFromSecrets, got:\n%s", yaml)
 	}


### PR DESCRIPTION
## Summary

- Remove hardcoded `gpt-oss:120b-cloud` default model (does not exist) from OpenClaw overlay and llmspy config
- Add `listOllamaModels()` to query the host's Ollama for actually pulled models during `SetupDefault()`
- Populate the OpenClaw overlay with real available models; set `agentModel` to the first one
- When Ollama has no models pulled, deploy with empty model list and guide users to `obol model setup` or `ollama pull`
- Update llmspy `llms.json` default model from `gpt-oss:120b-cloud` to empty string

## Test plan

- [ ] `go test ./...` passes
- [ ] With Ollama running and models pulled: `obol stack up` deploys OpenClaw with detected models in overlay
- [ ] With Ollama running but no models: deploys with empty model list, prints guidance
- [ ] Without Ollama: skips OpenClaw setup, prints guidance to run `obol model setup`