### PR TITLE
Dynamic provider discovery from llmspy pod

### DIFF
--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -23,7 +23,7 @@ func modelCommand(cfg *config.Config) *cli.Command {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "provider",
-						Usage: "Provider name (anthropic, openai)",
+						Usage: "Provider name (e.g. anthropic, openai, zai, deepseek)",
 					},
 					&cli.StringFlag{
 						Name:    "api-key",
@@ -38,7 +38,7 @@ func modelCommand(cfg *config.Config) *cli.Command {
 					// Interactive mode if flags not provided
 					if provider == "" || apiKey == "" {
 						var err error
-						provider, apiKey, err = promptModelConfig()
+						provider, apiKey, err = promptModelConfig(cfg)
 						if err != nil {
 							return err
 						}
@@ -64,7 +64,7 @@ func modelCommand(cfg *config.Config) *cli.Command {
 
 					fmt.Println("Global llmspy providers:")
 					fmt.Println()
-					fmt.Printf("  %-12s %-8s %-10s %s\n", "PROVIDER", "ENABLED", "API KEY", "ENV VAR")
+					fmt.Printf("  %-20s %-8s %-10s %s\n", "PROVIDER", "ENABLED", "API KEY", "ENV VAR")
 					for _, name := range providers {
 						s := status[name]
 						key := "n/a"
@@ -75,8 +75,12 @@ func modelCommand(cfg *config.Config) *cli.Command {
 								key = "missing"
 							}
 						}
-						fmt.Printf("  %-12s %-8t %-10s %s\n", name, s.Enabled, key, s.EnvVar)
+						fmt.Printf("  %-20s %-8t %-10s %s\n", name, s.Enabled, key, s.EnvVar)
 					}
+
+					// Show hint about available providers
+					fmt.Println()
+					fmt.Println("Run 'obol model setup' to configure a provider.")
 					return nil
 				},
 			},
@@ -85,13 +89,23 @@ func modelCommand(cfg *config.Config) *cli.Command {
 }
 
 // promptModelConfig interactively asks the user for provider and API key.
-func promptModelConfig() (string, string, error) {
+// It queries the running llmspy pod for available providers.
+func promptModelConfig(cfg *config.Config) (string, string, error) {
+	providers, err := model.GetAvailableProviders(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to discover providers: %w", err)
+	}
+	if len(providers) == 0 {
+		return "", "", fmt.Errorf("no cloud providers found in llmspy")
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Println("Select a provider:")
-	fmt.Println("  [1] Anthropic")
-	fmt.Println("  [2] OpenAI")
-	fmt.Print("\nChoice [1]: ")
+	fmt.Println("Available providers:")
+	for i, p := range providers {
+		fmt.Printf("  [%d] %s (%s)\n", i+1, p.Name, p.ID)
+	}
+	fmt.Printf("\nChoice [1]: ")
 
 	line, _ := reader.ReadString('\n')
 	choice := strings.TrimSpace(line)
@@ -99,24 +113,18 @@ func promptModelConfig() (string, string, error) {
 		choice = "1"
 	}
 
-	var provider, display string
-	switch choice {
-	case "1":
-		provider = "anthropic"
-		display = "Anthropic"
-	case "2":
-		provider = "openai"
-		display = "OpenAI"
-	default:
-		return "", "", fmt.Errorf("unknown choice: %s", choice)
+	idx := 0
+	if _, err := fmt.Sscanf(choice, "%d", &idx); err != nil || idx < 1 || idx > len(providers) {
+		return "", "", fmt.Errorf("invalid choice: %s", choice)
 	}
+	selected := providers[idx-1]
 
-	fmt.Printf("\n%s API key: ", display)
+	fmt.Printf("\n%s API key (%s): ", selected.Name, selected.EnvVar)
 	apiKey, _ := reader.ReadString('\n')
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return "", "", fmt.Errorf("API key is required")
 	}
 
-	return provider, apiKey, nil
+	return selected.ID, apiKey, nil
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -103,6 +103,11 @@ if p and p.get('env'):
 	if err != nil {
 		return "", fmt.Errorf("failed to query llmspy for provider %q: %w", provider, err)
 	}
+	return parseProviderEnvKey(provider, output)
+}
+
+// parseProviderEnvKey extracts an env var name from kubectl exec output.
+func parseProviderEnvKey(provider, output string) (string, error) {
 	envKey := strings.TrimSpace(output)
 	if envKey == "" {
 		return "", fmt.Errorf("unknown provider %q — run 'obol model status' to see available providers", provider)
@@ -134,8 +139,17 @@ for pid in sorted(d):
 		return nil, fmt.Errorf("failed to query llmspy providers: %w", err)
 	}
 
+	return parseAvailableProviders(output), nil
+}
+
+// parseAvailableProviders parses tab-separated kubectl exec output into ProviderInfo slices.
+func parseAvailableProviders(output string) []ProviderInfo {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
 	var providers []ProviderInfo
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+	for _, line := range strings.Split(trimmed, "\n") {
 		parts := strings.SplitN(line, "\t", 3)
 		if len(parts) != 3 {
 			continue
@@ -146,7 +160,7 @@ for pid in sorted(d):
 			EnvVar: parts[2],
 		})
 	}
-	return providers, nil
+	return providers
 }
 
 // GetProviderStatus reads llmspy state and returns global provider status.
@@ -164,10 +178,6 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	envKeyByProvider := make(map[string]string)
-	for _, p := range available {
-		envKeyByProvider[p.ID] = p.EnvVar
-	}
 
 	// Read enabled/disabled state from ConfigMap
 	llmsRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
@@ -175,8 +185,29 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Read Secret to check which API keys are set
+	secretRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+		"get", "secret", secretName, "-n", namespace, "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	return buildProviderStatus(available, []byte(llmsRaw), []byte(secretRaw))
+}
+
+// buildProviderStatus is the pure logic for building provider status from raw data.
+// available: providers discovered from the llmspy pod
+// llmsJSON: the llms.json content from the ConfigMap
+// secretJSON: the full Secret JSON (with base64-encoded .data)
+func buildProviderStatus(available []ProviderInfo, llmsJSON, secretJSON []byte) (map[string]ProviderStatus, error) {
+	envKeyByProvider := make(map[string]string)
+	for _, p := range available {
+		envKeyByProvider[p.ID] = p.EnvVar
+	}
+
 	var llmsConfig map[string]interface{}
-	if err := json.Unmarshal([]byte(llmsRaw), &llmsConfig); err != nil {
+	if err := json.Unmarshal(llmsJSON, &llmsConfig); err != nil {
 		return nil, fmt.Errorf("failed to parse llms.json from ConfigMap: %w", err)
 	}
 
@@ -199,16 +230,11 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 		}
 	}
 
-	// Read Secret to check which API keys are set
-	secretRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
-		"get", "secret", secretName, "-n", namespace, "-o", "json")
-	if err != nil {
-		return nil, err
-	}
+	// Parse Secret
 	var secret struct {
 		Data map[string]string `json:"data"`
 	}
