### PR TITLE
Replace DNS resolver with NM dnsmasq plugin + /etc/hosts fallback

### DIFF
--- a/internal/dns/resolver.go
+++ b/internal/dns/resolver.go
@@ -1,21 +1,19 @@
 // Package dns manages wildcard *.obol.stack resolution on the host machine.
 //
-// Three OS-specific strategies are used:
+// Two OS-specific strategies are used:
 //
 // macOS: A dnsmasq Docker container on port 5553 + /etc/resolver/obol.stack.
 // This is the native macOS approach for per-domain DNS resolution.
 //
-// Linux (with NetworkManager): NM's built-in dnsmasq plugin resolves
-// *.obol.stack → 127.0.0.1 directly. Two config files, no Docker container,
-// no bridge/veth hacks, no systemd-resolved drop-ins.
+// Linux: NetworkManager's built-in dnsmasq plugin resolves *.obol.stack →
+// 127.0.0.1 directly. Two config files, no Docker container, no bridge/veth
+// hacks, no systemd-resolved drop-ins. Works on any distro with NM
+// (Ubuntu, Fedora, Debian desktop, Arch, RHEL, openSUSE, Mint, Pop!_OS).
 //
-// Linux (without NetworkManager): Managed /etc/hosts entries for each
-// deployment. No wildcard support, but entries are added/removed
-// programmatically as services are deployed.
+// Systems without NetworkManager get instructions to install it.
 package dns
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,7 +26,6 @@ const (
 	containerName = "obol-dns"
 	dnsImage      = "alpine:3.21"
 	domain        = "obol.stack"
-	hostsMarker   = "# obol-stack-managed"
 
 	// macOS: custom port, /etc/resolver handles port directive
 	macHostPort = "5553"
@@ -38,23 +35,21 @@ const (
 	macResolverFile = "obol.stack"
 
 	// Linux NM dnsmasq plugin config
-	nmConfDir      = "/etc/NetworkManager/conf.d"
-	nmConfFile     = "obol-dns.conf"
-	nmDnsmasqDir   = "/etc/NetworkManager/dnsmasq.d"
-	nmDnsmasqFile  = "obol-stack.conf"
-	hostsFile      = "/etc/hosts"
+	nmConfDir     = "/etc/NetworkManager/conf.d"
+	nmConfFile    = "obol-dns.conf"
+	nmDnsmasqDir  = "/etc/NetworkManager/dnsmasq.d"
+	nmDnsmasqFile = "obol-stack.conf"
 )
 
 // --- Public API ---
 
 // EnsureRunning starts the DNS resolver. On macOS, this starts a dnsmasq
-// Docker container. On Linux, this is a no-op (NM dnsmasq or /etc/hosts
-// handle resolution without a container).
+// Docker container. On Linux, this is a no-op — NM dnsmasq handles
+// resolution without a container.
 func EnsureRunning() error {
 	if runtime.GOOS == "darwin" {
 		return ensureMacOSContainer()
 	}
-	// Linux: no container needed — NM dnsmasq plugin or /etc/hosts
 	return nil
 }
 
@@ -74,7 +69,7 @@ func Stop() {
 // to localhost. Requires sudo on first run.
 //
 // macOS: creates /etc/resolver/obol.stack
-// Linux: configures NM dnsmasq plugin, or falls back to /etc/hosts
+// Linux: configures NM dnsmasq plugin for wildcard resolution
 func ConfigureSystemResolver() error {
 	switch runtime.GOOS {
 	case "darwin":
@@ -92,7 +87,7 @@ func RemoveSystemResolver() {
 	case "darwin":
 		removeMacOSResolver()
 	case "linux":
-		removeLinuxResolver()
+		removeNMDnsmasq()
 	}
 }
 
@@ -103,35 +98,10 @@ func IsResolverConfigured() bool {
 		_, err := os.Stat(filepath.Join(macResolverDir, macResolverFile))
 		return err == nil
 	case "linux":
-		if hasNMDnsmasqConfig() {
-			return true
-		}
-		return hasHostsEntries()
+		return hasNMDnsmasqConfig()
 	default:
 		return false
 	}
-}
-
-// AddHostEntry ensures a hostname entry exists in /etc/hosts for the given
-// subdomain (e.g., "openclaw-default"). This is used as a fallback when NM
-// dnsmasq is not available, and is always safe to call — it no-ops if NM
-// dnsmasq is handling wildcard resolution.
-func AddHostEntry(subdomain string) error {
-	if runtime.GOOS == "darwin" || hasNMDnsmasqConfig() {
-		return nil // Wildcard resolution handles this
-	}
-	hostname := subdomain + "." + domain
-	return addHostsEntry(hostname)
-}
-
-// RemoveHostEntry removes a hostname entry from /etc/hosts for the given
-// subdomain. Safe to call even if the entry doesn't exist.
-func RemoveHostEntry(subdomain string) {
-	if runtime.GOOS == "darwin" || hasNMDnsmasqConfig() {
-		return // Wildcard resolution handles this
-	}
-	hostname := subdomain + "." + domain
-	removeHostsEntry(hostname)
 }
 
 // --- macOS ---
@@ -188,7 +158,7 @@ func configureMacOSResolver() error {
 
 	writeCmd := exec.Command("sudo", "tee", path)
 	writeCmd.Stdin = strings.NewReader(content)
-	writeCmd.Stdout = nil // suppress tee stdout
+	writeCmd.Stdout = nil
 	writeCmd.Stderr = os.Stderr
 	if err := writeCmd.Run(); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
@@ -211,29 +181,23 @@ func removeMacOSResolver() {
 	fmt.Printf("Removed DNS resolver config: %s\n", path)
 }
 
-// --- Linux ---
+// --- Linux (NetworkManager dnsmasq plugin) ---
 
-// configureLinuxResolver tries NM dnsmasq first, falls back to /etc/hosts.
+// configureLinuxResolver sets up NM's dnsmasq plugin for *.obol.stack.
 func configureLinuxResolver() error {
-	// Tier 1: NetworkManager dnsmasq plugin
 	if configureNMDnsmasq() {
 		return nil
 	}
 
-	// Tier 2: /etc/hosts fallback (add base domain entry)
-	fmt.Println("NetworkManager not available — using /etc/hosts for *.obol.stack resolution")
-	fmt.Println("Note: wildcard DNS is not supported in this mode.")
-	fmt.Println("      Entries will be added per deployment.")
-	return addHostsEntry(domain)
+	// NM not available — print instructions
+	fmt.Println("\nWildcard DNS for *.obol.stack requires NetworkManager with dnsmasq.")
+	fmt.Println("Install with:")
+	fmt.Println("  sudo apt install network-manager dnsmasq-base  # Debian/Ubuntu")
+	fmt.Println("  sudo dnf install NetworkManager dnsmasq        # Fedora/RHEL")
+	fmt.Println("  sudo pacman -S networkmanager dnsmasq           # Arch")
+	fmt.Println("\nThen re-run: obol stack up")
+	return fmt.Errorf("NetworkManager required for wildcard DNS on Linux")
 }
-
-// removeLinuxResolver removes NM dnsmasq config and/or /etc/hosts entries.
-func removeLinuxResolver() {
-	removeNMDnsmasq()
-	removeAllHostsEntries()
-}
-
-// --- Linux Tier 1: NetworkManager dnsmasq plugin ---
 
 // hasNMDnsmasqConfig checks if the NM dnsmasq config for obol.stack exists.
 func hasNMDnsmasqConfig() bool {
@@ -250,16 +214,13 @@ func configureNMDnsmasq() bool {
 		return false
 	}
 
-	// Check if dnsmasq is available (NM plugin requires it)
+	// Check if dnsmasq binary is available (NM plugin requires it)
 	if _, err := exec.LookPath("dnsmasq"); err != nil {
-		// Try to detect if it's available as an NM plugin without the binary
-		// On some distros, NM's dnsmasq support is built-in
-		if _, err := os.Stat("/usr/lib/NetworkManager"); err != nil {
-			fmt.Println("Note: dnsmasq not found. Install it for wildcard DNS support:")
-			fmt.Println("  sudo apt install dnsmasq-base  # Debian/Ubuntu")
-			fmt.Println("  sudo dnf install dnsmasq       # Fedora/RHEL")
-			return false
-		}
+		fmt.Println("Note: dnsmasq not found. Install it for wildcard DNS support:")
+		fmt.Println("  sudo apt install dnsmasq-base  # Debian/Ubuntu")
+		fmt.Println("  sudo dnf install dnsmasq       # Fedora/RHEL")
+		fmt.Println("  sudo pacman -S dnsmasq          # Arch")
+		return false
 	}
 
 	// Check if already configured
@@ -269,10 +230,9 @@ func configureNMDnsmasq() bool {
 
 	fmt.Println("Configuring NetworkManager DNS for *.obol.stack (requires sudo)...")
 
-	// Check if NM already uses dns=dnsmasq
 	nmDNSMode := getNMDNSMode()
 
-	// Create NM dnsmasq conf.d directory
+	// Create NM dnsmasq.d directory and write the rule
 	mkdirCmd := exec.Command("sudo", "mkdir", "-p", nmDnsmasqDir)
 	mkdirCmd.Stdout = os.Stdout
 	mkdirCmd.Stderr = os.Stderr
@@ -281,7 +241,6 @@ func configureNMDnsmasq() bool {
 		return false
 	}
 
-	// Write dnsmasq rule: *.obol.stack → 127.0.0.1
 	dnsmasqConf := "# Managed by obol-stack\naddress=/obol.stack/127.0.0.1\n"
 	writeCmd := exec.Command("sudo", "tee", filepath.Join(nmDnsmasqDir, nmDnsmasqFile))
 	writeCmd.Stdin = strings.NewReader(dnsmasqConf)
@@ -381,89 +340,4 @@ func removeNMDnsmasq() {
 		}
 		fmt.Println("Removed NM dnsmasq DNS config")
 	}
-}
-
-// --- Linux Tier 2: /etc/hosts fallback ---
-
-// hasHostsEntries checks if any obol-stack-managed entries exist in /etc/hosts.
-func hasHostsEntries() bool {
-	f, err := os.Open(hostsFile)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), hostsMarker) {
-			return true
-		}
-	}
-	return false
-}
-
-// addHostsEntry adds a single hostname entry to /etc/hosts if not present.
-func addHostsEntry(hostname string) error {
-	// Check if entry already exists
-	if hostsEntryExists(hostname) {
-		return nil
-	}
-
-	entry := fmt.Sprintf("127.0.0.1 %s %s", hostname, hostsMarker)
-
-	appendCmd := exec.Command("sudo", "sh", "-c", fmt.Sprintf("echo '%s' >> %s", entry, hostsFile))
-	appendCmd.Stdout = os.Stdout
-	appendCmd.Stderr = os.Stderr
-	if err := appendCmd.Run(); err != nil {
-		return fmt.Errorf("failed to add %s to /etc/hosts (sudo required): %w", hostname, err)
-	}
-
-	fmt.Printf("Added /etc/hosts entry: %s → 127.0.0.1\n", hostname)
-	return nil
-}
-
-// removeHostsEntry removes a single hostname entry from /etc/hosts.
-func removeHostsEntry(hostname string) {
-	if !hostsEntryExists(hostname) {
-		return
-	}
-
-	// Use sed to remove the specific line
-	pattern := fmt.Sprintf("/127\\.0\\.0\\.1.*%s.*%s/d", strings.ReplaceAll(hostname, ".", "\\."), hostsMarker)
-	if err := exec.Command("sudo", "sed", "-i", pattern, hostsFile).Run(); err != nil {
-		fmt.Printf("Warning: failed to remove %s from /etc/hosts: %v\n", hostname, err)
-	}
-}
-
-// removeAllHostsEntries removes all obol-stack-managed entries from /etc/hosts.
-func removeAllHostsEntries() {
-	if !hasHostsEntries() {
-		return
-	}
-
-	pattern := fmt.Sprintf("/%s/d", strings.ReplaceAll(hostsMarker, "/", "\\/"))
-	if err := exec.Command("sudo", "sed", "-i", pattern, hostsFile).Run(); err != nil {
-		fmt.Printf("Warning: failed to clean /etc/hosts: %v\n", err)
-		fmt.Printf("  Remove manually: sudo sed -i '/%s/d' %s\n", hostsMarker, hostsFile)
-		return
-	}
-	fmt.Println("Removed /etc/hosts entries for obol.stack")
-}
-
-// hostsEntryExists checks if a specific hostname is in /etc/hosts with our marker.
-func hostsEntryExists(hostname string) bool {
-	f, err := os.Open(hostsFile)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, hostname) && strings.Contains(line, hostsMarker) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -13,10 +13,6 @@ func TestConstants(t *testing.T) {
 	if domain != "obol.stack" {
 		t.Errorf("domain = %q, want %q", domain, "obol.stack")
 	}
-	if hostsMarker != "# obol-stack-managed" {
-		t.Errorf("hostsMarker = %q, want %q", hostsMarker, "# obol-stack-managed")
-	}
-
 	// macOS constants
 	if macHostPort != "5553" {
 		t.Errorf("macHostPort = %q, want %q", macHostPort, "5553")
@@ -52,9 +48,3 @@ func TestHasNMDnsmasqConfig(t *testing.T) {
 	}
 }
 
-func TestHostsEntryExists(t *testing.T) {
-	// Test with a hostname that shouldn't exist in /etc/hosts with our marker
-	if hostsEntryExists("nonexistent-test-host-12345.obol.stack") {
-		t.Error("hostsEntryExists returned true for nonexistent host")
-	}
-}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
-	"github.com/ObolNetwork/obol-stack/internal/dns"
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -274,9 +273,6 @@ func doSync(cfg *config.Config, id string) error {
 	}
 
 	hostname := fmt.Sprintf("openclaw-%s.%s", id, defaultDomain)
-
-	// Ensure /etc/hosts entry exists (no-op if NM dnsmasq handles wildcard)
-	dns.AddHostEntry(fmt.Sprintf("openclaw-%s", id)) //nolint:errcheck
 
 	fmt.Printf("\n✓ OpenClaw installed successfully!\n")
 	fmt.Printf("  Namespace: %s\n", namespace)
@@ -857,9 +853,6 @@ func Delete(cfg *config.Config, id string, force bool) error {
 			os.Remove(parentDir)
 		}
 	}
