### PR TITLE
ci: add x402-verifier Docker image build workflow

### DIFF
--- a/.github/workflows/docker-publish-x402-verifier.yml
+++ b/.github/workflows/docker-publish-x402-verifier.yml
@@ -1,0 +1,101 @@
+name: Build and Publish x402-verifier Image
+
+on:
+  push:
+    branches:
+      - main
+      - feat/secure-enclave-inference
+    tags:
+      - 'v*'
+    paths:
+      - 'internal/x402/**'
+      - 'cmd/x402-verifier/**'
+      - 'Dockerfile.x402-verifier'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: obolnetwork/x402-verifier
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Build the x402-verifier binary and publish the image.
+  # ---------------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/secure-enclave-inference' }}
+          labels: |
+            org.opencontainers.image.title=x402-verifier
+            org.opencontainers.image.description=x402 payment verification sidecar for Obol Stack
+            org.opencontainers.image.vendor=Obol Network
+            org.opencontainers.image.source=https://github.com/ObolNetwork/obol-stack
+
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: Dockerfile.x402-verifier
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=x402-verifier
+          cache-to: type=gha,scope=x402-verifier,mode=max
+          provenance: true
+          sbom: true
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Security scan the published image.
+  # ---------------------------------------------------------------------------
+  security-scan:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@b13d724d35ff0a814e21683638ed68ed34cf53d1 # main
+        with:
+          sarif_file: 'trivy-results.sarif'
+        if: always()


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to build and publish the `ghcr.io/obolnetwork/x402-verifier` Docker image
- Triggers on pushes to `main` and `feat/secure-enclave-inference` when relevant paths change (`internal/x402/**`, `cmd/x402-verifier/**`, `Dockerfile.x402-verifier`, `go.mod`, `go.sum`), on `v*` tags, and via manual dispatch
- Builds multi-platform (`linux/amd64,linux/arm64`) with Docker Buildx, GHA caching, provenance, and SBOM
- Includes Trivy security scan with SARIF upload to GitHub Security tab
- Uses the same pinned action versions as `docker-publish-openclaw.yml`

## Test plan
- [ ] Verify workflow YAML is valid (syntax, correct nesting of `on.push.branches/tags/paths`)
- [ ] Confirm the workflow appears in the Actions tab after merge
- [ ] Trigger a manual `workflow_dispatch` run and verify the image is pushed to GHCR
- [ ] Verify Trivy scan results appear in the Security tab