### PR TITLE
fix: prevent k3d and k3s backends running side by side

### DIFF
--- a/cmd/obol/bootstrap.go
+++ b/cmd/obol/bootstrap.go
@@ -26,8 +26,11 @@ func bootstrapCommand(cfg *config.Config) *cli.Command {
 			fmt.Println("Starting bootstrap process...")
 
 			// Step 1: Initialize stack
+			// Respect an existing backend choice (e.g., k3s) so bootstrap
+			// doesn't silently switch back to k3d.
+			backendName := stack.DetectExistingBackend(cfg)
 			fmt.Println("Initializing stack configuration...")
-			if err := stack.Init(cfg, false, ""); err != nil {
+			if err := stack.Init(cfg, false, backendName); err != nil {
 				// Check if it's an "already exists" error - that's okay
 				if !strings.Contains(err.Error(), "already exists") {
 					return fmt.Errorf("bootstrap init failed: %w", err)

--- a/internal/stack/backend.go
+++ b/internal/stack/backend.go
@@ -75,3 +75,20 @@ func SaveBackend(cfg *config.Config, name string) error {
 	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
 	return os.WriteFile(path, []byte(name), 0644)
 }
+
+// DetectExistingBackend reads the persisted backend choice without
+// falling back to a default. Returns empty string if no backend file exists,
+// which lets Init() apply its own default.
+func DetectExistingBackend(cfg *config.Config) string {
+	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	name := strings.TrimSpace(string(data))
+	// Validate it's a known backend; return empty if corrupted
+	if _, err := NewBackend(name); err != nil {
+		return ""
+	}
+	return name
+}

--- a/internal/stack/backend_test.go
+++ b/internal/stack/backend_test.go
@@ -281,6 +281,111 @@ func TestK3sBackendInit(t *testing.T) {
 	}
 }
 
+func TestDetectExistingBackend(t *testing.T) {
+	t.Run("returns saved backend name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		if err := SaveBackend(cfg, "k3s"); err != nil {
+			t.Fatalf("SaveBackend() error: %v", err)
+		}
+		got := DetectExistingBackend(cfg)
+		if got != "k3s" {
+			t.Errorf("DetectExistingBackend() = %q, want %q", got, "k3s")
+		}
+	})
+
+	t.Run("returns empty when no file exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		got := DetectExistingBackend(cfg)
+		if got != "" {
+			t.Errorf("DetectExistingBackend() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns empty for corrupted file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		path := filepath.Join(tmpDir, stackBackendFile)
+		os.WriteFile(path, []byte("docker-swarm"), 0644)
+
+		got := DetectExistingBackend(cfg)
+		if got != "" {
+			t.Errorf("DetectExistingBackend() = %q, want empty string for invalid backend", got)
+		}
+	})
+}
+
+func TestCleanupStaleBackendConfigs(t *testing.T) {
+	t.Run("cleans k3d files when switching from k3d", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		// Create k3d config file
+		k3dPath := filepath.Join(tmpDir, k3dConfigFile)
+		os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+
+		cleanupStaleBackendConfigs(cfg, BackendK3d)
+
+		if _, err := os.Stat(k3dPath); !os.IsNotExist(err) {
+			t.Error("k3d.yaml should be removed after cleanup")
+		}
+	})
+
+	t.Run("cleans k3s files when switching from k3s", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		// Create k3s files
+		for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
+			os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0644)
+		}
+
+		cleanupStaleBackendConfigs(cfg, BackendK3s)
+
+		for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
+			if _, err := os.Stat(filepath.Join(tmpDir, f)); !os.IsNotExist(err) {
+				t.Errorf("%s should be removed after cleanup", f)
+			}
+		}
+	})
+
+	t.Run("no-op for same backend", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.Config{ConfigDir: tmpDir}
+
+		// Create k3s config but clean up k3d (should not touch k3s files)
+		k3sPath := filepath.Join(tmpDir, k3sConfigFile)
+		os.WriteFile(k3sPath, []byte("k3s config"), 0644)
+
+		cleanupStaleBackendConfigs(cfg, BackendK3d)
+
+		if _, err := os.Stat(k3sPath); os.IsNotExist(err) {
+			t.Error("k3s-config.yaml should NOT be removed when cleaning k3d")
+		}
+	})
+}
+
+func TestOllamaHostForBackend(t *testing.T) {
+	t.Run("k3s returns localhost", func(t *testing.T) {
+		got := ollamaHostForBackend(BackendK3s)
+		if got != "127.0.0.1" {
+			t.Errorf("ollamaHostForBackend(k3s) = %q, want %q", got, "127.0.0.1")
+		}
+	})
+
+	t.Run("k3d returns docker host", func(t *testing.T) {
+		got := ollamaHostForBackend(BackendK3d)
+		// On macOS: host.docker.internal, on Linux: host.k3d.internal
+		if got != "host.docker.internal" && got != "host.k3d.internal" {
+			t.Errorf("ollamaHostForBackend(k3d) = %q, want docker host", got)
+		}
+	})
+}
+
 func TestGetStackID(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -63,6 +63,13 @@ func Init(cfg *config.Config, force bool, backendName string) error {
 		backendName = BackendK3d
 	}
 
+	// If switching backends, destroy the old one first to prevent
+	// orphaned clusters (e.g., k3d containers still running after
+	// switching to k3s, or k3s process still alive after switching to k3d).
+	if hasExistingConfig && force {
+		destroyOldBackendIfSwitching(cfg, backendName, stackID)
+	}
+
 	backend, err := NewBackend(backendName)
 	if err != nil {
 		return err
@@ -83,13 +90,10 @@ func Init(cfg *config.Config, force bool, backendName string) error {
 	}
 
 	// Copy embedded defaults (helmfile + charts for infrastructure)
-	// Resolve placeholders: {{OLLAMA_HOST}} → host DNS for the cluster runtime.
-	// On macOS (Docker Desktop), host.docker.internal resolves to the host.
-	// On Linux (native Docker), host.k3d.internal is added by k3d.
-	ollamaHost := "host.k3d.internal"
-	if runtime.GOOS == "darwin" {
-		ollamaHost = "host.docker.internal"
-	}
+	// Resolve {{OLLAMA_HOST}} based on backend:
+	// - k3d (Docker): host.docker.internal (macOS) or host.k3d.internal (Linux)
+	// - k3s (bare-metal): 127.0.0.1 (k3s runs directly on the host)
+	ollamaHost := ollamaHostForBackend(backendName)
 	defaultsDir := filepath.Join(cfg.ConfigDir, "defaults")
 	if err := embed.CopyDefaults(defaultsDir, map[string]string{
 		"{{OLLAMA_HOST}}": ollamaHost,
@@ -111,6 +115,62 @@ func Init(cfg *config.Config, force bool, backendName string) error {
 	fmt.Printf("Initialized stack configuration\n")
 	fmt.Printf("Stack ID: %s\n", stackID)
 	return nil
+}
+
+// destroyOldBackendIfSwitching checks if the backend is changing and tears down
+// the old one to prevent orphaned clusters running side by side.
+func destroyOldBackendIfSwitching(cfg *config.Config, newBackend, stackID string) {
+	oldBackend, err := LoadBackend(cfg)
+	if err != nil {
+		return
+	}
+	if oldBackend.Name() == newBackend {
+		return // same backend, nothing to clean up
+	}
+
+	fmt.Printf("Switching backend from %s to %s — destroying old cluster\n", oldBackend.Name(), newBackend)
+
+	// Destroy the old backend's cluster (best-effort, don't block init)
+	if stackID != "" {
+		if err := oldBackend.Destroy(cfg, stackID); err != nil {
+			fmt.Printf("Warning: failed to destroy old %s cluster: %v\n", oldBackend.Name(), err)
+		}
+	}
+
+	// Clean up stale config files from the old backend
+	cleanupStaleBackendConfigs(cfg, oldBackend.Name())
+}
+
+// cleanupStaleBackendConfigs removes config files belonging to the old backend
+// that would otherwise linger and confuse detection.
+func cleanupStaleBackendConfigs(cfg *config.Config, oldBackend string) {
+	var staleFiles []string
+	switch oldBackend {
+	case BackendK3d:
+		staleFiles = []string{k3dConfigFile}
+	case BackendK3s:
+		staleFiles = []string{k3sConfigFile, k3sPidFile, k3sLogFile}
+	}
+	for _, f := range staleFiles {
+		path := filepath.Join(cfg.ConfigDir, f)
+		if _, err := os.Stat(path); err == nil {
+			os.Remove(path)
+		}
+	}
+}
+
+// ollamaHostForBackend returns the hostname/IP that reaches the host Ollama
+// instance from inside the cluster.
+func ollamaHostForBackend(backendName string) string {
+	if backendName == BackendK3s {
+		// k3s runs directly on the host — Ollama is at localhost
+		return "127.0.0.1"
+	}
+	// k3d runs inside Docker containers
+	if runtime.GOOS == "darwin" {
+		return "host.docker.internal"
+	}
+	return "host.k3d.internal"
 }
 
 // Up starts the cluster using the configured backend

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -3,8 +3,12 @@ package stack
 import (
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
 )
 
 func TestCheckPortsAvailable_FreePorts(t *testing.T) {
@@ -89,4 +93,85 @@ func TestFormatPorts(t *testing.T) {
 			t.Errorf("formatPorts(%v) = %q, want %q", tt.ports, got, tt.expected)
 		}
 	}
+}
+
+func TestDestroyOldBackendIfSwitching_CleansStaleConfigs(t *testing.T) {
+	// Simulate a k3d → k3s switch: k3d.yaml should be cleaned up
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		ConfigDir: tmpDir,
+		DataDir:   filepath.Join(tmpDir, "data"),
+		BinDir:    filepath.Join(tmpDir, "bin"),
+	}
+
+	// Write k3d as the current backend + its config file
+	SaveBackend(cfg, BackendK3d)
+	k3dPath := filepath.Join(tmpDir, k3dConfigFile)
+	os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+
+	// Switch to k3s — k3d config should be cleaned up
+	// (Destroy will fail because no real cluster, but cleanup should still work)
+	destroyOldBackendIfSwitching(cfg, BackendK3s, "test-id")
+
+	if _, err := os.Stat(k3dPath); !os.IsNotExist(err) {
+		t.Error("k3d.yaml should be removed when switching to k3s")
+	}
+}
+
+func TestDestroyOldBackendIfSwitching_NoopSameBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		ConfigDir: tmpDir,
+		DataDir:   filepath.Join(tmpDir, "data"),
+		BinDir:    filepath.Join(tmpDir, "bin"),
+	}
+
+	SaveBackend(cfg, BackendK3d)
+	k3dPath := filepath.Join(tmpDir, k3dConfigFile)
+	os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+
+	// Same backend — nothing should be cleaned up
+	destroyOldBackendIfSwitching(cfg, BackendK3d, "test-id")
+
+	if _, err := os.Stat(k3dPath); os.IsNotExist(err) {
+		t.Error("k3d.yaml should NOT be removed when re-initing same backend")
+	}
+}
+
+func TestDestroyOldBackendIfSwitching_K3sToK3d(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		ConfigDir: tmpDir,
+		DataDir:   filepath.Join(tmpDir, "data"),
+		BinDir:    filepath.Join(tmpDir, "bin"),
+	}
+
+	SaveBackend(cfg, BackendK3s)
+	// Create k3s state files
+	for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
+		os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0644)
+	}
+
+	// Switch to k3d — k3s files should be cleaned up
+	destroyOldBackendIfSwitching(cfg, BackendK3d, "test-id")
+
+	for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed when switching from k3s to k3d", f)
+		}
+	}
+}
+
+func TestDestroyOldBackendIfSwitching_NoBackendFile(t *testing.T) {
+	// No .stack-backend file — LoadBackend defaults to k3d.
+	// Switching to k3d should be a no-op (same backend).
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		ConfigDir: tmpDir,
+		DataDir:   filepath.Join(tmpDir, "data"),
+		BinDir:    filepath.Join(tmpDir, "bin"),
+	}
+
+	// Should not panic or error
+	destroyOldBackendIfSwitching(cfg, BackendK3d, "test-id")
 }