-
-	// Remove /etc/hosts entry (no-op if NM dnsmasq handles wildcard)
-	dns.RemoveHostEntry(fmt.Sprintf("openclaw-%s", id))
 
 	fmt.Printf("\n✓ OpenClaw %s deleted successfully!\n", id)
 	return nil


### PR DESCRIPTION
## Summary

Replaces the complex DNS resolver stack (Docker dnsmasq + NM bridge + veth slave + systemd-resolved drop-in) with a simpler tiered approach:

- **Tier 1 (Linux + NetworkManager)**: Uses NM's built-in `dns=dnsmasq` plugin with two config files. No Docker container, no bridge, no veth, no resolved drop-in, no DNSOverTLS changes.
- **Tier 2 (Linux without NM)**: Managed `/etc/hosts` entries per deployment. No wildcard but entries added/removed programmatically.
- **Tier 3 (macOS)**: Unchanged — `/etc/resolver/obol.stack`.

### Problems with the old approach
- Global `DNSOverTLS=opportunistic` downgrade affecting ALL system DNS
- Failed on Ubuntu 20.04 (`nmcli type veth` requires NM >= 1.30)
- Failed on Ubuntu Server (no NetworkManager)
- Failed on Debian, openSUSE, RHEL (no systemd-resolved by default)
- `apk add` on every container restart (DNS breaks if Alpine CDN unreachable)
- Bridge + veth + resolved drop-in = 3 NM connections + 1 system file for a DNS entry

### Compatibility improvement

| Distro | Before | After |
|--------|--------|-------|
| Ubuntu 22.04+ Desktop | Works | Works (Tier 1) |
| Ubuntu 20.04 Desktop | **Broken** | Works (Tier 1) |
| Ubuntu Server | **Broken** | Works (Tier 2) |
| Fedora 33+ | Works | Works (Tier 1) |
| Debian 12 Desktop | **Broken** | Works (Tier 1) |
| RHEL 9 | **Broken** | Works (Tier 1) |
| Arch (NM) | Works | Works (Tier 1) |
| Any Linux (no NM) | **Broken** | Works (Tier 2) |

Fixes #187

## Test plan

- [ ] Clean system: `obol stack up` creates NM dnsmasq config, `*.obol.stack` resolves
- [ ] `obol stack purge` removes NM config files
- [ ] System without NM: falls back to `/etc/hosts` entries
- [ ] macOS: unchanged behavior with `/etc/resolver/obol.stack`
- [ ] Idempotent: re-running `stack up` is a no-op
- [ ] OpenClaw sync adds `/etc/hosts` entry (Tier 2 only)
- [ ] OpenClaw delete removes `/etc/hosts` entry (Tier 2 only)
- [ ] No DNSOverTLS changes to system DNS config