### PR TITLE
fix: replace ollama ExternalName with ClusterIP+Endpoints for Gateway API

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -2,25 +2,28 @@
 # LLM foundation services (OKR-1)
 #
 # This deploys:
-# - An ExternalName Service "ollama" that resolves to the host's Ollama server
+# - A ClusterIP Service + Endpoints "ollama" that routes to the host's Ollama server
 # - llms.py (LLMSpy) as an OpenAI-compatible gateway / router over providers
 #
 # Design notes:
 # - No in-cluster Ollama is deployed; the host is expected to run Ollama
 #   (or another OpenAI-compatible server) on port 11434.
-# - The ollama Service abstracts host resolution:
-#     k3d  → host.k3d.internal
-#     k3s  → resolved at stack init via node IP
+# - The ollama Service abstracts host resolution via ClusterIP + headless Endpoints:
+#     k3d  → host IP resolved at init (e.g. 192.168.65.254 on macOS Docker Desktop)
+#     k3s  → 127.0.0.1 (k3s runs directly on the host)
+# - Using ClusterIP+Endpoints instead of ExternalName for Traefik Gateway API
+#   compatibility (ExternalName services are rejected as HTTPRoute backends).
 # - LLMSpy and all consumers reference ollama.llm.svc.cluster.local:11434,
-#   which the ExternalName Service routes to the host.
+#   which the ClusterIP Service routes to the host via the Endpoints object.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: llm
 
 ---
-# ExternalName Service: routes ollama.llm.svc.cluster.local → host Ollama.
-# The externalName is resolved during `obol stack init` via the {{OLLAMA_HOST}} placeholder.
+# ClusterIP Service + Endpoints: routes ollama.llm.svc.cluster.local → host Ollama.
+# The endpoint IP is resolved during `obol stack init` via the {{OLLAMA_HOST_IP}} placeholder.
+# Using ClusterIP+Endpoints instead of ExternalName for Traefik Gateway API compatibility.
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,12 +32,27 @@ metadata:
   labels:
     app: ollama
 spec:
-  type: ExternalName
-  externalName: {{OLLAMA_HOST}}
+  type: ClusterIP
   ports:
     - name: http
       port: 11434
       protocol: TCP
