### PR TITLE
feat: /skill.md agent-optimized service catalog

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -35,7 +35,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.13"
+  tag: "v0.1.12"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

- **`/skill.md` endpoint**: Dynamic, agent-optimized markdown document served at the tunnel root, aggregating all Ready ServiceOffers into a structured catalog with x402 payment instructions, per-service details, curl examples, and USDC contract references.
- **Frontend v0.1.13**: Fixes `Cannot read properties of undefined (reading 'map')` crash in AgentRegistry when 8004scan API returns agents with undefined `supported_protocols`/`supported_trust_models`.

## How it works

The monetize reconciler (`monetize.py`) now publishes `/skill.md` on every heartbeat cycle using the proven busybox httpd pattern (ConfigMap + Deployment + Service + HTTPRoute). The document regenerates automatically as ServiceOffers are created/deleted/updated.

Resources deployed in `openclaw-obol-agent` namespace:
- `obol-skill-md` ConfigMap (markdown content + `httpd.conf` for `text/markdown` MIME)
- `obol-skill-md` Deployment (busybox httpd with content-hash annotation for auto-rollout)
- `obol-skill-md` Service (ClusterIP)
- `obol-skill-md-route` HTTPRoute (Exact `/skill.md`, public, no ForwardAuth)

No RBAC changes needed — existing `openclaw-monetize-workload` ClusterRole covers all resources.

## Test plan

- [ ] `curl -sI https://<tunnel>/skill.md` returns `Content-Type: text/markdown`
- [ ] Document lists all Ready ServiceOffers with correct endpoints and pricing
- [ ] Document regenerates when offers are added/removed
- [ ] Empty state shows "No services currently available"
- [ ] Frontend loads without crash on AgentRegistry page