### PR TITLE
chore: bump obol-frontend to v0.1.6

### DIFF
--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -196,7 +196,7 @@ releases:
     namespace: obol-frontend
     createNamespace: true
     chart: obol/obol-app
-    version: 0.1.6
+    version: 0.1.1
     needs:
       - traefik/traefik
       - erpc/erpc


### PR DESCRIPTION
Update frontend image tag from v0.1.5 to v0.1.6.