### PR TITLE
fix: harden monetize subsystem — RBAC split, URL validation, HA, kubectl extraction

### DIFF
--- a/cmd/obol/monetize.go
+++ b/cmd/obol/monetize.go
@@ -1,17 +1,15 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -623,59 +621,26 @@ func kubectlApply(cfg *config.Config, manifest interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
-
-	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	proc := exec.Command(kubectlPath, "apply", "-f", "-")
-	proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	proc.Stdin = bytes.NewReader(raw)
-	proc.Stdout = os.Stdout
-	proc.Stderr = os.Stderr
-
-	if err := proc.Run(); err != nil {
-		return fmt.Errorf("kubectl apply failed: %w", err)
-	}
-	return nil
+	bin, kc := kubectl.Paths(cfg)
+	return kubectl.Apply(bin, kc, raw)
 }
 
 // kubectlOutput executes kubectl and captures stdout.
 func kubectlOutput(cfg *config.Config, args ...string) (string, error) {
-	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("stack not running, use 'obol stack up' first")
-	}
-
-	proc := exec.Command(kubectlPath, args...)
-	proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	var stdout bytes.Buffer
-	proc.Stdout = &stdout
-	proc.Stderr = os.Stderr
-
-	if err := proc.Run(); err != nil {
+	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return "", err
 	}
-	return stdout.String(), nil
+	bin, kc := kubectl.Paths(cfg)
+	return kubectl.Output(bin, kc, args...)
 }
 
 // kubectlRun executes kubectl with the given arguments and stack kubeconfig.
 func kubectlRun(cfg *config.Config, args ...string) error {
-	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
-
-	proc := exec.Command(kubectlPath, args...)
-	proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	proc.Stdin = os.Stdin
-	proc.Stdout = os.Stdout
-	proc.Stderr = os.Stderr
-
-	return proc.Run()
+	bin, kc := kubectl.Paths(cfg)
+	return kubectl.Run(bin, kc, args...)
 }
 
 // mustMarshal JSON-encodes v, returning "{}" on error.

--- a/docs/guides/monetize-inference.md
+++ b/docs/guides/monetize-inference.md
@@ -632,15 +632,23 @@ Missing any of these fields causes the facilitator to reject the payment before 
 
 ### RBAC: forbidden
 
-If the OpenClaw agent cannot create or patch Kubernetes resources (ServiceOffers, Middlewares, HTTPRoutes), the ClusterRoleBinding may have an empty `subjects` list. Patch it manually:
+If the OpenClaw agent cannot create or patch Kubernetes resources (ServiceOffers, Middlewares, HTTPRoutes), the ClusterRoleBindings may have empty `subjects` lists. Patch them manually:
 
 ```bash
-kubectl patch clusterrolebinding openclaw-monetize-binding \
+# Patch both ClusterRoleBindings
+for BINDING in openclaw-monetize-read-binding openclaw-monetize-workload-binding; do
+  kubectl patch clusterrolebinding "$BINDING" \
+      --type=json \
+      -p '[{"op":"add","path":"/subjects","value":[{"kind":"ServiceAccount","name":"openclaw","namespace":"openclaw-obol-agent"}]}]'
+done
+
+# Patch x402 namespace RoleBinding
+kubectl patch rolebinding openclaw-x402-pricing-binding -n x402 \
     --type=json \
-    -p '[{"op":"add","path":"/subjects","value":[{"kind":"ServiceAccount","name":"openclaw","namespace":"openclaw-default"}]}]'
+    -p '[{"op":"add","path":"/subjects","value":[{"kind":"ServiceAccount","name":"openclaw","namespace":"openclaw-obol-agent"}]}]'
 ```
 
-Replace `openclaw-default` with your actual OpenClaw namespace if different.
+Replace `openclaw-obol-agent` with your actual OpenClaw namespace if different.
 
 ---
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,14 +1,13 @@
 package agent
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/openclaw"
 )
 
@@ -16,7 +15,7 @@ const agentID = "obol-agent"
 
 // Init sets up the singleton obol-agent OpenClaw instance.
 // It enforces a single agent by using a fixed deployment ID.