+      targetPort: 11434
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: ollama
+  namespace: llm
+  labels:
+    app: ollama
+subsets:
+  - addresses:
+      - ip: "{{OLLAMA_HOST_IP}}"
+    ports:
+      - name: http
+        port: 11434
+        protocol: TCP
 
 ---
 # llms.py v3 configuration for Obol Stack:

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -182,6 +182,13 @@ func ollamaHostForBackend(backendName string) string {
 
 // ollamaHostIPForBackend resolves the Ollama host to an IP address.
 // ClusterIP+Endpoints requires an IP (not a hostname).
+//
+// Resolution strategy:
+//  1. If already an IP (k3s: 127.0.0.1), return as-is
+//  2. Try DNS resolution (works on macOS with Docker Desktop: host.docker.internal)
+//  3. On Linux k3d: host.k3d.internal doesn't resolve on the host (only inside
+//     k3d's CoreDNS). Fall back to the docker0 interface IP, which is the Docker
+//     daemon's bridge gateway and is reachable from all Docker containers.
 func ollamaHostIPForBackend(backendName string) (string, error) {
 	host := ollamaHostForBackend(backendName)
 
@@ -190,15 +197,49 @@ func ollamaHostIPForBackend(backendName string) (string, error) {
 		return host, nil
 	}
 
-	// Resolve hostname to IP
+	// Try DNS resolution first (works on macOS Docker Desktop)
 	addrs, err := net.LookupHost(host)
+	if err == nil && len(addrs) > 0 {
+		return addrs[0], nil
+	}
+
+	// Fallback for Linux k3d: host.k3d.internal doesn't resolve on the host.
+	// Use the docker0 bridge interface IP instead — it's the Docker daemon's
+	// gateway and is reachable from all Docker containers regardless of network.
+	if runtime.GOOS == "linux" && backendName == BackendK3d {
+		ip, bridgeErr := dockerBridgeGatewayIP()
+		if bridgeErr == nil {
+			return ip, nil
+		}
+		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w; docker0 fallback also failed: %v", host, err, bridgeErr)
+	}
+
 	if err != nil {
-		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w\nEnsure Docker Desktop is running (macOS) or the Docker daemon is configured with host networking (Linux)", host, err)
+		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w\n\tEnsure Docker Desktop is running (macOS)", host, err)
 	}
-	if len(addrs) == 0 {
-		return "", fmt.Errorf("Ollama host %q resolved to no addresses", host)
+	return "", fmt.Errorf("Ollama host %q resolved to no addresses", host)
+}
+
+// dockerBridgeGatewayIP returns the IPv4 address of the docker0 network interface.
+// On Linux, docker0 is the default Docker bridge (typically 172.17.0.1). This IP
+// is reachable from any Docker container regardless of the container's network,
+// because the host has this address on its network stack and Docker enables
+// IP forwarding between bridge networks and the host.
+func dockerBridgeGatewayIP() (string, error) {
+	iface, err := net.InterfaceByName("docker0")
+	if err != nil {
+		return "", fmt.Errorf("docker0 interface not found: %w", err)
 	}
-	return addrs[0], nil
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("cannot get docker0 addresses: %w", err)
+	}
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
+			return ipNet.IP.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no IPv4 address found on docker0 interface")
 }
 
 // Up starts the cluster using the configured backend

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -93,10 +93,17 @@ func Init(cfg *config.Config, force bool, backendName string) error {
 	// Resolve {{OLLAMA_HOST}} based on backend:
 	// - k3d (Docker): host.docker.internal (macOS) or host.k3d.internal (Linux)
 	// - k3s (bare-metal): 127.0.0.1 (k3s runs directly on the host)
+	// Resolve {{OLLAMA_HOST_IP}} to a numeric IP for the Endpoints object:
+	// - Endpoints require an IP, not a hostname (ClusterIP+Endpoints pattern)
 	ollamaHost := ollamaHostForBackend(backendName)
+	ollamaHostIP, err := ollamaHostIPForBackend(backendName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Ollama host IP: %w", err)
+	}
 	defaultsDir := filepath.Join(cfg.ConfigDir, "defaults")
 	if err := embed.CopyDefaults(defaultsDir, map[string]string{
-		"{{OLLAMA_HOST}}": ollamaHost,
+		"{{OLLAMA_HOST}}":    ollamaHost,
+		"{{OLLAMA_HOST_IP}}": ollamaHostIP,
 	}); err != nil {
 		return fmt.Errorf("failed to copy defaults: %w", err)
 	}
@@ -171,6 +178,27 @@ func ollamaHostForBackend(backendName string) string {
 		return "host.docker.internal"
 	}
 	return "host.k3d.internal"
+}
+
+// ollamaHostIPForBackend resolves the Ollama host to an IP address.
+// ClusterIP+Endpoints requires an IP (not a hostname).
+func ollamaHostIPForBackend(backendName string) (string, error) {
+	host := ollamaHostForBackend(backendName)
+
+	// If already an IP, return as-is (k3s: 127.0.0.1)
+	if net.ParseIP(host) != nil {
+		return host, nil
+	}
+
+	// Resolve hostname to IP
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w\nEnsure Docker Desktop is running (macOS) or the Docker daemon is configured with host networking (Linux)", host, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("Ollama host %q resolved to no addresses", host)
+	}
+	return addrs[0], nil
 }
 
 // Up starts the cluster using the configured backend

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -175,3 +175,44 @@ func TestDestroyOldBackendIfSwitching_NoBackendFile(t *testing.T) {
 	// Should not panic or error
 	destroyOldBackendIfSwitching(cfg, BackendK3d, "test-id")
 }