--- a/obolup.sh
+++ b/obolup.sh
@@ -1090,7 +1090,11 @@ install_dependencies() {
 	# Install each dependency
 	install_kubectl || log_warn "kubectl installation failed (continuing...)"
 	install_helm || log_warn "helm installation failed (continuing...)"
-	install_k3d || log_warn "k3d installation failed (continuing...)"
+	if [[ "${OBOL_BACKEND:-k3d}" != "k3s" ]]; then
+		install_k3d || log_warn "k3d installation failed (continuing...)"
+	else
+		log_info "Skipping k3d (using k3s backend)"
+	fi
 	install_helmfile || log_warn "helmfile installation failed (continuing...)"
 	install_k9s || log_warn "k9s installation failed (continuing...)"
 	install_helm_diff || log_warn "helm-diff plugin installation failed (continuing...)"
@@ -1446,10 +1450,17 @@ main() {
 		log_info "Fresh installation starting..."
 	fi
 
-	# Check Docker prerequisites first
-	if ! check_docker; then
-		log_error "Docker requirements not met"
-		exit 1
+	# Check Docker prerequisites (only required for k3d backend, not k3s)
+	if [[ "${OBOL_BACKEND:-k3d}" != "k3s" ]]; then
+		if ! check_docker; then
+			log_error "Docker requirements not met"
+			echo ""
+			echo "If you want to use the k3s backend (no Docker required), run:"
+			echo "  OBOL_BACKEND=k3s $0"
+			exit 1
+		fi
+	else
+		log_info "Backend: k3s (Docker not required)"
 	fi
 	echo ""
 


### PR DESCRIPTION
## Summary

- **Backend switch cleanup**: `Init(--force)` now detects when the backend is changing (e.g., k3d → k3s) and destroys the old cluster + removes stale config files before proceeding. Prevents orphaned clusters running simultaneously.
- **Bootstrap respects existing backend**: `obol bootstrap` reads `.stack-backend` instead of always defaulting to k3d, so it won't silently switch backends on re-run.
- **Backend-aware Ollama host**: k3s uses `127.0.0.1` (bare-metal), k3d uses Docker-internal hostnames. Previously hardcoded for k3d only.
- **obolup.sh conditional Docker check**: `OBOL_BACKEND=k3s` skips Docker requirement and k3d installation.

## Test plan
- [x] `TestDetectExistingBackend` — returns saved backend, empty for missing/corrupted file
- [x] `TestCleanupStaleBackendConfigs` — removes k3d/k3s files on switch, no-op for same backend
- [x] `TestOllamaHostForBackend` — 127.0.0.1 for k3s, Docker host for k3d
- [x] `TestDestroyOldBackendIfSwitching_CleansStaleConfigs` — k3d→k3s cleans k3d.yaml
- [x] `TestDestroyOldBackendIfSwitching_NoopSameBackend` — same backend preserves files
- [x] `TestDestroyOldBackendIfSwitching_K3sToK3d` — k3s→k3d cleans k3s files
- [x] `TestDestroyOldBackendIfSwitching_NoBackendFile` — no panic on missing file
- [x] Full `go test ./...` passes