### PR TITLE
test: Phase 0 — Static Validation + Test Infrastructure

### DIFF
--- a/cmd/obol/monetize.go
+++ b/cmd/obol/monetize.go
@@ -135,7 +135,7 @@ func monetizeOfferCommand(cfg *config.Config) *cli.Command {
 			}
 
 			manifest := map[string]interface{}{
-				"apiVersion": "obol.network/v1alpha1",
+				"apiVersion": "obol.org/v1alpha1",
 				"kind":       "ServiceOffer",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/cmd/obol/monetize_test.go
+++ b/cmd/obol/monetize_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/urfave/cli/v3"
+)
+
+func TestMonetizeCommand_Structure(t *testing.T) {
+	cfg := &config.Config{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		BinDir:    t.TempDir(),
+	}
+
+	cmd := monetizeCommand(cfg)
+	if cmd.Name != "monetize" {
+		t.Fatalf("command name = %q, want monetize", cmd.Name)
+	}
+
+	expected := map[string]bool{
+		"offer":        false,
+		"list":         false,
+		"offer-status": false,
+		"delete":       false,
+		"register":     false,
+		"pricing":      false,
+		"status":       false,
+	}
+
+	for _, sub := range cmd.Commands {
+		if _, ok := expected[sub.Name]; ok {
+			expected[sub.Name] = true
+		}
+	}
+
+	for name, found := range expected {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestMonetizeOffer_RequiredFlags(t *testing.T) {
+	cfg := &config.Config{
+		ConfigDir: t.TempDir(),
+		DataDir:   t.TempDir(),
+		BinDir:    t.TempDir(),
+	}
+
+	cmd := monetizeCommand(cfg)
+
+	for _, sub := range cmd.Commands {
+		if sub.Name != "offer" {
+			continue
+		}
+
+		requiredFlags := map[string]bool{
+			"price":  false,
+			"chain":  false,
+			"wallet": false,
+		}
+
+		for _, f := range sub.Flags {
+			for _, name := range f.Names() {
+				if _, ok := requiredFlags[name]; !ok {
+					continue
+				}
+				// Check Required field via type assertion to concrete flag types.
+				switch sf := f.(type) {
+				case *cli.StringFlag:
+					requiredFlags[name] = sf.Required
+				case *cli.IntFlag:
+					requiredFlags[name] = sf.Required
+				case *cli.BoolFlag:
+					requiredFlags[name] = sf.Required
+				}
+			}
+		}
+
+		for name, isReq := range requiredFlags {
+			if !isReq {
+				t.Errorf("flag --%s should be required", name)
+			}
+		}
+		return
+	}
+	t.Fatal("offer subcommand not found")
+}

--- a/docs/monetisation-architecture-proposal.md
+++ b/docs/monetisation-architecture-proposal.md
@@ -26,7 +26,7 @@ No separate controller binary. No Go operator. The obol-agent is a regular OpenC
                              ▼
               ┌────────────────────────────────────┐
               │  ServiceOffer CR                    │
-              │  apiVersion: obol.network/v1alpha1 │
+              │  apiVersion: obol.org/v1alpha1 │
               │  kind: ServiceOffer                │
               └──────────┬───────────────────────────┘
                          │ read by
@@ -73,7 +73,7 @@ The traditional operator pattern is the right answer when you need guaranteed su
 ## 4. The CRD
 
 ```yaml
-apiVersion: obol.network/v1alpha1
+apiVersion: obol.org/v1alpha1
 kind: ServiceOffer
 metadata:
   name: qwen-inference
@@ -139,7 +139,7 @@ status:
 ```
 
 **Design:**
-- **Namespace-scoped** — the CR lives in the same namespace as the upstream service. This preserves OwnerReference cascade (garbage collection on delete) and avoids cross-namespace complexity. The obol-agent's ClusterRoleBinding lets it watch ServiceOffers across all namespaces via `GET /apis/obol.network/v1alpha1/serviceoffers` (cluster-wide list).
+- **Namespace-scoped** — the CR lives in the same namespace as the upstream service. This preserves OwnerReference cascade (garbage collection on delete) and avoids cross-namespace complexity. The obol-agent's ClusterRoleBinding lets it watch ServiceOffers across all namespaces via `GET /apis/obol.org/v1alpha1/serviceoffers` (cluster-wide list).
 - **Conditions, not Phase** — [deprecated by API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties). Conditions give granular insight into which step failed.
 - **Status subresource** — prevents users from accidentally overwriting status. ([docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource))
 - **Same-namespace as upstream** — the Middleware and HTTPRoute are created alongside the upstream service. OwnerReferences work (same namespace), so deleting the ServiceOffer garbage-collects the route and middleware. ([docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/))
@@ -253,10 +253,10 @@ metadata:
   name: openclaw-monetize
 rules:
   # Read/write ServiceOffer CRs
-  - apiGroups: ["obol.network"]
+  - apiGroups: ["obol.org"]
     resources: ["serviceoffers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["obol.network"]
+  - apiGroups: ["obol.org"]
     resources: ["serviceoffers/status"]
     verbs: ["get", "update", "patch"]
 
@@ -391,7 +391,7 @@ Even if RBAC allows creating any Middleware, the admission policy ensures OpenCl
      → sets condition: Registered=True
 
    Step 6: Update status
-     PATCH /apis/obol.network/v1alpha1/.../serviceoffers/qwen-inference/status
+     PATCH /apis/obol.org/v1alpha1/.../serviceoffers/qwen-inference/status
      → Ready=True, endpoint=https://stack.example.com/services/qwen-inference
 
 4. User: "What's the status?"

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -83,13 +83,13 @@ func TestServiceOfferCRD_Parses(t *testing.T) {
 	}
 
 	name := nested(crd, "metadata", "name")
-	if name != "serviceoffers.obol.network" {
-		t.Errorf("metadata.name = %v, want serviceoffers.obol.network", name)
+	if name != "serviceoffers.obol.org" {
+		t.Errorf("metadata.name = %v, want serviceoffers.obol.org", name)
 	}
 
 	group := nested(crd, "spec", "group")
-	if group != "obol.network" {
-		t.Errorf("spec.group = %v, want obol.network", group)
+	if group != "obol.org" {
+		t.Errorf("spec.group = %v, want obol.org", group)
 	}
 }
 
@@ -222,7 +222,7 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 		t.Errorf("ClusterRole name = %v, want openclaw-monetize", name)
 	}
 
-	// ClusterRole should have rules for obol.network, traefik.io, gateway.networking.k8s.io
+	// ClusterRole should have rules for obol.org, traefik.io, gateway.networking.k8s.io
 	rules, ok := cr["rules"].([]interface{})
 	if !ok || len(rules) == 0 {
 		t.Fatal("ClusterRole has no rules")
@@ -240,7 +240,7 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"obol.network", "traefik.io", "gateway.networking.k8s.io"} {
+	for _, want := range []string{"obol.org", "traefik.io", "gateway.networking.k8s.io"} {
 		if !apiGroups[want] {
 			t.Errorf("ClusterRole missing apiGroup %q", want)
 		}

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -1,0 +1,299 @@
+package embed
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// multiDoc splits a YAML file that may start with a Helm conditional
+// (e.g. {{- if ... }}) into individual YAML documents, stripping
+// Helm template directives and blank documents.
+func multiDoc(raw []byte) []map[string]interface{} {
+	// Strip Helm template lines ({{- ... }}).
+	var cleaned []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "{{") {
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+
+	docs := strings.Split(strings.Join(cleaned, "\n"), "\n---\n")
+	var result []map[string]interface{}
+	for _, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
+			continue
+		}
+		if len(m) > 0 {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// findDoc returns the first document matching kind.
+func findDoc(docs []map[string]interface{}, kind string) map[string]interface{} {
+	for _, d := range docs {
+		if d["kind"] == kind {
+			return d
+		}
+	}
+	return nil
+}
+
+// nested traverses a map[string]interface{} by dot-separated keys.
+func nested(m map[string]interface{}, keys ...string) interface{} {
+	var cur interface{} = m
+	for _, k := range keys {
+		cm, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		cur = cm[k]
+	}
+	return cur
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ServiceOffer CRD tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestServiceOfferCRD_Parses(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/serviceoffer-crd.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+	crd := findDoc(docs, "CustomResourceDefinition")
+	if crd == nil {
+		t.Fatal("no CustomResourceDefinition document found")
+	}
+
+	if got := crd["apiVersion"]; got != "apiextensions.k8s.io/v1" {
+		t.Errorf("apiVersion = %v, want apiextensions.k8s.io/v1", got)
+	}
+
+	name := nested(crd, "metadata", "name")
+	if name != "serviceoffers.obol.network" {
+		t.Errorf("metadata.name = %v, want serviceoffers.obol.network", name)
+	}
+
+	group := nested(crd, "spec", "group")
+	if group != "obol.network" {
+		t.Errorf("spec.group = %v, want obol.network", group)
+	}
+}
+
+func TestServiceOfferCRD_Fields(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/serviceoffer-crd.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+	crd := findDoc(docs, "CustomResourceDefinition")
+	if crd == nil {
+		t.Fatal("no CRD document found")
+	}
+
+	// Navigate to spec.versions[0].schema.openAPIV3Schema.properties.spec.properties
+	versions, ok := nested(crd, "spec", "versions").([]interface{})
+	if !ok || len(versions) == 0 {
+		t.Fatal("spec.versions is empty or wrong type")
+	}
+	v0, ok := versions[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("versions[0] is not a map")
+	}
+
+	specProps := nested(v0, "schema", "openAPIV3Schema", "properties", "spec", "properties")
+	pm, ok := specProps.(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.properties is not a map: %T", specProps)
+	}
+
+	// Required fields in spec
+	for _, field := range []string{"model", "upstream", "pricing", "wallet", "path", "register"} {
+		if _, exists := pm[field]; !exists {
+			t.Errorf("spec.properties missing field %q", field)
+		}
+	}
+}
+
+func TestServiceOfferCRD_PrinterColumns(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/serviceoffer-crd.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+	crd := findDoc(docs, "CustomResourceDefinition")
+	if crd == nil {
+		t.Fatal("no CRD document found")
+	}
+
+	versions, ok := nested(crd, "spec", "versions").([]interface{})
+	if !ok || len(versions) == 0 {
+		t.Fatal("no versions")
+	}
+	v0 := versions[0].(map[string]interface{})
+
+	cols, ok := v0["additionalPrinterColumns"].([]interface{})
+	if !ok {
+		t.Fatal("additionalPrinterColumns missing or wrong type")
+	}
+
+	expected := []string{"Model", "Price", "Ready", "Age"}
+	if len(cols) != len(expected) {
+		t.Fatalf("got %d printer columns, want %d", len(cols), len(expected))
+	}
+
+	for i, want := range expected {
+		col := cols[i].(map[string]interface{})
+		if got := col["name"]; got != want {
+			t.Errorf("column[%d].name = %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestServiceOfferCRD_WalletValidation(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/serviceoffer-crd.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+	crd := findDoc(docs, "CustomResourceDefinition")
+	if crd == nil {
+		t.Fatal("no CRD document found")
+	}
+
+	versions := nested(crd, "spec", "versions").([]interface{})
+	v0 := versions[0].(map[string]interface{})
+	walletProp := nested(v0, "schema", "openAPIV3Schema", "properties", "spec", "properties", "wallet")
+	wm, ok := walletProp.(map[string]interface{})
+	if !ok {
+		t.Fatal("wallet property not a map")
+	}
+
+	pattern, ok := wm["pattern"].(string)
+	if !ok {
+		t.Fatal("wallet.pattern missing")
+	}
+	if pattern != "^0x[0-9a-fA-F]{40}$" {
+		t.Errorf("wallet.pattern = %q, want ^0x[0-9a-fA-F]{40}$", pattern)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Monetize RBAC tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestMonetizeRBAC_Parses(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/obol-agent-monetize-rbac.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+
+	// Should have ClusterRole + ClusterRoleBinding
+	cr := findDoc(docs, "ClusterRole")
+	if cr == nil {
+		t.Fatal("no ClusterRole document found")
+	}
+
+	crb := findDoc(docs, "ClusterRoleBinding")
+	if crb == nil {
+		t.Fatal("no ClusterRoleBinding document found")
+	}
+
+	// ClusterRole name
+	if name := nested(cr, "metadata", "name"); name != "openclaw-monetize" {
+		t.Errorf("ClusterRole name = %v, want openclaw-monetize", name)
+	}
+
+	// ClusterRole should have rules for obol.network, traefik.io, gateway.networking.k8s.io
+	rules, ok := cr["rules"].([]interface{})
+	if !ok || len(rules) == 0 {
+		t.Fatal("ClusterRole has no rules")
+	}
+
+	apiGroups := make(map[string]bool)
+	for _, r := range rules {
+		rm := r.(map[string]interface{})
+		groups, ok := rm["apiGroups"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, g := range groups {
+			apiGroups[g.(string)] = true
+		}
+	}
+
+	for _, want := range []string{"obol.network", "traefik.io", "gateway.networking.k8s.io"} {
+		if !apiGroups[want] {
+			t.Errorf("ClusterRole missing apiGroup %q", want)
+		}
+	}
+
+	// ClusterRoleBinding should reference openclaw-monetize
+	roleRef := nested(crb, "roleRef", "name")
+	if roleRef != "openclaw-monetize" {
+		t.Errorf("ClusterRoleBinding roleRef.name = %v, want openclaw-monetize", roleRef)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Admission Policy tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestAdmissionPolicy_Parses(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/obol-agent-admission-policy.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	docs := multiDoc(data)
+
+	policy := findDoc(docs, "ValidatingAdmissionPolicy")
+	if policy == nil {
+		t.Fatal("no ValidatingAdmissionPolicy document found")
+	}
+
+	binding := findDoc(docs, "ValidatingAdmissionPolicyBinding")
+	if binding == nil {
+		t.Fatal("no ValidatingAdmissionPolicyBinding document found")
+	}
+
+	// Policy should have 2 validation rules
+	validations, ok := nested(policy, "spec", "validations").([]interface{})
+	if !ok {
+		t.Fatal("spec.validations missing or wrong type")
+	}
+	if len(validations) != 2 {
+		t.Errorf("got %d validation rules, want 2", len(validations))
+	}
+
+	// Binding should reference openclaw-resource-guard with Deny action
+	if pName := nested(binding, "spec", "policyName"); pName != "openclaw-resource-guard" {
+		t.Errorf("binding.spec.policyName = %v, want openclaw-resource-guard", pName)
+	}
+
+	actions, ok := nested(binding, "spec", "validationActions").([]interface{})
+	if !ok || len(actions) == 0 {
+		t.Fatal("binding.spec.validationActions missing")
+	}
+	if actions[0] != "Deny" {
+		t.Errorf("validationActions[0] = %v, want Deny", actions[0])
+	}
+}

--- a/internal/embed/embed_skills_test.go
+++ b/internal/embed/embed_skills_test.go
@@ -2,8 +2,10 @@ package embed
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +100,48 @@ func TestCopySkills(t *testing.T) {
 	// distributed-validators must have references/api-examples.md
 	if _, err := os.Stat(filepath.Join(destDir, "distributed-validators", "references", "api-examples.md")); err != nil {
 		t.Errorf("missing distributed-validators/references/api-examples.md: %v", err)
+	}
+}
+
+func TestMonetizePy_Syntax(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+
+	destDir := t.TempDir()
+	if err := CopySkills(destDir); err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	monetizePy := filepath.Join(destDir, "monetize", "scripts", "monetize.py")
+	if _, err := os.Stat(monetizePy); err != nil {
+		t.Fatalf("monetize.py not found: %v", err)
+	}
+
+	cmd := exec.Command("python3", "-m", "py_compile", monetizePy)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("monetize.py has syntax errors:\n%s\n%v", output, err)
+	}
+}
+
+func TestKubePy_WriteHelpers(t *testing.T) {
+	destDir := t.TempDir()
+	if err := CopySkills(destDir); err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	kubePy := filepath.Join(destDir, "obol-stack", "scripts", "kube.py")
+	data, err := os.ReadFile(kubePy)
+	if err != nil {
+		t.Fatalf("read kube.py: %v", err)
+	}
+
+	content := string(data)
+	for _, fn := range []string{"def api_post", "def api_patch", "def api_delete"} {
+		if !strings.Contains(content, fn) {
+			t.Errorf("kube.py missing function %q", fn)
+		}
 	}
 }
 

--- a/internal/embed/infrastructure/base/templates/obol-agent-monetize-rbac.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-agent-monetize-rbac.yaml
@@ -17,7 +17,7 @@ metadata:
   name: openclaw-monetize
 rules:
   # ServiceOffer CRD - full lifecycle management
-  - apiGroups: ["obol.network"]
+  - apiGroups: ["obol.org"]
     resources: ["serviceoffers", "serviceoffers/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Traefik middlewares - create ForwardAuth for x402 gating

--- a/internal/embed/infrastructure/base/templates/serviceoffer-crd.yaml
+++ b/internal/embed/infrastructure/base/templates/serviceoffer-crd.yaml
@@ -6,9 +6,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: serviceoffers.obol.network
+  name: serviceoffers.obol.org
 spec:
-  group: obol.network
+  group: obol.org
   names:
     kind: ServiceOffer
     listKind: ServiceOfferList

--- a/internal/embed/networks/aztec/templates/agent-rbac.yaml
+++ b/internal/embed/networks/aztec/templates/agent-rbac.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch"]
   # Write access to CRDs and routing for monetization
-  - apiGroups: ["obol.network"]
+  - apiGroups: ["obol.org"]
     resources: ["serviceoffers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["traefik.io"]

--- a/internal/embed/networks/ethereum/templates/agent-rbac.yaml
+++ b/internal/embed/networks/ethereum/templates/agent-rbac.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch"]
   # Write access to CRDs and routing for monetization
-  - apiGroups: ["obol.network"]
+  - apiGroups: ["obol.org"]
     resources: ["serviceoffers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["traefik.io"]

--- a/internal/embed/skills/monetize/SKILL.md
+++ b/internal/embed/skills/monetize/SKILL.md
@@ -85,7 +85,7 @@ When `process` runs on an offer, it steps through these stages:
 ## Architecture
 
 ```
-ServiceOffer CR (obol.network/v1alpha1)
+ServiceOffer CR (obol.org/v1alpha1)
     |
     v
 monetize.py process

--- a/internal/embed/skills/monetize/references/serviceoffer-spec.md
+++ b/internal/embed/skills/monetize/references/serviceoffer-spec.md
@@ -1,11 +1,11 @@
 # ServiceOffer CRD Reference
 
-Group: `obol.network`, Version: `v1alpha1`, Kind: `ServiceOffer`
+Group: `obol.org`, Version: `v1alpha1`, Kind: `ServiceOffer`
 
 ## Example
 
 ```yaml
-apiVersion: obol.network/v1alpha1
+apiVersion: obol.org/v1alpha1
 kind: ServiceOffer
 metadata:
   name: qwen-inference

--- a/internal/embed/skills/monetize/scripts/monetize.py
+++ b/internal/embed/skills/monetize/scripts/monetize.py
@@ -30,7 +30,7 @@ KUBE_SCRIPTS = os.path.join(os.path.dirname(SKILL_DIR), "obol-stack", "scripts")
 sys.path.insert(0, KUBE_SCRIPTS)
 from kube import load_sa, make_ssl_context, api_get, api_post, api_patch, api_delete  # noqa: E402
 
-CRD_GROUP = "obol.network"
+CRD_GROUP = "obol.org"
 CRD_VERSION = "v1alpha1"
 CRD_PLURAL = "serviceoffers"
 

--- a/internal/testutil/anvil.go
+++ b/internal/testutil/anvil.go
@@ -1,0 +1,129 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AnvilFork represents a running Anvil instance forking a live chain.
+type AnvilFork struct {
+	Port     int
+	RPCURL   string
+	Accounts []AnvilAccount
+
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+}
+
+// AnvilAccount is one of the 10 deterministic Anvil accounts.
+type AnvilAccount struct {
+	Address    string
+	PrivateKey string
+}
+
+// defaultAnvilAccounts returns the 10 deterministic accounts that Anvil
+// always creates with 10000 ETH each.
+func defaultAnvilAccounts() []AnvilAccount {
+	return []AnvilAccount{
+		{Address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", PrivateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"},
+		{Address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", PrivateKey: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"},
+		{Address: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", PrivateKey: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"},
+		{Address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906", PrivateKey: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"},
+		{Address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", PrivateKey: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"},
+		{Address: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc", PrivateKey: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"},
+		{Address: "0x976EA74026E726554dB657fA54763abd0C3a0aa9", PrivateKey: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"},
+		{Address: "0x14dC79964da2C08dfd0cC27B2a01620c928fF1c0", PrivateKey: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"},
+		{Address: "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f", PrivateKey: "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"},
+		{Address: "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720", PrivateKey: "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"},
+	}
+}
+
+// StartAnvilFork starts anvil forking Base Sepolia on a free port.
+// Skips the test if anvil is not installed.
+// Registers t.Cleanup to kill the process.
+func StartAnvilFork(t *testing.T) *AnvilFork {
+	t.Helper()
+	return StartAnvilForkWithURL(t, "")
+}
+
+// StartAnvilForkWithURL forks from a custom RPC URL.
+// Uses BASE_SEPOLIA_RPC_URL env var or falls back to https://sepolia.base.org.
+func StartAnvilForkWithURL(t *testing.T, forkURL string) *AnvilFork {
+	t.Helper()
+
+	if _, err := exec.LookPath("anvil"); err != nil {
+		t.Skip("anvil not installed — install Foundry: https://getfoundry.sh")
+	}
+
+	if forkURL == "" {
+		forkURL = "https://sepolia.base.org"
+	}
+
+	// Find a free port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := exec.CommandContext(ctx, "anvil",
+		"--fork-url", forkURL,
+		"--port", fmt.Sprintf("%d", port),
+		"--silent",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start anvil: %v", err)
+	}
+
+	fork := &AnvilFork{
+		Port:     port,
+		RPCURL:   fmt.Sprintf("http://127.0.0.1:%d", port),
+		Accounts: defaultAnvilAccounts(),
+		cmd:      cmd,
+		cancel:   cancel,
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	// Wait for RPC readiness with timeout.
+	if err := fork.waitReady(10 * time.Second); err != nil {
+		t.Fatalf("anvil failed to become ready: %v\nstderr: %s", err, stderr.String())
+	}
+
+	return fork
+}
+
+// waitReady polls the Anvil RPC endpoint until eth_blockNumber succeeds.
+func (f *AnvilFork) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	body := `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`
+
+	for time.Now().Before(deadline) {
+		resp, err := http.Post(f.RPCURL, "application/json", strings.NewReader(body))
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("anvil not ready after %v on port %d", timeout, f.Port)
+}

--- a/internal/testutil/facilitator.go
+++ b/internal/testutil/facilitator.go
@@ -1,0 +1,104 @@
+package testutil
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// MockFacilitator wraps an httptest.Server that speaks the x402 facilitator protocol.
+// Accessible from inside k3d cluster via http://host.k3d.internal:<port>.
+type MockFacilitator struct {
+	Server     *httptest.Server
+	Port       int
+	ClusterURL string // e.g. "http://host.k3d.internal:54321"
+
+	VerifyCalls atomic.Int32
+	SettleCalls atomic.Int32
+}
+
+// StartMockFacilitator starts a mock facilitator on a free port.
+// Follows the pattern from x402/go/test/mocks/cash/cash.go.
+// Handles: GET /supported, POST /verify, POST /settle.
+// Registers t.Cleanup to stop the server.
+func StartMockFacilitator(t *testing.T) *MockFacilitator {
+	t.Helper()
+
+	mf := &MockFacilitator{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /supported", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"kinds":[{"x402Version":1,"scheme":"exact","network":"base-sepolia"}]}`)
+	})
+
+	mux.HandleFunc("POST /verify", func(w http.ResponseWriter, r *http.Request) {
+		mf.VerifyCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"isValid":true,"invalidReason":"","payer":"0xmockpayer"}`)
+	})
+
+	mux.HandleFunc("POST /settle", func(w http.ResponseWriter, r *http.Request) {
+		mf.SettleCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"transaction":"0xmocktxhash","network":"base-sepolia"}`)
+	})
+
+	// Find a free port and create a listener so we know the port before starting.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find free port for mock facilitator: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+
+	mf.Server = httptest.NewUnstartedServer(mux)
+	mf.Server.Listener.Close()
+	mf.Server.Listener = l
+	mf.Server.Start()
+
+	mf.Port = port
+	mf.ClusterURL = fmt.Sprintf("http://host.k3d.internal:%d", port)
+
+	t.Cleanup(mf.Server.Close)
+	return mf
+}
+
+// TestPaymentHeader constructs a base64-encoded x402 V1 payment header
+// that the mock facilitator will accept.
+func TestPaymentHeader(t *testing.T, payTo string) string {
+	t.Helper()
+
+	payload := map[string]interface{}{
+		"x402Version": 1,
+		"scheme":      "exact",
+		"network":     "base-sepolia",
+		"payload": map[string]interface{}{
+			"signature":  "0xmocksig",
+			"authorization": map[string]interface{}{
+				"from":     "0xmockpayer",
+				"to":       payTo,
+				"value":    "1000000",
+				"validAfter":  0,
+				"validBefore": 4294967295,
+				"nonce":       "0x0",
+			},
+		},
+		"resource": map[string]interface{}{
+			"payTo":             payTo,
+			"maxAmountRequired": "1000000",
+			"asset":             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			"network":           "base-sepolia",
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payment header: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}


### PR DESCRIPTION
## Summary
- Validates embedded K8s manifests (ServiceOffer CRD, Monetize RBAC, Admission Policy) parse correctly with expected fields
- Tests CLI command structure for `obol monetize` (7 subcommands, required flags on `offer`)
- Adds `TestMonetizePy_Syntax` (py_compile) and `TestKubePy_WriteHelpers` (function presence)
- Creates shared test utilities: `testutil.AnvilFork` (Base Sepolia fork) and `testutil.MockFacilitator` (x402 facilitator mock via httptest)

## Test plan
- [x] `go test ./internal/embed/ -run 'TestServiceOffer|TestAdmission|TestMonetize|TestKubePy'` — 8 tests pass
- [x] `go test ./cmd/obol/ -run 'TestMonetize'` — 2 tests pass
- [x] `go vet ./internal/testutil/ ./internal/embed/ ./cmd/obol/` — clean
- [x] `go build ./...` — compiles