-	if err := json.Unmarshal([]byte(secretRaw), &secret); err != nil {
+	if err := json.Unmarshal(secretJSON, &secret); err != nil {
 		return nil, fmt.Errorf("failed to parse llms secret: %w", err)
 	}
 
@@ -241,45 +267,18 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 // sets providers.<name>.enabled = true, and patches the ConfigMap back.
 func enableProviderInConfigMap(kubectlBinary, kubeconfigPath, provider string) error {
 	// Read current llms.json from ConfigMap
-	var stdout bytes.Buffer
-	cmd := exec.Command(kubectlBinary, "get", "configmap", configMapName,
-		"-n", namespace, "-o", "jsonpath={.data.llms\\.json}")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	cmd.Stdout = &stdout
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to read ConfigMap: %w\n%s", err, stderr.String())
-	}
-
-	// Parse JSON
-	var llmsConfig map[string]interface{}
-	if err := json.Unmarshal(stdout.Bytes(), &llmsConfig); err != nil {
-		return fmt.Errorf("failed to parse llms.json: %w", err)
-	}
-
-	// Set providers.<name>.enabled = true
-	providers, ok := llmsConfig["providers"].(map[string]interface{})
-	if !ok {
-		providers = make(map[string]interface{})
-		llmsConfig["providers"] = providers
-	}
-
-	providerCfg, ok := providers[provider].(map[string]interface{})
-	if !ok {
-		providerCfg = make(map[string]interface{})
-		providers[provider] = providerCfg
-	}
-	providerCfg["enabled"] = true
-
-	// Marshal back to JSON
-	updated, err := json.Marshal(llmsConfig)
+	raw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.llms\\.json}")
 	if err != nil {
-		return fmt.Errorf("failed to marshal llms.json: %w", err)
+		return fmt.Errorf("failed to read ConfigMap: %w", err)
 	}
 
