### PR TITLE
security: pin LiteLLM to v1.82.3 (supply chain compromise)

### DIFF
--- a/.agents/skills/obol-stack-dev/references/litellm-routing.md
+++ b/.agents/skills/obol-stack-dev/references/litellm-routing.md
@@ -13,7 +13,7 @@ A cluster-wide OpenAI-compatible proxy that routes LLM traffic to actual provide
 | `llm` | Namespace | Dedicated namespace for LLM infrastructure |
 | `litellm-config` | ConfigMap | `config.yaml` with `model_list` (model definitions + routing) |
 | `litellm-secrets` | Secret | `LITELLM_MASTER_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` |
-| `litellm` | Deployment | `ghcr.io/berriai/litellm:main-stable`, port 4000 |
+| `litellm` | Deployment | `ghcr.io/berriai/litellm:main-v1.82.3`, port 4000 |
 | `litellm` | Service | `litellm.llm.svc.cluster.local:4000` |
 | `ollama` | Service (ExternalName) | Routes to host Ollama |
 

--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -132,7 +132,10 @@ spec:
     spec:
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:main-stable
+          # Pinned to v1.82.3 — main-stable is a floating tag vulnerable to
+          # supply-chain attacks (see BerriAI/litellm#24512: PyPI 1.82.7-1.82.8
+          # contained credential-stealing malware). Always pin to a versioned tag.
+          image: ghcr.io/berriai/litellm:main-v1.82.3
           imagePullPolicy: IfNotPresent
           args:
             - --config


### PR DESCRIPTION
## Summary

- Pin LiteLLM Docker image from floating `main-stable` tag to versioned `main-v1.82.3`
- LiteLLM PyPI 1.82.7 and 1.82.8 contain malware that exfiltrates credentials (BerriAI/litellm#24512)
- Our clusters are currently running 1.82.3 (safe), but the floating tag could pull a compromised build on next deployment

## What was compromised

The `litellm_init.pth` file in PyPI packages 1.82.7-1.82.8 auto-executes on Python startup and steals:
- Environment variables (API keys, secrets)
- SSH keys
- Cloud credentials (AWS, GCP, Azure)
- Kubernetes configs
- Database passwords

Data is encrypted and exfiltrated to `https://models.litellm.cloud/`.

## Changes

- `internal/embed/infrastructure/base/templates/llm.yaml` — pin image to `ghcr.io/berriai/litellm:main-v1.82.3`
- `.agents/skills/obol-stack-dev/references/litellm-routing.md` — update reference

## Remediation for existing deployments

If running `main-stable`, verify your version:
```bash
obol kubectl -n llm exec deploy/litellm -c litellm -- pip show litellm | grep Version
```

If version is 1.82.7 or 1.82.8, **rotate all credentials immediately** and redeploy with the pinned tag.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/embed/...` passes
- [x] Verified `main-v1.82.3` tag exists on GHCR
- [x] Confirmed running cluster uses 1.82.3 (pre-compromise)