### PR TITLE
fix: update trivy-action to safe SHA (v0.35.0)

### DIFF
--- a/.github/workflows/docker-publish-openclaw.yml
+++ b/.github/workflows/docker-publish-openclaw.yml
@@ -224,7 +224,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: 'sarif'

--- a/.github/workflows/docker-publish-x402-verifier.yml
+++ b/.github/workflows/docker-publish-x402-verifier.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
           format: 'sarif'


### PR DESCRIPTION
## Summary
- Update `aquasecurity/trivy-action` from `@22438a...` to `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- Affects: `docker-publish-openclaw.yml`, `docker-publish-x402-verifier.yml`
- Mitigates supply chain risk from [trivy-action compromise (March 19, 2026)](https://github.com/aquasecurity/trivy-action/issues/541)

## Risk assessment
- Previous SHA was pinned (good) but pointed to an untagged commit on master
- 3 scheduled/push runs occurred during the March 19-20 window but used the pinned SHA (not affected by tag poisoning)
- Updating to official v0.35.0 release SHA for clarity and safety