-// After onboarding, it patches the openclaw-monetize ClusterRoleBinding
+// After onboarding, it patches the monetize RBAC bindings
 // to grant the agent's ServiceAccount monetization permissions,
 // and injects HEARTBEAT.md to drive periodic reconciliation.
 func Init(cfg *config.Config) error {
@@ -52,33 +51,41 @@ func Init(cfg *config.Config) error {
 
 	// Patch ClusterRoleBinding to add the agent's ServiceAccount.
 	if err := patchMonetizeBinding(cfg); err != nil {
-		fmt.Printf("Warning: could not patch ClusterRoleBinding: %v\n", err)
+		return fmt.Errorf("failed to patch ClusterRoleBinding: %w", err)
 	}
 
 	// Inject HEARTBEAT.md for periodic reconciliation.
 	if err := injectHeartbeatFile(cfg); err != nil {
-		fmt.Printf("Warning: could not inject HEARTBEAT.md: %v\n", err)
+		return fmt.Errorf("failed to inject HEARTBEAT.md: %w", err)
 	}
 
 	return nil
 }
 
 // patchMonetizeBinding adds the obol-agent's OpenClaw ServiceAccount
-// as a subject on the openclaw-monetize-binding ClusterRoleBinding.
+// as a subject on the monetize ClusterRoleBindings and x402 RoleBinding.
+//
+//	ClusterRoleBindings patched:
+//	  openclaw-monetize-read-binding      (cluster-wide read)
+//	  openclaw-monetize-workload-binding  (cluster-wide mutate)
+//	RoleBindings patched:
+//	  openclaw-x402-pricing-binding       (x402 namespace, pricing ConfigMap)
 func patchMonetizeBinding(cfg *config.Config) error {
 	namespace := fmt.Sprintf("openclaw-%s", agentID)
 
+	subject := []map[string]interface{}{
+		{
+			"kind":      "ServiceAccount",
+			"name":      "openclaw",
+			"namespace": namespace,
+		},
+	}
+
 	patch := []map[string]interface{}{
 		{
-			"op":   "replace",
-			"path": "/subjects",
-			"value": []map[string]interface{}{
-				{
-					"kind":      "ServiceAccount",
-					"name":      "openclaw",
-					"namespace": namespace,
-				},
-			},
+			"op":    "replace",
+			"path":  "/subjects",
+			"value": subject,
 		},
 	}
 
@@ -87,22 +94,33 @@ func patchMonetizeBinding(cfg *config.Config) error {
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	bin, kc := kubectl.Paths(cfg)
+	patchArg := fmt.Sprintf("-p=%s", string(patchData))
 
-	cmd := exec.Command(kubectlBinary,
-		"patch", "clusterrolebinding", "openclaw-monetize-binding",
-		"--type=json",
-		fmt.Sprintf("-p=%s", string(patchData)),
-	)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%v: %s", err, stderr.String())
+	// Patch both ClusterRoleBindings.
+	clusterBindings := []string{
+		"openclaw-monetize-read-binding",
+		"openclaw-monetize-workload-binding",
+	}
+	for _, name := range clusterBindings {
+		if err := kubectl.RunSilent(bin, kc,
+			"patch", "clusterrolebinding", name,
+			"--type=json", patchArg,
+		); err != nil {
+			return fmt.Errorf("patch clusterrolebinding %s: %w", name, err)
+		}
 	}
 
-	fmt.Printf("✓ ClusterRoleBinding openclaw-monetize-binding patched (SA: openclaw in %s)\n", namespace)
+	// Patch x402 namespace RoleBinding.
+	if err := kubectl.RunSilent(bin, kc,
+		"patch", "rolebinding", "openclaw-x402-pricing-binding",
+		"-n", "x402",
+		"--type=json", patchArg,
+	); err != nil {
+		return fmt.Errorf("patch rolebinding openclaw-x402-pricing-binding: %w", err)
+	}
+
+	fmt.Printf("✓ RBAC bindings patched (SA: openclaw in %s)\n", namespace)
 	return nil
 }
 

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -49,6 +49,16 @@ func findDoc(docs []map[string]interface{}, kind string) map[string]interface{} 
 	return nil
 }
 
+// findDocByName returns the first document matching kind and metadata.name.
+func findDocByName(docs []map[string]interface{}, kind, name string) map[string]interface{} {
+	for _, d := range docs {
+		if d["kind"] == kind && nested(d, "metadata", "name") == name {
+			return d
+		}
+	}
+	return nil
+}
+
 // nested traverses a map[string]interface{} by dot-separated keys.
 func nested(m map[string]interface{}, keys ...string) interface{} {
 	var cur interface{} = m
@@ -208,119 +218,177 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 
 	docs := multiDoc(data)
 
-	// Should have ClusterRole + ClusterRoleBinding
-	cr := findDoc(docs, "ClusterRole")
-	if cr == nil {
-		t.Fatal("no ClusterRole document found")
+	// ── Read ClusterRole ────────────────────────────────────────────────
+	readCR := findDocByName(docs, "ClusterRole", "openclaw-monetize-read")
+	if readCR == nil {
+		t.Fatal("no ClusterRole 'openclaw-monetize-read' found")
 	}
 
-	crb := findDoc(docs, "ClusterRoleBinding")
-	if crb == nil {
-		t.Fatal("no ClusterRoleBinding document found")
+	readRules, ok := readCR["rules"].([]interface{})
+	if !ok || len(readRules) == 0 {
+		t.Fatal("read ClusterRole has no rules")
 	}
 
-	// ClusterRole name
-	if name := nested(cr, "metadata", "name"); name != "openclaw-monetize" {
-		t.Errorf("ClusterRole name = %v, want openclaw-monetize", name)
-	}
-
-	// ClusterRole should have rules for obol.org, traefik.io, gateway.networking.k8s.io
-	rules, ok := cr["rules"].([]interface{})
-	if !ok || len(rules) == 0 {
-		t.Fatal("ClusterRole has no rules")
-	}
-
-	apiGroups := make(map[string]bool)
-	for _, r := range rules {
+	// Read role should be read-only: no create/update/patch/delete verbs.
+	for _, r := range readRules {
 		rm := r.(map[string]interface{})
-		groups, ok := rm["apiGroups"].([]interface{})
+		verbs, ok := rm["verbs"].([]interface{})
 		if !ok {
 			continue
 		}
-		for _, g := range groups {
-			apiGroups[g.(string)] = true
+		for _, v := range verbs {
+			switch v.(string) {
+			case "create", "update", "patch", "delete":
+				t.Errorf("read ClusterRole has mutate verb %q — should be read-only", v)
+			}
 		}
 	}
 
-	for _, want := range []string{"obol.org", "traefik.io", "gateway.networking.k8s.io"} {
-		if !apiGroups[want] {
-			t.Errorf("ClusterRole missing apiGroup %q", want)
+	// Read role should cover obol.org (serviceoffers) and core ("") groups.
+	readGroups := collectAPIGroups(readRules)
+	if !readGroups["obol.org"] {
+		t.Error("read ClusterRole missing obol.org apiGroup")
+	}
+	if !readGroups[""] {
+		t.Error("read ClusterRole missing core API group")
+	}
+
+	// ── Workload ClusterRole ────────────────────────────────────────────
+	workloadCR := findDocByName(docs, "ClusterRole", "openclaw-monetize-workload")
+	if workloadCR == nil {
+		t.Fatal("no ClusterRole 'openclaw-monetize-workload' found")
+	}
+
+	workloadRules, ok := workloadCR["rules"].([]interface{})
+	if !ok || len(workloadRules) == 0 {
+		t.Fatal("workload ClusterRole has no rules")
+	}
+
+	// Workload role should have mutate verbs and cover all agent-managed apiGroups.
+	workloadGroups := collectAPIGroups(workloadRules)
+	for _, want := range []string{"obol.org", "traefik.io", "gateway.networking.k8s.io", "", "apps"} {
+		if !workloadGroups[want] {
+			t.Errorf("workload ClusterRole missing apiGroup %q", want)
 		}
 	}
 
-	// Core API group ("") should have configmaps for x402-pricing management
-	if !apiGroups[""] {
-		t.Error("ClusterRole missing core API group (needed for configmaps)")
+	// Workload: apps/deployments should have create (for registration httpd).
+	if !hasVerbOnResource(workloadRules, "apps", "deployments", "create") {
+		t.Error("workload ClusterRole missing 'create' on apps/deployments")
 	}
 
-	// Verify configmaps resource is present in one of the core rules
-	hasConfigMaps := false
+	// Workload: configmaps should have create (for registration JSON).
+	if !hasVerbOnResource(workloadRules, "", "configmaps", "create") {
+		t.Error("workload ClusterRole missing 'create' on configmaps")
+	}
+
+	// ── ClusterRoleBindings ─────────────────────────────────────────────
+	readCRB := findDocByName(docs, "ClusterRoleBinding", "openclaw-monetize-read-binding")
+	if readCRB == nil {
+		t.Fatal("no ClusterRoleBinding 'openclaw-monetize-read-binding' found")
+	}
+	if ref := nested(readCRB, "roleRef", "name"); ref != "openclaw-monetize-read" {
+		t.Errorf("read binding roleRef.name = %v, want openclaw-monetize-read", ref)
+	}
+
+	workloadCRB := findDocByName(docs, "ClusterRoleBinding", "openclaw-monetize-workload-binding")
+	if workloadCRB == nil {
+		t.Fatal("no ClusterRoleBinding 'openclaw-monetize-workload-binding' found")
+	}
+	if ref := nested(workloadCRB, "roleRef", "name"); ref != "openclaw-monetize-workload" {
+		t.Errorf("workload binding roleRef.name = %v, want openclaw-monetize-workload", ref)
+	}
+
+	// ── x402 namespace Role + RoleBinding ───────────────────────────────
+	x402Role := findDocByName(docs, "Role", "openclaw-x402-pricing")
+	if x402Role == nil {
+		t.Fatal("no Role 'openclaw-x402-pricing' found")
+	}
+	if ns := nested(x402Role, "metadata", "namespace"); ns != "x402" {
+		t.Errorf("x402 Role namespace = %v, want x402", ns)
+	}
+
+	// x402 Role should be scoped to x402-pricing ConfigMap only.
+	x402Rules, ok := x402Role["rules"].([]interface{})
+	if !ok || len(x402Rules) != 1 {
+		t.Fatalf("x402 Role should have exactly 1 rule, got %d", len(x402Rules))
+	}
+	rm := x402Rules[0].(map[string]interface{})
+	resNames, ok := rm["resourceNames"].([]interface{})
+	if !ok || len(resNames) != 1 || resNames[0] != "x402-pricing" {
+		t.Errorf("x402 Role should be scoped to resourceNames: [x402-pricing], got %v", resNames)
+	}
+
+	x402RB := findDocByName(docs, "RoleBinding", "openclaw-x402-pricing-binding")
+	if x402RB == nil {
+		t.Fatal("no RoleBinding 'openclaw-x402-pricing-binding' found")
+	}
+	if ns := nested(x402RB, "metadata", "namespace"); ns != "x402" {
+		t.Errorf("x402 RoleBinding namespace = %v, want x402", ns)
+	}
+	if ref := nested(x402RB, "roleRef", "name"); ref != "openclaw-x402-pricing" {
+		t.Errorf("x402 RoleBinding roleRef.name = %v, want openclaw-x402-pricing", ref)
+	}
+}
+
+// collectAPIGroups extracts all unique apiGroup strings from a list of rules.
+func collectAPIGroups(rules []interface{}) map[string]bool {
+	groups := make(map[string]bool)
 	for _, r := range rules {
 		rm := r.(map[string]interface{})
-		groups, ok := rm["apiGroups"].([]interface{})
+		gs, ok := rm["apiGroups"].([]interface{})
 		if !ok {
 			continue
 		}
-		for _, g := range groups {
-			if g.(string) != "" {
-				continue
-			}
-			resources, ok := rm["resources"].([]interface{})
-			if !ok {
-				continue
-			}
-			for _, res := range resources {
-				if res.(string) == "configmaps" {
-					hasConfigMaps = true
-				}
-			}
+		for _, g := range gs {
+			groups[g.(string)] = true
 		}
 	}
-	if !hasConfigMaps {
-		t.Error("ClusterRole missing 'configmaps' resource in core API group")
-	}
+	return groups
+}
 
-	// apps/deployments should have create (required for agent-managed busybox httpd)
-	hasDeployCreate := false
+// hasVerbOnResource checks if any rule grants the given verb on the given
+// apiGroup + resource combination.
+func hasVerbOnResource(rules []interface{}, apiGroup, resource, verb string) bool {
 	for _, r := range rules {
 		rm := r.(map[string]interface{})
-		groups, ok := rm["apiGroups"].([]interface{})
+		gs, ok := rm["apiGroups"].([]interface{})
 		if !ok {
 			continue
 		}
-		for _, g := range groups {
-			if g.(string) != "apps" {
-				continue
+		groupMatch := false
+		for _, g := range gs {
+			if g.(string) == apiGroup {
+				groupMatch = true
 			}
-			resources, ok := rm["resources"].([]interface{})
-			if !ok {
-				continue
+		}
+		if !groupMatch {
+			continue
+		}
+		res, ok := rm["resources"].([]interface{})
+		if !ok {
+			continue
+		}
+		resMatch := false
+		for _, rr := range res {
+			if rr.(string) == resource {
+				resMatch = true
 			}
-			for _, res := range resources {
-				if res.(string) != "deployments" {
-					continue
-				}
-				verbs, ok := rm["verbs"].([]interface{})
-				if !ok {
-					continue
-				}
-				for _, v := range verbs {
-					if v.(string) == "create" {
-						hasDeployCreate = true
-					}
-				}
+		}
+		if !resMatch {
+			continue
+		}
+		verbs, ok := rm["verbs"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, v := range verbs {
+			if v.(string) == verb {
+				return true
 			}
 		}
 	}
-	if !hasDeployCreate {
-		t.Error("ClusterRole missing 'create' verb on apps/deployments (required for registration httpd)")
-	}
-
-	// ClusterRoleBinding should reference openclaw-monetize
-	roleRef := nested(crb, "roleRef", "name")
-	if roleRef != "openclaw-monetize" {
-		t.Errorf("ClusterRoleBinding roleRef.name = %v, want openclaw-monetize", roleRef)
-	}
+	return false
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/embed/infrastructure/base/templates/obol-agent-monetize-rbac.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-agent-monetize-rbac.yaml
@@ -1,24 +1,63 @@
 ---
 # Monetize RBAC for OpenClaw Agents
-# Grants OpenClaw service accounts the ability to create and manage
-# ServiceOffers (CRD), Traefik middlewares, and Gateway API HTTPRoutes.
-# Subjects are intentionally empty — they are patched dynamically by
-# `obol agent init` when an OpenClaw instance is provisioned.
+#
+# Split into least-privilege roles:
+#   1. openclaw-monetize-read      — cluster-wide read-only (low risk)
+#   2. openclaw-monetize-workload  — cluster-wide mutate for agent-managed resources
+#   3. openclaw-x402-pricing       — namespace-scoped x402 pricing ConfigMap access
+#
+# Subjects pre-populated with obol-agent ServiceAccount.
+# Patched dynamically by `obol agent init` for additional instances.
 
 #------------------------------------------------------------------------------
-# ClusterRole - Monetize permissions for OpenClaw agents
-# Allows creating tunnel routes, x402 ForwardAuth middlewares, and
-# reading workload status across namespaces.
+# ClusterRole - Read-only permissions (low privilege, cluster-wide)
+# Allows reading ServiceOffers, workload status, and cluster capacity.
 #------------------------------------------------------------------------------
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: openclaw-monetize
+  name: openclaw-monetize-read
+rules:
+  # ServiceOffer CRD - discover and watch across namespaces
+  - apiGroups: ["obol.org"]
+    resources: ["serviceoffers", "serviceoffers/status"]
+    verbs: ["get", "list", "watch"]
+  # Pods - read workload status
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Read pod logs for diagnostics
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Services/Endpoints - read workload status
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list"]
+  # Deployments - read workload status
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  # Cluster-wide read for capacity assessment
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+
+---
+#------------------------------------------------------------------------------
+# ClusterRole - Workload mutate permissions for agent-managed resources
+# Cluster-wide because the agent creates resources in the upstream's namespace
+# (e.g., Middlewares in "llm", HTTPRoutes in "llm", registration ConfigMaps).
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openclaw-monetize-workload
 rules:
   # ServiceOffer CRD - full lifecycle management
   - apiGroups: ["obol.org"]
     resources: ["serviceoffers", "serviceoffers/status"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["create", "update", "patch", "delete"]
   # Traefik middlewares - create ForwardAuth for x402 gating
   - apiGroups: ["traefik.io"]
     resources: ["middlewares"]
@@ -27,43 +66,84 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
-  # ConfigMaps - x402-pricing routes + agent-managed registration JSON
+  # ConfigMaps - agent-managed registration JSON (in upstream namespace)
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
-  # Services - agent-managed registration httpd + read workload status
+  # Services + Endpoints - agent-managed registration httpd
   - apiGroups: [""]
     resources: ["services", "endpoints"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
-  # Pods - read workload status
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list"]
-  # Deployments - agent-managed registration httpd + read workload status
+    verbs: ["create", "update", "patch", "delete"]
+  # Deployments - agent-managed registration httpd
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
-  # Read pod logs for diagnostics
-  - apiGroups: [""]
-    resources: ["pods/log"]
-    verbs: ["get"]
-  # Cluster-wide read for capacity assessment
-  - apiGroups: [""]
-    resources: ["namespaces", "nodes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["create", "update", "patch", "delete"]
 
 ---
 #------------------------------------------------------------------------------
-# ClusterRoleBinding - Binds monetize role to OpenClaw service accounts
-# Subjects are empty and patched dynamically by `obol agent init` to add
-# the ServiceAccount for each OpenClaw instance (e.g., openclaw-<id>).
+# ClusterRoleBinding - Read permissions
 #------------------------------------------------------------------------------
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openclaw-monetize-binding
+  name: openclaw-monetize-read-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openclaw-monetize
-subjects: []
+  name: openclaw-monetize-read
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-obol-agent
+
+---
+#------------------------------------------------------------------------------
+# ClusterRoleBinding - Workload mutate permissions
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-monetize-workload-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openclaw-monetize-workload
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-obol-agent
+
+---
+#------------------------------------------------------------------------------
+# Role - x402 pricing ConfigMap access (scoped to x402 namespace)
+# Separate from the cluster-wide workload role to limit pricing config
+# mutations to the x402 namespace only.
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-x402-pricing
+  namespace: x402
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["x402-pricing"]
+    verbs: ["get", "list", "update", "patch"]
+
+---
+#------------------------------------------------------------------------------
+# RoleBinding - Binds x402 pricing access to agent ServiceAccount
+#------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-x402-pricing-binding
+  namespace: x402
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-x402-pricing
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-obol-agent

--- a/internal/embed/infrastructure/base/templates/obol-agent.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-agent.yaml
@@ -1,7 +1,7 @@
 ---
 # Agent namespace — retained for backward compatibility.
 # The obol-agent OpenClaw instance runs in openclaw-obol-agent namespace;
-# RBAC is managed by the openclaw-monetize ClusterRole.
+# RBAC is managed by the openclaw-monetize-read/workload ClusterRoles.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -56,7 +56,7 @@ metadata:
   annotations:
     configmap.reloader.stakater.com/reload: "x402-pricing"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: x402-verifier
@@ -126,3 +126,17 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
+
+---
+# PDB ensures at least 1 replica stays available during rollouts/evictions.
+# Without this, Traefik ForwardAuth fails open when the verifier is unavailable.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: x402-verifier
+  namespace: x402
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: x402-verifier

--- a/internal/embed/skills/monetize/scripts/monetize.py
+++ b/internal/embed/skills/monetize/scripts/monetize.py
@@ -23,6 +23,7 @@ Commands:
 import argparse
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
@@ -37,6 +38,45 @@ from kube import load_sa, make_ssl_context, api_get, api_post, api_patch, api_de
 CRD_GROUP = "obol.org"
 CRD_VERSION = "v1alpha1"
 CRD_PLURAL = "serviceoffers"
+
+# ---------------------------------------------------------------------------
+# Input validation — prevents YAML injection via f-string interpolation.
+# All values are validated before being used in YAML string construction.
+# ---------------------------------------------------------------------------
+
+_ROUTE_PATTERN_RE = re.compile(r"^/[a-zA-Z0-9_./*-]+$")
+_PRICE_RE = re.compile(r"^\d+(\.\d+)?$")
+_ADDRESS_RE = re.compile(r"^0x[a-fA-F0-9]{40}$")
+_NETWORK_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def _validate_route_pattern(pattern):
+    """Validate route pattern is safe for YAML interpolation."""
+    if not pattern or not _ROUTE_PATTERN_RE.match(pattern):
+        raise ValueError(f"invalid route pattern: {pattern!r}")
+    return pattern
+
+
+def _validate_price(price):
+    """Validate price is a numeric string safe for YAML interpolation."""
+    if not price or not _PRICE_RE.match(str(price)):
+        raise ValueError(f"invalid price: {price!r}")
+    return str(price)
+
+
+def _validate_address(addr):
+    """Validate Ethereum address if non-empty."""
+    if addr and not _ADDRESS_RE.match(addr):
+        raise ValueError(f"invalid Ethereum address: {addr!r}")
+    return addr
+
+
+def _validate_network(network):
+    """Validate network name if non-empty."""
+    if network and not _NETWORK_RE.match(network):
+        raise ValueError(f"invalid network name: {network!r}")
+    return network
+
 
 # ---------------------------------------------------------------------------
 # ERC-8004 constants
@@ -418,18 +458,33 @@ def stage_upstream_healthy(spec, ns, name, token, ssl_ctx):
     else:
         req = urllib.request.Request(health_url)
 
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            resp.read()
-            print(f"  Upstream healthy (HTTP {resp.status})")
-    except urllib.error.HTTPError as e:
-        # An HTTP error (400, 405, etc.) still proves the upstream is reachable
-        # and accepting connections — only connection failures mean "unhealthy".
-        print(f"  Upstream reachable (HTTP {e.code} — acceptable for health check)")
-    except (urllib.error.URLError, OSError) as e:
-        msg = str(e)[:200]
-        print(f"  Health-check failed: {msg}", file=sys.stderr)
-        set_condition(ns, name, "UpstreamHealthy", "False", "Unhealthy", msg, token, ssl_ctx)
+    # Retry transient connection failures (pod starting, DNS propagation).
+    max_attempts = 3
+    backoff = 2  # seconds
+    last_err = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                resp.read()
+                print(f"  Upstream healthy (HTTP {resp.status})")
+                last_err = None
+                break
+        except urllib.error.HTTPError as e:
+            # An HTTP error (400, 405, etc.) still proves the upstream is reachable
+            # and accepting connections — only connection failures mean "unhealthy".
+            print(f"  Upstream reachable (HTTP {e.code} — acceptable for health check)")
+            last_err = None
+            break
+        except (urllib.error.URLError, OSError) as e:
+            last_err = str(e)[:200]
+            if attempt < max_attempts:
+                print(f"  Health-check attempt {attempt}/{max_attempts} failed: {last_err}, retrying in {backoff}s...")
+                time.sleep(backoff)
+            else:
+                print(f"  Health-check failed after {max_attempts} attempts: {last_err}", file=sys.stderr)
+
+    if last_err:
+        set_condition(ns, name, "UpstreamHealthy", "False", "Unhealthy", last_err, token, ssl_ctx)
         return False
 
     set_condition(ns, name, "UpstreamHealthy", "True", "Healthy", "Upstream responded successfully", token, ssl_ctx)
@@ -506,11 +561,11 @@ def _add_pricing_route(spec, name, token, ssl_ctx):
     Now includes per-route payTo and network fields aligned with x402.
     """
     url_path = spec.get("path", f"/services/{name}")
-    price = get_effective_price(spec)
-    pay_to = get_pay_to(spec)
-    network = get_network(spec)
+    price = _validate_price(get_effective_price(spec))
+    pay_to = _validate_address(get_pay_to(spec))
+    network = _validate_network(get_network(spec))
 
-    route_pattern = f"{url_path}/*"
+    route_pattern = _validate_route_pattern(f"{url_path}/*")
 
     # Read current x402-pricing ConfigMap.
     cm_path = "/api/v1/namespaces/x402/configmaps/x402-pricing"

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -1,0 +1,103 @@
+// Package kubectl provides helpers for running kubectl commands with the
+// correct KUBECONFIG environment variable set. It centralises the pattern
+// that was previously duplicated across network, x402, model, agent, and
+// cmd/obol packages.
+package kubectl
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// EnsureCluster checks that the kubeconfig file exists, returning a
+// descriptive error when the cluster is not running.
+func EnsureCluster(cfg *config.Config) error {
+	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
+		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	}
+	return nil
+}
+
+// Paths returns the absolute paths to the kubectl binary and kubeconfig.
+func Paths(cfg *config.Config) (binary, kubeconfig string) {
+	return filepath.Join(cfg.BinDir, "kubectl"),
+		filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+}
+
+// Run executes kubectl with the given arguments, inheriting stdout and
+// capturing stderr. The error message includes stderr output on failure.
+func Run(binary, kubeconfig string, args ...string) error {
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return fmt.Errorf("%w: %s", err, errMsg)
+		}
+		return err
+	}
+	return nil
+}
+
+// RunSilent executes kubectl without inheriting stdout. Stderr is captured
+// and included in the returned error on failure.
+func RunSilent(binary, kubeconfig string, args ...string) error {
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return fmt.Errorf("%w: %s", err, errMsg)
+		}
+		return err
+	}
+	return nil
+}
+
+// Output executes kubectl and returns the captured stdout. Stderr is
+// captured and included in the returned error on failure.
+func Output(binary, kubeconfig string, args ...string) (string, error) {
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return "", fmt.Errorf("%w: %s", err, errMsg)
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}
+
+// Apply pipes the given data into kubectl apply -f -.
+func Apply(binary, kubeconfig string, data []byte) error {
+	cmd := exec.Command(binary, "apply", "-f", "-")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = os.Stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return fmt.Errorf("kubectl apply: %w: %s", err, errMsg)
+		}
+		return fmt.Errorf("kubectl apply: %w", err)
+	}
+	return nil
+}

--- a/internal/kubectl/kubectl_test.go
+++ b/internal/kubectl/kubectl_test.go
@@ -1,0 +1,56 @@
+package kubectl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+func TestEnsureCluster_Missing(t *testing.T) {
+	cfg := &config.Config{ConfigDir: t.TempDir()}
+	err := EnsureCluster(cfg)
+	if err == nil {
+		t.Fatal("expected error when kubeconfig missing")
+	}
+}
+
+func TestEnsureCluster_Exists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{ConfigDir: dir}
+	if err := EnsureCluster(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPaths(t *testing.T) {
+	cfg := &config.Config{
+		BinDir:    "/usr/local/bin",
+		ConfigDir: "/home/user/.config/obol",
+	}
+	bin, kc := Paths(cfg)
+	if bin != "/usr/local/bin/kubectl" {
+		t.Errorf("binary = %q, want /usr/local/bin/kubectl", bin)
+	}
+	if kc != "/home/user/.config/obol/kubeconfig.yaml" {
+		t.Errorf("kubeconfig = %q, want /home/user/.config/obol/kubeconfig.yaml", kc)
+	}
+}
+
+func TestOutput_BinaryNotFound(t *testing.T) {
+	_, err := Output("/nonexistent/kubectl", "/tmp/kc.yaml", "version")
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}
+
+func TestRunSilent_BinaryNotFound(t *testing.T) {
+	err := RunSilent("/nonexistent/kubectl", "/tmp/kc.yaml", "version")
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 )
 
 const (
@@ -58,7 +58,7 @@ func ConfigureLLMSpy(cfg *config.Config, provider, apiKey string) error {
 	// 1. Patch the Secret with the API key
 	fmt.Printf("Configuring llmspy: setting %s key...\n", provider)
 	patchJSON := fmt.Sprintf(`{"stringData":{"%s":"%s"}}`, envKey, apiKey)
-	if err := kubectl(kubectlBinary, kubeconfigPath,
+	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
 		"patch", "secret", secretName, "-n", namespace,
 		"-p", patchJSON, "--type=merge"); err != nil {
 		return fmt.Errorf("failed to patch llmspy secret: %w", err)
@@ -72,13 +72,13 @@ func ConfigureLLMSpy(cfg *config.Config, provider, apiKey string) error {
 
 	// 3. Restart the deployment so it picks up new Secret + ConfigMap
 	fmt.Printf("Restarting llmspy deployment...\n")
-	if err := kubectl(kubectlBinary, kubeconfigPath,
+	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
 		"rollout", "restart", fmt.Sprintf("deployment/%s", deployName), "-n", namespace); err != nil {
 		return fmt.Errorf("failed to restart llmspy: %w", err)
 	}
 
 	// 4. Wait for rollout to complete
-	if err := kubectl(kubectlBinary, kubeconfigPath,
+	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
 		"rollout", "status", fmt.Sprintf("deployment/%s", deployName), "-n", namespace,
 		"--timeout=60s"); err != nil {
 		fmt.Printf("Warning: llmspy rollout not confirmed: %v\n", err)
@@ -101,7 +101,7 @@ if p and p.get('env'):
     print(p['env'][0])
 `, provider)
 
-	output, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+	output, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 		"exec", "-n", namespace, fmt.Sprintf("deploy/%s", deployName), "--",
 		"python3", "-c", script)
 	if err != nil {
@@ -136,7 +136,7 @@ for pid in sorted(d):
     if env:
         print(pid + '\t' + p.get('name', pid) + '\t' + env[0])
 `
-	output, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+	output, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 		"exec", "-n", namespace, fmt.Sprintf("deploy/%s", deployName), "--",
 		"python3", "-c", script)
 	if err != nil {
@@ -184,14 +184,14 @@ func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	}
 
 	// Read enabled/disabled state from ConfigMap
-	llmsRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+	llmsRaw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.llms\\.json}")
 	if err != nil {
 		return nil, err
 	}
 
 	// Read Secret to check which API keys are set
-	secretRaw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+	secretRaw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 		"get", "secret", secretName, "-n", namespace, "-o", "json")
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func buildProviderStatus(available []ProviderInfo, llmsJSON, secretJSON []byte) 
 // sets providers.<name>.enabled = true, and patches the ConfigMap back.
 func enableProviderInConfigMap(kubectlBinary, kubeconfigPath, provider string) error {
 	// Read current llms.json from ConfigMap
-	raw, err := kubectlOutput(kubectlBinary, kubeconfigPath,
+	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.llms\\.json}")
 	if err != nil {
 		return fmt.Errorf("failed to read ConfigMap: %w", err)
@@ -293,7 +293,7 @@ func enableProviderInConfigMap(kubectlBinary, kubeconfigPath, provider string) e
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	return kubectl(kubectlBinary, kubeconfigPath,
+	return kubectl.Run(kubectlBinary, kubeconfigPath,
 		"patch", "configmap", configMapName, "-n", namespace,
 		"-p", string(patchJSON), "--type=merge")
 }
@@ -322,39 +322,6 @@ func patchLLMsJSON(llmsJSON []byte, provider string) ([]byte, error) {
 	return json.Marshal(llmsConfig)
 }
 
-// kubectl runs a kubectl command with the given kubeconfig and returns any error.
-func kubectl(binary, kubeconfig string, args ...string) error {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return err
-	}
-	return nil
-}
-
-func kubectlOutput(binary, kubeconfig string, args ...string) (string, error) {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return "", fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return "", err
-	}
-	return stdout.String(), nil
-}
 
 // ollamaEndpoint returns the base URL where host Ollama should be reachable.
 // It respects the OLLAMA_HOST environment variable, falling back to http://localhost:11434.

--- a/internal/network/erpc.go
+++ b/internal/network/erpc.go
@@ -1,15 +1,14 @@
 package network
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"gopkg.in/yaml.v3"
 )
 
@@ -73,15 +72,13 @@ func DeregisterERPCUpstream(cfg *config.Config, networkType, id string) error {
 // restarts the eRPC deployment. When add is true, it adds/updates the
 // upstream. When false, it removes it.
 func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID int, add bool) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap
-	configYAML, err := kubectlOutput(kubectlBin, kubeconfigPath,
+	configYAML, err := kubectl.Output(kubectlBin, kubeconfigPath,
 		"get", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(erpcConfigKey, ".", "\\.")))
 	if err != nil {
@@ -198,14 +195,14 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 		return fmt.Errorf("could not marshal patch: %w", err)
 	}
 
-	if err := kubectl(kubectlBin, kubeconfigPath,
+	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
 		"patch", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-p", string(patchJSON), "--type=merge"); err != nil {
 		return fmt.Errorf("could not patch eRPC ConfigMap: %w", err)
 	}
 
 	// Restart eRPC to pick up new config
-	if err := kubectl(kubectlBin, kubeconfigPath,
+	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
 		"rollout", "restart", fmt.Sprintf("deployment/%s", erpcDeployment), "-n", erpcNamespace); err != nil {
 		return fmt.Errorf("could not restart eRPC: %w", err)
 	}
@@ -217,37 +214,4 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 	}
 
 	return nil
-}
-
-// kubectl runs a kubectl command, capturing stderr for error messages.
-func kubectl(binary, kubeconfig string, args ...string) error {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return err
-	}
-	return nil
-}
-
-// kubectlOutput runs a kubectl command and returns stdout.
-func kubectlOutput(binary, kubeconfig string, args ...string) (string, error) {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return "", fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return "", err
-	}
-	return stdout.String(), nil
 }

--- a/internal/network/rpc.go
+++ b/internal/network/rpc.go
@@ -3,11 +3,10 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"gopkg.in/yaml.v3"
 )
 
@@ -165,15 +164,13 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string) e
 
 // AddPublicRPCs adds ChainList RPCs for a chain to the eRPC ConfigMap.
 func AddPublicRPCs(cfg *config.Config, chainID int, chainName string, endpoints []RPCEndpoint) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running, use 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap.
-	configYAML, err := kubectlOutput(kubectlBin, kubeconfigPath,
+	configYAML, err := kubectl.Output(kubectlBin, kubeconfigPath,
 		"get", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(erpcConfigKey, ".", "\\.")))
 	if err != nil {
@@ -258,15 +255,13 @@ func AddPublicRPCs(cfg *config.Config, chainID int, chainName string, endpoints 
 
 // RemovePublicRPCs removes all ChainList RPCs for a chain from the eRPC ConfigMap.
 func RemovePublicRPCs(cfg *config.Config, chainID int) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running, use 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap.
-	configYAML, err := kubectlOutput(kubectlBin, kubeconfigPath,
+	configYAML, err := kubectl.Output(kubectlBin, kubeconfigPath,
 		"get", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(erpcConfigKey, ".", "\\.")))
 	if err != nil {
@@ -316,15 +311,13 @@ func RemovePublicRPCs(cfg *config.Config, chainID int) error {
 
 // GetERPCStatus returns eRPC pod status and upstream counts.
 func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int]int, err error) {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", nil, fmt.Errorf("cluster not running, use 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return "", nil, err
 	}
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Get pod status.
-	podStatus, err = kubectlOutput(kubectlBin, kubeconfigPath,
+	podStatus, err = kubectl.Output(kubectlBin, kubeconfigPath,
 		"get", "pods", "-n", erpcNamespace, "-l", "app.kubernetes.io/name=erpc",
 		"-o", "custom-columns=NAME:.metadata.name,STATUS:.status.phase,READY:.status.containerStatuses[0].ready,RESTARTS:.status.containerStatuses[0].restartCount",
 		"--no-headers")
@@ -367,14 +360,12 @@ func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int
 
 // readERPCConfig reads and parses the eRPC ConfigMap YAML.
 func readERPCConfig(cfg *config.Config) (map[string]interface{}, error) {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster not running, use 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return nil, err
 	}
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
-	configYAML, err := kubectlOutput(kubectlBin, kubeconfigPath,
+	configYAML, err := kubectl.Output(kubectlBin, kubeconfigPath,
 		"get", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(erpcConfigKey, ".", "\\.")))
 	if err != nil {
@@ -391,8 +382,7 @@ func readERPCConfig(cfg *config.Config) (map[string]interface{}, error) {
 
 // writeERPCConfig serializes the eRPC config and patches the ConfigMap, then restarts eRPC.
 func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	updatedYAML, err := yaml.Marshal(erpcConfig)
 	if err != nil {
@@ -409,14 +399,14 @@ func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) erro
 		return fmt.Errorf("could not marshal patch: %w", err)
 	}
 
-	if err := kubectl(kubectlBin, kubeconfigPath,
+	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
 		"patch", "configmap", erpcConfigMapName, "-n", erpcNamespace,
 		"-p", string(patchJSON), "--type=merge"); err != nil {
 		return fmt.Errorf("could not patch eRPC ConfigMap: %w", err)
 	}
 
 	// Restart eRPC to pick up new config.
-	if err := kubectl(kubectlBin, kubeconfigPath,
+	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
 		"rollout", "restart", fmt.Sprintf("deployment/%s", erpcDeployment), "-n", erpcNamespace); err != nil {
 		return fmt.Errorf("could not restart eRPC: %w", err)
 	}

--- a/internal/openclaw/monetize_integration_test.go
+++ b/internal/openclaw/monetize_integration_test.go
@@ -358,21 +358,30 @@ func execInAgentErr(cfg *config.Config, args ...string) (string, error) {
 	return obolRunErr(cfg, fullArgs...)
 }
 
-func TestIntegration_RBAC_ClusterRoleExists(t *testing.T) {
+func TestIntegration_RBAC_ClusterRolesExist(t *testing.T) {
 	cfg := requireCluster(t)
 
-	out := obolRun(t, cfg, "kubectl", "get", "clusterrole", "openclaw-monetize", "-o", "json")
+	// Both ClusterRoles should exist after stack init.
+	for _, name := range []string{"openclaw-monetize-read", "openclaw-monetize-workload"} {
+		out := obolRun(t, cfg, "kubectl", "get", "clusterrole", name, "-o", "json")
+		var cr map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &cr); err != nil {
+			t.Fatalf("parse clusterrole %s JSON: %v", name, err)
+		}
+
+		rules, ok := cr["rules"].([]interface{})
+		if !ok || len(rules) == 0 {
+			t.Errorf("ClusterRole %s has no rules", name)
+		}
+	}
+
+	// Workload role should cover key mutate apiGroups.
+	out := obolRun(t, cfg, "kubectl", "get", "clusterrole", "openclaw-monetize-workload", "-o", "json")
 	var cr map[string]interface{}
 	if err := json.Unmarshal([]byte(out), &cr); err != nil {
 		t.Fatalf("parse clusterrole JSON: %v", err)
 	}
-
-	rules, ok := cr["rules"].([]interface{})
-	if !ok || len(rules) == 0 {
-		t.Fatal("ClusterRole has no rules")
-	}
-
-	// Verify key apiGroups are present
+	rules := cr["rules"].([]interface{})
 	apiGroups := make(map[string]bool)
 	for _, r := range rules {
 		rm := r.(map[string]interface{})
@@ -384,41 +393,42 @@ func TestIntegration_RBAC_ClusterRoleExists(t *testing.T) {
 			apiGroups[g.(string)] = true
 		}
 	}
-
 	for _, want := range []string{"obol.org", "traefik.io", "gateway.networking.k8s.io"} {
 		if !apiGroups[want] {
-			t.Errorf("ClusterRole missing apiGroup %q", want)
+			t.Errorf("workload ClusterRole missing apiGroup %q", want)
 		}
 	}
 }
 
-func TestIntegration_RBAC_BindingPatched(t *testing.T) {
+func TestIntegration_RBAC_BindingsPatched(t *testing.T) {
 	cfg := requireCluster(t)
 	requireAgent(t, cfg)
 
-	out := obolRun(t, cfg, "kubectl", "get", "clusterrolebinding", "openclaw-monetize-binding", "-o", "json")
-	var crb map[string]interface{}
-	if err := json.Unmarshal([]byte(out), &crb); err != nil {
-		t.Fatalf("parse binding JSON: %v", err)
-	}
-
-	subjects, ok := crb["subjects"].([]interface{})
-	if !ok || len(subjects) == 0 {
-		t.Skip("ClusterRoleBinding has no subjects yet — obol agent init may not have run")
-	}
-
-	// Check that at least one subject is an openclaw service account
-	found := false
-	for _, s := range subjects {
-		sm := s.(map[string]interface{})
-		ns, _ := sm["namespace"].(string)
-		if strings.HasPrefix(ns, "openclaw-") {
-			found = true
-			break
+	// Both ClusterRoleBindings should have subjects after obol agent init.
+	for _, name := range []string{"openclaw-monetize-read-binding", "openclaw-monetize-workload-binding"} {
+		out := obolRun(t, cfg, "kubectl", "get", "clusterrolebinding", name, "-o", "json")
+		var crb map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &crb); err != nil {
+			t.Fatalf("parse binding %s JSON: %v", name, err)
 		}
-	}
-	if !found {
-		t.Error("no openclaw-* service account found in binding subjects")
+
+		subjects, ok := crb["subjects"].([]interface{})
+		if !ok || len(subjects) == 0 {
+			t.Skipf("ClusterRoleBinding %s has no subjects yet — obol agent init may not have run", name)
+		}
+
+		found := false
+		for _, s := range subjects {
+			sm := s.(map[string]interface{})
+			ns, _ := sm["namespace"].(string)
+			if strings.HasPrefix(ns, "openclaw-") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("no openclaw-* service account found in %s subjects", name)
+		}
 	}
 }
 

--- a/internal/testutil/verifier.go
+++ b/internal/testutil/verifier.go
@@ -1,14 +1,13 @@
 package testutil
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 )
 
 // PatchVerifierFacilitator patches the x402-pricing ConfigMap to use the given
@@ -23,14 +22,14 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 	t.Helper()
 
 	// Read current pricing YAML from ConfigMap.
-	currentYAML, err := kubectlExecOutput(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
+	currentYAML, err := kubectl.Output(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
 		"-n", "x402", "-o", `jsonpath={.data.pricing\.yaml}`)
 	if err != nil {
 		t.Fatalf("read x402-pricing ConfigMap: %v", err)
 	}
 
 	// Save original ConfigMap JSON for restore.
-	originalJSON, err := kubectlExecOutput(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
+	originalJSON, err := kubectl.Output(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
 		"-n", "x402", "-o", "json")
 	if err != nil {
 		t.Fatalf("read x402-pricing ConfigMap (json): %v", err)
@@ -51,7 +50,7 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 			"pricing.yaml": updated,
 		},
 	})
-	if err := kubectlExecRun(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
+	if err := kubectl.RunSilent(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
 		"--type=merge", fmt.Sprintf("-p=%s", string(patchJSON))); err != nil {
 		t.Fatalf("patch x402-pricing ConfigMap: %v", err)
 	}
@@ -80,7 +79,7 @@ func restoreVerifierConfigMap(t *testing.T, kubectlBin, kubeconfig, originalJSON
 		"data": cm.Data,
 	})
 
-	if err := kubectlExecRun(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
+	if err := kubectl.RunSilent(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
 		"--type=merge", fmt.Sprintf("-p=%s", string(patchJSON))); err != nil {
 		t.Logf("Warning: could not restore x402-pricing ConfigMap: %v", err)
 	} else {
@@ -94,14 +93,14 @@ func waitForVerifierRestart(t *testing.T, kubectlBin, kubeconfig, expectedURL st
 	t.Helper()
 
 	// Force restart so the verifier picks up the new ConfigMap immediately.
-	if err := kubectlExecRun(kubectlBin, kubeconfig, "rollout", "restart",
+	if err := kubectl.RunSilent(kubectlBin, kubeconfig, "rollout", "restart",
 		"deploy/x402-verifier", "-n", "x402"); err != nil {
 		t.Fatalf("rollout restart x402-verifier: %v", err)
 	}
 
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		logs, err := kubectlExecOutput(kubectlBin, kubeconfig, "logs", "deploy/x402-verifier",
+		logs, err := kubectl.Output(kubectlBin, kubeconfig, "logs", "deploy/x402-verifier",
 			"-n", "x402", "--tail=10")
 		if err == nil && strings.Contains(logs, expectedURL) {
 			t.Log("x402-verifier restarted with updated facilitator URL")
@@ -112,35 +111,3 @@ func waitForVerifierRestart(t *testing.T, kubectlBin, kubeconfig, expectedURL st
 	t.Log("Warning: did not confirm verifier restart with new URL (continuing anyway)")
 }
 
-// kubectlExecRun runs a kubectl command, returning an error if it fails.
-func kubectlExecRun(binary, kubeconfig string, args ...string) error {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return err
-	}
-	return nil
-}
-
-// kubectlExecOutput runs a kubectl command and returns its stdout.
-func kubectlExecOutput(binary, kubeconfig string, args ...string) (string, error) {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return "", fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return "", err
-	}
-	return stdout.String(), nil
-}

--- a/internal/tunnel/login.go
+++ b/internal/tunnel/login.go
@@ -1,7 +1,6 @@
 package tunnel
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 )
 
 type LoginOptions struct {
@@ -140,13 +140,14 @@ func applyLocalManagedK8sResources(cfg *config.Config, kubeconfigPath, hostname,
 	if err != nil {
 		return err
 	}
-	if err := kubectlApply(cfg, kubeconfigPath, secretYAML); err != nil {
+	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
+	if err := kubectl.Apply(kubectlBin, kubeconfigPath, secretYAML); err != nil {
 		return err
 	}
 
 	// ConfigMap: config.yml + tunnel_id used for command arg expansion.
 	cfgYAML := buildLocalManagedConfigYAML(hostname, tunnelID)
-	if err := kubectlApply(cfg, kubeconfigPath, cfgYAML); err != nil {
+	if err := kubectl.Apply(kubectlBin, kubeconfigPath, cfgYAML); err != nil {
 		return err
 	}
 
@@ -196,18 +197,3 @@ data:
 	return []byte(cfg)
 }
 
-func kubectlApply(cfg *config.Config, kubeconfigPath string, manifest []byte) error {
-	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
-
-	cmd := exec.Command(kubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"apply", "-f", "-",
-	)
-	cmd.Stdin = bytes.NewReader(manifest)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("kubectl apply failed: %w", err)
-	}
-	return nil
-}

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -2,8 +2,8 @@ package x402
 
 import (
 	"fmt"
+	"net/url"
 	"os"
-	"strings"
 
 	x402lib "github.com/mark3labs/x402-go"
 	"gopkg.in/yaml.v3"
@@ -82,20 +82,29 @@ func LoadConfig(path string) (*PricingConfig, error) {
 
 // ValidateFacilitatorURL checks that the facilitator URL uses HTTPS.
 // Payment proofs sent over plain HTTP could be intercepted.
-// Loopback addresses (localhost, 127.0.0.1) and k3d internal addresses
-// (host.k3d.internal) are exempted for local development and testing.
+// Loopback addresses (localhost, 127.0.0.1, [::1]) and k3d/Docker internal
+// addresses are exempted for local development and testing.
 func ValidateFacilitatorURL(u string) error {
-	if strings.HasPrefix(u, "https://") {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return fmt.Errorf("invalid facilitator URL %q: %w", u, err)
+	}
+
+	if parsed.Scheme == "https" {
 		return nil
 	}
-	// Allow loopback and container-internal addresses for local development and testing.
-	if strings.HasPrefix(u, "http://localhost") ||
-		strings.HasPrefix(u, "http://127.0.0.1") ||
-		strings.HasPrefix(u, "http://[::1]") ||
-		strings.HasPrefix(u, "http://host.k3d.internal") ||
-		strings.HasPrefix(u, "http://host.docker.internal") {
+	if parsed.Scheme != "http" {
+		return fmt.Errorf("facilitator URL must use HTTPS (except localhost): %q", u)
+	}
+
+	// Allow loopback and container-internal hostnames for local dev/testing.
+	host := parsed.Hostname()
+	switch host {
+	case "localhost", "127.0.0.1", "::1",
+		"host.k3d.internal", "host.docker.internal":
 		return nil
 	}
+
 	return fmt.Errorf("facilitator URL must use HTTPS (except localhost): %q", u)
 }
 

--- a/internal/x402/config_test.go
+++ b/internal/x402/config_test.go
@@ -172,3 +172,88 @@ func TestResolveChain_Unsupported(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFacilitatorURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		// HTTPS always allowed.
+		{"https standard", "https://facilitator.x402.rs", false},
+		{"https custom", "https://my-facilitator.example.com:8443/verify", false},
+
+		// Loopback/internal addresses allowed over HTTP.
+		{"http localhost", "http://localhost:4040", false},
+		{"http localhost no port", "http://localhost", false},
+		{"http 127.0.0.1", "http://127.0.0.1:4040", false},
+		{"http ipv6 loopback", "http://[::1]:4040", false},
+		{"http k3d internal", "http://host.k3d.internal:4040", false},
+		{"http docker internal", "http://host.docker.internal:4040", false},
+
+		// Issue 7 regression: prefix bypass must be caught.
+		{"bypass localhost-hacker", "http://localhost-hacker.com", true},
+		{"bypass localhost.evil", "http://localhost.evil.com:4040", true},
+
+		// Plain HTTP to external hosts rejected.
+		{"http external", "http://facilitator.x402.rs", true},
+		{"http arbitrary", "http://evil.com:4040", true},
+
+		// Invalid URLs.
+		{"empty string", "", true},
+		{"no scheme", "facilitator.x402.rs", true},
+		{"ftp scheme", "ftp://facilitator.x402.rs", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFacilitatorURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFacilitatorURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_HTTPFacilitatorRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	yaml := `wallet: "0x1234"
+facilitatorURL: "http://evil.example.com"
+routes:
+  - pattern: "/api/*"
+    price: "0.01"
+`
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for HTTP facilitator URL to external host")
+	}
+}
+
+func TestLoadConfig_LocalhostHTTPAllowed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	yaml := `wallet: "0x1234"
+facilitatorURL: "http://localhost:4040"
+routes:
+  - pattern: "/api/*"
+    price: "0.01"
+`
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig should allow localhost HTTP: %v", err)
+	}
+	if cfg.FacilitatorURL != "http://localhost:4040" {
+		t.Errorf("facilitatorURL = %q, want http://localhost:4040", cfg.FacilitatorURL)
+	}
+}

--- a/internal/x402/e2e_test.go
+++ b/internal/x402/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/testutil"
 )
 
@@ -39,7 +40,7 @@ func TestIntegration_PaymentGate_FullLifecycle(t *testing.T) {
 	kubeconfig := filepath.Join(cfg.configDir, "kubeconfig.yaml")
 
 	// Verify x402-verifier is running.
-	out, err := kubectlOutput(kubectlBin, kubeconfig, "get", "pods", "-n", "x402",
+	out, err := kubectl.Output(kubectlBin, kubeconfig, "get", "pods", "-n", "x402",
 		"-l", "app=x402-verifier", "--no-headers")
 	if err != nil {
 		t.Fatalf("kubectl get pods: %v", err)
@@ -49,7 +50,7 @@ func TestIntegration_PaymentGate_FullLifecycle(t *testing.T) {
 	}
 
 	// Check that a pricing route exists (from monetize.py reconciliation).
-	cmYAML, err := kubectlOutput(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
+	cmYAML, err := kubectl.Output(kubectlBin, kubeconfig, "get", "cm", "x402-pricing",
 		"-n", "x402", "-o", `jsonpath={.data.pricing\.yaml}`)
 	if err != nil {
 		t.Fatalf("kubectl get cm: %v", err)

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -1,15 +1,13 @@
 package x402
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,13 +24,10 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	if err := ValidateWallet(wallet); err != nil {
 		return err
 	}
-
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
+	bin, kc := kubectl.Paths(cfg)
 
 	// 1. Patch the Secret with the wallet address.
 	fmt.Printf("Configuring x402: setting wallet address...\n")
@@ -41,7 +36,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	if err != nil {
 		return fmt.Errorf("marshal secret patch: %w", err)
 	}
-	if err := kubectlRun(kubectlBin, kubeconfig,
+	if err := kubectl.Run(bin, kc,
 		"patch", "secret", x402SecretName, "-n", x402Namespace,
 		"-p", string(patchJSON), "--type=merge"); err != nil {
 		return fmt.Errorf("failed to patch x402 secret: %w", err)
@@ -59,7 +54,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 		VerifyOnly:     false,
 		Routes:         []RouteRule{},
 	}
-	if err := patchPricingConfig(kubectlBin, kubeconfig, pricingCfg); err != nil {
+	if err := patchPricingConfig(bin, kc, pricingCfg); err != nil {
 		return fmt.Errorf("failed to patch x402 pricing: %w", err)
 	}
 
@@ -70,11 +65,8 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 // AddRoute adds a pricing route to the x402 ConfigMap.
 // Optional per-route payTo and network override the global config when set.
 func AddRoute(cfg *config.Config, pattern, price, description string, opts ...RouteOption) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return err
 	}
 
 	// Read current pricing config.
@@ -96,7 +88,8 @@ func AddRoute(cfg *config.Config, pattern, price, description string, opts ...Ro
 	pricingCfg.Routes = append(pricingCfg.Routes, rule)
 
 	// Re-serialize and patch.
-	return patchPricingConfig(kubectlBin, kubeconfig, pricingCfg)
+	bin, kc := kubectl.Paths(cfg)
+	return patchPricingConfig(bin, kc, pricingCfg)
 }
 
 // RouteOption is a functional option for AddRoute.
@@ -114,14 +107,12 @@ func WithNetwork(network string) RouteOption {
 
 // GetPricingConfig reads the current x402 pricing ConfigMap from the cluster.
 func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster not running. Run 'obol stack up' first")
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return nil, err
 	}
+	bin, kc := kubectl.Paths(cfg)
 
-	raw, err := kubectlOutput(kubectlBin, kubeconfig,
+	raw, err := kubectl.Output(bin, kc,
 		"get", "configmap", pricingConfigMap, "-n", x402Namespace,
 		"-o", `jsonpath={.data.pricing\.yaml}`)
 	if err != nil {
@@ -150,12 +141,11 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 
 // WritePricingConfig writes the pricing config to the cluster ConfigMap.
 func WritePricingConfig(cfg *config.Config, pcfg *PricingConfig) error {
-	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
-	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-	return patchPricingConfig(kubectlBin, kubeconfig, pcfg)
+	bin, kc := kubectl.Paths(cfg)
+	return patchPricingConfig(bin, kc, pcfg)
 }
 
-func patchPricingConfig(kubectlBin, kubeconfig string, pcfg *PricingConfig) error {
+func patchPricingConfig(bin, kc string, pcfg *PricingConfig) error {
 	pricingBytes, err := yaml.Marshal(pcfg)
 	if err != nil {
 		return fmt.Errorf("marshal pricing config: %w", err)
@@ -171,40 +161,7 @@ func patchPricingConfig(kubectlBin, kubeconfig string, pcfg *PricingConfig) erro
 		return fmt.Errorf("marshal pricing patch: %w", err)
 	}
 
-	return kubectlRun(kubectlBin, kubeconfig,
+	return kubectl.Run(bin, kc,
 		"patch", "configmap", pricingConfigMap, "-n", x402Namespace,
 		"-p", string(cmPatchJSON), "--type=merge")
-}
-
-func kubectlRun(binary, kubeconfig string, args ...string) error {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return err
-	}
-	return nil
-}
-
-func kubectlOutput(binary, kubeconfig string, args ...string) (string, error) {
-	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg != "" {
-			return "", fmt.Errorf("%w: %s", err, errMsg)
-		}
-		return "", err
-	}
-	return stdout.String(), nil
 }

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -18,6 +18,7 @@ import (
 type Verifier struct {
 	config       atomic.Pointer[PricingConfig]
 	chain        atomic.Pointer[x402lib.ChainConfig]
+	chains       atomic.Pointer[map[string]x402lib.ChainConfig] // pre-resolved: chain name → config
 	registration atomic.Pointer[erc8004.AgentRegistration]
 }
 
@@ -40,7 +41,24 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 	if err != nil {
 		return fmt.Errorf("resolve chain: %w", err)
 	}
+
+	// Pre-resolve all unique chain names (global + per-route overrides)
+	// so HandleVerify avoids per-request chain resolution.
+	chains := map[string]x402lib.ChainConfig{cfg.Chain: chain}
+	for _, r := range cfg.Routes {
+		if r.Network != "" {
+			if _, ok := chains[r.Network]; !ok {
+				rc, err := ResolveChain(r.Network)
+				if err != nil {
+					return fmt.Errorf("resolve chain for route %q: %w", r.Pattern, err)
+				}
+				chains[r.Network] = rc
+			}
+		}
+	}
+
 	v.chain.Store(&chain)
+	v.chains.Store(&chains)
 	v.config.Store(cfg)
 	return nil
 }
@@ -82,9 +100,11 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		chainName = rule.Network
 	}
 
-	chain, err := ResolveChain(chainName)
-	if err != nil {
-		log.Printf("x402-verifier: failed to resolve chain %q for route %q: %v", chainName, rule.Pattern, err)
+	// Look up pre-resolved chain (populated during config load).
+	chains := v.chains.Load()
+	chain, ok := (*chains)[chainName]
+	if !ok {
+		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/x402/verifier_test.go
+++ b/internal/x402/verifier_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -610,10 +611,10 @@ func TestVerifier_PerRoutePayTo_WithValidPayment(t *testing.T) {
 	}
 }
 
-func TestVerifier_PerRouteNetwork_InvalidChain_Returns500(t *testing.T) {
+func TestVerifier_PerRouteNetwork_InvalidChain_RejectsAtLoad(t *testing.T) {
 	fac := newMockFacilitator(t, mockFacilitatorOpts{})
 
-	v, err := NewVerifier(&PricingConfig{
+	_, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		Chain:          "base-sepolia",
 		FacilitatorURL: fac.URL,
@@ -623,18 +624,11 @@ func TestVerifier_PerRouteNetwork_InvalidChain_Returns500(t *testing.T) {
 			Network: "invalid-chain",
 		}},
 	})
-	if err != nil {
-		t.Fatalf("NewVerifier: %v", err)
+	if err == nil {
+		t.Fatal("expected NewVerifier to reject invalid per-route chain at load time")
 	}
-
-	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
-	req.Header.Set("X-Forwarded-Uri", "/services/bad/endpoint")
-	req.Header.Set("X-Forwarded-Host", "obol.stack")
-	w := httptest.NewRecorder()
-	v.HandleVerify(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500 for invalid per-route chain, got %d", w.Code)
+	if !strings.Contains(err.Error(), "unsupported chain") {
+		t.Errorf("expected 'unsupported chain' error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses 11 review findings from plan-exit-review plus 1 e2e test fix discovered during operational walkthrough:

1. **RBAC refactor**: Split monolithic `openclaw-monetize` ClusterRole into `openclaw-monetize-read` (cluster-wide read-only) and `openclaw-monetize-workload` (cluster-wide mutate). Add scoped `openclaw-x402-pricing` Role in x402 namespace for pricing ConfigMap. Update `patchMonetizeBinding()` to patch all 3 bindings.

2. **Extract `internal/kubectl`**: Eliminate ~250 lines of duplicated kubectl path construction and cluster-presence checks across 8 consumer files into a single package.

3. **Fix ValidateFacilitatorURL bypass**: Replace `strings.HasPrefix` with `url.Parse()` + exact hostname matching to prevent `http://localhost-hacker.com` bypass (15-case regression test added).

4. **Pre-compute per-route chains**: Resolve all chain configs at Verifier load time instead of per-request, catching invalid chains early and eliminating hot-path allocations.

5. **x402-verifier HA**: Bump replicas to 2, add PodDisruptionBudget (`minAvailable: 1`) to prevent fail-open during rolling updates.

6. **Agent init errors fatal**: Make `patchMonetizeBinding` and `injectHeartbeatFile` failures return errors instead of warnings.

7. **Input validation in monetize.py**: Add strict regex validation for route patterns, prices, addresses, and network names to prevent YAML injection.

8. **Health check retries**: Add 3-attempt retry with 2s backoff to `stage_upstream_healthy` for transient pod startup failures.

9. **Fix e2e_test.go build**: Update `kubectlOutput` → `kubectl.Output` after kubectl extraction.

## Operational Walkthrough Results

Full lifecycle walkthrough on fresh cluster (`rested-woodcock`) with `qwen3.5:35b`:

| Test | Result |
|------|--------|
| Split RBAC deployed + patched by `obol agent init` | PASS |
| x402-verifier 2 replicas + PDB active | PASS |
| ServiceOffer CRD created | PASS |
| Offer → reconcile → 402 → mock payment → 200 (real inference) | PASS |
| `TestIntegration_E2E_OfferLifecycle` | PASS (53s) |
| `TestIntegration_PaymentGate_FullLifecycle` | PASS (47s) |
| `TestValidateFacilitatorURL` (15 bypass cases) | PASS |
| All x402 verifier unit tests (22) | PASS |
| `TestIntegration_Fork_FullPaymentFlow` | FAIL (Traefik route propagation timing — pre-existing) |

### Known issues found during walkthrough (not blocking)

- **Reconciler trusts CR status**: After external cleanup of pricing route, re-reconcile sees `Ready=True` and short-circuits without verifying actual state. Pricing route not restored.
- **`obol monetize stop` leaves HTTPRoute + Middleware**: Only removes pricing route from ConfigMap. Dangling ForwardAuth causes 500.
- **Fork payment test timing**: New HTTPRoute + Middleware need seconds before Traefik applies them. Test sees 200 immediately after creation.

## Test plan

- [x] `go test ./...` (all unit tests)
- [x] `TestIntegration_E2E_OfferLifecycle` — CLI → CR → reconcile → 402 → 200 → delete cascade
- [x] `TestIntegration_PaymentGate_FullLifecycle` — real Ollama inference through x402 payment gate
- [x] Operational walkthrough: fresh cluster, all hardened resources verified via kubectl
- [x] Lifecycle cleanup: stop (removes pricing route), delete (ownerRef cascade)