-	// Patch ConfigMap
-	// Use strategic merge patch with the new llms.json
+	updated, err := patchLLMsJSON([]byte(raw), provider)
+	if err != nil {
+		return err
+	}
+
+	// Build ConfigMap patch
 	patchData := map[string]interface{}{
 		"data": map[string]string{
 			"llms.json": string(updated),
@@ -293,6 +292,30 @@ func enableProviderInConfigMap(kubectlBinary, kubeconfigPath, provider string) e
 	return kubectl(kubectlBinary, kubeconfigPath,
 		"patch", "configmap", configMapName, "-n", namespace,
 		"-p", string(patchJSON), "--type=merge")
+}
+
+// patchLLMsJSON takes raw llms.json content and returns updated JSON
+// with providers.<name>.enabled = true.
+func patchLLMsJSON(llmsJSON []byte, provider string) ([]byte, error) {
+	var llmsConfig map[string]interface{}
+	if err := json.Unmarshal(llmsJSON, &llmsConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse llms.json: %w", err)
+	}
+
+	providers, ok := llmsConfig["providers"].(map[string]interface{})
+	if !ok {
+		providers = make(map[string]interface{})
+		llmsConfig["providers"] = providers
+	}
+
+	providerCfg, ok := providers[provider].(map[string]interface{})
+	if !ok {
+		providerCfg = make(map[string]interface{})
+		providers[provider] = providerCfg
+	}
+	providerCfg["enabled"] = true
+
+	return json.Marshal(llmsConfig)
 }
 
 // kubectl runs a kubectl command with the given kubeconfig and returns any error.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -19,10 +19,11 @@ const (
 	deployName    = "llmspy"
 )
 