+
+func TestOllamaHostIPForBackend_K3s(t *testing.T) {
+	// k3s backend should return 127.0.0.1 (already an IP, no DNS resolution needed)
+	ip, err := ollamaHostIPForBackend(BackendK3s)
+	if err != nil {
+		t.Fatalf("unexpected error for k3s backend: %v", err)
+	}
+	if ip != "127.0.0.1" {
+		t.Errorf("expected 127.0.0.1 for k3s backend, got %s", ip)
+	}
+}
+
+func TestOllamaHostIPForBackend_K3d(t *testing.T) {
+	// k3d backend should return a valid, non-empty IP (or an error if
+	// host.docker.internal / host.k3d.internal cannot be resolved, e.g.
+	// in CI without Docker Desktop).
+	ip, err := ollamaHostIPForBackend(BackendK3d)
+	if err != nil {
+		t.Skipf("skipping: DNS resolution failed (expected in CI): %v", err)
+	}
+	if ip == "" {
+		t.Fatal("expected non-empty IP for k3d backend")
+	}
+	// The result must be a parseable IP address (not a hostname)
+	if net.ParseIP(ip) == nil {
+		t.Errorf("expected a valid IP address for k3d backend, got %q", ip)
+	}
+}
+
+func TestOllamaHostIPForBackend_AlreadyIP(t *testing.T) {
+	// Verify the function passes through an already-numeric IP unchanged.
+	// k3s returns "127.0.0.1" from ollamaHostForBackend, so it should
+	// short-circuit on net.ParseIP without attempting DNS.
+	ip, err := ollamaHostIPForBackend(BackendK3s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "127.0.0.1" {
+		t.Errorf("expected pass-through of 127.0.0.1, got %s", ip)
+	}
+}

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -188,12 +189,13 @@ func TestOllamaHostIPForBackend_K3s(t *testing.T) {
 }
 
 func TestOllamaHostIPForBackend_K3d(t *testing.T) {
-	// k3d backend should return a valid, non-empty IP (or an error if
-	// host.docker.internal / host.k3d.internal cannot be resolved, e.g.
-	// in CI without Docker Desktop).
+	// k3d backend should return a valid IP via one of two strategies:
+	//   macOS: DNS resolution of host.docker.internal
+	//   Linux: DNS resolution of host.k3d.internal, or docker0 bridge fallback
+	// In CI without Docker, both may fail → skip.
 	ip, err := ollamaHostIPForBackend(BackendK3d)
 	if err != nil {
-		t.Skipf("skipping: DNS resolution failed (expected in CI): %v", err)
+		t.Skipf("skipping: resolution failed (expected in CI without Docker): %v", err)
 	}
 	if ip == "" {
 		t.Fatal("expected non-empty IP for k3d backend")
@@ -215,4 +217,20 @@ func TestOllamaHostIPForBackend_AlreadyIP(t *testing.T) {
 	if ip != "127.0.0.1" {
 		t.Errorf("expected pass-through of 127.0.0.1, got %s", ip)
 	}
+}
+
+func TestDockerBridgeGatewayIP(t *testing.T) {
+	// On Linux with Docker installed, docker0 should exist with an IPv4 address.
+	// On macOS or CI without Docker, skip gracefully.
+	if runtime.GOOS != "linux" {
+		t.Skip("docker0 interface only exists on Linux")
+	}
+	ip, err := dockerBridgeGatewayIP()
+	if err != nil {
+		t.Skipf("skipping: docker0 not available (expected without Docker): %v", err)
+	}
+	if net.ParseIP(ip) == nil {
+		t.Errorf("expected valid IP from docker0, got %q", ip)
+	}
+	t.Logf("docker0 gateway IP: %s", ip)
 }


### PR DESCRIPTION
## Summary

- Replace the `ollama` ExternalName Service in the `llm` namespace with ClusterIP + Endpoints for Traefik Gateway API compatibility
- ExternalName services are rejected as HTTPRoute backends by Traefik (`type ExternalName is not supported`)
- Add `ollamaHostIPForBackend()` to resolve the host IP at `obol stack init` time
- On macOS: resolves `host.docker.internal` via DNS
- On Linux k3d: falls back to `docker0` bridge interface IP (host.k3d.internal only resolves inside k3d's CoreDNS)
- Remove Go template conditionals (`{{- if x402Enabled }}`) from `helmfile.yaml` — breaks Helmfile v1 (requires `.gotmpl` extension). x402 ForwardAuth middleware is now always deployed (verifier returns 200 for unmatched routes)

## Tested on

- **macOS** (Docker Desktop): `host.docker.internal` resolves to Docker Desktop gateway IP
- **Linux** (Ubuntu 24.04, Docker 27.3.1, k3d): `docker0` interface IP (`172.17.0.1`) used as fallback. Full inference verified: llmspy → ollama ClusterIP → Endpoints 172.17.0.1:11434 → host Ollama → qwen3:8b response ✓

## Test plan

- [x] `go test ./internal/stack/ -run TestOllamaHostIP` — passes on both macOS and Linux
- [x] `go test ./internal/stack/ -run TestDockerBridge` — passes on Linux (skips on macOS)
- [x] Fresh `obol stack init` + `obol stack up` on Linux — ClusterIP+Endpoints with `172.17.0.1` deployed
- [x] `kubectl run` curl test: `ollama.llm.svc.cluster.local:11434` returns "Ollama is running"
- [x] Full inference through llmspy → ollama ClusterIP → qwen3:8b responds correctly
- [ ] Verify existing macOS clusters continue working after upgrade