### PR TITLE
fix: monetize healthPath default and dev skill documentation

### DIFF
--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -189,3 +189,55 @@ obol kubectl exec -i -n openclaw-<id> deploy/openclaw -c openclaw -- python3 - <
 - Assume TCP connectivity means HTTP is ready (port-forward warmup race)
 - Use `app.kubernetes.io/instance=openclaw-<id>` for pod labels (Helm uses `openclaw`)
 - Run multiple integration tests without cleaning up between them (pod sandbox errors)
+
+## Sell-Side Monetize Lifecycle
+
+### Architecture
+
+The monetize subsystem enables pay-per-request access to local compute via x402:
+
+```
+ServiceOffer CR → monetize.py reconciliation → Middleware + HTTPRoute + pricing route
+                                                       │
+Client request ──► Traefik ──► x402-verifier (ForwardAuth) ──► backend (Ollama)
+                                    │                              │
+                               402 (no payment)              200 (valid payment)
+                               Payment requirements          Inference response
+```
+
+### Three-Layer Integration
+
+1. **monetize.py** (OpenClaw skill) — Creates Middleware, HTTPRoute, pricing ConfigMap route
+2. **x402-verifier** (ForwardAuth) — Checks X-PAYMENT header against facilitator
+3. **Traefik Gateway API** — Routes traffic; requires ClusterIP backends (not ExternalName)
+
+### Testing the Monetize Flow
+
+```bash
+# Prerequisites
+obol stack up && obol agent init
+
+# Create offer
+obol monetize offer qwen35 --model "qwen3.5:35b" --per-request "0.001" \
+  --network "base-sepolia" --pay-to "0x<wallet>"
+
+# Trigger reconciliation (or wait for heartbeat)
+obol kubectl exec -n openclaw-obol-agent deploy/openclaw -c openclaw -- \
+  python3 /data/.openclaw/skills/monetize/scripts/monetize.py process qwen35 --namespace llm
+
+# Verify 402
+curl -X POST http://obol.stack:8080/services/qwen35/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3.5:35b","messages":[{"role":"user","content":"hi"}],"stream":false}'
+
+# Run e2e test (with mock facilitator)
+export OBOL_CONFIG_DIR=$(pwd)/.workspace/config OBOL_BIN_DIR=$(pwd)/.workspace/bin
+go test -tags integration -v -run TestIntegration_PaymentGate_FullLifecycle -timeout 5m ./internal/x402/
+```
+
+### Known Gotchas
+
+- **ExternalName services**: Traefik Gateway API rejects ExternalName as HTTPRoute backends → 500 after valid payment. Use ClusterIP+Endpoints.
+- **Model pull timeout**: monetize.py checks `/api/tags` before `/api/pull` to avoid hanging on cached models.
+- **Facilitator HTTPS**: URLs must be HTTPS except localhost, 127.0.0.1, host.k3d.internal, host.docker.internal.
+- **ConfigMap propagation**: File watcher takes 60-120s. Force restart verifier for immediate effect.

--- a/internal/embed/skills/monetize/scripts/monetize.py
+++ b/internal/embed/skills/monetize/scripts/monetize.py
@@ -231,7 +231,7 @@ def stage_upstream_healthy(spec, ns, name, token, ssl_ctx):
     svc = upstream.get("service", "ollama")
     svc_ns = upstream.get("namespace", ns)
     port = upstream.get("port", 11434)
-    health_path = upstream.get("healthPath", "/health")
+    health_path = upstream.get("healthPath", "/")
 
     model_spec = spec.get("model", {})
     model_name = model_spec.get("name", "")
@@ -311,7 +311,7 @@ def stage_payment_gate(spec, ns, name, token, ssl_ctx):
 
     # Check if middleware already exists.
     try:
-        existing = api_get(f"{mw_path}/{middleware_name}", token, ssl_ctx)
+        existing = api_get(f"{mw_path}/{middleware_name}", token, ssl_ctx, quiet=True)
         if existing:
             print(f"  Middleware {middleware_name} already exists, updating...")
             api_patch(f"{mw_path}/{middleware_name}", middleware, token, ssl_ctx, patch_type="merge")