-// providerEnvKeys maps provider names to their Secret key names.
-var providerEnvKeys = map[string]string{
-	"anthropic": "ANTHROPIC_API_KEY",
-	"openai":    "OPENAI_API_KEY",
+// ProviderInfo describes an llmspy provider discovered from the running pod.
+type ProviderInfo struct {
+	ID      string // provider id (e.g. "zai", "anthropic")
+	Name    string // display name (e.g. "Z.AI", "Anthropic")
+	EnvVar  string // env var for API key (e.g. "ZHIPU_API_KEY")
 }
 
 // ProviderStatus captures effective global llmspy provider state.
@@ -33,19 +34,21 @@ type ProviderStatus struct {
 }
 
 // ConfigureLLMSpy enables a cloud provider in the llmspy gateway.
-// It patches the llms-secrets Secret with the API key, enables the provider
+// It discovers the provider's env var from the running llmspy pod,
+// patches the llms-secrets Secret with the API key, enables the provider
 // in the llmspy-config ConfigMap, and restarts the deployment.
 func ConfigureLLMSpy(cfg *config.Config, provider, apiKey string) error {
-	envKey, ok := providerEnvKeys[provider]
-	if !ok {
-		return fmt.Errorf("unsupported llmspy provider: %s (supported: anthropic, openai)", provider)
-	}
-
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	}
+
+	// Discover the env var name from the llmspy pod's providers.json
+	envKey, err := getProviderEnvKey(kubectlBinary, kubeconfigPath, provider)
+	if err != nil {
+		return err
 	}
 
 	// 1. Patch the Secret with the API key
@@ -83,7 +86,72 @@ func ConfigureLLMSpy(cfg *config.Config, provider, apiKey string) error {
 	return nil
 }
 
-// GetProviderStatus reads llmspy ConfigMap + Secret and returns global provider status.
+// getProviderEnvKey queries the llmspy pod for the env var name a provider uses.
+// It reads the merged providers.json inside the pod (package defaults + ConfigMap overrides).
+func getProviderEnvKey(kubectlBinary, kubeconfigPath, provider string) (string, error) {
+	script := fmt.Sprintf(`import json
+with open('/home/llms/.llms/providers.json') as f:
+    d = json.load(f)
+p = d.get('%s')
+if p and p.get('env'):
+    print(p['env'][0])
+`, provider)
+
+	output, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+		"exec", "-n", namespace, fmt.Sprintf("deploy/%s", deployName), "--",
+		"python3", "-c", script)
+	if err != nil {
+		return "", fmt.Errorf("failed to query llmspy for provider %q: %w", provider, err)
+	}
+	envKey := strings.TrimSpace(output)
+	if envKey == "" {
+		return "", fmt.Errorf("unknown provider %q — run 'obol model status' to see available providers", provider)
+	}
+	return envKey, nil
+}
+
+// GetAvailableProviders queries the llmspy pod for all providers that accept an API key.
+func GetAvailableProviders(cfg *config.Config) ([]ProviderInfo, error) {
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	}
+
+	script := `import json
+with open('/home/llms/.llms/providers.json') as f:
+    d = json.load(f)
+for pid in sorted(d):
+    p = d[pid]
+    env = p.get('env', [])
+    if env:
+        print(pid + '\t' + p.get('name', pid) + '\t' + env[0])
+`
+	output, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+		"exec", "-n", namespace, fmt.Sprintf("deploy/%s", deployName), "--",
+		"python3", "-c", script)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query llmspy providers: %w", err)
+	}
+
+	var providers []ProviderInfo
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		providers = append(providers, ProviderInfo{
+			ID:     parts[0],
+			Name:   parts[1],
+			EnvVar: parts[2],
+		})
+	}
+	return providers, nil
+}
+
+// GetProviderStatus reads llmspy state and returns global provider status.
+// It queries the llmspy pod for available providers and cross-references
+// with the ConfigMap (enabled/disabled) and Secret (API keys).
 func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
@@ -91,6 +159,17 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 		return nil, fmt.Errorf("cluster not running. Run 'obol stack up' first")
 	}
 
+	// Get all available providers from llmspy (with env var names)
+	available, err := GetAvailableProviders(cfg)
+	if err != nil {
+		return nil, err
+	}
+	envKeyByProvider := make(map[string]string)
+	for _, p := range available {
+		envKeyByProvider[p.ID] = p.EnvVar
+	}
+
+	// Read enabled/disabled state from ConfigMap
 	llmsRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
 		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.llms\\.json}")
 	if err != nil {
@@ -102,6 +181,8 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	}
 
 	status := make(map[string]ProviderStatus)
+
+	// Seed from ConfigMap providers (shows what's been configured)
 	if providers, ok := llmsConfig["providers"].(map[string]interface{}); ok {
 		for name, raw := range providers {
 			enabled := false
@@ -110,17 +191,15 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 					enabled = v
 				}
 			}
-			keyEnv := providerEnvKeys[name]
 			status[name] = ProviderStatus{
-				Enabled: enabled,
-				// Ollama needs no API key, so it's always considered "has key".
-				// Cloud providers are updated below from the actual K8s Secret.
+				Enabled:   enabled,
 				HasAPIKey: name == "ollama",
-				EnvVar:    keyEnv,
+				EnvVar:    envKeyByProvider[name],
 			}
 		}
 	}
 
+	// Read Secret to check which API keys are set
 	secretRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
 		"get", "secret", secretName, "-n", namespace, "-o", "json")
 	if err != nil {
@@ -133,15 +212,21 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 		return nil, fmt.Errorf("failed to parse llms secret: %w", err)
 	}
 
