### PR TITLE
chore(openclaw): bump to v2026.2.23 and fix Renovate versioning

### DIFF
--- a/internal/openclaw/OPENCLAW_VERSION
+++ b/internal/openclaw/OPENCLAW_VERSION
@@ -1,3 +1,3 @@
 # renovate: datasource=github-releases depName=openclaw/openclaw
 # Pins the upstream OpenClaw version to build and publish.
-v2026.2.15
+v2026.2.23

--- a/renovate.json
+++ b/renovate.json
@@ -38,12 +38,12 @@
       "customType": "regex",
       "description": "Update OpenClaw version from upstream GitHub releases",
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\n(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\n(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9]+)?)"
       ],
       "fileMatch": [
         "^internal/openclaw/OPENCLAW_VERSION$"
       ],
-      "versioningTemplate": "semver"
+      "versioningTemplate": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<build>\\d+))?$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Bumps OpenClaw from `v2026.2.15` → `v2026.2.23` (latest upstream release)
- Fixes Renovate custom manager for OpenClaw: replaces `semver` versioning with a regex pattern that correctly handles calver tags with same-day patch suffixes (e.g. `v2026.2.6-3`)
- Extends `matchStrings` to capture pinned versions with `-N` suffixes

## Notes
- Merging to `main` will trigger the `docker-publish-openclaw.yml` workflow to build and publish `ghcr.io/obolnetwork/openclaw:v2026.2.23`
- Renovate GitHub App still needs to be installed on the repo for auto-bump PRs to work