@@ -347,7 +347,7 @@ def _add_pricing_route(spec, name, token, ssl_ctx):
     # Read current x402-pricing ConfigMap.
     cm_path = "/api/v1/namespaces/x402/configmaps/x402-pricing"
     try:
-        cm = api_get(cm_path, token, ssl_ctx)
+        cm = api_get(cm_path, token, ssl_ctx, quiet=True)
     except SystemExit:
         print(f"  Warning: x402-pricing ConfigMap not found, skipping pricing route")
         return
@@ -487,7 +487,7 @@ def stage_route_published(spec, ns, name, token, ssl_ctx):
 
     # Check if route already exists.
     try:
-        existing = api_get(f"{route_path}/{route_name}", token, ssl_ctx)
+        existing = api_get(f"{route_path}/{route_name}", token, ssl_ctx, quiet=True)
         if existing:
             print(f"  HTTPRoute {route_name} already exists, updating...")
             api_patch(f"{route_path}/{route_name}", httproute, token, ssl_ctx, patch_type="merge")
@@ -718,7 +718,7 @@ def cmd_delete(ns, name, token, ssl_ctx):
     # Read the offer to get the path before deleting.
     so_path = f"/apis/{CRD_GROUP}/{CRD_VERSION}/namespaces/{ns}/{CRD_PLURAL}/{name}"
     try:
-        so = api_get(so_path, token, ssl_ctx)
+        so = api_get(so_path, token, ssl_ctx, quiet=True)
         url_path = so.get("spec", {}).get("path", f"/services/{name}")
         _remove_pricing_route(url_path, name, token, ssl_ctx)
     except SystemExit:
@@ -734,7 +734,7 @@ def _remove_pricing_route(url_path, name, token, ssl_ctx):
 
     cm_path = "/api/v1/namespaces/x402/configmaps/x402-pricing"
     try:
-        cm = api_get(cm_path, token, ssl_ctx)
+        cm = api_get(cm_path, token, ssl_ctx, quiet=True)
     except SystemExit:
         return
 

--- a/internal/embed/skills/obol-stack/scripts/kube.py
+++ b/internal/embed/skills/obol-stack/scripts/kube.py
@@ -53,8 +53,13 @@ def make_ssl_context():
     return ctx
 
 
-def api_get(path, token, ssl_ctx):
-    """GET request to the Kubernetes API."""
+def api_get(path, token, ssl_ctx, quiet=False):
+    """GET request to the Kubernetes API.
+
+    Args:
+        quiet: If True, suppress stderr output on HTTP errors (useful for
+               existence checks where a 404 is expected).
+    """
     url = f"{API_SERVER}{path}"
     req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
     try:
@@ -62,7 +67,8 @@ def api_get(path, token, ssl_ctx):
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         body = e.read().decode() if e.fp else ""
-        print(f"API error {e.code}: {body[:200]}", file=sys.stderr)
+        if not quiet:
+            print(f"API error {e.code}: {body[:200]}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

- **healthPath default fix**: Changed upstream healthPath default from `/health` to `/` in `monetize.py`. Ollama responds with "Ollama is running" at `/` but returns 404 at `/health`, causing `stage_upstream_healthy` to always fail on default config.
- **api_get noise fix**: Added `quiet=False` parameter to `kube.py`'s `api_get()` function. When `quiet=True`, stderr output is suppressed for expected 404s during existence checks (middleware, HTTPRoute, ConfigMap lookups). All six existence-check call sites in `monetize.py` now pass `quiet=True`.
- **Dev skill documentation**: Added sell-side monetize lifecycle section to `.agents/skills/obol-stack-dev/SKILL.md` covering architecture diagram, three-layer integration explanation, step-by-step testing commands, and known gotchas (ExternalName, model pull timeout, facilitator HTTPS, ConfigMap propagation).

## Test plan

- [x] `python3 -m py_compile` passes for both `monetize.py` and `kube.py`
- [x] `go build ./...` succeeds (embedded files compile)
- [x] Pre-commit hooks pass
- [ ] Manual: create a ServiceOffer with default upstream config and verify `stage_upstream_healthy` passes against Ollama at `/`
- [ ] Manual: run reconciliation and confirm no spurious `API error 404` messages on stderr during resource creation