-	for provider, envKey := range providerEnvKeys {
-		st := status[provider]
-		st.EnvVar = envKey
-		if v, ok := secret.Data[envKey]; ok && strings.TrimSpace(v) != "" {
-			st.HasAPIKey = true
+	// Cross-reference Secret keys with provider env vars
+	secretKeys := make(map[string]bool)
+	for k, v := range secret.Data {
+		if strings.TrimSpace(v) != "" {
+			secretKeys[k] = true
 		}
-		status[provider] = st
+	}
+	for name, st := range status {
+		if st.EnvVar != "" && secretKeys[st.EnvVar] {
+			st.HasAPIKey = true
+			status[name] = st
+		}
 	}
 
+	// Ensure Ollama always shows
 	if _, ok := status["ollama"]; !ok {
 		status["ollama"] = ProviderStatus{
 			Enabled:   true,

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,369 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseProviderEnvKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		output   string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "anthropic",
+			provider: "anthropic",
+			output:   "ANTHROPIC_API_KEY\n",
+			want:     "ANTHROPIC_API_KEY",
+		},
+		{
+			name:     "zai with trailing whitespace",
+			provider: "zai",
+			output:   "  ZHIPU_API_KEY  \n",
+			want:     "ZHIPU_API_KEY",
+		},
+		{
+			name:     "empty output means unknown provider",
+			provider: "nosuchprovider",
+			output:   "",
+			wantErr:  true,
+		},
+		{
+			name:     "whitespace-only output means unknown provider",
+			provider: "nosuchprovider",
+			output:   "  \n  ",
+			wantErr:  true,
+		},
+		{
+			name:     "openai",
+			provider: "openai",
+			output:   "OPENAI_API_KEY",
+			want:     "OPENAI_API_KEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProviderEnvKey(tt.provider, tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAvailableProviders(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []ProviderInfo
+	}{
+		{
+			name:   "empty output",
+			output: "",
+			want:   nil,
+		},
+		{
+			name:   "whitespace only",
+			output: "  \n  ",
+			want:   nil,
+		},
+		{
+			name:   "single provider",
+			output: "anthropic\tAnthropic\tANTHROPIC_API_KEY\n",
+			want: []ProviderInfo{
+				{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+			},
+		},
+		{
+			name: "multiple providers sorted",
+			output: "anthropic\tAnthropic\tANTHROPIC_API_KEY\n" +
+				"openai\tOpenAI\tOPENAI_API_KEY\n" +
+				"zai\tZ.AI\tZHIPU_API_KEY\n",
+			want: []ProviderInfo{
+				{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+				{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY"},
+				{ID: "zai", Name: "Z.AI", EnvVar: "ZHIPU_API_KEY"},
+			},
+		},
+		{
+			name:   "malformed line skipped",
+			output: "badline\n" + "anthropic\tAnthropic\tANTHROPIC_API_KEY\n",
+			want: []ProviderInfo{
+				{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+			},
+		},
+		{
+			name:   "tab in name preserved",
+			output: "deepseek\tDeepSeek\tDEEPSEEK_API_KEY\n",
+			want: []ProviderInfo{
+				{ID: "deepseek", Name: "DeepSeek", EnvVar: "DEEPSEEK_API_KEY"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAvailableProviders(tt.output)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d providers, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("provider[%d]: got %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildProviderStatus(t *testing.T) {
+	t.Run("basic status with cloud provider key set", func(t *testing.T) {
+		available := []ProviderInfo{
+			{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+			{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY"},
+			{ID: "zai", Name: "Z.AI", EnvVar: "ZHIPU_API_KEY"},
+		}
+
+		llmsJSON := []byte(`{
+			"providers": {
+				"ollama": {"enabled": true},
+				"anthropic": {"enabled": true},
+				"openai": {"enabled": false},
+				"zai": {"enabled": true}
+			}
+		}`)
+
+		// Secret .data values are base64 in real k8s, but our code just checks
+		// if the key exists and the value is non-empty (the cross-reference uses
+		// the raw string from the JSON — k8s returns base64 in .data).
+		secretJSON := []byte(`{
+			"data": {
+				"ANTHROPIC_API_KEY": "c2stYW50LXh4eA==",
+				"OPENAI_API_KEY": "",
+				"ZHIPU_API_KEY": "ZWU1NjM5Nzk="
+			}
+		}`)
+
+		status, err := buildProviderStatus(available, llmsJSON, secretJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Ollama: enabled, always has key
+		if s := status["ollama"]; !s.Enabled || !s.HasAPIKey {
+			t.Errorf("ollama: got enabled=%t hasKey=%t, want enabled=true hasKey=true", s.Enabled, s.HasAPIKey)
+		}
+
+		// Anthropic: enabled, key set
+		if s := status["anthropic"]; !s.Enabled || !s.HasAPIKey || s.EnvVar != "ANTHROPIC_API_KEY" {
+			t.Errorf("anthropic: got %+v, want enabled=true hasKey=true envVar=ANTHROPIC_API_KEY", s)
+		}
+
+		// OpenAI: disabled, key empty
+		if s := status["openai"]; s.Enabled || s.HasAPIKey || s.EnvVar != "OPENAI_API_KEY" {
+			t.Errorf("openai: got %+v, want enabled=false hasKey=false envVar=OPENAI_API_KEY", s)
+		}
+
+		// Z.AI: enabled, key set
+		if s := status["zai"]; !s.Enabled || !s.HasAPIKey || s.EnvVar != "ZHIPU_API_KEY" {
+			t.Errorf("zai: got %+v, want enabled=true hasKey=true envVar=ZHIPU_API_KEY", s)
+		}
+	})
+
+	t.Run("ollama injected when missing from configmap", func(t *testing.T) {
+		available := []ProviderInfo{
+			{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+		}
+		llmsJSON := []byte(`{"providers":{"anthropic":{"enabled":false}}}`)
+		secretJSON := []byte(`{"data":{}}`)
+
+		status, err := buildProviderStatus(available, llmsJSON, secretJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s, ok := status["ollama"]; !ok || !s.Enabled || !s.HasAPIKey {
+			t.Errorf("ollama should be injected as enabled with key; got %+v, ok=%t", s, ok)
+		}
+	})
+
+	t.Run("provider in configmap but not in available list gets no env var", func(t *testing.T) {
+		available := []ProviderInfo{} // no providers discovered
+		llmsJSON := []byte(`{"providers":{"mystery":{"enabled":true}}}`)
+		secretJSON := []byte(`{"data":{}}`)
+
+		status, err := buildProviderStatus(available, llmsJSON, secretJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s := status["mystery"]; !s.Enabled || s.EnvVar != "" {
+			t.Errorf("mystery: got %+v, want enabled=true envVar=''", s)
+		}
+	})
+
+	t.Run("empty providers section", func(t *testing.T) {
+		llmsJSON := []byte(`{}`)
+		secretJSON := []byte(`{"data":{}}`)
+
+		status, err := buildProviderStatus(nil, llmsJSON, secretJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Only ollama (injected)
+		if len(status) != 1 {
+			t.Errorf("expected 1 provider (ollama), got %d", len(status))
+		}
+	})
+
+	t.Run("invalid llms json", func(t *testing.T) {
+		_, err := buildProviderStatus(nil, []byte(`not json`), []byte(`{"data":{}}`))
+		if err == nil {
+			t.Fatal("expected error for invalid llms.json")
+		}
+	})
+
+	t.Run("invalid secret json", func(t *testing.T) {
+		_, err := buildProviderStatus(nil, []byte(`{}`), []byte(`not json`))
+		if err == nil {
+			t.Fatal("expected error for invalid secret JSON")
+		}
+	})
+}
+
+func TestPatchLLMsJSON(t *testing.T) {
+	t.Run("enable existing disabled provider", func(t *testing.T) {
+		input := []byte(`{"providers":{"anthropic":{"enabled":false},"ollama":{"enabled":true}}}`)
+
+		got, err := patchLLMsJSON(input, "anthropic")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(got, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		providers := result["providers"].(map[string]interface{})
+		anthropic := providers["anthropic"].(map[string]interface{})
+		if anthropic["enabled"] != true {
+			t.Errorf("anthropic.enabled = %v, want true", anthropic["enabled"])
+		}
+
+		// Ollama should be untouched
+		ollama := providers["ollama"].(map[string]interface{})
+		if ollama["enabled"] != true {
+			t.Errorf("ollama.enabled = %v, want true (untouched)", ollama["enabled"])
+		}
+	})
+
+	t.Run("enable new provider not in config", func(t *testing.T) {
+		input := []byte(`{"providers":{"ollama":{"enabled":true}}}`)
+
+		got, err := patchLLMsJSON(input, "zai")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(got, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		providers := result["providers"].(map[string]interface{})
+		zai := providers["zai"].(map[string]interface{})
+		if zai["enabled"] != true {
+			t.Errorf("zai.enabled = %v, want true", zai["enabled"])
+		}
+	})
+
+	t.Run("create providers section if missing", func(t *testing.T) {
+		input := []byte(`{"version":"1.0"}`)
+
+		got, err := patchLLMsJSON(input, "deepseek")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(got, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		// version preserved
+		if result["version"] != "1.0" {
+			t.Errorf("version lost: got %v", result["version"])
+		}
+
+		providers := result["providers"].(map[string]interface{})
+		ds := providers["deepseek"].(map[string]interface{})
+		if ds["enabled"] != true {
+			t.Errorf("deepseek.enabled = %v, want true", ds["enabled"])
+		}
+	})
+
+	t.Run("preserves other provider fields", func(t *testing.T) {
+		input := []byte(`{"providers":{"anthropic":{"enabled":false,"customField":"keep"}}}`)
+
+		got, err := patchLLMsJSON(input, "anthropic")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(got, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		providers := result["providers"].(map[string]interface{})
+		anthropic := providers["anthropic"].(map[string]interface{})
+		if anthropic["enabled"] != true {
+			t.Errorf("enabled = %v, want true", anthropic["enabled"])
+		}
+		if anthropic["customField"] != "keep" {
+			t.Errorf("customField = %v, want 'keep'", anthropic["customField"])
+		}
+	})
+
+	t.Run("invalid json input", func(t *testing.T) {
+		_, err := patchLLMsJSON([]byte(`{bad`), "anthropic")
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("idempotent enable", func(t *testing.T) {
+		input := []byte(`{"providers":{"anthropic":{"enabled":true}}}`)
+
+		got, err := patchLLMsJSON(input, "anthropic")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(got, &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		providers := result["providers"].(map[string]interface{})
+		anthropic := providers["anthropic"].(map[string]interface{})
+		if anthropic["enabled"] != true {
+			t.Errorf("enabled = %v, want true", anthropic["enabled"])
+		}
+	})
+}

--- a/internal/openclaw/integration_test.go
+++ b/internal/openclaw/integration_test.go
@@ -485,6 +485,46 @@ func TestIntegration_OpenAIInference(t *testing.T) {
 	t.Logf("OpenAI response: %s", reply)
 }
 
+func TestIntegration_ZaiInference(t *testing.T) {
+	cfg := requireCluster(t)
+	apiKey := requireEnvKey(t, "ZHIPU_API_KEY")
+
+	const id = "test-zai"
+	t.Cleanup(func() { cleanupInstance(t, cfg, id) })
+
+	// Configure llmspy gateway via obol model setup — this provider was NOT in
+	// the old hardcoded map, so it only works with dynamic provider discovery.
+	t.Log("configuring llmspy via: obol model setup --provider zai")
+	obolRun(t, cfg, "model", "setup", "--provider", "zai", "--api-key", apiKey)
+
+	cloud := &CloudProviderInfo{
+		Name:    "zai",
+		APIKey:  apiKey,
+		ModelID: "glm-4-flash",
+		Display: "GLM-4 Flash",
+	}
+
+	// Scaffold cloud overlay + deploy via obol openclaw sync
+	t.Logf("scaffolding OpenClaw instance %q with Z.AI via llmspy", id)
+	scaffoldCloudInstance(t, cfg, id, cloud)
+
+	t.Log("deploying via: obol openclaw sync " + id)
+	obolRun(t, cfg, "openclaw", "sync", id)
+
+	namespace := fmt.Sprintf("%s-%s", appName, id)
+	waitForPodReady(t, cfg, namespace)
+
+	token := getGatewayToken(t, cfg, id)
+	t.Logf("retrieved gateway token (%d chars)", len(token))
+
+	baseURL := portForward(t, cfg, namespace)
+	agentModel := "ollama/glm-4-flash" // routed through llmspy
+	t.Logf("testing inference with model %s at %s", agentModel, baseURL)
+
+	reply := chatCompletion(t, baseURL, agentModel, token)
+	t.Logf("Z.AI response: %s", reply)
+}
+
 func TestIntegration_MultiInstance(t *testing.T) {
 	cfg := requireCluster(t)
 	models := requireOllama(t)


### PR DESCRIPTION
## Summary

Remove the hardcoded `providerEnvKeys` map (anthropic/openai only) and instead query the running llmspy pod at runtime for provider metadata. This means **any provider llmspy supports** (zai, deepseek, google, mistral, groq, etc.) works with `obol model setup` without code changes.

### Before

```go
var providerEnvKeys = map[string]string{
    "anthropic": "ANTHROPIC_API_KEY",
    "openai":    "OPENAI_API_KEY",
}
```

Adding a new provider required editing Go code, rebuilding, and releasing.

### After

Provider info is discovered dynamically by executing a Python script inside the llmspy pod that reads `providers.json` — the same file llmspy itself uses. The CLI becomes a thin layer over llmspy's own provider registry.

## What changed

**`internal/model/model.go`**
- Removed `providerEnvKeys` hardcoded map
- Added `getProviderEnvKey()` — queries the llmspy pod via `kubectl exec` for a single provider's env var name
- Added `GetAvailableProviders()` — returns all providers that accept API keys, discovered from the running pod
- Refactored `ConfigureLLMSpy()` to use dynamic env var lookup instead of the hardcoded map
- Refactored `GetProviderStatus()` to cross-reference dynamic providers with ConfigMap and Secret state
- Extracted pure functions (`parseProviderEnvKey`, `parseAvailableProviders`, `buildProviderStatus`, `patchLLMsJSON`) from kubectl-calling wrappers for testability

**`cmd/obol/model.go`**
- `promptModelConfig()` now accepts `cfg` and queries llmspy for available providers dynamically
- Interactive menu shows all discovered providers instead of hardcoded Anthropic/OpenAI
- `obol model status` table widened to accommodate longer provider names
- Added hint: `Run 'obol model setup' to configure a provider.`

**`internal/model/model_test.go`** (new)
- 23 unit tests covering all extracted pure functions:
  - `TestParseProviderEnvKey` — 5 cases (valid output, whitespace, empty, unknown)
  - `TestParseAvailableProviders` — 6 cases (empty, single, multiple, malformed lines)
  - `TestBuildProviderStatus` — 6 cases (full status, ollama injection, missing env vars, invalid JSON)
  - `TestPatchLLMsJSON` — 6 cases (enable, create new, idempotent, preserve fields, invalid JSON)

## How it works

```
obol model setup --provider=zai --api-key=xxx
  │
  ├── kubectl exec deploy/llmspy -n llm -- python3 -c "read providers.json, print env var"
  │   → "ZHIPU_API_KEY"
  │
  ├── kubectl patch secret llms-secrets -n llm (set ZHIPU_API_KEY=xxx)
  ├── kubectl patch configmap llmspy-config -n llm (enable zai in llms.json)
  └── kubectl rollout restart deploy/llmspy -n llm
```

Interactive mode (`obol model setup` with no flags) now shows all providers from llmspy:
```
Available providers:
  [1] Anthropic (anthropic)
  [2] DeepSeek (deepseek)
  [3] Google (google)
  [4] OpenAI (openai)
  [5] Z.AI (zai)
  ...
```

## Test plan

- [x] `go build ./cmd/obol` compiles cleanly
- [x] `go test ./...` passes (23 new tests + existing tests)
- [ ] `obol model setup --provider=zai --api-key=<key>` with running cluster
- [ ] `obol model status` shows dynamically discovered providers
- [ ] `obol model setup` (interactive) lists all llmspy providers