### PR TITLE
chore: add golangci-lint v2 config with gofumpt formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.go) ~/.local/bin/golangci-lint run --fix \"$(dirname \"$f\")/...\" ;; esac; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Linting Go files..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,9 +6,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.go) ~/.local/bin/golangci-lint run --fix \"$(dirname \"$f\")/...\" ;; esac; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.go) golangci-lint fmt \"$f\" ;; esac; } 2>/dev/null || true",
             "timeout": 30,
-            "statusMessage": "Linting Go files..."
+            "statusMessage": "Formatting Go file..."
           }
         ]
       }

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -175,7 +175,7 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  fix: true
+  fix: false
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,193 @@
+version: "2"
+run:
+  go: "1.25"
+linters:
+  default: all
+  disable:
+    - containedctx
+    - contextcheck
+    - cyclop
+    - depguard
+    - err113
+    - exhaustruct
+    - forbidigo       # CLI uses fmt.Print* for user output
+    - forcetypeassert
+    - funlen
+    - funcorder
+    - gochecknoglobals
+    - gocognit
+    - gocyclo
+    - godoclint       # don't require doc comments on all exports
+    - godot
+    - godox
+    - gomoddirectives
+    - inamedparam
+    - interfacebloat
+    - intrange
+    - ireturn
+    - lll
+    - maintidx
+    - mnd
+    - musttag
+    - nestif
+    - nlreturn        # stylistic, too noisy
+    - noctx           # too much to retrofit; revisit later
+    - noinlineerr
+    - nonamedreturns
+    - paralleltest
+    - prealloc
+    - recvcheck
+    - tagliatelle
+    - testpackage     # internal test packages are fine here
+    - varnamelen
+    - wrapcheck       # obol-stack has no app/errors wrapper package
+    - wsl
+    # TODO: re-enable incrementally as issues are fixed
+    - errcheck        # 15 issues in non-test code
+    - errchkjson      # 5 issues
+    - goconst         # 32 repeated strings
+    - gocritic        # 10 issues
+    - gosec           # 67 issues, review separately
+    - nilerr          # 10 issues
+    - nilnil          # 3 issues
+    - nosprintfhostport # 2 issues
+    - staticcheck     # 8 issues (autofix conflicts)
+    - unconvert       # 5 unnecessary conversions
+    - unparam         # 28 unused params
+    - wastedassign    # 1 issue
+  settings:
+    dupl:
+      threshold: 400
+    exhaustive:
+      default-signifies-exhaustive: true
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+    gosec:
+      excludes:
+        - G115
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    revive:
+      severity: warning
+      enable-all-rules: true
+      rules:
+        - name: add-constant
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: banned-characters
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: comment-spacings
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: line-length-limit
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: range-val-address
+          disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: unused-parameter
+          disabled: true
+        - name: unused-receiver
+          disabled: true
+        - name: use-fmt-print
+          disabled: true
+        - name: unnecessary-format
+          disabled: true
+        - name: enforce-switch-style
+          disabled: true
+        - name: unsecure-url-scheme
+          disabled: true
+        - name: deep-exit
+          disabled: true
+        # TODO: re-enable as issues are fixed
+        - name: confusing-results
+          disabled: true
+        - name: early-return
+          disabled: true
+        - name: exported
+          disabled: true
+        - name: identical-branches
+          disabled: true
+        - name: identical-switch-branches
+          disabled: true
+        - name: if-return
+          disabled: true
+        - name: import-alias-naming
+          disabled: true
+        - name: superfluous-else
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+        - name: unexported-return
+          disabled: true
+        - name: use-slices-sort
+          disabled: true
+        - name: var-naming
+          disabled: true
+    staticcheck:
+      checks:
+        - -SA1019
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - errcheck
+          - errchkjson
+          - gosec
+          - revive
+        path: (.+)_test\.go
+      - path: (.+)\.go$
+        text: error returned from interface method should be wrapped
+      - path: (.+)\.go$
+        text: "defer: prefer not to defer chains of function calls"
+      - path: (.+)\.go$
+        text: avoid control coupling
+      - path: (.+)\.go$
+        text: shadows an import name
+      - path: (.+)\.go$
+        text: confusing-naming
+      - path: (.+)\.go$
+        text: nested-structs
+      - path: (.+)\.go$
+        text: 'shadow: declaration of "err" shadows declaration'
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  fix: true
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - prefix(github.com/ObolNetwork/obol-stack)
+  exclusions:
+    generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,18 +43,10 @@ linters:
     - wrapcheck       # obol-stack has no app/errors wrapper package
     - wsl
     # TODO: re-enable incrementally as issues are fixed
-    - errcheck        # 15 issues in non-test code
-    - errchkjson      # 5 issues
-    - goconst         # 32 repeated strings
-    - gocritic        # 10 issues
-    # gosec — re-enabled
-    - nilerr          # 10 issues
-    - nilnil          # 3 issues
-    - nosprintfhostport # 2 issues
-    - staticcheck     # 8 issues (autofix conflicts)
-    - unconvert       # 5 unnecessary conversions
-    - unparam         # 28 unused params
-    - wastedassign    # 1 issue
+    - goconst         # 32 repeated strings — low priority, re-enable later
+    - unparam         # 28 unused params — low priority, re-enable later
+    # Re-enabled: errcheck, errchkjson, gocritic, gosec, nilerr, nilnil,
+    # nosprintfhostport, staticcheck, unconvert, wastedassign
   settings:
     dupl:
       threshold: 400

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ linters:
     - errchkjson      # 5 issues
     - goconst         # 32 repeated strings
     - gocritic        # 10 issues
-    - gosec           # 67 issues, review separately
+    # gosec — re-enabled
     - nilerr          # 10 issues
     - nilnil          # 3 issues
     - nosprintfhostport # 2 issues
@@ -66,6 +66,8 @@ linters:
     gosec:
       excludes:
         - G115
+        - G204  # CLI tool intentionally runs subprocesses (k3d, helm, kubectl)
+        - G101  # false positives from variable names containing "key", "token", "secret"
     govet:
       disable:
         - fieldalignment
@@ -159,6 +161,9 @@ linters:
           - gosec
           - revive
         path: (.+)_test\.go
+      - linters:
+          - gosec
+        path: internal/testutil/
       - path: (.+)\.go$
         text: error returned from interface method should be wrapped
       - path: (.+)\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,10 +43,7 @@ linters:
     - wrapcheck       # obol-stack has no app/errors wrapper package
     - wsl
     # TODO: re-enable incrementally as issues are fixed
-    - goconst         # 32 repeated strings — low priority, re-enable later
-    - unparam         # 28 unused params — low priority, re-enable later
-    # Re-enabled: errcheck, errchkjson, gocritic, gosec, nilerr, nilnil,
-    # nosprintfhostport, staticcheck, unconvert, wastedassign
+    # All linters re-enabled
   settings:
     dupl:
       threshold: 400
@@ -152,6 +149,8 @@ linters:
           - errchkjson
           - gosec
           - revive
+          - unparam
+          - goconst
         path: (.+)_test\.go
       - linters:
           - gosec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,16 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Project Overview
 
 Obol Stack: framework for AI agents to run decentralised infrastructure locally. k3d cluster with OpenClaw AI agent, blockchain networks, payment-gated inference (x402), Cloudflare tunnels. CLI: `github.com/urfave/cli/v3`.
+
+## Conventions
+
+- **Commits**: Conventional commits — `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `security:` with optional scope
+- **Branches**: `feat/`, `fix/`, `research/`, `codex/` prefixes
+- **Detailed architecture reference**: `@.claude/skills/obol-stack-dev/SKILL.md` (invoke with `/obol-stack-dev`)
 
 ## Build, Test, Run
 
@@ -113,14 +121,7 @@ k3d: 1 server, ports 80:80 + 8080:80 + 443:443 + 8443:443, `rancher/k3s:v1.35.1-
 
 ## Standalone Inference Gateway
 
-`obol sell inference` — standalone OpenAI-compatible HTTP gateway with x402 payment gating, for bare metal / Secure Enclave. `--vm` flag runs Ollama in Apple Containerization Linux VM.
-
-| Component | File | Role |
-|-----------|------|------|
-| `Gateway` | `internal/inference/gateway.go` | HTTP server, x402 middleware, Ollama proxy |
-| `ContainerManager` | `internal/inference/container.go` | Apple Containerization VM lifecycle |
-| `Store` | `internal/inference/store.go` | Deployment config persistence |
-| `Key` interface | `internal/enclave/enclave.go` | Secure Enclave signing (`enclave_darwin.go`: CGo/Security.framework, `enclave_stub.go`: fallback) |
+`obol sell inference` — standalone OpenAI-compatible HTTP gateway with x402 payment gating, for bare metal / Secure Enclave. `--vm` flag runs Ollama in Apple Containerization Linux VM. Key code: `internal/inference/` (gateway, container, store) and `internal/enclave/` (Secure Enclave signing via CGo/Security.framework on Darwin, stub fallback elsewhere).
 
 ## OpenClaw & Skills
 
@@ -132,15 +133,7 @@ Skills = SKILL.md + optional scripts/references, embedded in `obol` binary (`int
 
 ## Buyer Sidecar
 
-`x402-buyer` — lean Go sidecar for buy-side x402 payments using pre-signed ERC-3009 authorizations. It runs as a second container in the `litellm` Deployment, not as a separate Service. Agent `buy.py` commands mutate only buyer ConfigMaps; LiteLLM keeps one static public namespace `paid/<remote-model>`. The sidecar exposes `/status`, `/healthz`, and `/metrics`; metrics are scraped via `PodMonitor`. Zero signer access, bounded spending (max loss = N × price).
-
-| Component | File |
-|-----------|------|
-| Sidecar binary | `cmd/x402-buyer/main.go` |
-| PreSignedSigner | `internal/x402/buyer/signer.go` |
-| Reverse proxy | `internal/x402/buyer/proxy.go` |
-| Config/types | `internal/x402/buyer/config.go` |
-| Buy skill | `internal/embed/skills/buy-inference/` |
+`x402-buyer` — lean Go sidecar for buy-side x402 payments using pre-signed ERC-3009 authorizations. It runs as a second container in the `litellm` Deployment, not as a separate Service. Agent `buy.py` commands mutate only buyer ConfigMaps; LiteLLM keeps one static public namespace `paid/<remote-model>`. The sidecar exposes `/status`, `/healthz`, and `/metrics`; metrics are scraped via `PodMonitor`. Zero signer access, bounded spending (max loss = N × price). Key code: `cmd/x402-buyer/` and `internal/x402/buyer/`.
 
 ## Development Constraints
 
@@ -183,31 +176,9 @@ The Cloudflare tunnel exposes the cluster to the public internet. Only x402-gate
 - `/skill.md` — machine-readable service catalog
 - `/` on tunnel hostname — static storefront landing page (busybox httpd)
 
-## Key Packages
+## Dependencies
 
-| Package | Key Files | Role |
-|---------|-----------|------|
-| `cmd/obol` | `main.go`, `sell.go`, `network.go`, `openclaw.go`, `model.go` | CLI commands |
-| `internal/config` | `config.go` | XDG Config struct |
-| `internal/stack` | `stack.go` | Cluster lifecycle |
-| `internal/network` | `network.go`, `erpc.go`, `rpc.go`, `parser.go` | Networks, eRPC, RPC gateway |
-| `internal/x402` | `config.go`, `setup.go`, `verifier.go`, `matcher.go`, `watcher.go` | ForwardAuth verifier |
-| `internal/x402/buyer` | `signer.go`, `proxy.go`, `config.go` | Buy-side sidecar |
-| `internal/erc8004` | `client.go`, `types.go`, `abi.go` | ERC-8004 Identity Registry |
-| `internal/agent` | `agent.go` | obol-agent singleton, RBAC patching |
-| `internal/model` | `model.go` | LiteLLM gateway configuration |
-| `internal/openclaw` | `openclaw.go`, `wallet.go`, `resolve.go` | OpenClaw setup, wallet, instance resolution |
-| `internal/inference` | `gateway.go`, `container.go`, `store.go` | Standalone x402 gateway |
-| `internal/enclave` | `enclave.go`, `enclave_darwin.go`, `enclave_stub.go` | Secure Enclave keys |
-| `internal/embed` | `embed.go` | Embedded assets (skills, infrastructure, networks) |
-
-**Embedded assets**: `internal/embed/infrastructure/` (K8s templates), `internal/embed/networks/` (ethereum, helios, aztec), `internal/embed/skills/` (23 skills).
-
-**Tests**: `cmd/obol/sell_test.go` (CLI flags), `internal/x402/*_test.go` (verifier, config, matcher, E2E), `internal/erc8004/*_test.go` (ABI, client), `internal/embed/embed_crd_test.go` (CRD+RBAC validation), `internal/openclaw/integration_test.go` (full-cluster inference), `internal/openclaw/overlay_test.go`, `internal/inference/gateway_test.go`.
-
-**Docs**: `docs/guides/monetize-inference.md` (E2E monetize walkthrough), `README.md`.
-
-**Deps**: Docker 20.10.0+, Go 1.25+. Installed by obolup.sh: kubectl 1.35.0, helm 3.19.4, k3d 5.8.3, helmfile 1.2.3, k9s 0.50.18, helm-diff 3.14.1. Key Go: `urfave/cli/v3`, `dustinkirkland/golang-petname`, `mark3labs/x402-go`.
+Docker 20.10.0+, Go 1.25+. Toolchain installed by `obolup.sh` (kubectl, helm, k3d, helmfile, k9s). Key Go deps: `urfave/cli/v3`, `dustinkirkland/golang-petname`, `mark3labs/x402-go`. E2E monetize walkthrough: `@docs/guides/monetize-inference.md`.
 
 ## Related Codebases
 

--- a/cmd/obol/bootstrap.go
+++ b/cmd/obol/bootstrap.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -34,6 +35,7 @@ func bootstrapCommand(cfg *config.Config) *cli.Command {
 				if !strings.Contains(err.Error(), "already exists") {
 					return fmt.Errorf("bootstrap init failed: %w", err)
 				}
+
 				u.Warn("Stack already initialized, continuing")
 			}
 
@@ -50,6 +52,7 @@ func bootstrapCommand(cfg *config.Config) *cli.Command {
 			// Step 4: Open browser
 			url := "http://obol.stack"
 			u.Infof("Opening browser to %s", url)
+
 			if err := openBrowser(url); err != nil {
 				u.Warnf("Failed to open browser: %v", err)
 				u.Printf("  Please open manually: %s", url)
@@ -86,9 +89,11 @@ func waitForClusterReady(cfg *config.Config, u *ui.UI) error {
 			if _, err := os.Stat(kubeconfigPath); err == nil {
 				return nil
 			}
+
 			time.Sleep(pollInterval)
 		}
-		return fmt.Errorf("kubeconfig not created within timeout")
+
+		return errors.New("kubeconfig not created within timeout")
 	})
 	if err != nil {
 		return err
@@ -98,26 +103,33 @@ func waitForClusterReady(cfg *config.Config, u *ui.UI) error {
 	err = u.RunWithSpinner("Waiting for pods to be ready", func() error {
 		for time.Now().Before(deadline) {
 			cmd := exec.Command(kubectlPath, "get", "pods", "--all-namespaces", "-o", "jsonpath={.items[*].status.phase}")
-			cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+			cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 			output, err := cmd.Output()
 			if err != nil {
 				time.Sleep(pollInterval)
 				continue
 			}
+
 			phases := strings.Fields(string(output))
 			allReady := true
+
 			for _, phase := range phases {
 				if phase != "Running" && phase != "Succeeded" {
 					allReady = false
 					break
 				}
 			}
+
 			if allReady && len(phases) > 0 {
 				return nil
 			}
+
 			time.Sleep(pollInterval)
 		}
-		return fmt.Errorf("pods did not become ready within timeout")
+
+		return errors.New("pods did not become ready within timeout")
 	})
 	if err != nil {
 		return err
@@ -126,19 +138,24 @@ func waitForClusterReady(cfg *config.Config, u *ui.UI) error {
 	// Wait for ingress to respond
 	err = u.RunWithSpinner("Waiting for ingress to respond", func() error {
 		ingressURL := "http://obol.stack:8080"
+
 		client := &http.Client{Timeout: 5 * time.Second}
 		for time.Now().Before(deadline) {
 			resp, err := client.Get(ingressURL)
 			if err == nil {
 				resp.Body.Close()
+
 				if resp.StatusCode < 500 {
 					return nil
 				}
 			}
+
 			time.Sleep(pollInterval)
 		}
-		return fmt.Errorf("ingress did not respond within timeout")
+
+		return errors.New("ingress did not respond within timeout")
 	})
+
 	return err
 }
 

--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -123,6 +124,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 			u := ui.NewWithOptions(cmd.Bool("verbose"), cmd.Bool("quiet"))
 			cmd.Metadata = map[string]any{"ui": u}
+
 			return ctx, nil
 		},
 		Commands: []*cli.Command{
@@ -313,7 +315,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Check if kubeconfig exists
 					if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-						return fmt.Errorf("stack not running, use 'obol stack up' first")
+						return errors.New("stack not running, use 'obol stack up' first")
 					}
 
 					kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
@@ -325,20 +327,24 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Execute kubectl directly with KUBECONFIG set
 					proc := exec.Command(kubectlPath, cmd.Args().Slice()...)
-					proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+					proc.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 					proc.Stdin = os.Stdin
 					proc.Stdout = os.Stdout
 					proc.Stderr = os.Stderr
 
 					if err := proc.Run(); err != nil {
 						// Preserve the exit code from kubectl
-						if exitErr, ok := err.(*exec.ExitError); ok {
+						exitErr := &exec.ExitError{}
+						if errors.As(err, &exitErr) {
 							if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 								os.Exit(status.ExitStatus())
 							}
 						}
+
 						return err
 					}
+
 					return nil
 				},
 			},
@@ -351,7 +357,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Check if kubeconfig exists
 					if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-						return fmt.Errorf("stack not running, use 'obol stack up' first")
+						return errors.New("stack not running, use 'obol stack up' first")
 					}
 
 					helmPath := filepath.Join(cfg.BinDir, "helm")
@@ -363,20 +369,24 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Execute helm directly with KUBECONFIG set
 					proc := exec.Command(helmPath, cmd.Args().Slice()...)
-					proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+					proc.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 					proc.Stdin = os.Stdin
 					proc.Stdout = os.Stdout
 					proc.Stderr = os.Stderr
 
 					if err := proc.Run(); err != nil {
 						// Preserve the exit code from helm
-						if exitErr, ok := err.(*exec.ExitError); ok {
+						exitErr := &exec.ExitError{}
+						if errors.As(err, &exitErr) {
 							if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 								os.Exit(status.ExitStatus())
 							}
 						}
+
 						return err
 					}
+
 					return nil
 				},
 			},
@@ -389,7 +399,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Check if kubeconfig exists
 					if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-						return fmt.Errorf("stack not running, use 'obol stack up' first")
+						return errors.New("stack not running, use 'obol stack up' first")
 					}
 
 					helmfilePath := filepath.Join(cfg.BinDir, "helmfile")
@@ -402,9 +412,10 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 					// Execute helmfile directly with KUBECONFIG and HELMFILE_FILE_PATH set
 					helmfileConfigPath := filepath.Join(cfg.ConfigDir, "helmfile.yaml")
 					proc := exec.Command(helmfilePath, cmd.Args().Slice()...)
+
 					proc.Env = append(os.Environ(),
-						fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath),
-						fmt.Sprintf("HELMFILE_FILE_PATH=%s", helmfileConfigPath),
+						"KUBECONFIG="+kubeconfigPath,
+						"HELMFILE_FILE_PATH="+helmfileConfigPath,
 					)
 					proc.Stdin = os.Stdin
 					proc.Stdout = os.Stdout
@@ -412,13 +423,16 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					if err := proc.Run(); err != nil {
 						// Preserve the exit code from helmfile
-						if exitErr, ok := err.(*exec.ExitError); ok {
+						exitErr := &exec.ExitError{}
+						if errors.As(err, &exitErr) {
 							if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 								os.Exit(status.ExitStatus())
 							}
 						}
+
 						return err
 					}
+
 					return nil
 				},
 			},
@@ -431,7 +445,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Check if kubeconfig exists
 					if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-						return fmt.Errorf("stack not running, use 'obol stack up' first")
+						return errors.New("stack not running, use 'obol stack up' first")
 					}
 
 					k9sPath := filepath.Join(cfg.BinDir, "k9s")
@@ -443,20 +457,24 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 
 					// Execute k9s directly with KUBECONFIG set
 					proc := exec.Command(k9sPath, cmd.Args().Slice()...)
-					proc.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+					proc.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 					proc.Stdin = os.Stdin
 					proc.Stdout = os.Stdout
 					proc.Stderr = os.Stderr
 
 					if err := proc.Run(); err != nil {
 						// Preserve the exit code from k9s
-						if exitErr, ok := err.(*exec.ExitError); ok {
+						exitErr := &exec.ExitError{}
+						if errors.As(err, &exitErr) {
 							if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 								os.Exit(status.ExitStatus())
 							}
 						}
+
 						return err
 					}
+
 					return nil
 				},
 			},
@@ -522,7 +540,7 @@ Find charts at https://artifacthub.io`,
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.NArg() == 0 {
-								return fmt.Errorf("chart reference required\n\n" +
+								return errors.New("chart reference required\n\n" +
 									"Examples:\n" +
 									"  obol app install bitnami/redis\n" +
 									"  obol app install bitnami/postgresql@15.0.0\n" +
@@ -530,6 +548,7 @@ Find charts at https://artifacthub.io`,
 									"  obol app install oci://registry-1.docker.io/bitnamicharts/redis\n\n" +
 									"Find charts at https://artifacthub.io")
 							}
+
 							chartRef := cmd.Args().First()
 							opts := app.InstallOptions{
 								Name:    cmd.String("name"),
@@ -537,6 +556,7 @@ Find charts at https://artifacthub.io`,
 								ID:      cmd.String("id"),
 								Force:   cmd.Bool("force"),
 							}
+
 							return app.Install(cfg, getUI(cmd), chartRef, opts)
 						},
 					},
@@ -549,6 +569,7 @@ Find charts at https://artifacthub.io`,
 							if err != nil {
 								return err
 							}
+
 							return app.Sync(cfg, getUI(cmd), identifier)
 						},
 					},
@@ -566,6 +587,7 @@ Find charts at https://artifacthub.io`,
 							opts := app.ListOptions{
 								Verbose: cmd.Bool("verbose"),
 							}
+
 							return app.List(cfg, getUI(cmd), opts)
 						},
 					},
@@ -585,6 +607,7 @@ Find charts at https://artifacthub.io`,
 							if err != nil {
 								return err
 							}
+
 							return app.Delete(cfg, getUI(cmd), identifier, cmd.Bool("force"))
 						},
 					},
@@ -599,6 +622,7 @@ Find charts at https://artifacthub.io`,
 		if u == nil {
 			u = ui.New(false)
 		}
+
 		u.Error(err.Error())
 		os.Exit(1)
 	}
@@ -612,5 +636,6 @@ func getUI(cmd *cli.Command) *ui.UI {
 			return u
 		}
 	}
+
 	return ui.New(false)
 }

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
@@ -62,12 +64,14 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 			if provider == "" {
 				creds := detectCredentials()
 				providers, _ := model.GetAvailableProviders(cfg)
+
 				options := make([]string, len(providers))
 				for i, p := range providers {
 					label := fmt.Sprintf("%s (%s)", p.Name, p.ID)
 					if det, ok := creds[p.ID]; ok {
-						label += fmt.Sprintf(" — detected: %s", det.source)
+						label += " — detected: " + det.source
 					}
+
 					options[i] = label
 				}
 
@@ -75,11 +79,13 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 				if err != nil {
 					return err
 				}
+
 				provider = providers[idx].ID
 
 				// If a credential was detected for the chosen provider, offer to use it
 				if det, ok := creds[provider]; ok && det.key != "" && apiKey == "" {
 					u.Infof("%s API key detected (%s)", providers[idx].Name, det.source)
+
 					if u.Confirm("Use detected credential?", true) {
 						apiKey = det.key
 					}
@@ -103,6 +109,7 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 	if len(models) == 0 {
 		// Diagnostic: check Ollama connectivity
 		u.Info("Checking Ollama connectivity...")
+
 		ollamaModels, err := model.ListOllamaModels()
 		if err != nil {
 			u.Errorf("Ollama not reachable")
@@ -110,8 +117,10 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 			u.Print("  Hint: Is Ollama running? Try: ollama serve")
 			u.Print("  Hint: Using a custom host? Set OLLAMA_HOST=http://your-host:port")
 			u.Print("  Hint: Install from https://ollama.ai")
+
 			return fmt.Errorf("Ollama is not running: %w", err)
 		}
+
 		u.Success("Ollama is reachable")
 
 		if len(ollamaModels) == 0 {
@@ -119,17 +128,21 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 			u.Print("")
 			u.Print("  Hint: Pull a model with: ollama pull qwen3.5:4b")
 			u.Print("  Hint: Or run: obol model pull")
-			return fmt.Errorf("Ollama is running but has no models")
+
+			return errors.New("Ollama is running but has no models")
 		}
+
 		u.Successf("Found %d pulled model(s)", len(ollamaModels))
 
 		for _, m := range ollamaModels {
 			name := m.Name
-			if strings.HasSuffix(name, ":latest") {
-				name = strings.TrimSuffix(name, ":latest")
+			if before, ok := strings.CutSuffix(name, ":latest"); ok {
+				name = before
 			}
+
 			models = append(models, name)
 		}
+
 		u.Infof("Models: %s", strings.Join(models, ", "))
 	}
 
@@ -138,19 +151,23 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 	}
 
 	u.Successf("Ollama configured. To change later, run: obol model setup (or obol model remove <name>)")
+
 	return syncOpenClawModels(cfg, u)
 }
 
 func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, models []string) error {
 	if apiKey == "" {
 		var err error
+
 		info := providerInfo(provider)
+
 		apiKey, err = u.SecretInput(fmt.Sprintf("%s API key (%s)", info.Name, info.EnvVar))
 		if err != nil {
 			return err
 		}
+
 		if apiKey == "" {
-			return fmt.Errorf("API key is required")
+			return errors.New("API key is required")
 		}
 	}
 
@@ -167,11 +184,13 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 	if err := model.ConfigureLiteLLM(cfg, u, provider, apiKey, models); err != nil {
 		u.Print("")
 		u.Print("  Hint: Configuration stored in: litellm-config ConfigMap (llm namespace)")
+
 		return err
 	}
 
 	u.Print("")
 	u.Successf("Model configured. To change later, run: obol model setup (or obol model remove <name>)")
+
 	return syncOpenClawModels(cfg, u)
 }
 
@@ -185,6 +204,7 @@ func syncOpenClawModels(cfg *config.Config, u *ui.UI) error {
 		u.Warnf("Could not read LiteLLM model list: %v", err)
 		return nil // non-fatal
 	}
+
 	return openclaw.SyncOverlayModels(cfg, allModels, u)
 }
 
@@ -195,6 +215,7 @@ func modelSyncCommand(cfg *config.Config) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
 			u.Info("Reading model list from LiteLLM...")
+
 			return syncOpenClawModels(cfg, u)
 		},
 	}
@@ -220,6 +241,7 @@ func modelSetupCustomCommand(cfg *config.Config) *cli.Command {
 			if err := model.AddCustomEndpoint(cfg, u, name, endpoint, modelName, apiKey); err != nil {
 				return err
 			}
+
 			return syncOpenClawModels(cfg, u)
 		},
 	}
@@ -231,6 +253,7 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 		Usage: "Show LiteLLM gateway provider status",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
+
 			status, err := model.GetProviderStatus(cfg)
 			if err != nil {
 				return err
@@ -240,14 +263,17 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 			for name := range status {
 				providers = append(providers, name)
 			}
+
 			sort.Strings(providers)
 
 			u.Bold("LiteLLM gateway providers:")
 			u.Blank()
 			u.Printf("  %-20s %-8s %-10s %-10s %s", "PROVIDER", "ENABLED", "API KEY", "MODELS", "ENV VAR")
+
 			for _, name := range providers {
 				s := status[name]
 				key := "n/a"
+
 				if s.EnvVar != "" {
 					if s.HasAPIKey {
 						key = "set"
@@ -255,16 +281,19 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 						key = "missing"
 					}
 				}
-				modelCount := fmt.Sprintf("%d", len(s.Models))
+
+				modelCount := strconv.Itoa(len(s.Models))
 				if len(s.Models) == 0 {
 					modelCount = "-"
 				}
+
 				u.Printf("  %-20s %-8t %-10s %-10s %s", name, s.Enabled, key, modelCount, s.EnvVar)
 			}
 
 			u.Blank()
 			u.Dim("Run 'obol model setup' to configure a provider.")
 			u.Dim("Run 'obol model setup custom' to add a custom endpoint.")
+
 			return nil
 		},
 	}
@@ -280,6 +309,7 @@ func modelPullCommand() *cli.Command {
 
 			if modelName == "" {
 				var err error
+
 				modelName, err = promptModelPull()
 				if err != nil {
 					return err
@@ -287,10 +317,13 @@ func modelPullCommand() *cli.Command {
 			}
 
 			fmt.Printf("Pulling model: %s\n\n", modelName)
+
 			if err := model.PullOllamaModel(modelName); err != nil {
 				return err
 			}
+
 			fmt.Printf("\nModel %s is ready.\n", modelName)
+
 			return nil
 		},
 	}
@@ -313,10 +346,12 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 				fmt.Println("Local models (Ollama):")
 				fmt.Println()
 				fmt.Printf("  %-35s %s\n", "NAME", "SIZE")
+
 				for _, m := range models {
 					fmt.Printf("  %-35s %s\n", m.Name, model.FormatBytes(m.Size))
 				}
 			}
+
 			fmt.Println()
 
 			// Show LiteLLM configured models
@@ -330,21 +365,26 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 				for name := range providerStatus {
 					providers = append(providers, name)
 				}
+
 				sort.Strings(providers)
 
 				fmt.Println("LiteLLM gateway models:")
 				fmt.Println()
 				fmt.Printf("  %-20s %-10s %s\n", "PROVIDER", "STATUS", "MODELS")
+
 				for _, name := range providers {
 					s := providerStatus[name]
+
 					status := "disabled"
 					if s.Enabled {
 						status = "enabled"
 					}
+
 					modelList := strings.Join(s.Models, ", ")
 					if modelList == "" {
 						modelList = "-"
 					}
+
 					fmt.Printf("  %-20s %-10s %s\n", name, status, modelList)
 				}
 			}
@@ -361,13 +401,16 @@ func modelRemoveCommand(cfg *config.Config) *cli.Command {
 		ArgsUsage: "<model-name>",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
+
 			modelName := cmd.Args().First()
 			if modelName == "" {
-				return fmt.Errorf("model name is required\n\nUsage: obol model remove <model-name>\n\nList configured models with: obol model list")
+				return errors.New("model name is required\n\nUsage: obol model remove <model-name>\n\nList configured models with: obol model list")
 			}
+
 			if err := model.RemoveModel(cfg, u, modelName); err != nil {
 				return err
 			}
+
 			return syncOpenClawModels(cfg, u)
 		},
 	}
@@ -380,6 +423,7 @@ func providerInfo(id string) model.ProviderInfo {
 			return p
 		}
 	}
+
 	return model.ProviderInfo{ID: id, Name: id}
 }
 
@@ -424,6 +468,7 @@ func promptModelPull() (string, error) {
 		size string
 		desc string
 	}
+
 	suggestions := []suggestion{
 		{"qwen3.5:4b", "2.7 GB", "Fast general-purpose (recommended)"},
 		{"qwen2.5-coder:7b", "4.7 GB", "Code generation"},
@@ -435,13 +480,16 @@ func promptModelPull() (string, error) {
 
 	fmt.Println("Popular models:")
 	fmt.Println()
+
 	for i, s := range suggestions {
 		fmt.Printf("  [%d] %-25s (%s) — %s\n", i+1, s.name, s.size, s.desc)
 	}
+
 	fmt.Printf("  [%d] Other (enter name)\n", len(suggestions)+1)
 	fmt.Printf("\nChoice [1]: ")
 
 	line, _ := reader.ReadString('\n')
+
 	choice := strings.TrimSpace(line)
 	if choice == "" {
 		choice = "1"
@@ -458,10 +506,13 @@ func promptModelPull() (string, error) {
 
 	// Custom model name
 	fmt.Printf("Model name (e.g. mistral:7b): ")
+
 	name, _ := reader.ReadString('\n')
+
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", fmt.Errorf("model name is required")
+		return "", errors.New("model name is required")
 	}
+
 	return name, nil
 }

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -118,7 +118,7 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 			u.Print("  Hint: Using a custom host? Set OLLAMA_HOST=http://your-host:port")
 			u.Print("  Hint: Install from https://ollama.ai")
 
-			return fmt.Errorf("Ollama is not running: %w", err)
+			return fmt.Errorf("ollama is not running: %w", err)
 		}
 
 		u.Success("Ollama is reachable")
@@ -129,7 +129,7 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 			u.Print("  Hint: Pull a model with: ollama pull qwen3.5:4b")
 			u.Print("  Hint: Or run: obol model pull")
 
-			return errors.New("Ollama is running but has no models")
+			return errors.New("ollama is running but has no models")
 		}
 
 		u.Successf("Found %d pulled model(s)", len(ollamaModels))

--- a/cmd/obol/network.go
+++ b/cmd/obol/network.go
@@ -297,7 +297,7 @@ Examples:
 			}
 
 			// ChainList mode.
-			maxCount := int(cmd.Int("count"))
+			maxCount := cmd.Int("count")
 			if maxCount <= 0 {
 				maxCount = 3
 			}

--- a/cmd/obol/network.go
+++ b/cmd/obol/network.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -47,10 +48,12 @@ func networkCommand(cfg *config.Config) *cli.Command {
 					if cmd.Bool("all") {
 						return network.SyncAll(cfg, u)
 					}
+
 					identifier, _, err := network.ResolveInstance(cfg, cmd.Args().Slice())
 					if err != nil {
 						return fmt.Errorf("%w\n\nOr use --all to sync all deployments", err)
 					}
+
 					return network.Sync(cfg, u, identifier)
 				},
 			},
@@ -63,6 +66,7 @@ func networkCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return network.Delete(cfg, getUI(cmd), identifier)
 				},
 			},
@@ -82,6 +86,7 @@ func buildNetworkInstallCommands(cfg *config.Config) []*cli.Command {
 	}
 
 	var commands []*cli.Command
+
 	for _, networkName := range networks {
 		// Parse the embedded values template to get fields
 		fields, err := network.ParseTemplateFields(networkName)
@@ -111,7 +116,7 @@ func buildNetworkInstallCommands(cfg *config.Config) []*cli.Command {
 			// Build usage string
 			usage := field.Description
 			if usage == "" {
-				usage = fmt.Sprintf("Override %s", field.Name)
+				usage = "Override " + field.Name
 			}
 
 			// Mark as required if no default value
@@ -139,6 +144,7 @@ func buildNetworkInstallCommands(cfg *config.Config) []*cli.Command {
 		// Create the network-specific install command
 		netName := networkName // Capture for closure
 		netFields := fields    // Capture for validation
+
 		commands = append(commands, &cli.Command{
 			Name:  netName,
 			Usage: fmt.Sprintf("Install %s network", netName),
@@ -164,6 +170,7 @@ func buildNetworkInstallCommands(cfg *config.Config) []*cli.Command {
 									value, field.FlagName, strings.Join(field.EnumValues, ", "))
 							}
 						}
+
 						overrides[field.FlagName] = value
 					}
 				}
@@ -190,6 +197,7 @@ func networkListCommand(cfg *config.Config) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			// Show local node deployments.
 			fmt.Println("Local Nodes:")
+
 			if err := network.List(cfg, getUI(cmd)); err != nil {
 				fmt.Printf("  (unable to list: %v)\n", err)
 			}
@@ -198,11 +206,13 @@ func networkListCommand(cfg *config.Config) *cli.Command {
 
 			// Show remote RPC networks from eRPC config.
 			fmt.Println("Remote RPCs:")
+
 			rpcNetworks, err := network.ListRPCNetworks(cfg)
 			if err != nil {
 				fmt.Printf("  (unable to read eRPC config: %v)\n", err)
 				return nil
 			}
+
 			if len(rpcNetworks) == 0 {
 				fmt.Println("  (none configured)")
 			} else {
@@ -211,9 +221,11 @@ func networkListCommand(cfg *config.Config) *cli.Command {
 					if alias == "" {
 						alias = fmt.Sprintf("chain-%d", net.ChainID)
 					}
+
 					fmt.Printf("  %-20s chain=%-8d %d upstream(s)\n", alias, net.ChainID, len(net.Upstreams))
 				}
 			}
+
 			return nil
 		},
 	}
@@ -255,10 +267,11 @@ Examples:
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
-				return fmt.Errorf("chain name or ID required\n\nExamples:\n  obol network add base\n  obol network add base-sepolia --endpoint http://host.k3d.internal:8545")
+				return errors.New("chain name or ID required\n\nExamples:\n  obol network add base\n  obol network add base-sepolia --endpoint http://host.k3d.internal:8545")
 			}
 
 			chainArg := cmd.Args().First()
+
 			chainID, chainName, err := network.ResolveChainID(chainArg)
 			if err != nil {
 				return err
@@ -269,13 +282,17 @@ Examples:
 			// Custom endpoint mode.
 			if endpoint := cmd.String("endpoint"); endpoint != "" {
 				fmt.Printf("Adding custom RPC for %s (chain ID: %d): %s\n", chainName, chainID, endpoint)
+
 				if readOnly {
 					fmt.Printf("  Write methods blocked (use --allow-writes to enable)\n")
 				}
+
 				if err := network.AddCustomRPC(cfg, chainID, chainName, endpoint, readOnly); err != nil {
 					return fmt.Errorf("failed to add custom RPC: %w", err)
 				}
+
 				fmt.Printf("Added custom RPC for %s (chain ID: %d) to eRPC\n", chainName, chainID)
+
 				return nil
 			}
 
@@ -305,6 +322,7 @@ Examples:
 			}
 
 			fmt.Printf("Found %d quality RPCs for %s:\n", len(endpoints), chainName)
+
 			for i, ep := range endpoints {
 				fmt.Printf("  %d. %s (tracking: %s)\n", i+1, ep.URL, ep.Tracking)
 			}
@@ -314,11 +332,13 @@ Examples:
 			}
 
 			fmt.Printf("Adding to eRPC gateway...\n")
+
 			if err := network.AddPublicRPCs(cfg, chainID, chainName, endpoints, readOnly); err != nil {
 				return fmt.Errorf("failed to add RPCs: %w", err)
 			}
 
 			fmt.Printf("Added %d RPCs for %s (chain ID: %d) to eRPC\n", len(endpoints), chainName, chainID)
+
 			return nil
 		},
 	}
@@ -341,10 +361,11 @@ Examples:
   obol network remove 8453`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
-				return fmt.Errorf("chain name or ID required\n\nExamples:\n  obol network remove base\n  obol network remove 8453")
+				return errors.New("chain name or ID required\n\nExamples:\n  obol network remove base\n  obol network remove 8453")
 			}
 
 			chainArg := cmd.Args().First()
+
 			chainID, chainName, err := network.ResolveChainID(chainArg)
 			if err != nil {
 				return err
@@ -357,6 +378,7 @@ Examples:
 			}
 
 			fmt.Printf("Removed ChainList RPCs for %s (chain ID: %d) from eRPC\n", chainName, chainID)
+
 			return nil
 		},
 	}
@@ -380,6 +402,7 @@ func networkStatusCommand(cfg *config.Config) *cli.Command {
 			fmt.Printf("====================\n\n")
 
 			fmt.Printf("Pod:\n")
+
 			if podStatus != "" {
 				fmt.Printf("  %s\n", podStatus)
 			} else {
@@ -387,6 +410,7 @@ func networkStatusCommand(cfg *config.Config) *cli.Command {
 			}
 
 			fmt.Printf("\nUpstreams per chain:\n")
+
 			if len(upstreamCounts) == 0 {
 				fmt.Printf("  (no upstreams configured)\n")
 			} else {
@@ -394,6 +418,7 @@ func networkStatusCommand(cfg *config.Config) *cli.Command {
 				for id := range upstreamCounts {
 					chainIDs = append(chainIDs, id)
 				}
+
 				sort.Ints(chainIDs)
 
 				for _, id := range chainIDs {
@@ -430,5 +455,6 @@ func chainIDToName(chainID int) string {
 	if name, ok := names[chainID]; ok {
 		return name
 	}
+
 	return fmt.Sprintf("Chain %d", chainID)
 }

--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
@@ -51,6 +52,7 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return openclaw.Sync(cfg, id, getUI(cmd))
 				},
 			},
@@ -69,15 +71,19 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					u := getUI(cmd)
 					if cmd.Bool("regenerate") {
 						newToken, err := openclaw.RegenerateToken(cfg, id, u)
 						if err != nil {
 							return err
 						}
+
 						u.Print(newToken)
+
 						return nil
 					}
+
 					return openclaw.Token(cfg, id, u)
 				},
 			},
@@ -104,6 +110,7 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return openclaw.Delete(cfg, id, cmd.Bool("force"), getUI(cmd))
 				},
 			},
@@ -116,6 +123,7 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return openclaw.Setup(cfg, id, openclaw.SetupOptions{}, getUI(cmd))
 				},
 			},
@@ -139,7 +147,9 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					noBrowser := cmd.Bool("no-browser")
+
 					return openclaw.Dashboard(cfg, id, openclaw.DashboardOptions{
 						Port:      int(cmd.Int("port")),
 						NoBrowser: noBrowser,
@@ -171,12 +181,14 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 
 					// Strip the "--" separator if present
 					var openclawArgs []string
+
 					for i, arg := range remaining {
 						if arg == "--" {
 							openclawArgs = remaining[i+1:]
 							break
 						}
 					}
+
 					if len(openclawArgs) == 0 && len(remaining) > 0 {
 						openclawArgs = remaining
 					}
@@ -212,10 +224,12 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 					if err := kubectl.EnsureCluster(cfg); err != nil {
 						return err
 					}
+
 					id, _, err := openclaw.ResolveInstance(cfg, cmd.Args().Slice())
 					if err != nil {
 						return err
 					}
+
 					return openclaw.BackupWalletCmd(cfg, id, openclaw.BackupWalletOptions{
 						Output:      cmd.String("output"),
 						Passphrase:  cmd.String("passphrase"),
@@ -246,10 +260,12 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 					if err := kubectl.EnsureCluster(cfg); err != nil {
 						return err
 					}
+
 					id, _, err := openclaw.ResolveInstance(cfg, cmd.Args().Slice())
 					if err != nil {
 						return err
 					}
+
 					return openclaw.RestoreWalletCmd(cfg, id, openclaw.RestoreWalletOptions{
 						Input:       cmd.String("input"),
 						Passphrase:  cmd.String("passphrase"),
@@ -264,14 +280,18 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 				ArgsUsage: "[instance-name]",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					args := cmd.Args().Slice()
+
 					var id string
+
 					if len(args) > 0 {
 						var err error
+
 						id, _, err = openclaw.ResolveInstance(cfg, args)
 						if err != nil {
 							return err
 						}
 					}
+
 					return openclaw.ListWallets(cfg, id, getUI(cmd))
 				},
 			},
@@ -292,13 +312,16 @@ func openclawSkillsCommand(cfg *config.Config) *cli.Command {
 				SkipFlagParsing: true,
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					args := cmd.Args().Slice()
+
 					id, remaining, err := openclaw.ResolveInstance(cfg, args)
 					if err != nil {
 						return err
 					}
+
 					if len(remaining) == 0 {
-						return fmt.Errorf("skill package or path required\n\nUsage: obol openclaw skill add <package-or-path>")
+						return errors.New("skill package or path required\n\nUsage: obol openclaw skill add <package-or-path>")
 					}
+
 					return openclaw.SkillAdd(cfg, id, remaining, getUI(cmd))
 				},
 			},
@@ -309,13 +332,16 @@ func openclawSkillsCommand(cfg *config.Config) *cli.Command {
 				SkipFlagParsing: true,
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					args := cmd.Args().Slice()
+
 					id, remaining, err := openclaw.ResolveInstance(cfg, args)
 					if err != nil {
 						return err
 					}
+
 					if len(remaining) == 0 {
-						return fmt.Errorf("skill name required\n\nUsage: obol openclaw skill remove <skill-name>")
+						return errors.New("skill name required\n\nUsage: obol openclaw skill remove <skill-name>")
 					}
+
 					return openclaw.SkillRemove(cfg, id, remaining, getUI(cmd))
 				},
 			},
@@ -328,6 +354,7 @@ func openclawSkillsCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return openclaw.SkillList(cfg, id, getUI(cmd))
 				},
 			},
@@ -347,6 +374,7 @@ func openclawSkillsCommand(cfg *config.Config) *cli.Command {
 					if err != nil {
 						return err
 					}
+
 					return openclaw.SkillsSync(cfg, id, cmd.String("from"), getUI(cmd))
 				},
 			},

--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -151,11 +151,11 @@ func openclawCommand(cfg *config.Config) *cli.Command {
 					noBrowser := cmd.Bool("no-browser")
 
 					return openclaw.Dashboard(cfg, id, openclaw.DashboardOptions{
-						Port:      int(cmd.Int("port")),
+						Port:      cmd.Int("port"),
 						NoBrowser: noBrowser,
 					}, func(url string) {
 						if !noBrowser {
-							openBrowser(url)
+							_ = openBrowser(url)
 						}
 					}, getUI(cmd))
 				},

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3,8 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,7 +17,6 @@ import (
 	"syscall"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
-	"github.com/ObolNetwork/obol-stack/internal/enclave"
 	"github.com/ObolNetwork/obol-stack/internal/erc8004"
 	"github.com/ObolNetwork/obol-stack/internal/inference"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
@@ -158,25 +157,28 @@ Examples:
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.Args().First()
 			if name == "" {
-				return fmt.Errorf("name required: obol sell inference <name> --wallet <addr>")
+				return errors.New("name required: obol sell inference <name> --wallet <addr>")
 			}
 
 			wallet := cmd.String("wallet")
 			if wallet == "" {
-				return fmt.Errorf("wallet required: use --wallet <addr> or set X402_WALLET")
+				return errors.New("wallet required: use --wallet <addr> or set X402_WALLET")
 			}
+
 			if err := x402verifier.ValidateWallet(wallet); err != nil {
 				return err
 			}
 
 			teeType := cmd.String("tee")
 			modelHash := cmd.String("model-hash")
+
 			if teeType != "" {
 				if _, err := tee.ParseTEEType(teeType); err != nil {
 					return err
 				}
+
 				if modelHash == "" {
-					return fmt.Errorf("--model-hash is required when --tee is set")
+					return errors.New("--model-hash is required when --tee is set")
 				}
 			}
 
@@ -189,6 +191,7 @@ Examples:
 			if err != nil {
 				return err
 			}
+
 			perRequest, err := priceTable.EffectiveRequestPriceE()
 			if err != nil {
 				return fmt.Errorf("invalid pricing: %w", err)
@@ -218,10 +221,12 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("load provenance: %w", err)
 				}
+
 				d.Provenance = prov
 				fmt.Printf("Loaded provenance: %s (metric %s=%s, params %s)\n",
 					prov.Framework, prov.MetricName, prov.MetricValue, prov.ParamCount)
 			}
+
 			if priceTable.PerMTok != "" {
 				d.ApproxTokensPerRequest = schemas.ApproxTokensPerRequest
 			}
@@ -235,7 +240,8 @@ Examples:
 			// If a cluster is available, route through the cluster's x402 flow
 			// (tunnel → Traefik → x402-verifier → host gateway → Ollama).
 			// The gateway's built-in x402 is disabled to avoid double-gating.
-			kubeconfigPath := fmt.Sprintf("%s/kubeconfig.yaml", cfg.ConfigDir)
+			kubeconfigPath := cfg.ConfigDir + "/kubeconfig.yaml"
+
 			clusterAvailable := false
 			if _, statErr := os.Stat(kubeconfigPath); statErr == nil {
 				clusterAvailable = true
@@ -246,6 +252,7 @@ Examples:
 
 				// Resolve the gateway port from the listen address.
 				listenAddr := d.ListenAddr
+
 				port := "8402"
 				if idx := strings.LastIndex(listenAddr, ":"); idx >= 0 {
 					port = listenAddr[idx+1:]
@@ -261,14 +268,16 @@ Examples:
 				if err := createHostService(cfg, name, svcNs, port); err != nil {
 					fmt.Printf("Warning: could not create cluster service: %v\n", err)
 					fmt.Println("Falling back to standalone mode with built-in x402 payment gate.")
+
 					d.NoPaymentGate = false
 				} else {
 					// Create a ServiceOffer CR pointing at the host service.
 					soSpec := buildInferenceServiceOfferSpec(d, priceTable, svcNs, port)
-					soManifest := map[string]interface{}{
+
+					soManifest := map[string]any{
 						"apiVersion": "obol.org/v1alpha1",
 						"kind":       "ServiceOffer",
-						"metadata": map[string]interface{}{
+						"metadata": map[string]any{
 							"name":      name,
 							"namespace": svcNs,
 						},
@@ -276,6 +285,7 @@ Examples:
 					}
 					if err := kubectlApply(cfg, soManifest); err != nil {
 						fmt.Printf("Warning: could not create ServiceOffer: %v\n", err)
+
 						d.NoPaymentGate = false
 					} else {
 						fmt.Printf("ServiceOffer %s/%s created (type: inference, routed via cluster)\n", svcNs, name)
@@ -284,6 +294,7 @@ Examples:
 						u := getUI(cmd)
 						u.Blank()
 						u.Info("Ensuring tunnel is active for public access...")
+
 						if tunnelURL, tErr := tunnel.EnsureTunnelForSell(cfg, u); tErr != nil {
 							u.Warnf("Tunnel not started: %v", tErr)
 							u.Dim("  Start manually with: obol tunnel restart")
@@ -408,8 +419,9 @@ Examples:
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
-				return fmt.Errorf("name required: obol sell http <name> --wallet <addr> --chain <chain>")
+				return errors.New("name required: obol sell http <name> --wallet <addr> --chain <chain>")
 			}
+
 			name := cmd.Args().First()
 			ns := cmd.String("namespace")
 
@@ -417,7 +429,9 @@ Examples:
 			if err != nil {
 				return err
 			}
-			price := map[string]interface{}{}
+
+			price := map[string]any{}
+
 			switch {
 			case priceTable.PerRequest != "":
 				price["perRequest"] = priceTable.PerRequest
@@ -427,15 +441,15 @@ Examples:
 				price["perHour"] = priceTable.PerHour
 			}
 
-			spec := map[string]interface{}{
+			spec := map[string]any{
 				"type": "http",
-				"upstream": map[string]interface{}{
+				"upstream": map[string]any{
 					"service":    cmd.String("upstream"),
 					"namespace":  ns,
 					"port":       cmd.Int("port"),
 					"healthPath": cmd.String("health-path"),
 				},
-				"payment": map[string]interface{}{
+				"payment": map[string]any{
 					"scheme":            "exact",
 					"network":           cmd.String("chain"),
 					"payTo":             cmd.String("wallet"),
@@ -458,48 +472,58 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("marshal provenance: %w", err)
 				}
-				var provMap map[string]interface{}
+
+				var provMap map[string]any
 				if err := json.Unmarshal(provBytes, &provMap); err != nil {
 					return fmt.Errorf("unmarshal provenance: %w", err)
 				}
+
 				spec["provenance"] = provMap
+
 				fmt.Printf("Loaded provenance: %s (metric %s=%s, params %s)\n",
 					prov.Framework, prov.MetricName, prov.MetricValue, prov.ParamCount)
 			}
 
 			if cmd.Bool("register") || cmd.String("register-name") != "" {
-				reg := map[string]interface{}{
+				reg := map[string]any{
 					"enabled": cmd.Bool("register"),
 				}
 				if n := cmd.String("register-name"); n != "" {
 					reg["name"] = n
 				}
+
 				if d := cmd.String("register-description"); d != "" {
 					reg["description"] = d
 				}
+
 				if img := cmd.String("register-image"); img != "" {
 					reg["image"] = img
 				}
+
 				if skills := cmd.StringSlice("register-skills"); len(skills) > 0 {
 					reg["skills"] = skills
 				}
+
 				if domains := cmd.StringSlice("register-domains"); len(domains) > 0 {
 					reg["domains"] = domains
 				}
+
 				if metaPairs := cmd.StringSlice("register-metadata"); len(metaPairs) > 0 {
 					meta, err := parseMetadataPairs(metaPairs)
 					if err != nil {
 						return err
 					}
+
 					reg["metadata"] = meta
 				}
+
 				spec["registration"] = reg
 			}
 
-			manifest := map[string]interface{}{
+			manifest := map[string]any{
 				"apiVersion": "obol.org/v1alpha1",
 				"kind":       "ServiceOffer",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      name,
 					"namespace": ns,
 				},
@@ -509,10 +533,13 @@ Examples:
 			if err := kubectlApply(cfg, manifest); err != nil {
 				return err
 			}
+
 			fmt.Printf("ServiceOffer %s/%s created (type: http)\n", ns, name)
+
 			if priceTable.PerMTok != "" {
 				fmt.Printf("Requests will be charged at %s\n", formatPriceTableSummary(priceTable))
 			}
+
 			fmt.Printf("The agent will reconcile: health-check → payment gate → route\n")
 			fmt.Printf("Check status: obol sell status %s -n %s\n", name, ns)
 
@@ -520,12 +547,14 @@ Examples:
 			u := getUI(cmd)
 			u.Blank()
 			u.Info("Ensuring tunnel is active for public access...")
+
 			if tunnelURL, err := tunnel.EnsureTunnelForSell(cfg, u); err != nil {
 				u.Warnf("Tunnel not started: %v", err)
 				u.Dim("  Start manually with: obol tunnel restart")
 			} else {
 				u.Successf("Tunnel active: %s", tunnelURL)
 			}
+
 			return nil
 		},
 	}
@@ -553,7 +582,9 @@ func sellListCommand(cfg *config.Config) *cli.Command {
 			} else {
 				args = append(args, "-A")
 			}
+
 			args = append(args, "-o", "wide")
+
 			return kubectlRun(cfg, args...)
 		},
 	}
@@ -579,10 +610,12 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 			// If a name is provided, show per-offer conditions.
 			if cmd.NArg() > 0 {
 				name := cmd.Args().First()
+
 				ns := cmd.String("namespace")
 				if ns == "" {
-					return fmt.Errorf("namespace required: obol sell status <name> -n <ns>")
+					return errors.New("namespace required: obol sell status <name> -n <ns>")
 				}
+
 				return kubectlRun(cfg, "get", "serviceoffers.obol.org", name, "-n", ns, "-o", "yaml")
 			}
 
@@ -597,15 +630,18 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 				fmt.Printf("  Facilitator: %s\n", valueOrNone(pricingCfg.FacilitatorURL))
 				fmt.Printf("  Verify Only: %v\n", pricingCfg.VerifyOnly)
 				fmt.Printf("  Routes:      %d\n", len(pricingCfg.Routes))
+
 				for _, r := range pricingCfg.Routes {
 					desc := r.Description
 					if desc == "" {
 						desc = "(no description)"
 					}
+
 					payTo := r.PayTo
 					if payTo == "" {
 						payTo = "(global)"
 					}
+
 					fmt.Printf("    %s → %s  payTo=%s  %s\n", r.Pattern, formatRoutePriceSummary(r), payTo, desc)
 				}
 			}
@@ -618,9 +654,11 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 
 			// Also show local inference gateway deployments.
 			store := inference.NewStore(cfg.ConfigDir)
+
 			deployments, _ := store.List()
 			if len(deployments) > 0 {
 				fmt.Printf("\nLocal Inference Gateways:\n")
+
 				for _, d := range deployments {
 					fmt.Printf("  %-20s %s → %s  %s  chain=%s\n",
 						d.Name, d.ListenAddr, d.UpstreamURL, formatInferencePriceSummary(d), d.Chain)
@@ -669,11 +707,12 @@ Examples:
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.Args().First()
 			if name == "" {
-				return fmt.Errorf("name required: obol sell probe <name> -n <ns>")
+				return errors.New("name required: obol sell probe <name> -n <ns>")
 			}
+
 			ns := cmd.String("namespace")
 			if ns == "" {
-				return fmt.Errorf("namespace required: obol sell probe <name> -n <ns>")
+				return errors.New("namespace required: obol sell probe <name> -n <ns>")
 			}
 
 			// Get the ServiceOffer's endpoint from the CR status.
@@ -682,6 +721,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("get ServiceOffer %s/%s: %w", ns, name, err)
 			}
+
 			endpoint = strings.TrimSpace(endpoint)
 			if endpoint == "" {
 				return fmt.Errorf("ServiceOffer %s/%s has no endpoint (not yet reconciled?)", ns, name)
@@ -712,16 +752,20 @@ Examples:
 				} else {
 					fmt.Println(string(body))
 				}
+
 				fmt.Println("\nEndpoint is live and payment-gated.")
+
 				return nil
 			}
 
 			if len(body) > 0 {
 				fmt.Println(string(body))
 			}
+
 			if resp.StatusCode == http.StatusOK {
 				fmt.Println("\nWarning: endpoint returned 200 (not payment-gated).")
 			}
+
 			return nil
 		},
 	}
@@ -746,8 +790,9 @@ func sellStopCommand(cfg *config.Config) *cli.Command {
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
-				return fmt.Errorf("name required: obol sell stop <name> -n <ns>")
+				return errors.New("name required: obol sell stop <name> -n <ns>")
 			}
+
 			name := cmd.Args().First()
 			ns := cmd.String("namespace")
 
@@ -756,6 +801,7 @@ func sellStopCommand(cfg *config.Config) *cli.Command {
 			removePricingRoute(cfg, name)
 
 			patchJSON := `{"status":{"conditions":[{"type":"Ready","status":"False","reason":"Stopped","message":"Offer stopped by user"}]}}`
+
 			err := kubectlRun(cfg, "patch", "serviceoffers.obol.org", name, "-n", ns,
 				"--type=merge", "--subresource=status", "-p", patchJSON)
 			if err != nil {
@@ -763,6 +809,7 @@ func sellStopCommand(cfg *config.Config) *cli.Command {
 			}
 
 			fmt.Printf("ServiceOffer %s/%s stopped.\n", ns, name)
+
 			return nil
 		},
 	}
@@ -792,8 +839,9 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
-				return fmt.Errorf("name required: obol sell delete <name> -n <ns>")
+				return errors.New("name required: obol sell delete <name> -n <ns>")
 			}
+
 			name := cmd.Args().First()
 			ns := cmd.String("namespace")
 
@@ -803,8 +851,10 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 				fmt.Println("  - Remove the pricing route from the x402 verifier")
 				fmt.Println("  - Deactivate the ERC-8004 registration (if registered)")
 				fmt.Print("[y/N] ")
+
 				var response string
 				fmt.Scanln(&response)
+
 				if !strings.EqualFold(response, "y") && !strings.EqualFold(response, "yes") {
 					fmt.Println("Aborted.")
 					return nil
@@ -820,17 +870,19 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 				fmt.Printf("Deactivating ERC-8004 registration (agent %s)...\n", agentID)
 
 				cmName := fmt.Sprintf("so-%s-registration", name)
+
 				rawJSON, readErr := kubectlOutput(cfg, "get", "configmap", cmName, "-n", ns,
 					"-o", `jsonpath={.data.agent-registration\.json}`)
 				if readErr != nil || strings.TrimSpace(rawJSON) == "" {
 					fmt.Printf("  No registration document found. Agent %s NFT persists on-chain.\n", agentID)
 				} else {
-					var regDoc map[string]interface{}
+					var regDoc map[string]any
 					if jsonErr := json.Unmarshal([]byte(rawJSON), &regDoc); jsonErr != nil {
 						fmt.Printf("  Warning: corrupt registration JSON, skipping deactivation: %v\n", jsonErr)
 					} else {
 						regDoc["active"] = false
-						patchJSON, _ := json.Marshal(map[string]interface{}{
+
+						patchJSON, _ := json.Marshal(map[string]any{
 							"data": map[string]string{
 								"agent-registration.json": mustMarshal(regDoc),
 							},
@@ -862,6 +914,7 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 					_ = tunnel.DeleteStorefront(cfg)
 				}
 			}
+
 			return nil
 		},
 	}
@@ -900,6 +953,7 @@ Stakater Reloader auto-restarts the verifier pod on config changes.`,
 			if err := x402verifier.ValidateWallet(wallet); err != nil {
 				return err
 			}
+
 			return x402verifier.Setup(cfg, wallet, cmd.String("chain"), cmd.String("facilitator-url"))
 		},
 	}
@@ -952,15 +1006,19 @@ Requires a funded Base Sepolia wallet (private key).`,
 					if err != nil {
 						return fmt.Errorf("read private key file: %w", err)
 					}
+
 					keyHex = strings.TrimSpace(string(data))
 				}
 			}
+
 			if keyHex == "" {
-				return fmt.Errorf("private key required: use --private-key-file <path> or set ERC8004_PRIVATE_KEY")
+				return errors.New("private key required: use --private-key-file <path> or set ERC8004_PRIVATE_KEY")
 			}
+
 			if cmd.IsSet("private-key") {
 				fmt.Fprintf(os.Stderr, "Warning: --private-key flag exposes key in process args. Use --private-key-file or ERC8004_PRIVATE_KEY env var instead.\n")
 			}
+
 			keyHex = strings.TrimPrefix(keyHex, "0x")
 
 			key, err := crypto.HexToECDSA(keyHex)
@@ -972,13 +1030,15 @@ Requires a funded Base Sepolia wallet (private key).`,
 			if endpoint == "" {
 				tunnelURL, err := tunnel.GetTunnelURL(cfg)
 				if err != nil {
-					return fmt.Errorf("--endpoint required (tunnel auto-detect failed: %v)", err)
+					return fmt.Errorf("--endpoint required (tunnel auto-detect failed: %w)", err)
 				}
+
 				endpoint = tunnelURL
 				fmt.Printf("Auto-detected endpoint from tunnel: %s\n", endpoint)
 			}
 
 			agentURI := endpoint + "/.well-known/agent-registration.json"
+
 			fmt.Printf("Registering agent on ERC-8004 Identity Registry (Base Sepolia)...\n")
 			fmt.Printf("  Agent URI: %s\n", agentURI)
 			fmt.Printf("  Registry:  %s\n", erc8004.IdentityRegistryBaseSepolia)
@@ -995,6 +1055,7 @@ Requires a funded Base Sepolia wallet (private key).`,
 			}
 
 			txAddr := crypto.PubkeyToAddress(key.PublicKey)
+
 			fmt.Printf("\nAgent registered successfully!\n")
 			fmt.Printf("  Agent ID:  %s\n", agentID.String())
 			fmt.Printf("  Owner:     %s\n", txAddr.Hex())
@@ -1040,9 +1101,11 @@ func runInferenceGateway(d *inference.Deployment, chain x402.ChainConfig) error 
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
 	go func() {
 		<-sigCh
 		fmt.Println("\nShutting down gateway...")
+
 		if err := gw.Stop(); err != nil {
 			fmt.Fprintf(os.Stderr, "shutdown error: %v\n", err)
 		}
@@ -1071,102 +1134,18 @@ func resolveX402Chain(name string) (x402.ChainConfig, error) {
 	}
 }
 
-// sellInfoCommand returns info about a local inference gateway deployment.
-// Kept for the enclave pubkey functionality.
-func sellInfoCommand(cfg *config.Config) *cli.Command {
-	return &cli.Command{
-		Name:      "info",
-		Usage:     "Show inference gateway deployment details and encryption key",
-		ArgsUsage: "<name>",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "json",
-				Aliases: []string{"j"},
-				Usage:   "Output as JSON",
-			},
-		},
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			name := cmd.Args().First()
-			if name == "" {
-				return fmt.Errorf("usage: obol sell info <name>")
-			}
-
-			store := inference.NewStore(cfg.ConfigDir)
-			d, err := store.Get(name)
-			if err != nil {
-				return err
-			}
-
-			var k enclave.Key
-			var keyErr error
-			if d.TEEType != "" {
-				k, keyErr = tee.NewKey(d.EnclaveTag, d.ModelHash)
-			} else {
-				k, keyErr = enclave.NewKey(d.EnclaveTag)
-			}
-
-			if cmd.Bool("json") {
-				out := map[string]any{
-					"name":                      d.Name,
-					"enclave_tag":               d.EnclaveTag,
-					"listen_addr":               d.ListenAddr,
-					"upstream_url":              d.UpstreamURL,
-					"wallet_address":            d.WalletAddress,
-					"price_per_request":         d.PricePerRequest,
-					"price_per_mtok":            d.PricePerMTok,
-					"approx_tokens_per_request": d.ApproxTokensPerRequest,
-					"chain":                     d.Chain,
-					"facilitator_url":           d.FacilitatorURL,
-					"created_at":                d.CreatedAt,
-					"updated_at":                d.UpdatedAt,
-					"algorithm":                 "ECIES-P256-HKDF-SHA256-AES256GCM",
-				}
-				if keyErr == nil {
-					out["pubkey"] = hex.EncodeToString(k.PublicKeyBytes())
-					out["persistent"] = k.Persistent()
-				} else {
-					out["pubkey_error"] = keyErr.Error()
-				}
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				return enc.Encode(out)
-			}
-
-			fmt.Printf("Name:         %s\n", d.Name)
-			fmt.Printf("Enclave tag:  %s\n", d.EnclaveTag)
-			fmt.Printf("Algorithm:    ECIES-P256-HKDF-SHA256-AES256GCM\n")
-			if keyErr == nil {
-				fmt.Printf("Pubkey:       %s\n", hex.EncodeToString(k.PublicKeyBytes()))
-				fmt.Printf("Persistent:   %v\n", k.Persistent())
-			} else {
-				fmt.Printf("Pubkey:       (unavailable: %v)\n", keyErr)
-			}
-			fmt.Println()
-			fmt.Printf("Listen:       %s\n", d.ListenAddr)
-			fmt.Printf("Upstream:     %s\n", d.UpstreamURL)
-			fmt.Printf("Wallet:       %s\n", d.WalletAddress)
-			fmt.Printf("Price:        %s\n", formatInferencePriceSummary(d))
-			fmt.Printf("Chain:        %s\n", d.Chain)
-			fmt.Printf("Facilitator:  %s\n", d.FacilitatorURL)
-			fmt.Printf("Created:      %s\n", d.CreatedAt)
-			if d.UpdatedAt != "" {
-				fmt.Printf("Updated:      %s\n", d.UpdatedAt)
-			}
-			return nil
-		},
-	}
-}
-
 // ---------------------------------------------------------------------------
 // kubectl helpers
 // ---------------------------------------------------------------------------
 
-func kubectlApply(cfg *config.Config, manifest interface{}) error {
+func kubectlApply(cfg *config.Config, manifest any) error {
 	raw, err := json.Marshal(manifest)
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
+
 	bin, kc := kubectl.Paths(cfg)
+
 	return kubectl.Apply(bin, kc, raw)
 }
 
@@ -1174,7 +1153,9 @@ func kubectlOutput(cfg *config.Config, args ...string) (string, error) {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return "", err
 	}
+
 	bin, kc := kubectl.Paths(cfg)
+
 	return kubectl.Output(bin, kc, args...)
 }
 
@@ -1182,15 +1163,18 @@ func kubectlRun(cfg *config.Config, args ...string) error {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return err
 	}
+
 	bin, kc := kubectl.Paths(cfg)
+
 	return kubectl.Run(bin, kc, args...)
 }
 
-func mustMarshal(v interface{}) string {
+func mustMarshal(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return "{}"
 	}
+
 	return string(b)
 }
 
@@ -1198,6 +1182,7 @@ func valueOrNone(s string) string {
 	if s == "" {
 		return "(not set)"
 	}
+
 	return s
 }
 
@@ -1208,8 +1193,10 @@ func parseMetadataPairs(values []string) (map[string]string, error) {
 		if !ok || strings.TrimSpace(key) == "" {
 			return nil, fmt.Errorf("invalid --register-metadata value %q: expected key=value", raw)
 		}
+
 		meta[strings.TrimSpace(key)] = strings.TrimSpace(value)
 	}
+
 	return meta, nil
 }
 
@@ -1218,7 +1205,9 @@ func resolvePriceTable(cmd *cli.Command, allowPerHour bool) (schemas.PriceTable,
 	if perRequest == "" {
 		perRequest = cmd.String("per-request")
 	}
+
 	perMTok := cmd.String("per-mtok")
+
 	var perHour string
 	if allowPerHour {
 		perHour = cmd.String("per-hour")
@@ -1231,24 +1220,27 @@ func resolvePriceTable(cmd *cli.Command, allowPerHour bool) (schemas.PriceTable,
 		if _, err := schemas.ApproximateRequestPriceFromPerMTok(perMTok); err != nil {
 			return schemas.PriceTable{}, fmt.Errorf("invalid --per-mtok value %q: %w", perMTok, err)
 		}
+
 		return schemas.PriceTable{PerMTok: perMTok}, nil
 	case perHour != "":
 		if _, err := schemas.ApproximateRequestPriceFromPerHour(perHour); err != nil {
 			return schemas.PriceTable{}, fmt.Errorf("invalid --per-hour value %q: %w", perHour, err)
 		}
+
 		return schemas.PriceTable{PerHour: perHour}, nil
 	default:
 		if allowPerHour {
-			return schemas.PriceTable{}, fmt.Errorf("price required: use --price, --per-request, --per-mtok, or --per-hour")
+			return schemas.PriceTable{}, errors.New("price required: use --price, --per-request, --per-mtok, or --per-hour")
 		}
-		return schemas.PriceTable{}, fmt.Errorf("price required: use --price, --per-request, or --per-mtok")
+
+		return schemas.PriceTable{}, errors.New("price required: use --price, --per-request, or --per-mtok")
 	}
 }
 
 func formatPriceTableSummary(priceTable schemas.PriceTable) string {
 	switch {
 	case priceTable.PerRequest != "":
-		return fmt.Sprintf("%s USDC/request", priceTable.PerRequest)
+		return priceTable.PerRequest + " USDC/request"
 	case priceTable.PerMTok != "":
 		return fmt.Sprintf("%s USDC/request (approx from %s USDC/MTok @ %d tok/request)",
 			priceTable.EffectiveRequestPrice(),
@@ -1271,9 +1263,11 @@ func formatRoutePriceSummary(route x402verifier.RouteRule) string {
 		return fmt.Sprintf("%s USDC/request (approx from %s USDC/MTok @ %d tok/request)",
 			route.Price, route.PerMTok, route.ApproxTokensPerRequest)
 	}
+
 	if route.Price != "" {
-		return fmt.Sprintf("%s USDC/request", route.Price)
+		return route.Price + " USDC/request"
 	}
+
 	return "0 USDC/request"
 }
 
@@ -1282,7 +1276,8 @@ func formatInferencePriceSummary(d *inference.Deployment) string {
 		return fmt.Sprintf("%s USDC/request (approx from %s USDC/MTok @ %d tok/request)",
 			d.PricePerRequest, d.PricePerMTok, d.ApproxTokensPerRequest)
 	}
-	return fmt.Sprintf("%s USDC/request", d.PricePerRequest)
+
+	return d.PricePerRequest + " USDC/request"
 }
 
 // loadProvenance reads a provenance JSON file and returns the parsed struct.
@@ -1291,12 +1286,16 @@ func loadProvenance(path string) (*inference.Provenance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
+
 	var prov inference.Provenance
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
+
 	if err := dec.Decode(&prov); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
+
 	return &prov, nil
 }
 
@@ -1314,32 +1313,32 @@ func createHostService(cfg *config.Config, name, ns, port string) error {
 
 	portNum, _ := strconv.Atoi(port)
 
-	svc := map[string]interface{}{
+	svc := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Service",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"spec": map[string]interface{}{
-			"ports": []map[string]interface{}{
+		"spec": map[string]any{
+			"ports": []map[string]any{
 				{"port": portNum, "targetPort": portNum, "protocol": "TCP"},
 			},
 		},
 	}
-	ep := map[string]interface{}{
+	ep := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Endpoints",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
 		},
-		"subsets": []map[string]interface{}{
+		"subsets": []map[string]any{
 			{
-				"addresses": []map[string]interface{}{
+				"addresses": []map[string]any{
 					{"ip": hostIP},
 				},
-				"ports": []map[string]interface{}{
+				"ports": []map[string]any{
 					{"port": portNum, "protocol": "TCP"},
 				},
 			},
@@ -1349,9 +1348,11 @@ func createHostService(cfg *config.Config, name, ns, port string) error {
 	if err := kubectlApply(cfg, svc); err != nil {
 		return fmt.Errorf("failed to create service: %w", err)
 	}
+
 	if err := kubectlApply(cfg, ep); err != nil {
 		return fmt.Errorf("failed to create endpoints: %w", err)
 	}
+
 	return nil
 }
 
@@ -1384,31 +1385,32 @@ func resolveHostIP(cfg *config.Config) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("cannot determine host IP; ensure Docker is running or using k3s backend")
+
+	return "", errors.New("cannot determine host IP; ensure Docker is running or using k3s backend")
 }
 
 // buildInferenceServiceOfferSpec builds a ServiceOffer spec for a host-side
 // inference gateway routed through the cluster's x402 flow.
-func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTable, ns, port string) map[string]interface{} {
+func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTable, ns, port string) map[string]any {
 	portNum, _ := strconv.Atoi(port)
-	spec := map[string]interface{}{
+	spec := map[string]any{
 		"type": "inference",
-		"upstream": map[string]interface{}{
+		"upstream": map[string]any{
 			"service":    d.Name,
 			"namespace":  ns,
 			"port":       portNum,
 			"healthPath": "/health",
 		},
-		"payment": map[string]interface{}{
+		"payment": map[string]any{
 			"scheme":  "exact",
 			"network": d.Chain,
 			"payTo":   d.WalletAddress,
-			"price":   map[string]interface{}{},
+			"price":   map[string]any{},
 		},
-		"path": fmt.Sprintf("/services/%s", d.Name),
+		"path": "/services/" + d.Name,
 	}
 
-	price := spec["payment"].(map[string]interface{})["price"].(map[string]interface{})
+	price := spec["payment"].(map[string]any)["price"].(map[string]any)
 	if pt.PerMTok != "" {
 		price["perMTok"] = pt.PerMTok
 	} else {
@@ -1416,27 +1418,31 @@ func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTab
 	}
 
 	if d.UpstreamURL != "" {
-		spec["model"] = map[string]interface{}{
+		spec["model"] = map[string]any{
 			"name":    "ollama",
 			"runtime": "ollama",
 		}
 	}
+
 	return spec
 }
 
 // removePricingRoute removes the x402-verifier pricing route for the given offer.
 func removePricingRoute(cfg *config.Config, name string) {
-	urlPath := fmt.Sprintf("/services/%s", name)
+	urlPath := "/services/" + name
+
 	pricingCfg, err := x402verifier.GetPricingConfig(cfg)
 	if err != nil {
 		return
 	}
+
 	updatedRoutes := make([]x402verifier.RouteRule, 0, len(pricingCfg.Routes))
 	for _, r := range pricingCfg.Routes {
 		if !strings.Contains(r.Pattern, urlPath) {
 			updatedRoutes = append(updatedRoutes, r)
 		}
 	}
+
 	if len(updatedRoutes) < len(pricingCfg.Routes) {
 		pricingCfg.Routes = updatedRoutes
 		if err := x402verifier.WritePricingConfig(cfg, pricingCfg); err != nil {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -209,9 +209,9 @@ Examples:
 				FacilitatorURL:  cmd.String("facilitator"),
 				VMMode:          cmd.Bool("vm"),
 				VMImage:         cmd.String("vm-image"),
-				VMCPUs:          int(cmd.Int("vm-cpus")),
-				VMMemoryMB:      int(cmd.Int("vm-memory")),
-				VMHostPort:      int(cmd.Int("vm-host-port")),
+				VMCPUs:          cmd.Int("vm-cpus"),
+				VMMemoryMB:      cmd.Int("vm-memory"),
+				VMHostPort:      cmd.Int("vm-host-port"),
 				TEEType:         teeType,
 				ModelHash:       modelHash,
 			}
@@ -649,7 +649,8 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 			fmt.Println()
 
 			fmt.Printf("ERC-8004 Registration:\n")
-			kubectlRun(cfg, "get", "serviceoffers.obol.org", "-A",
+
+			_ = kubectlRun(cfg, "get", "serviceoffers.obol.org", "-A",
 				"-o", "custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,AGENT_ID:.status.agentId,TX:.status.registrationTxHash,REGISTERED:.status.conditions[?(@.type=='Registered')].status")
 
 			// Also show local inference gateway deployments.
@@ -853,7 +854,8 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 				fmt.Print("[y/N] ")
 
 				var response string
-				fmt.Scanln(&response)
+
+				_, _ = fmt.Scanln(&response)
 
 				if !strings.EqualFold(response, "y") && !strings.EqualFold(response, "yes") {
 					fmt.Println("Aborted.")

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -14,27 +14,33 @@ import (
 
 func findSubcommand(t *testing.T, parent *cli.Command, name string) *cli.Command {
 	t.Helper()
+
 	for _, sub := range parent.Commands {
 		if sub.Name == name {
 			return sub
 		}
 	}
+
 	t.Fatalf("subcommand %q not found in %q", name, parent.Name)
+
 	return nil
 }
 
 func flagMap(cmd *cli.Command) map[string]cli.Flag {
 	m := map[string]cli.Flag{}
+
 	for _, f := range cmd.Flags {
 		for _, name := range f.Names() {
 			m[name] = f
 		}
 	}
+
 	return m
 }
 
 func requireFlags(t *testing.T, flags map[string]cli.Flag, names ...string) {
 	t.Helper()
+
 	for _, name := range names {
 		if _, ok := flags[name]; !ok {
 			t.Errorf("missing flag: --%s", name)
@@ -44,16 +50,19 @@ func requireFlags(t *testing.T, flags map[string]cli.Flag, names ...string) {
 
 func assertStringDefault(t *testing.T, flags map[string]cli.Flag, name, want string) {
 	t.Helper()
+
 	f, ok := flags[name]
 	if !ok {
 		t.Errorf("missing flag: --%s", name)
 		return
 	}
+
 	sf, ok := f.(*cli.StringFlag)
 	if !ok {
 		t.Errorf("flag --%s is %T, want *cli.StringFlag", name, f)
 		return
 	}
+
 	if sf.Value != want {
 		t.Errorf("flag --%s default = %q, want %q", name, sf.Value, want)
 	}
@@ -61,16 +70,19 @@ func assertStringDefault(t *testing.T, flags map[string]cli.Flag, name, want str
 
 func assertIntDefault(t *testing.T, flags map[string]cli.Flag, name string, want int) {
 	t.Helper()
+
 	f, ok := flags[name]
 	if !ok {
 		t.Errorf("missing flag: --%s", name)
 		return
 	}
+
 	sf, ok := f.(*cli.IntFlag)
 	if !ok {
 		t.Errorf("flag --%s is %T, want *cli.IntFlag", name, f)
 		return
 	}
+
 	if sf.Value != want {
 		t.Errorf("flag --%s default = %d, want %d", name, sf.Value, want)
 	}
@@ -78,11 +90,13 @@ func assertIntDefault(t *testing.T, flags map[string]cli.Flag, name string, want
 
 func assertFlagRequired(t *testing.T, flags map[string]cli.Flag, name string) {
 	t.Helper()
+
 	f, ok := flags[name]
 	if !ok {
 		t.Errorf("missing flag: --%s", name)
 		return
 	}
+
 	switch sf := f.(type) {
 	case *cli.StringFlag:
 		if !sf.Required {
@@ -103,6 +117,7 @@ func assertFlagRequired(t *testing.T, flags map[string]cli.Flag, name string) {
 
 func assertFlagHasAlias(t *testing.T, flags map[string]cli.Flag, primary, alias string) {
 	t.Helper()
+
 	if _, ok := flags[alias]; !ok {
 		t.Errorf("flag --%s missing alias %q", primary, alias)
 	}
@@ -110,6 +125,7 @@ func assertFlagHasAlias(t *testing.T, flags map[string]cli.Flag, primary, alias 
 
 func newTestConfig(t *testing.T) *config.Config {
 	t.Helper()
+
 	return &config.Config{
 		ConfigDir: t.TempDir(),
 		DataDir:   t.TempDir(),
@@ -255,11 +271,13 @@ func TestSellList_Flags(t *testing.T) {
 }
 
 func TestMustMarshal_ValidJSON(t *testing.T) {
-	doc := map[string]interface{}{"active": false, "name": "test"}
+	doc := map[string]any{"active": false, "name": "test"}
+
 	got := mustMarshal(doc)
 	if got == "{}" {
 		t.Fatal("mustMarshal returned empty object for valid input")
 	}
+
 	for _, want := range []string{`"active":false`, `"name":"test"`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("mustMarshal output missing %s, got: %s", want, got)

--- a/cmd/obol/update.go
+++ b/cmd/obol/update.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -26,6 +26,7 @@ func updateCommand(cfg *config.Config) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
 			kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
 			clusterRunning := true
 			if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 				clusterRunning = false
@@ -66,6 +67,7 @@ func updateCommand(cfg *config.Config) *cli.Command {
 			// Print CLI status
 			u.Blank()
 			u.Info("Checking CLI version...")
+
 			if result.CLIError != "" {
 				u.Warnf("%s", result.CLIError)
 			} else {
@@ -108,7 +110,7 @@ Examples:
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 			if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-				return fmt.Errorf("stack not running, use 'obol stack up' first")
+				return errors.New("stack not running, use 'obol stack up' first")
 			}
 
 			chartFilter := ""
@@ -164,6 +166,7 @@ func printUpdateJSON(result *update.UpdateResult) error {
 		} else if result.CLIUpdateAvail {
 			status = "update_available"
 		}
+
 		out.CLI = &jsonCLI{
 			Current: version.Short(),
 			Latest:  result.CLIRelease.Version,
@@ -173,5 +176,6 @@ func printUpdateJSON(result *update.UpdateResult) error {
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
+
 	return enc.Encode(out)
 }

--- a/cmd/x402-buyer/main.go
+++ b/cmd/x402-buyer/main.go
@@ -34,6 +34,7 @@ func main() {
 		listen         = flag.String("listen", ":8402", "listen address")
 		reloadInterval = flag.Duration("reload-interval", 5*time.Second, "config/auth reload interval")
 	)
+
 	flag.Parse()
 
 	state, err := buyer.LoadStateStore(*statePath)
@@ -77,6 +78,7 @@ func main() {
 
 	go func() {
 		log.Printf("x402-buyer listening on %s", *listen)
+
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("serve: %v", err)
 		}
@@ -85,6 +87,7 @@ func main() {
 	if *reloadInterval > 0 {
 		ticker := time.NewTicker(*reloadInterval)
 		defer ticker.Stop()
+
 		go func() {
 			for {
 				select {
@@ -96,11 +99,13 @@ func main() {
 						log.Printf("reload config: %v", err)
 						continue
 					}
+
 					auths, err := buyer.LoadAuths(*authsPath)
 					if err != nil {
 						log.Printf("reload auths: %v", err)
 						continue
 					}
+
 					if err := proxy.Reload(cfg, auths); err != nil {
 						log.Printf("reload proxy: %v", err)
 					}
@@ -114,6 +119,7 @@ func main() {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "shutdown: %v\n", err)
 	}

--- a/cmd/x402-verifier/main.go
+++ b/cmd/x402-verifier/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	listener, err := net.Listen("tcp", *listen)
 	if err != nil {
-		log.Fatalf("listen: %v", err)
+		log.Fatalf("listen: %v", err) //nolint:gocritic // intentional fatal in main; defers are for graceful shutdown only
 	}
 
 	log.Printf("x402 verifier listening on %s", *listen)

--- a/cmd/x402-verifier/main.go
+++ b/cmd/x402-verifier/main.go
@@ -19,6 +19,7 @@ func main() {
 	configPath := flag.String("config", "/config/pricing.yaml", "Path to pricing config YAML")
 	listen := flag.String("listen", ":8080", "Listen address")
 	watch := flag.Bool("watch", true, "Watch config file for changes")
+
 	flag.Parse()
 
 	cfg, err := x402verifier.LoadConfig(*configPath)
@@ -61,12 +62,15 @@ func main() {
 	// Handle graceful shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
 	go func() {
 		<-sigCh
 		log.Println("shutting down...")
 		cancel()
+
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
+
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			log.Printf("shutdown error: %v", err)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -31,6 +31,7 @@ func Init(cfg *config.Config, u *ui.UI) error {
 	}
 
 	u.Success("Agent capabilities applied to default OpenClaw instance")
+
 	return nil
 }
 
@@ -43,9 +44,9 @@ func Init(cfg *config.Config, u *ui.UI) error {
 //	RoleBindings patched:
 //	  openclaw-x402-pricing-binding       (x402 namespace, pricing ConfigMap)
 func patchMonetizeBinding(cfg *config.Config, u *ui.UI) error {
-	namespace := fmt.Sprintf("openclaw-%s", DefaultInstanceID)
+	namespace := "openclaw-" + DefaultInstanceID
 
-	subject := []map[string]interface{}{
+	subject := []map[string]any{
 		{
 			"kind":      "ServiceAccount",
 			"name":      "openclaw",
@@ -53,7 +54,7 @@ func patchMonetizeBinding(cfg *config.Config, u *ui.UI) error {
 		},
 	}
 
-	patch := []map[string]interface{}{
+	patch := []map[string]any{
 		{
 			"op":    "replace",
 			"path":  "/subjects",
@@ -67,7 +68,7 @@ func patchMonetizeBinding(cfg *config.Config, u *ui.UI) error {
 	}
 
 	bin, kc := kubectl.Paths(cfg)
-	patchArg := fmt.Sprintf("-p=%s", string(patchData))
+	patchArg := "-p=" + string(patchData)
 
 	// Patch both ClusterRoleBindings.
 	clusterBindings := []string{
@@ -94,6 +95,7 @@ func patchMonetizeBinding(cfg *config.Config, u *ui.UI) error {
 	}
 
 	u.Successf("RBAC bindings patched (SA: openclaw in %s)", namespace)
+
 	return nil
 }
 
@@ -103,10 +105,10 @@ func patchMonetizeBinding(cfg *config.Config, u *ui.UI) error {
 // (resolveAgentWorkspaceDir → /data/.openclaw/workspace/HEARTBEAT.md),
 // NOT the root .openclaw directory.
 func injectHeartbeatFile(cfg *config.Config, u *ui.UI) error {
-	namespace := fmt.Sprintf("openclaw-%s", DefaultInstanceID)
+	namespace := "openclaw-" + DefaultInstanceID
 	heartbeatDir := filepath.Join(cfg.DataDir, namespace, "openclaw-data", ".openclaw", "workspace")
 
-	if err := os.MkdirAll(heartbeatDir, 0755); err != nil {
+	if err := os.MkdirAll(heartbeatDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create heartbeat directory: %w", err)
 	}
 
@@ -115,10 +117,11 @@ python3 /data/.openclaw/skills/sell/scripts/monetize.py process --all --quick
 `
 
 	heartbeatPath := filepath.Join(heartbeatDir, "HEARTBEAT.md")
-	if err := os.WriteFile(heartbeatPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(heartbeatPath, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("failed to write HEARTBEAT.md: %w", err)
 	}
 
 	u.Successf("HEARTBEAT.md injected at %s", heartbeatPath)
+
 	return nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -117,7 +117,7 @@ python3 /data/.openclaw/skills/sell/scripts/monetize.py process --all --quick
 `
 
 	heartbeatPath := filepath.Join(heartbeatDir, "HEARTBEAT.md")
-	if err := os.WriteFile(heartbeatPath, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(heartbeatPath, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("failed to write HEARTBEAT.md: %w", err)
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -111,7 +111,7 @@ func Install(cfg *config.Config, u *ui.UI, chartRef string, opts InstallOptions)
 
 	// 8. Write values.yaml
 	valuesPath := filepath.Join(deploymentDir, "values.yaml")
-	if err := os.WriteFile(valuesPath, values, 0o644); err != nil {
+	if err := os.WriteFile(valuesPath, values, 0o600); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
@@ -256,7 +256,7 @@ releases:
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(dir, "helmfile.yaml"), buf.Bytes(), 0o644)
+	return os.WriteFile(filepath.Join(dir, "helmfile.yaml"), buf.Bytes(), 0o600)
 }
 
 // Sync deploys or updates an application to the cluster

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
-	"github.com/dustinkirkland/golang-petname"
+	petname "github.com/dustinkirkland/golang-petname"
 )
 
 // InstallOptions contains options for the install command
@@ -40,16 +41,21 @@ func Install(cfg *config.Config, u *ui.UI, chartRef string, opts InstallOptions)
 	// 2. If repo/chart format, resolve via ArtifactHub
 	if chart.NeedsResolution() {
 		u.Info("Resolving chart via ArtifactHub...")
+
 		client := NewArtifactHubClient()
+
 		info, err := client.ResolveChart(chartRef)
 		if err != nil {
 			return err
 		}
+
 		chart.RepoURL = info.RepoURL
+
 		chart.RepoName = info.RepoName
 		if chart.Version == "" {
 			chart.Version = info.Version
 		}
+
 		u.Detail("Resolved", fmt.Sprintf("%s/%s version %s", info.RepoName, info.ChartName, info.Version))
 		u.Detail("Repository URL", info.RepoURL)
 	}
@@ -64,6 +70,7 @@ func Install(cfg *config.Config, u *ui.UI, chartRef string, opts InstallOptions)
 	if appName == "" {
 		appName = chart.GetChartName()
 	}
+
 	u.Detail("Application name", appName)
 
 	// 4. Generate or use provided ID
@@ -83,16 +90,18 @@ func Install(cfg *config.Config, u *ui.UI, chartRef string, opts InstallOptions)
 				"Directory: %s\n"+
 				"Use --force or -f to overwrite", appName, id, deploymentDir)
 		}
+
 		u.Warnf("Overwriting existing deployment at %s", deploymentDir)
 	}
 
 	// 6. Create deployment directory
-	if err := os.MkdirAll(deploymentDir, 0755); err != nil {
+	if err := os.MkdirAll(deploymentDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create deployment directory: %w", err)
 	}
 
 	// 7. Fetch default values using helm show values
 	u.Info("Fetching chart default values...")
+
 	values, err := fetchChartValues(cfg, chart)
 	if err != nil {
 		// Clean up on failure
@@ -102,7 +111,7 @@ func Install(cfg *config.Config, u *ui.UI, chartRef string, opts InstallOptions)
 
 	// 8. Write values.yaml
 	valuesPath := filepath.Join(deploymentDir, "values.yaml")
-	if err := os.WriteFile(valuesPath, values, 0644); err != nil {
+	if err := os.WriteFile(valuesPath, values, 0o644); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
@@ -134,6 +143,7 @@ func fetchChartValues(cfg *config.Config, chart *ChartReference) ([]byte, error)
 	helmPath := filepath.Join(cfg.BinDir, "helm")
 
 	var args []string
+
 	switch chart.Format {
 	case FormatURL:
 		// Direct URL reference
@@ -153,7 +163,9 @@ func fetchChartValues(cfg *config.Config, chart *ChartReference) ([]byte, error)
 	}
 
 	cmd := exec.Command(helmPath, args...)
+
 	var stdout, stderr bytes.Buffer
+
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
@@ -223,7 +235,7 @@ releases:
 `
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Original":  chart.Original,
 		"ChartURL":  chart.ChartURL,
 		"RepoName":  chart.RepoName,
@@ -244,7 +256,7 @@ releases:
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(dir, "helmfile.yaml"), buf.Bytes(), 0644)
+	return os.WriteFile(filepath.Join(dir, "helmfile.yaml"), buf.Bytes(), 0o644)
 }
 
 // Sync deploys or updates an application to the cluster
@@ -277,7 +289,7 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	// Check kubeconfig exists (cluster must be running)
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	// Get helmfile binary path
@@ -292,8 +304,9 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	// Execute helmfile sync
 	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
 	cmd.Dir = deploymentDir
+
 	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath),
+		"KUBECONFIG="+kubeconfigPath,
 	)
 
 	if err := u.Exec(ui.ExecConfig{Name: "Running helmfile sync", Cmd: cmd}); err != nil {
@@ -301,6 +314,7 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	}
 
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	u.Blank()
 	u.Success("Application synced successfully!")
 	u.Detail("Namespace", namespace)
@@ -317,12 +331,13 @@ func parseDeploymentIdentifier(identifier string) (appName, id string, err error
 	if strings.Contains(identifier, "/") {
 		parts := strings.SplitN(identifier, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return "", "", fmt.Errorf("invalid format. Use: <app>/<id>")
+			return "", "", errors.New("invalid format. Use: <app>/<id>")
 		}
+
 		return parts[0], parts[1], nil
 	}
 
-	return "", "", fmt.Errorf("please use <app>/<id> format (e.g., postgresql/eager-fox)")
+	return "", "", errors.New("please use <app>/<id> format (e.g., postgresql/eager-fox)")
 }
 
 // List displays installed applications
@@ -338,6 +353,7 @@ func List(cfg *config.Config, u *ui.UI, opts ListOptions) error {
 		u.Print("  obol app install https://charts.bitnami.com/bitnami/redis-19.0.0.tgz")
 		u.Blank()
 		u.Print("Find charts at https://artifacthub.io")
+
 		return nil
 	}
 
@@ -356,6 +372,7 @@ func List(cfg *config.Config, u *ui.UI, opts ListOptions) error {
 	u.Blank()
 
 	count := 0
+
 	for _, appDir := range apps {
 		if !appDir.IsDir() {
 			continue
@@ -383,7 +400,9 @@ func List(cfg *config.Config, u *ui.UI, opts ListOptions) error {
 			if err != nil {
 				// Helmfile not found - show basic info
 				u.Printf("  %s/%s", appName, id)
+
 				count++
+
 				continue
 			}
 
@@ -392,14 +411,17 @@ func List(cfg *config.Config, u *ui.UI, opts ListOptions) error {
 				u.Printf("  %s/%s", appName, id)
 				u.Detail("    Chart", info.ChartRef)
 				u.Detail("    Version", info.Version)
+
 				if modTime, err := GetHelmfileModTime(deploymentPath); err == nil {
 					u.Detail("    Modified", modTime)
 				}
+
 				u.Blank()
 			} else {
 				u.Printf("  %s/%s (chart: %s, version: %s)",
 					appName, id, info.ChartRef, info.Version)
 			}
+
 			count++
 		}
 	}
@@ -432,11 +454,13 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string, force boo
 
 	// Check if namespace exists in cluster
 	namespaceExists := false
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); err == nil {
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		cmd := exec.Command(kubectlBinary, "get", "namespace", namespaceName)
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 		if err := cmd.Run(); err == nil {
 			namespaceExists = true
 		}
@@ -445,11 +469,13 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string, force boo
 	// Display what will be deleted
 	u.Blank()
 	u.Print("Resources to be deleted:")
+
 	if namespaceExists {
 		u.Printf("  [x] Kubernetes namespace: %s", namespaceName)
 	} else {
 		u.Printf("  [ ] Kubernetes namespace: %s (not found)", namespaceName)
 	}
+
 	if configExists {
 		u.Printf("  [x] Configuration directory: %s", deploymentDir)
 	} else {
@@ -464,6 +490,7 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string, force boo
 	// Confirm deletion (unless --force)
 	if !force {
 		u.Blank()
+
 		if !u.Confirm("Proceed with deletion?", false) {
 			u.Print("Deletion cancelled")
 			return nil
@@ -475,9 +502,10 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string, force boo
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		cmd := exec.Command(kubectlBinary, "delete", "namespace", namespaceName,
 			"--force", "--grace-period=0")
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
 
-		if err := u.Exec(ui.ExecConfig{Name: fmt.Sprintf("Deleting namespace %s", namespaceName), Cmd: cmd}); err != nil {
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
+		if err := u.Exec(ui.ExecConfig{Name: "Deleting namespace " + namespaceName, Cmd: cmd}); err != nil {
 			return fmt.Errorf("failed to delete namespace: %w", err)
 		}
 	}
@@ -485,13 +513,16 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string, force boo
 	// Delete configuration directory
 	if configExists {
 		u.Info("Deleting configuration directory...")
+
 		if err := os.RemoveAll(deploymentDir); err != nil {
 			return fmt.Errorf("failed to delete config directory: %w", err)
 		}
+
 		u.Success("Configuration deleted")
 
 		// Clean up empty parent directories
 		appDir := filepath.Join(cfg.ConfigDir, "applications", appName)
+
 		entries, err := os.ReadDir(appDir)
 		if err == nil && len(entries) == 0 {
 			os.Remove(appDir)

--- a/internal/app/artifacthub.go
+++ b/internal/app/artifacthub.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,11 +17,11 @@ type ArtifactHubClient struct {
 
 // ArtifactHubPackage represents the API response for a package
 type ArtifactHubPackage struct {
-	Name       string                   `json:"name"`
-	Version    string                   `json:"version"`
-	Repository ArtifactHubRepository    `json:"repository"`
-	ContentURL string                   `json:"content_url"`
-	AvailableVersions []ArtifactHubVersion `json:"available_versions"`
+	Name              string                `json:"name"`
+	Version           string                `json:"version"`
+	Repository        ArtifactHubRepository `json:"repository"`
+	ContentURL        string                `json:"content_url"`
+	AvailableVersions []ArtifactHubVersion  `json:"available_versions"`
 }
 
 // ArtifactHubRepository represents repository info in the API response
@@ -86,6 +87,7 @@ func (c *ArtifactHubClient) ResolveChart(ref string) (*ChartInfo, error) {
 			return nil, fmt.Errorf("chart not found: %s/%s version %s\n"+
 				"Verify the repository, chart name, and version are correct on https://artifacthub.io", repoName, chartName, version)
 		}
+
 		return nil, fmt.Errorf("chart not found: %s/%s\n"+
 			"Verify the repository and chart name are correct on https://artifacthub.io", repoName, chartName)
 	}
@@ -103,7 +105,7 @@ func (c *ArtifactHubClient) ResolveChart(ref string) (*ChartInfo, error) {
 
 	// Validate we got the required fields
 	if pkg.Repository.URL == "" {
-		return nil, fmt.Errorf("ArtifactHub returned incomplete data: missing repository URL")
+		return nil, errors.New("ArtifactHub returned incomplete data: missing repository URL")
 	}
 
 	return &ChartInfo{

--- a/internal/app/chart.go
+++ b/internal/app/chart.go
@@ -57,6 +57,7 @@ func isRepoChartFormat(ref string) bool {
 	if idx := strings.LastIndex(ref, "@"); idx != -1 {
 		base = ref[:idx]
 	}
+
 	return strings.Count(base, "/") == 1 && !strings.Contains(ref, "://")
 }
 
@@ -76,6 +77,7 @@ func parseURLReference(ref string) (*ChartReference, error) {
 	// Extract chart name and version (e.g., redis-19.0.0 -> redis, 19.0.0)
 	chartName := nameWithVersion
 	version := ""
+
 	re := regexp.MustCompile(`^(.+)-(\d+\.\d+\.\d+.*)$`)
 	if matches := re.FindStringSubmatch(nameWithVersion); len(matches) > 2 {
 		chartName = matches[1]
@@ -94,8 +96,8 @@ func parseURLReference(ref string) (*ChartReference, error) {
 func parseOCIReference(ref string) (*ChartReference, error) {
 	// oci://registry-1.docker.io/bitnamicharts/redis
 	// oci://registry-1.docker.io/bitnamicharts/redis:19.0.0
-
 	withoutScheme := strings.TrimPrefix(ref, "oci://")
+
 	parts := strings.Split(withoutScheme, "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid OCI reference: %s", ref)
@@ -105,6 +107,7 @@ func parseOCIReference(ref string) (*ChartReference, error) {
 	last := parts[len(parts)-1]
 	chartName := last
 	version := ""
+
 	if idx := strings.LastIndex(last, ":"); idx != -1 {
 		chartName = last[:idx]
 		version = last[idx+1:]
@@ -122,6 +125,7 @@ func parseOCIReference(ref string) (*ChartReference, error) {
 func parseRepoChartReference(ref string) (*ChartReference, error) {
 	// Parse repo/chart[@version]
 	version := ""
+
 	base := ref
 	if idx := strings.LastIndex(ref, "@"); idx != -1 {
 		version = ref[idx+1:]

--- a/internal/app/metadata.go
+++ b/internal/app/metadata.go
@@ -50,7 +50,7 @@ func ParseHelmfile(dir string) (*HelmfileInfo, error) {
 		} `yaml:"releases"`
 	}
 	if err := yaml.Unmarshal(data, &helmfile); err != nil {
-		return info, nil // Return partial info if YAML parsing fails
+		return info, nil //nolint:nilerr // return partial info (name from dir) if YAML parsing fails
 	}
 
 	if len(helmfile.Releases) > 0 {

--- a/internal/app/metadata.go
+++ b/internal/app/metadata.go
@@ -19,6 +19,7 @@ type HelmfileInfo struct {
 // ParseHelmfile extracts chart information from a helmfile.yaml
 func ParseHelmfile(dir string) (*HelmfileInfo, error) {
 	helmfilePath := filepath.Join(dir, "helmfile.yaml")
+
 	data, err := os.ReadFile(helmfilePath)
 	if err != nil {
 		return nil, err
@@ -30,12 +31,13 @@ func ParseHelmfile(dir string) (*HelmfileInfo, error) {
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "# Installed from: ") {
-			info.ChartRef = strings.TrimPrefix(line, "# Installed from: ")
+		if after, ok := strings.CutPrefix(line, "# Installed from: "); ok {
+			info.ChartRef = after
 			// Remove any trailing annotation like "(resolved via ArtifactHub)"
 			if idx := strings.Index(info.ChartRef, " ("); idx != -1 {
 				info.ChartRef = info.ChartRef[:idx]
 			}
+
 			break
 		}
 	}
@@ -62,9 +64,11 @@ func ParseHelmfile(dir string) (*HelmfileInfo, error) {
 // GetHelmfileModTime returns the modification time of helmfile.yaml
 func GetHelmfileModTime(dir string) (modTime string, err error) {
 	helmfilePath := filepath.Join(dir, "helmfile.yaml")
+
 	stat, err := os.Stat(helmfilePath)
 	if err != nil {
 		return "", err
 	}
+
 	return stat.ModTime().Format("2006-01-02 15:04:05"), nil
 }

--- a/internal/app/resolve.go
+++ b/internal/app/resolve.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,18 +20,22 @@ func ListInstanceIDs(cfg *config.Config) ([]string, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, fmt.Errorf("failed to read applications directory: %w", err)
 	}
 
 	var ids []string
+
 	for _, appDir := range appDirs {
 		if !appDir.IsDir() {
 			continue
 		}
+
 		deployments, err := os.ReadDir(filepath.Join(appsDir, appDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, deployment := range deployments {
 			if !deployment.IsDir() {
 				continue
@@ -42,9 +47,11 @@ func ListInstanceIDs(cfg *config.Config) ([]string, error) {
 			if _, err := os.Stat(valuesPath); err != nil {
 				continue
 			}
+
 			ids = append(ids, fmt.Sprintf("%s/%s", appDir.Name(), deployment.Name()))
 		}
 	}
+
 	return ids, nil
 }
 
@@ -63,7 +70,7 @@ func ResolveInstance(cfg *config.Config, args []string) (identifier string, rema
 
 	switch len(instances) {
 	case 0:
-		return "", nil, fmt.Errorf("no app deployments found — run 'obol app install <chart>' to create one")
+		return "", nil, errors.New("no app deployments found — run 'obol app install <chart>' to create one")
 	case 1:
 		return instances[0], args, nil
 	default:
@@ -76,15 +83,18 @@ func ResolveInstance(cfg *config.Config, args []string) (identifier string, rema
 			}
 			// Type-prefix match: "postgresql" → auto-select if only one of that type
 			var prefixMatches []string
+
 			for _, inst := range instances {
 				if typ, _, ok := strings.Cut(inst, "/"); ok && typ == args[0] {
 					prefixMatches = append(prefixMatches, inst)
 				}
 			}
+
 			if len(prefixMatches) == 1 {
 				return prefixMatches[0], args[1:], nil
 			}
 		}
+
 		return "", nil, fmt.Errorf("multiple app deployments found, specify one: %s", strings.Join(instances, ", "))
 	}
 }

--- a/internal/app/resolve_test.go
+++ b/internal/app/resolve_test.go
@@ -11,18 +11,21 @@ import (
 // mkAppDeployment creates a directory with a values.yaml to simulate an app deployment.
 func mkAppDeployment(t *testing.T, base, identifier string) {
 	t.Helper()
+
 	dir := filepath.Join(base, identifier)
-	os.MkdirAll(dir, 0755)
-	os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("# test"), 0644)
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("# test"), 0o644)
 }
 
 func TestListInstanceIDs(t *testing.T) {
 	t.Run("no applications directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -30,12 +33,13 @@ func TestListInstanceIDs(t *testing.T) {
 
 	t.Run("empty directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
-		os.MkdirAll(filepath.Join(cfg.ConfigDir, "applications"), 0755)
+		os.MkdirAll(filepath.Join(cfg.ConfigDir, "applications"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -50,9 +54,11 @@ func TestListInstanceIDs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 1 {
 			t.Fatalf("expected 1 instance, got %d", len(ids))
 		}
+
 		if ids[0] != "postgresql/eager-fox" {
 			t.Fatalf("expected 'postgresql/eager-fox', got '%s'", ids[0])
 		}
@@ -69,6 +75,7 @@ func TestListInstanceIDs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 3 {
 			t.Fatalf("expected 3 instances, got %d", len(ids))
 		}
@@ -78,12 +85,13 @@ func TestListInstanceIDs(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
 		base := filepath.Join(cfg.ConfigDir, "applications", "postgresql")
 		mkAppDeployment(t, filepath.Join(cfg.ConfigDir, "applications"), "postgresql/eager-fox")
-		os.WriteFile(filepath.Join(base, "some-file.txt"), []byte("test"), 0644)
+		os.WriteFile(filepath.Join(base, "some-file.txt"), []byte("test"), 0o644)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 1 {
 			t.Fatalf("expected 1 instance, got %d", len(ids))
 		}
@@ -94,15 +102,17 @@ func TestListInstanceIDs(t *testing.T) {
 		base := filepath.Join(cfg.ConfigDir, "applications")
 		mkAppDeployment(t, base, "postgresql/eager-fox")
 		// Simulate an openclaw instance (directory exists but no values.yaml)
-		os.MkdirAll(filepath.Join(base, "openclaw", "obol-agent"), 0755)
+		os.MkdirAll(filepath.Join(base, "openclaw", "obol-agent"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 1 {
 			t.Fatalf("expected 1 instance (openclaw excluded), got %d: %v", len(ids), ids)
 		}
+
 		if ids[0] != "postgresql/eager-fox" {
 			t.Fatalf("expected 'postgresql/eager-fox', got '%s'", ids[0])
 		}
@@ -115,19 +125,23 @@ func TestResolveInstance(t *testing.T) {
 	setupInstances := func(t *testing.T, identifiers ...string) *config.Config {
 		t.Helper()
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		base := filepath.Join(cfg.ConfigDir, "applications")
 		for _, id := range identifiers {
 			mkAppDeployment(t, base, id)
 		}
+
 		return cfg
 	}
 
 	t.Run("zero instances returns error", func(t *testing.T) {
 		cfg := setupInstances(t)
+
 		_, _, err := ResolveInstance(cfg, []string{"postgresql/eager-fox"})
 		if err == nil {
 			t.Fatal("expected error for zero instances")
 		}
+
 		if got := err.Error(); got != "no app deployments found — run 'obol app install <chart>' to create one" {
 			t.Fatalf("unexpected error: %s", got)
 		}
@@ -135,13 +149,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance auto-selects", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"extra-arg"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "postgresql/eager-fox" {
 			t.Fatalf("expected id 'postgresql/eager-fox', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra-arg" {
 			t.Fatalf("expected remaining args [extra-arg], got %v", remaining)
 		}
@@ -149,13 +166,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance with no args", func(t *testing.T) {
 		cfg := setupInstances(t, "redis/happy-otter")
+
 		id, remaining, err := ResolveInstance(cfg, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "redis/happy-otter" {
 			t.Fatalf("expected id 'redis/happy-otter', got '%s'", id)
 		}
+
 		if len(remaining) != 0 {
 			t.Fatalf("expected no remaining args, got %v", remaining)
 		}
@@ -163,13 +183,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with valid name", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox", "redis/staging")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"redis/staging", "extra"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "redis/staging" {
 			t.Fatalf("expected id 'redis/staging', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra" {
 			t.Fatalf("expected remaining [extra], got %v", remaining)
 		}
@@ -177,6 +200,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances without name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox", "redis/staging")
+
 		_, _, err := ResolveInstance(cfg, nil)
 		if err == nil {
 			t.Fatal("expected error for multiple instances without name")
@@ -185,6 +209,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with unknown name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox", "redis/staging")
+
 		_, _, err := ResolveInstance(cfg, []string{"mysql/nonexistent"})
 		if err == nil {
 			t.Fatal("expected error for unknown instance name")
@@ -193,13 +218,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("type prefix selects sole instance of that type", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox", "redis/staging")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"redis", "extra"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "redis/staging" {
 			t.Fatalf("expected id 'redis/staging', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra" {
 			t.Fatalf("expected remaining [extra], got %v", remaining)
 		}
@@ -207,6 +235,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("type prefix errors when multiple of same type", func(t *testing.T) {
 		cfg := setupInstances(t, "postgresql/eager-fox", "postgresql/prod")
+
 		_, _, err := ResolveInstance(cfg, []string{"postgresql"})
 		if err == nil {
 			t.Fatal("expected error when type prefix matches multiple instances")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,12 @@ func Load() *Config {
 	}
 }
 
+// isDevMode returns true when OBOL_DEVELOPMENT=true, indicating the CLI
+// should use .workspace/ directories relative to the working directory.
+func isDevMode() bool {
+	return os.Getenv("OBOL_DEVELOPMENT") == "true"
+}
+
 // getConfigDir returns OBOL_CONFIG_DIR or XDG_CONFIG_HOME/obol
 // In development mode (OBOL_DEVELOPMENT=true), uses .workspace/config
 func getConfigDir() string {
@@ -31,7 +37,7 @@ func getConfigDir() string {
 	}
 
 	// Development mode: use .workspace directory in project root
-	if os.Getenv("OBOL_DEVELOPMENT") == "true" {
+	if isDevMode() {
 		cwd, _ := os.Getwd()
 		return filepath.Join(cwd, ".workspace", "config")
 	}
@@ -54,7 +60,7 @@ func getBinDir() string {
 	}
 
 	// Development mode: use .workspace directory in project root
-	if os.Getenv("OBOL_DEVELOPMENT") == "true" {
+	if isDevMode() {
 		cwd, _ := os.Getwd()
 		return filepath.Join(cwd, ".workspace", "bin")
 	}
@@ -78,7 +84,7 @@ func getDataDir() string {
 	}
 
 	// Development mode: use .workspace directory in project root
-	if os.Getenv("OBOL_DEVELOPMENT") == "true" {
+	if isDevMode() {
 		cwd, _ := os.Getwd()
 		return filepath.Join(cwd, ".workspace", "data")
 	}
@@ -102,7 +108,7 @@ func getStateDir() string {
 	}
 
 	// Development mode: use .workspace directory in project root
-	if os.Getenv("OBOL_DEVELOPMENT") == "true" {
+	if isDevMode() {
 		cwd, _ := os.Getwd()
 		return filepath.Join(cwd, ".workspace", "state")
 	}

--- a/internal/dns/resolver.go
+++ b/internal/dns/resolver.go
@@ -29,6 +29,10 @@ const (
 	dnsImage      = "alpine:3.21"
 	domain        = "obol.stack"
 
+	// OS name constants for runtime.GOOS comparisons.
+	osDarwin = "darwin"
+	osLinux  = "linux"
+
 	// macOS: custom port, /etc/resolver handles port directive
 	macHostPort = "5553"
 
@@ -56,7 +60,7 @@ const (
 // Docker container. On Linux, this is a no-op — NM dnsmasq handles
 // resolution without a container.
 func EnsureRunning() error {
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == osDarwin {
 		return ensureMacOSContainer()
 	}
 
@@ -65,7 +69,7 @@ func EnsureRunning() error {
 
 // Stop removes the DNS resolver container (macOS only).
 func Stop() {
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != osDarwin {
 		return
 	}
 
@@ -84,9 +88,9 @@ func Stop() {
 // Linux: configures NM dnsmasq plugin for wildcard resolution
 func ConfigureSystemResolver() error {
 	switch runtime.GOOS {
-	case "darwin":
+	case osDarwin:
 		return configureMacOSResolver()
-	case "linux":
+	case osLinux:
 		return configureLinuxResolver()
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
@@ -96,9 +100,9 @@ func ConfigureSystemResolver() error {
 // RemoveSystemResolver removes the host OS DNS configuration for *.obol.stack.
 func RemoveSystemResolver() {
 	switch runtime.GOOS {
-	case "darwin":
+	case osDarwin:
 		removeMacOSResolver()
-	case "linux":
+	case osLinux:
 		removeNMDnsmasq()
 	}
 
@@ -108,10 +112,10 @@ func RemoveSystemResolver() {
 // IsResolverConfigured checks whether the system resolver is already set up.
 func IsResolverConfigured() bool {
 	switch runtime.GOOS {
-	case "darwin":
+	case osDarwin:
 		_, err := os.Stat(filepath.Join(macResolverDir, macResolverFile))
 		return err == nil
-	case "linux":
+	case osLinux:
 		return hasNMDnsmasqConfig() && isNMResolvConfActive()
 	default:
 		return false

--- a/internal/dns/resolver.go
+++ b/internal/dns/resolver.go
@@ -14,6 +14,7 @@
 package dns
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,11 +43,11 @@ const (
 	nmDnsmasqFile = "obol-stack.conf"
 
 	// resolv.conf management — NM dnsmasq takes over from systemd-resolved stub
-	nmResolvConf        = "/run/NetworkManager/resolv.conf"
-	systemResolvConf    = "/etc/resolv.conf"
-	resolvedStubConf    = "/run/systemd/resolve/stub-resolv.conf"
-	resolvedDropInDir   = "/etc/systemd/resolved.conf.d"
-	resolvedDropInFile  = "obol-stack.conf"
+	nmResolvConf       = "/run/NetworkManager/resolv.conf"
+	systemResolvConf   = "/etc/resolv.conf"
+	resolvedStubConf   = "/run/systemd/resolve/stub-resolv.conf"
+	resolvedDropInDir  = "/etc/systemd/resolved.conf.d"
+	resolvedDropInFile = "obol-stack.conf"
 )
 
 // --- Public API ---
@@ -58,6 +59,7 @@ func EnsureRunning() error {
 	if runtime.GOOS == "darwin" {
 		return ensureMacOSContainer()
 	}
+
 	return nil
 }
 
@@ -66,9 +68,11 @@ func Stop() {
 	if runtime.GOOS != "darwin" {
 		return
 	}
+
 	if out, err := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", containerName).Output(); err != nil || strings.TrimSpace(string(out)) != "true" {
 		return
 	}
+
 	exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
 	fmt.Println("DNS resolver stopped")
 }
@@ -97,6 +101,7 @@ func RemoveSystemResolver() {
 	case "linux":
 		removeNMDnsmasq()
 	}
+
 	RemoveHostsEntries()
 }
 
@@ -119,9 +124,11 @@ func IsResolverConfigured() bool {
 // reliably forward subdomain queries to custom nameservers. As a fallback,
 // we also write entries to /etc/hosts for known hostnames.
 
-const hostsMarkerBegin = "# BEGIN obol-stack managed entries"
-const hostsMarkerEnd = "# END obol-stack managed entries"
-const hostsFile = "/etc/hosts"
+const (
+	hostsMarkerBegin = "# BEGIN obol-stack managed entries"
+	hostsMarkerEnd   = "# END obol-stack managed entries"
+	hostsFile        = "/etc/hosts"
+)
 
 // EnsureHostsEntries adds /etc/hosts entries for the given hostnames.
 // Always includes "obol.stack" plus any additional hostnames (e.g. openclaw subdomains).
@@ -129,6 +136,7 @@ const hostsFile = "/etc/hosts"
 func EnsureHostsEntries(hostnames []string) error {
 	// Always include the base domain.
 	all := []string{domain}
+
 	seen := map[string]bool{domain: true}
 	for _, h := range hostnames {
 		if h != "" && !seen[h] {
@@ -140,9 +148,11 @@ func EnsureHostsEntries(hostnames []string) error {
 	// Build the managed block.
 	var block strings.Builder
 	block.WriteString(hostsMarkerBegin + "\n")
+
 	for _, h := range all {
-		block.WriteString(fmt.Sprintf("127.0.0.1 %s\n", h))
+		fmt.Fprintf(&block, "127.0.0.1 %s\n", h)
 	}
+
 	block.WriteString(hostsMarkerEnd + "\n")
 
 	data, err := os.ReadFile(hostsFile)
@@ -151,6 +161,7 @@ func EnsureHostsEntries(hostnames []string) error {
 	}
 
 	content := string(data)
+
 	newContent := replaceOrAppendBlock(content, block.String())
 	if newContent == content {
 		return nil // no change needed
@@ -167,10 +178,12 @@ func EnsureHostsEntries(hostnames []string) error {
 	writeCmd := exec.Command("sudo", "tee", hostsFile)
 	writeCmd.Stdin = strings.NewReader(newContent)
 	writeCmd.Stdout = nil
+
 	writeCmd.Stderr = os.Stderr
 	if err := writeCmd.Run(); err != nil {
 		return fmt.Errorf("write %s: %w", hostsFile, err)
 	}
+
 	return nil
 }
 
@@ -180,11 +193,14 @@ func RemoveHostsEntries() {
 	if err != nil {
 		return
 	}
+
 	content := string(data)
+
 	cleaned := removeBlock(content)
 	if cleaned == content {
 		return
 	}
+
 	writeCmd := exec.Command("sudo", "tee", hostsFile)
 	writeCmd.Stdin = strings.NewReader(cleaned)
 	writeCmd.Stdout = nil
@@ -205,12 +221,14 @@ func ensureSudoCached() error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
 	return cmd.Run()
 }
 
 // replaceOrAppendBlock replaces an existing managed block or appends a new one.
 func replaceOrAppendBlock(content, block string) string {
 	start := strings.Index(content, hostsMarkerBegin)
+
 	end := strings.Index(content, hostsMarkerEnd)
 	if start >= 0 && end > start {
 		return content[:start] + block + content[end+len(hostsMarkerEnd)+1:]
@@ -219,12 +237,14 @@ func replaceOrAppendBlock(content, block string) string {
 	if !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
+
 	return content + "\n" + block
 }
 
 // removeBlock strips the managed block from content.
 func removeBlock(content string) string {
 	start := strings.Index(content, hostsMarkerBegin)
+
 	end := strings.Index(content, hostsMarkerEnd)
 	if start < 0 || end <= start {
 		return content
@@ -234,6 +254,7 @@ func removeBlock(content string) string {
 	if after < len(content) && content[after] == '\n' {
 		after++
 	}
+
 	return content[:start] + content[after:]
 }
 
@@ -266,6 +287,7 @@ func ensureMacOSContainer() error {
 	}
 
 	fmt.Printf("DNS resolver running (*.obol.stack → 127.0.0.1, port %s)\n", macHostPort)
+
 	return nil
 }
 
@@ -284,6 +306,7 @@ func configureMacOSResolver() error {
 
 	mkdirCmd := exec.Command("sudo", "mkdir", "-p", macResolverDir)
 	mkdirCmd.Stdout = os.Stdout
+
 	mkdirCmd.Stderr = os.Stderr
 	if err := mkdirCmd.Run(); err != nil {
 		return fmt.Errorf("failed to create %s (sudo required): %w", macResolverDir, err)
@@ -292,12 +315,14 @@ func configureMacOSResolver() error {
 	writeCmd := exec.Command("sudo", "tee", path)
 	writeCmd.Stdin = strings.NewReader(content)
 	writeCmd.Stdout = nil
+
 	writeCmd.Stderr = os.Stderr
 	if err := writeCmd.Run(); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 
 	fmt.Printf("Resolver configured: %s → 127.0.0.1:%s\n", path, macHostPort)
+
 	return nil
 }
 
@@ -306,11 +331,14 @@ func removeMacOSResolver() {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return
 	}
+
 	if err := exec.Command("sudo", "rm", path).Run(); err != nil {
 		fmt.Printf("Warning: failed to remove %s: %v\n", path, err)
 		fmt.Printf("  Remove manually: sudo rm %s\n", path)
+
 		return
 	}
+
 	fmt.Printf("Removed DNS resolver config: %s\n", path)
 }
 
@@ -329,13 +357,15 @@ func configureLinuxResolver() error {
 	fmt.Println("  sudo dnf install NetworkManager dnsmasq        # Fedora/RHEL")
 	fmt.Println("  sudo pacman -S networkmanager dnsmasq           # Arch")
 	fmt.Println("\nThen re-run: obol stack up")
-	return fmt.Errorf("NetworkManager required for wildcard DNS on Linux")
+
+	return errors.New("NetworkManager required for wildcard DNS on Linux")
 }
 
 // hasNMDnsmasqConfig checks if the NM dnsmasq config for obol.stack exists.
 func hasNMDnsmasqConfig() bool {
 	path := filepath.Join(nmDnsmasqDir, nmDnsmasqFile)
 	_, err := os.Stat(path)
+
 	return err == nil
 }
 
@@ -346,6 +376,7 @@ func isNMResolvConfActive() bool {
 	if err != nil {
 		return false
 	}
+
 	return strings.Contains(string(data), "Generated by NetworkManager")
 }
 
@@ -363,6 +394,7 @@ func configureNMDnsmasq() bool {
 		fmt.Println("  sudo apt install dnsmasq-base  # Debian/Ubuntu")
 		fmt.Println("  sudo dnf install dnsmasq       # Fedora/RHEL")
 		fmt.Println("  sudo pacman -S dnsmasq          # Arch")
+
 		return false
 	}
 
@@ -378,6 +410,7 @@ func configureNMDnsmasq() bool {
 		updateResolvConf()
 		cleanupResolvedDropIn()
 		fmt.Printf("DNS resolver configured: *.%s → 127.0.0.1 (NM dnsmasq plugin)\n", domain)
+
 		return true
 	}
 
@@ -388,6 +421,7 @@ func configureNMDnsmasq() bool {
 	// Create NM dnsmasq.d directory and write the rule
 	mkdirCmd := exec.Command("sudo", "mkdir", "-p", nmDnsmasqDir)
 	mkdirCmd.Stdout = os.Stdout
+
 	mkdirCmd.Stderr = os.Stderr
 	if err := mkdirCmd.Run(); err != nil {
 		fmt.Printf("Warning: failed to create %s: %v\n", nmDnsmasqDir, err)
@@ -398,6 +432,7 @@ func configureNMDnsmasq() bool {
 	writeCmd := exec.Command("sudo", "tee", filepath.Join(nmDnsmasqDir, nmDnsmasqFile))
 	writeCmd.Stdin = strings.NewReader(dnsmasqConf)
 	writeCmd.Stdout = nil
+
 	writeCmd.Stderr = os.Stderr
 	if err := writeCmd.Run(); err != nil {
 		fmt.Printf("Warning: failed to write dnsmasq config: %v\n", err)
@@ -408,6 +443,7 @@ func configureNMDnsmasq() bool {
 	if nmDNSMode != "dnsmasq" {
 		mkdirCmd2 := exec.Command("sudo", "mkdir", "-p", nmConfDir)
 		mkdirCmd2.Stdout = os.Stdout
+
 		mkdirCmd2.Stderr = os.Stderr
 		if err := mkdirCmd2.Run(); err != nil {
 			fmt.Printf("Warning: failed to create %s: %v\n", nmConfDir, err)
@@ -418,6 +454,7 @@ func configureNMDnsmasq() bool {
 		writeCmd2 := exec.Command("sudo", "tee", filepath.Join(nmConfDir, nmConfFile))
 		writeCmd2.Stdin = strings.NewReader(nmConf)
 		writeCmd2.Stdout = nil
+
 		writeCmd2.Stderr = os.Stderr
 		if err := writeCmd2.Run(); err != nil {
 			fmt.Printf("Warning: failed to write NM config: %v\n", err)
@@ -428,10 +465,12 @@ func configureNMDnsmasq() bool {
 	// Restart NetworkManager to pick up changes
 	restartCmd := exec.Command("sudo", "systemctl", "restart", "NetworkManager")
 	restartCmd.Stdout = os.Stdout
+
 	restartCmd.Stderr = os.Stderr
 	if err := restartCmd.Run(); err != nil {
 		fmt.Printf("Warning: failed to restart NetworkManager: %v\n", err)
 		fmt.Println("  Run manually: sudo systemctl restart NetworkManager")
+
 		return true // Config files are in place, will work after manual restart
 	}
 
@@ -443,6 +482,7 @@ func configureNMDnsmasq() bool {
 	cleanupResolvedDropIn()
 
 	fmt.Printf("DNS resolver configured: *.%s → 127.0.0.1 (NM dnsmasq plugin)\n", domain)
+
 	return true
 }
 
@@ -452,30 +492,35 @@ func configureNMDnsmasq() bool {
 // local addresses) and sends all DNS queries directly to NM's dnsmasq.
 func updateResolvConf() {
 	// Wait for NM to generate its resolv.conf after restart (max 3s)
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		if _, err := os.Stat(nmResolvConf); err == nil {
 			break
 		}
+
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	cmd := exec.Command("sudo", "ln", "-sf", nmResolvConf, systemResolvConf)
 	cmd.Stdout = os.Stdout
+
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("Warning: failed to update %s: %v\n", systemResolvConf, err)
 		fmt.Printf("  Run manually: sudo ln -sf %s %s\n", nmResolvConf, systemResolvConf)
+
 		return
 	}
 
 	// Wait for DNS to actually resolve after NM restart (max 10s).
 	// NM's dnsmasq needs a moment to start accepting queries.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if err := exec.Command("nslookup", "github.com").Run(); err == nil {
 			return
 		}
+
 		time.Sleep(500 * time.Millisecond)
 	}
+
 	fmt.Println("Warning: DNS not yet responding after NM restart; may need a moment to stabilize")
 }
 
@@ -487,6 +532,7 @@ func cleanupResolvedDropIn() {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return
 	}
+
 	exec.Command("sudo", "rm", path).Run() //nolint:errcheck
 }
 
@@ -495,9 +541,9 @@ func getNMDNSMode() string {
 	// Check our own conf file first
 	path := filepath.Join(nmConfDir, nmConfFile)
 	if data, err := os.ReadFile(path); err == nil {
-		for _, line := range strings.Split(string(data), "\n") {
-			if strings.HasPrefix(strings.TrimSpace(line), "dns=") {
-				return strings.TrimPrefix(strings.TrimSpace(line), "dns=")
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if after, ok := strings.CutPrefix(strings.TrimSpace(line), "dns="); ok {
+				return after
 			}
 		}
 	}
@@ -507,11 +553,13 @@ func getNMDNSMode() string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "dns=") {
-			return strings.TrimPrefix(strings.TrimSpace(line), "dns=")
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if after, ok := strings.CutPrefix(strings.TrimSpace(line), "dns="); ok {
+			return after
 		}
 	}
+
 	return ""
 }
 
@@ -550,6 +598,7 @@ func removeNMDnsmasq() {
 				fmt.Printf("  Run manually: sudo ln -sf %s %s\n", resolvedStubConf, systemResolvConf)
 			}
 		}
+
 		fmt.Println("Removed NM dnsmasq DNS config")
 	}
 }

--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -10,6 +10,7 @@ func TestConstants(t *testing.T) {
 	if containerName != "obol-dns" {
 		t.Errorf("containerName = %q, want %q", containerName, "obol-dns")
 	}
+
 	if domain != "obol.stack" {
 		t.Errorf("domain = %q, want %q", domain, "obol.stack")
 	}
@@ -17,6 +18,7 @@ func TestConstants(t *testing.T) {
 	if macHostPort != "5553" {
 		t.Errorf("macHostPort = %q, want %q", macHostPort, "5553")
 	}
+
 	if macResolverFile != "obol.stack" {
 		t.Errorf("macResolverFile = %q, want %q", macResolverFile, "obol.stack")
 	}
@@ -25,6 +27,7 @@ func TestConstants(t *testing.T) {
 	if nmConfFile != "obol-dns.conf" {
 		t.Errorf("nmConfFile = %q, want %q", nmConfFile, "obol-dns.conf")
 	}
+
 	if nmDnsmasqFile != "obol-stack.conf" {
 		t.Errorf("nmDnsmasqFile = %q, want %q", nmDnsmasqFile, "obol-stack.conf")
 	}
@@ -42,9 +45,9 @@ func TestHasNMDnsmasqConfig(t *testing.T) {
 	// unless the test system has it installed
 	result := hasNMDnsmasqConfig()
 	path := filepath.Join(nmDnsmasqDir, nmDnsmasqFile)
+
 	_, fileExists := os.Stat(path)
 	if result != (fileExists == nil) {
 		t.Errorf("hasNMDnsmasqConfig() = %v, but file exists = %v", result, fileExists == nil)
 	}
 }
-

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -47,15 +47,16 @@ func CopyDefaults(destDir string, replacements map[string]string) error {
 
 		if d.IsDir() {
 			// Create directory and continue walking
-			if err := os.MkdirAll(destPath, 0755); err != nil {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", destPath, err)
 			}
+
 			return nil
 		}
 
 		// Ensure parent directory exists
 		parentDir := filepath.Dir(destPath)
-		if err := os.MkdirAll(parentDir, 0755); err != nil {
+		if err := os.MkdirAll(parentDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create parent directory %s: %w", parentDir, err)
 		}
 
@@ -72,7 +73,7 @@ func CopyDefaults(destDir string, replacements map[string]string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 
@@ -88,6 +89,7 @@ func GetAvailableNetworks() ([]string, error) {
 	}
 
 	var networks []string
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			networks = append(networks, entry.Name())
@@ -100,10 +102,12 @@ func GetAvailableNetworks() ([]string, error) {
 // ReadEmbeddedNetworkFile reads a file from an embedded network
 func ReadEmbeddedNetworkFile(networkName, filename string) ([]byte, error) {
 	path := filepath.Join("networks", networkName, filename)
+
 	content, err := networksFS.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s from network %s: %w", filename, networkName, err)
 	}
+
 	return content, nil
 }
 
@@ -113,6 +117,7 @@ func ReadInfrastructureFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read infrastructure file %s: %w", path, err)
 	}
+
 	return content, nil
 }
 
@@ -135,15 +140,16 @@ func CopySkills(destDir string) error {
 		destPath := filepath.Join(destDir, relPath)
 
 		if d.IsDir() {
-			if err := os.MkdirAll(destPath, 0755); err != nil {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", destPath, err)
 			}
+
 			return nil
 		}
 
 		// Ensure parent directory exists
 		parentDir := filepath.Dir(destPath)
-		if err := os.MkdirAll(parentDir, 0755); err != nil {
+		if err := os.MkdirAll(parentDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create parent directory %s: %w", parentDir, err)
 		}
 
@@ -154,7 +160,7 @@ func CopySkills(destDir string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, data, 0644); err != nil {
+		if err := os.WriteFile(destPath, data, 0o644); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 
@@ -170,11 +176,13 @@ func GetEmbeddedSkillNames() ([]string, error) {
 	}
 
 	var names []string
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			names = append(names, entry.Name())
 		}
 	}
+
 	return names, nil
 }
 
@@ -204,15 +212,16 @@ func CopyNetwork(networkName, destDir string) error {
 
 		if d.IsDir() {
 			// Create directory and continue walking
-			if err := os.MkdirAll(destPath, 0755); err != nil {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", destPath, err)
 			}
+
 			return nil
 		}
 
 		// Ensure parent directory exists
 		parentDir := filepath.Dir(destPath)
-		if err := os.MkdirAll(parentDir, 0755); err != nil {
+		if err := os.MkdirAll(parentDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create parent directory %s: %w", parentDir, err)
 		}
 
@@ -223,7 +232,7 @@ func CopyNetwork(networkName, destDir string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, data, 0644); err != nil {
+		if err := os.WriteFile(destPath, data, 0o644); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -73,7 +73,7 @@ func CopyDefaults(destDir string, replacements map[string]string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(destPath, []byte(content), 0o600); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 
@@ -160,7 +160,7 @@ func CopySkills(destDir string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		if err := os.WriteFile(destPath, data, 0o600); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 
@@ -232,7 +232,7 @@ func CopyNetwork(networkName, destDir string) error {
 		}
 
 		// Write to destination
-		if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		if err := os.WriteFile(destPath, data, 0o600); err != nil {
 			return fmt.Errorf("failed to write file %s: %w", destPath, err)
 		}
 

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -10,65 +10,76 @@ import (
 // multiDoc splits a YAML file that may start with a Helm conditional
 // (e.g. {{- if ... }}) into individual YAML documents, stripping
 // Helm template directives and blank documents.
-func multiDoc(raw []byte) []map[string]interface{} {
+func multiDoc(raw []byte) []map[string]any {
 	// Strip Helm template lines ({{- ... }}).
 	var cleaned []string
-	for _, line := range strings.Split(string(raw), "\n") {
+
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "{{") {
 			continue
 		}
+
 		cleaned = append(cleaned, line)
 	}
 
 	docs := strings.Split(strings.Join(cleaned, "\n"), "\n---\n")
-	var result []map[string]interface{}
+
+	var result []map[string]any
+
 	for _, doc := range docs {
 		doc = strings.TrimSpace(doc)
 		if doc == "" {
 			continue
 		}
-		var m map[string]interface{}
+
+		var m map[string]any
 		if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
 			continue
 		}
+
 		if len(m) > 0 {
 			result = append(result, m)
 		}
 	}
+
 	return result
 }
 
 // findDoc returns the first document matching kind.
-func findDoc(docs []map[string]interface{}, kind string) map[string]interface{} {
+func findDoc(docs []map[string]any, kind string) map[string]any {
 	for _, d := range docs {
 		if d["kind"] == kind {
 			return d
 		}
 	}
+
 	return nil
 }
 
 // findDocByName returns the first document matching kind and metadata.name.
-func findDocByName(docs []map[string]interface{}, kind, name string) map[string]interface{} {
+func findDocByName(docs []map[string]any, kind, name string) map[string]any {
 	for _, d := range docs {
 		if d["kind"] == kind && nested(d, "metadata", "name") == name {
 			return d
 		}
 	}
+
 	return nil
 }
 
 // nested traverses a map[string]interface{} by dot-separated keys.
-func nested(m map[string]interface{}, keys ...string) interface{} {
-	var cur interface{} = m
+func nested(m map[string]any, keys ...string) any {
+	var cur any = m
 	for _, k := range keys {
-		cm, ok := cur.(map[string]interface{})
+		cm, ok := cur.(map[string]any)
 		if !ok {
 			return nil
 		}
+
 		cur = cm[k]
 	}
+
 	return cur
 }
 
@@ -83,6 +94,7 @@ func TestServiceOfferCRD_Parses(t *testing.T) {
 	}
 
 	docs := multiDoc(data)
+
 	crd := findDoc(docs, "CustomResourceDefinition")
 	if crd == nil {
 		t.Fatal("no CustomResourceDefinition document found")
@@ -110,23 +122,26 @@ func TestServiceOfferCRD_Fields(t *testing.T) {
 	}
 
 	docs := multiDoc(data)
+
 	crd := findDoc(docs, "CustomResourceDefinition")
 	if crd == nil {
 		t.Fatal("no CRD document found")
 	}
 
 	// Navigate to spec.versions[0].schema.openAPIV3Schema.properties.spec.properties
-	versions, ok := nested(crd, "spec", "versions").([]interface{})
+	versions, ok := nested(crd, "spec", "versions").([]any)
 	if !ok || len(versions) == 0 {
 		t.Fatal("spec.versions is empty or wrong type")
 	}
-	v0, ok := versions[0].(map[string]interface{})
+
+	v0, ok := versions[0].(map[string]any)
 	if !ok {
 		t.Fatal("versions[0] is not a map")
 	}
 
 	specProps := nested(v0, "schema", "openAPIV3Schema", "properties", "spec", "properties")
-	pm, ok := specProps.(map[string]interface{})
+
+	pm, ok := specProps.(map[string]any)
 	if !ok {
 		t.Fatalf("spec.properties is not a map: %T", specProps)
 	}
@@ -146,18 +161,20 @@ func TestServiceOfferCRD_PrinterColumns(t *testing.T) {
 	}
 
 	docs := multiDoc(data)
+
 	crd := findDoc(docs, "CustomResourceDefinition")
 	if crd == nil {
 		t.Fatal("no CRD document found")
 	}
 
-	versions, ok := nested(crd, "spec", "versions").([]interface{})
+	versions, ok := nested(crd, "spec", "versions").([]any)
 	if !ok || len(versions) == 0 {
 		t.Fatal("no versions")
 	}
-	v0 := versions[0].(map[string]interface{})
 
-	cols, ok := v0["additionalPrinterColumns"].([]interface{})
+	v0 := versions[0].(map[string]any)
+
+	cols, ok := v0["additionalPrinterColumns"].([]any)
 	if !ok {
 		t.Fatal("additionalPrinterColumns missing or wrong type")
 	}
@@ -168,7 +185,7 @@ func TestServiceOfferCRD_PrinterColumns(t *testing.T) {
 	}
 
 	for i, want := range expected {
-		col := cols[i].(map[string]interface{})
+		col := cols[i].(map[string]any)
 		if got := col["name"]; got != want {
 			t.Errorf("column[%d].name = %v, want %v", i, got, want)
 		}
@@ -182,17 +199,19 @@ func TestServiceOfferCRD_WalletValidation(t *testing.T) {
 	}
 
 	docs := multiDoc(data)
+
 	crd := findDoc(docs, "CustomResourceDefinition")
 	if crd == nil {
 		t.Fatal("no CRD document found")
 	}
 
-	versions := nested(crd, "spec", "versions").([]interface{})
-	v0 := versions[0].(map[string]interface{})
+	versions := nested(crd, "spec", "versions").([]any)
+	v0 := versions[0].(map[string]any)
 	// Wallet validation is now at spec.payment.properties.payTo (aligned with x402)
 	payToProp := nested(v0, "schema", "openAPIV3Schema", "properties", "spec", "properties",
 		"payment", "properties", "payTo")
-	wm, ok := payToProp.(map[string]interface{})
+
+	wm, ok := payToProp.(map[string]any)
 	if !ok {
 		t.Fatal("payment.payTo property not a map")
 	}
@@ -201,6 +220,7 @@ func TestServiceOfferCRD_WalletValidation(t *testing.T) {
 	if !ok {
 		t.Fatal("payment.payTo.pattern missing")
 	}
+
 	if pattern != "^0x[0-9a-fA-F]{40}$" {
 		t.Errorf("payment.payTo.pattern = %q, want ^0x[0-9a-fA-F]{40}$", pattern)
 	}
@@ -224,18 +244,20 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 		t.Fatal("no ClusterRole 'openclaw-monetize-read' found")
 	}
 
-	readRules, ok := readCR["rules"].([]interface{})
+	readRules, ok := readCR["rules"].([]any)
 	if !ok || len(readRules) == 0 {
 		t.Fatal("read ClusterRole has no rules")
 	}
 
 	// Read role should be read-only: no create/update/patch/delete verbs.
 	for _, r := range readRules {
-		rm := r.(map[string]interface{})
-		verbs, ok := rm["verbs"].([]interface{})
+		rm := r.(map[string]any)
+
+		verbs, ok := rm["verbs"].([]any)
 		if !ok {
 			continue
 		}
+
 		for _, v := range verbs {
 			switch v.(string) {
 			case "create", "update", "patch", "delete":
@@ -249,6 +271,7 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 	if !readGroups["obol.org"] {
 		t.Error("read ClusterRole missing obol.org apiGroup")
 	}
+
 	if !readGroups[""] {
 		t.Error("read ClusterRole missing core API group")
 	}
@@ -259,7 +282,7 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 		t.Fatal("no ClusterRole 'openclaw-monetize-workload' found")
 	}
 
-	workloadRules, ok := workloadCR["rules"].([]interface{})
+	workloadRules, ok := workloadCR["rules"].([]any)
 	if !ok || len(workloadRules) == 0 {
 		t.Fatal("workload ClusterRole has no rules")
 	}
@@ -287,6 +310,7 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 	if readCRB == nil {
 		t.Fatal("no ClusterRoleBinding 'openclaw-monetize-read-binding' found")
 	}
+
 	if ref := nested(readCRB, "roleRef", "name"); ref != "openclaw-monetize-read" {
 		t.Errorf("read binding roleRef.name = %v, want openclaw-monetize-read", ref)
 	}
@@ -295,27 +319,30 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 	if workloadCRB == nil {
 		t.Fatal("no ClusterRoleBinding 'openclaw-monetize-workload-binding' found")
 	}
+
 	if ref := nested(workloadCRB, "roleRef", "name"); ref != "openclaw-monetize-workload" {
 		t.Errorf("workload binding roleRef.name = %v, want openclaw-monetize-workload", ref)
 	}
-
 
 	// ── x402 namespace Role + RoleBinding ───────────────────────────────
 	x402Role := findDocByName(docs, "Role", "openclaw-x402-pricing")
 	if x402Role == nil {
 		t.Fatal("no Role 'openclaw-x402-pricing' found")
 	}
+
 	if ns := nested(x402Role, "metadata", "namespace"); ns != "x402" {
 		t.Errorf("x402 Role namespace = %v, want x402", ns)
 	}
 
 	// x402 Role should be scoped to x402-pricing ConfigMap only.
-	x402Rules, ok := x402Role["rules"].([]interface{})
+	x402Rules, ok := x402Role["rules"].([]any)
 	if !ok || len(x402Rules) != 1 {
 		t.Fatalf("x402 Role should have exactly 1 rule, got %d", len(x402Rules))
 	}
-	rm := x402Rules[0].(map[string]interface{})
-	resNames, ok := rm["resourceNames"].([]interface{})
+
+	rm := x402Rules[0].(map[string]any)
+
+	resNames, ok := rm["resourceNames"].([]any)
 	if !ok || len(resNames) != 1 || resNames[0] != "x402-pricing" {
 		t.Errorf("x402 Role should be scoped to resourceNames: [x402-pricing], got %v", resNames)
 	}
@@ -324,71 +351,88 @@ func TestMonetizeRBAC_Parses(t *testing.T) {
 	if x402RB == nil {
 		t.Fatal("no RoleBinding 'openclaw-x402-pricing-binding' found")
 	}
+
 	if ns := nested(x402RB, "metadata", "namespace"); ns != "x402" {
 		t.Errorf("x402 RoleBinding namespace = %v, want x402", ns)
 	}
+
 	if ref := nested(x402RB, "roleRef", "name"); ref != "openclaw-x402-pricing" {
 		t.Errorf("x402 RoleBinding roleRef.name = %v, want openclaw-x402-pricing", ref)
 	}
 }
 
 // collectAPIGroups extracts all unique apiGroup strings from a list of rules.
-func collectAPIGroups(rules []interface{}) map[string]bool {
+func collectAPIGroups(rules []any) map[string]bool {
 	groups := make(map[string]bool)
+
 	for _, r := range rules {
-		rm := r.(map[string]interface{})
-		gs, ok := rm["apiGroups"].([]interface{})
+		rm := r.(map[string]any)
+
+		gs, ok := rm["apiGroups"].([]any)
 		if !ok {
 			continue
 		}
+
 		for _, g := range gs {
 			groups[g.(string)] = true
 		}
 	}
+
 	return groups
 }
 
 // hasVerbOnResource checks if any rule grants the given verb on the given
 // apiGroup + resource combination.
-func hasVerbOnResource(rules []interface{}, apiGroup, resource, verb string) bool {
+func hasVerbOnResource(rules []any, apiGroup, resource, verb string) bool {
 	for _, r := range rules {
-		rm := r.(map[string]interface{})
-		gs, ok := rm["apiGroups"].([]interface{})
+		rm := r.(map[string]any)
+
+		gs, ok := rm["apiGroups"].([]any)
 		if !ok {
 			continue
 		}
+
 		groupMatch := false
+
 		for _, g := range gs {
 			if g.(string) == apiGroup {
 				groupMatch = true
 			}
 		}
+
 		if !groupMatch {
 			continue
 		}
-		res, ok := rm["resources"].([]interface{})
+
+		res, ok := rm["resources"].([]any)
 		if !ok {
 			continue
 		}
+
 		resMatch := false
+
 		for _, rr := range res {
 			if rr.(string) == resource {
 				resMatch = true
 			}
 		}
+
 		if !resMatch {
 			continue
 		}
-		verbs, ok := rm["verbs"].([]interface{})
+
+		verbs, ok := rm["verbs"].([]any)
 		if !ok {
 			continue
 		}
+
 		for _, v := range verbs {
 			if v.(string) == verb {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 
@@ -415,10 +459,11 @@ func TestAdmissionPolicy_Parses(t *testing.T) {
 	}
 
 	// Policy should have 2 validation rules
-	validations, ok := nested(policy, "spec", "validations").([]interface{})
+	validations, ok := nested(policy, "spec", "validations").([]any)
 	if !ok {
 		t.Fatal("spec.validations missing or wrong type")
 	}
+
 	if len(validations) != 2 {
 		t.Errorf("got %d validation rules, want 2", len(validations))
 	}
@@ -428,10 +473,11 @@ func TestAdmissionPolicy_Parses(t *testing.T) {
 		t.Errorf("binding.spec.policyName = %v, want openclaw-resource-guard", pName)
 	}
 
-	actions, ok := nested(binding, "spec", "validationActions").([]interface{})
+	actions, ok := nested(binding, "spec", "validationActions").([]any)
 	if !ok || len(actions) == 0 {
 		t.Fatal("binding.spec.validationActions missing")
 	}
+
 	if actions[0] != "Deny" {
 		t.Errorf("validationActions[0] = %v, want Deny", actions[0])
 	}

--- a/internal/embed/embed_skills_test.go
+++ b/internal/embed/embed_skills_test.go
@@ -21,6 +21,7 @@ func TestGetEmbeddedSkillNames(t *testing.T) {
 		"distributed-validators", "ethereum-networks", "ethereum-local-wallet",
 		"gas", "indexing", "l2s", "sell", "obol-stack", "standards", "wallets", "why",
 	}
+
 	sort.Strings(names)
 
 	if len(names) < len(coreSkills) {
@@ -31,6 +32,7 @@ func TestGetEmbeddedSkillNames(t *testing.T) {
 	for _, n := range names {
 		nameSet[n] = true
 	}
+
 	for _, core := range coreSkills {
 		if !nameSet[core] {
 			t.Errorf("missing core skill %q in %v", core, names)
@@ -49,11 +51,13 @@ func TestCopySkills(t *testing.T) {
 	skills := []string{"discovery", "distributed-validators", "ethereum-networks", "ethereum-local-wallet", "sell", "obol-stack", "addresses", "wallets"}
 	for _, skill := range skills {
 		skillMD := filepath.Join(destDir, skill, "SKILL.md")
+
 		info, err := os.Stat(skillMD)
 		if err != nil {
 			t.Errorf("%s/SKILL.md: %v", skill, err)
 			continue
 		}
+
 		if info.Size() == 0 {
 			t.Errorf("%s/SKILL.md is empty", skill)
 		}
@@ -128,6 +132,7 @@ func TestMonetizePy_Syntax(t *testing.T) {
 	}
 
 	cmd := exec.Command("python3", "-m", "py_compile", monetizePy)
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("monetize.py has syntax errors:\n%s\n%v", output, err)
@@ -141,6 +146,7 @@ func TestKubePy_WriteHelpers(t *testing.T) {
 	}
 
 	kubePy := filepath.Join(destDir, "obol-stack", "scripts", "kube.py")
+
 	data, err := os.ReadFile(kubePy)
 	if err != nil {
 		t.Fatalf("read kube.py: %v", err)
@@ -170,6 +176,7 @@ func TestDiscoveryPy_Syntax(t *testing.T) {
 	}
 
 	cmd := exec.Command("python3", "-m", "py_compile", discoveryPy)
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("discovery.py has syntax errors:\n%s\n%v", output, err)
@@ -183,6 +190,7 @@ func TestDiscoverySkill_Commands(t *testing.T) {
 	}
 
 	discoveryPy := filepath.Join(destDir, "discovery", "scripts", "discovery.py")
+
 	data, err := os.ReadFile(discoveryPy)
 	if err != nil {
 		t.Fatalf("read discovery.py: %v", err)
@@ -225,11 +233,12 @@ func TestCopySkillsSkipsExisting(t *testing.T) {
 
 	// Pre-create a skill directory with custom content
 	customDir := filepath.Join(destDir, "obol-stack")
-	if err := os.MkdirAll(customDir, 0755); err != nil {
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+
 	customFile := filepath.Join(customDir, "custom.txt")
-	if err := os.WriteFile(customFile, []byte("user content"), 0644); err != nil {
+	if err := os.WriteFile(customFile, []byte("user content"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/internal/enclave/ecies.go
+++ b/internal/enclave/ecies.go
@@ -15,6 +15,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 
@@ -25,11 +26,12 @@ import (
 // recipientPubKey must be a 65-byte uncompressed SEC1 P-256 public key (0x04 prefix).
 func encrypt(recipientPubKey, plaintext []byte) ([]byte, error) {
 	if len(recipientPubKey) != 65 || recipientPubKey[0] != 0x04 {
-		return nil, fmt.Errorf("enclave: Encrypt: recipientPubKey must be 65-byte uncompressed SEC1")
+		return nil, errors.New("enclave: Encrypt: recipientPubKey must be 65-byte uncompressed SEC1")
 	}
 
 	// Parse recipient public key.
 	curve := ecdh.P256()
+
 	recipKey, err := curve.NewPublicKey(recipientPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("enclave: Encrypt: invalid recipient public key: %w", err)
@@ -40,6 +42,7 @@ func encrypt(recipientPubKey, plaintext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("enclave: Encrypt: GenerateKey: %w", err)
 	}
+
 	ephPubBytes := ephKey.PublicKey().Bytes() // 65-byte uncompressed
 
 	// ECDH shared secret.
@@ -59,14 +62,17 @@ func encrypt(recipientPubKey, plaintext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("enclave: Encrypt: aes.NewCipher: %w", err)
 	}
+
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, fmt.Errorf("enclave: Encrypt: cipher.NewGCM: %w", err)
 	}
+
 	nonce := make([]byte, gcm.NonceSize()) // 12 bytes
 	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("enclave: Encrypt: rand nonce: %w", err)
 	}
+
 	ct := gcm.Seal(nil, nonce, plaintext, nil)
 
 	// Wire format: [1:version][65:ephPub][12:nonce][ciphertext+tag]
@@ -75,6 +81,7 @@ func encrypt(recipientPubKey, plaintext []byte) ([]byte, error) {
 	out = append(out, ephPubBytes...)
 	out = append(out, nonce...)
 	out = append(out, ct...)
+
 	return out, nil
 }
 
@@ -86,9 +93,11 @@ func deriveKey(sharedPoint, ephPubBytes, recipPubBytes []byte) ([]byte, error) {
 	info = append(info, recipPubBytes...)
 
 	kdf := hkdf.New(sha256.New, sharedPoint, nil, info)
+
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(kdf, key); err != nil {
 		return nil, fmt.Errorf("enclave: HKDF: %w", err)
 	}
+
 	return key, nil
 }

--- a/internal/enclave/enclave_darwin.go
+++ b/internal/enclave/enclave_darwin.go
@@ -340,7 +340,7 @@ func (k *seKey) Sign(digest []byte) ([]byte, error) {
 		C.size_t(len(digest)),
 		(*C.uint8_t)(unsafe.Pointer(&sigBuf[0])),
 		C.size_t(len(sigBuf)),
-		&errStr,
+		&errStr, //nolint:gocritic // CGo pointer arguments, not duplicate subexpressions
 	)
 	if n == 0 {
 		msg := cfStringToGo(errStr)
@@ -366,7 +366,7 @@ func (k *seKey) ECDH(peerPubKeyBytes []byte) ([]byte, error) {
 		C.size_t(len(peerPubKeyBytes)),
 		(*C.uint8_t)(unsafe.Pointer(&outBuf[0])),
 		C.size_t(len(outBuf)),
-		&errStr,
+		&errStr, //nolint:gocritic // CGo pointer arguments, not duplicate subexpressions
 	)
 	if n == 0 {
 		msg := cfStringToGo(errStr)
@@ -411,7 +411,7 @@ func newKey(tag string) (Key, error) {
 	// Attempt persistent (keychain-backed) creation first.
 	var errCode C.CFIndex
 	var errStr C.CFStringRef
-	privRef := C.create_se_key(ctag, C.int(1), &errCode, &errStr)
+	privRef := C.create_se_key(ctag, C.int(1), &errCode, &errStr) //nolint:gocritic // CGo pointer arguments, not duplicate subexpressions
 
 	if unsafe.Pointer(privRef) != nil {
 		// Success — key is in keychain.
@@ -441,7 +441,7 @@ func newKey(tag string) (Key, error) {
 
 	// Ephemeral fallback.
 	var errStr2 C.CFStringRef
-	privRef = C.create_se_key(ctag, C.int(0), &errCode, &errStr2)
+	privRef = C.create_se_key(ctag, C.int(0), &errCode, &errStr2) //nolint:gocritic // CGo pointer arguments, not duplicate subexpressions
 	if unsafe.Pointer(privRef) == nil {
 		msg := cfStringToGo(errStr2)
 		if unsafe.Pointer(errStr2) != nil {
@@ -472,7 +472,7 @@ func loadKey(tag string) (Key, error) {
 
 	var found C.int
 	var errStr C.CFStringRef
-	privRef := C.load_se_key(ctag, &found, &errStr)
+	privRef := C.load_se_key(ctag, &found, &errStr) //nolint:gocritic // CGo pointer arguments, not duplicate subexpressions
 
 	if found == 0 {
 		if unsafe.Pointer(errStr) != nil {

--- a/internal/enclave/enclave_test.go
+++ b/internal/enclave/enclave_test.go
@@ -4,6 +4,7 @@ package enclave_test
 
 import (
 	"crypto/sha256"
+	"errors"
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/enclave"
@@ -14,6 +15,7 @@ const testTag = "com.obol.enclave.test"
 // cleanup removes the test key if it exists.
 func cleanup(t *testing.T) {
 	t.Helper()
+
 	_ = enclave.DeleteKey(testTag)
 }
 
@@ -25,6 +27,7 @@ func TestNewKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewKey: %v", err)
 	}
+
 	if k == nil {
 		t.Fatal("NewKey returned nil key")
 	}
@@ -33,9 +36,11 @@ func TestNewKey(t *testing.T) {
 	if len(pub) != 65 {
 		t.Fatalf("PublicKeyBytes: want 65 bytes, got %d", len(pub))
 	}
+
 	if pub[0] != 0x04 {
 		t.Fatalf("PublicKeyBytes: expected uncompressed prefix 0x04, got 0x%02x", pub[0])
 	}
+
 	if k.Tag() != testTag {
 		t.Fatalf("Tag: want %q, got %q", testTag, k.Tag())
 	}
@@ -71,7 +76,7 @@ func TestLoadKeyNotFound(t *testing.T) {
 	_ = enclave.DeleteKey("com.obol.enclave.nonexistent")
 
 	_, err := enclave.LoadKey("com.obol.enclave.nonexistent")
-	if err != enclave.ErrKeyNotFound {
+	if !errors.Is(err, enclave.ErrKeyNotFound) {
 		t.Fatalf("expected ErrKeyNotFound, got %v", err)
 	}
 }
@@ -92,6 +97,7 @@ func TestSign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sign: %v", err)
 	}
+
 	if len(sig) < 64 {
 		t.Fatalf("Sign: signature too short (%d bytes)", len(sig))
 	}
@@ -118,6 +124,7 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	if len(ciphertext) < minLen {
 		t.Fatalf("ciphertext too short: got %d, want >= %d", len(ciphertext), minLen)
 	}
+
 	if ciphertext[0] != 0x01 {
 		t.Fatalf("unexpected version byte: 0x%02x", ciphertext[0])
 	}
@@ -143,6 +150,7 @@ func TestEncryptDecryptTampered(t *testing.T) {
 	}
 
 	plaintext := []byte("sensitive data")
+
 	ciphertext, err := enclave.Encrypt(k.PublicKeyBytes(), plaintext)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
@@ -179,6 +187,7 @@ func TestNewKeyIdempotent(t *testing.T) {
 		if !k1.Persistent() {
 			t.Skip("key is ephemeral and in-process cache returned different instance; acceptable in test isolation")
 		}
+
 		t.Fatal("second NewKey returned a different key than the first")
 	}
 }
@@ -187,12 +196,12 @@ func TestCheckSIP(t *testing.T) {
 	// CheckSIP should not return an unexpected error on Apple Silicon.
 	// ErrSIPDisabled is legitimate on developer machines with csrutil disabled.
 	err := enclave.CheckSIP()
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		t.Log("SIP is enabled")
-	case enclave.ErrSIPDisabled:
+	case errors.Is(err, enclave.ErrSIPDisabled):
 		t.Log("WARNING: System Integrity Protection is disabled on this machine")
-	case enclave.ErrNotSupported:
+	case errors.Is(err, enclave.ErrNotSupported):
 		t.Skip("Secure Enclave not supported on this platform")
 	default:
 		t.Fatalf("CheckSIP unexpected error: %v", err)

--- a/internal/enclave/sysctl_darwin.go
+++ b/internal/enclave/sysctl_darwin.go
@@ -25,7 +25,9 @@ func sysctlCsrActiveConfig() (uint32, error) {
 		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ENODEV) {
 			return 0, nil
 		}
+
 		return 0, err
 	}
+
 	return val, nil
 }

--- a/internal/erc8004/abi_test.go
+++ b/internal/erc8004/abi_test.go
@@ -24,9 +24,9 @@ func TestABI_AllFunctionsPresent(t *testing.T) {
 	// names by appending a disambiguator (register, register0, register1).
 	// We check for the 7 unique method names plus the overload variants.
 	wantMethods := []string{
-		"register",   // overload with 1 input (string)
-		"register0",  // overload with 0 inputs
-		"register1",  // overload with 2 inputs (string, tuple[])
+		"register",  // overload with 1 input (string)
+		"register0", // overload with 0 inputs
+		"register1", // overload with 2 inputs (string, tuple[])
 		"setAgentURI",
 		"setMetadata",
 		"getMetadata",
@@ -83,6 +83,7 @@ func TestABI_RegisterOverloads(t *testing.T) {
 			t.Errorf("missing method %q", tt.name)
 			continue
 		}
+
 		if len(m.Inputs) != tt.wantInputs {
 			t.Errorf("method %q: got %d inputs, want %d", tt.name, len(m.Inputs), tt.wantInputs)
 		}
@@ -104,10 +105,12 @@ func TestConstants_Addresses(t *testing.T) {
 			if !strings.HasPrefix(a.addr, "0x") {
 				t.Fatalf("address %q does not start with 0x", a.addr)
 			}
+
 			hex := a.addr[2:]
 			if len(hex) != 40 {
 				t.Errorf("address hex part is %d chars, want 40", len(hex))
 			}
+
 			for _, c := range hex {
 				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 					t.Errorf("address contains non-hex char %q", string(c))
@@ -124,5 +127,6 @@ func methodNames(a abi.ABI) string {
 	for n := range a.Methods {
 		names = append(names, n)
 	}
+
 	return strings.Join(names, ", ")
 }

--- a/internal/erc8004/abi_test.go
+++ b/internal/erc8004/abi_test.go
@@ -112,7 +112,7 @@ func TestConstants_Addresses(t *testing.T) {
 			}
 
 			for _, c := range hex {
-				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 					t.Errorf("address contains non-hex char %q", string(c))
 					break
 				}

--- a/internal/erc8004/client.go
+++ b/internal/erc8004/client.go
@@ -65,6 +65,7 @@ func (c *Client) Register(ctx context.Context, key *ecdsa.PrivateKey, agentURI s
 	if err != nil {
 		return nil, fmt.Errorf("erc8004: transactor: %w", err)
 	}
+
 	opts.Context = ctx
 
 	tx, err := c.contract.Transact(opts, "register", agentURI)
@@ -85,6 +86,7 @@ func (c *Client) Register(ctx context.Context, key *ecdsa.PrivateKey, agentURI s
 		}
 		// agentId is indexed (topic[1]).
 		agentID := new(big.Int).SetBytes(vLog.Topics[1].Bytes())
+
 		return agentID, nil
 	}
 
@@ -97,6 +99,7 @@ func (c *Client) SetAgentURI(ctx context.Context, key *ecdsa.PrivateKey, agentID
 	if err != nil {
 		return fmt.Errorf("erc8004: transactor: %w", err)
 	}
+
 	opts.Context = ctx
 
 	tx, err := c.contract.Transact(opts, "setAgentURI", agentID, uri)
@@ -107,6 +110,7 @@ func (c *Client) SetAgentURI(ctx context.Context, key *ecdsa.PrivateKey, agentID
 	if _, err := bind.WaitMined(ctx, c.eth, tx); err != nil {
 		return fmt.Errorf("erc8004: wait mined: %w", err)
 	}
+
 	return nil
 }
 
@@ -116,6 +120,7 @@ func (c *Client) SetMetadata(ctx context.Context, key *ecdsa.PrivateKey, agentID
 	if err != nil {
 		return fmt.Errorf("erc8004: transactor: %w", err)
 	}
+
 	opts.Context = ctx
 
 	tx, err := c.contract.Transact(opts, "setMetadata", agentID, k, v)
@@ -126,39 +131,48 @@ func (c *Client) SetMetadata(ctx context.Context, key *ecdsa.PrivateKey, agentID
 	if _, err := bind.WaitMined(ctx, c.eth, tx); err != nil {
 		return fmt.Errorf("erc8004: wait mined: %w", err)
 	}
+
 	return nil
 }
 
 // GetMetadata reads metadata for the given key from the agent NFT.
 func (c *Client) GetMetadata(ctx context.Context, agentID *big.Int, k string) ([]byte, error) {
-	var out []interface{}
+	var out []any
+
 	err := c.contract.Call(&bind.CallOpts{Context: ctx}, &out, "getMetadata", agentID, k)
 	if err != nil {
 		return nil, fmt.Errorf("erc8004: getMetadata: %w", err)
 	}
+
 	if len(out) == 0 {
 		return nil, nil
 	}
+
 	b, ok := out[0].([]byte)
 	if !ok {
 		return nil, fmt.Errorf("erc8004: getMetadata: unexpected type %T", out[0])
 	}
+
 	return b, nil
 }
 
 // TokenURI returns the ERC-721 tokenURI for the agent NFT.
 func (c *Client) TokenURI(ctx context.Context, agentID *big.Int) (string, error) {
-	var out []interface{}
+	var out []any
+
 	err := c.contract.Call(&bind.CallOpts{Context: ctx}, &out, "tokenURI", agentID)
 	if err != nil {
 		return "", fmt.Errorf("erc8004: tokenURI: %w", err)
 	}
+
 	if len(out) == 0 {
 		return "", nil
 	}
+
 	s, ok := out[0].(string)
 	if !ok {
 		return "", fmt.Errorf("erc8004: tokenURI: unexpected type %T", out[0])
 	}
+
 	return s, nil
 }

--- a/internal/erc8004/client_test.go
+++ b/internal/erc8004/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -37,11 +38,13 @@ type jsonrpcResp struct {
 // The handler map keys are method names; values return the hex-encoded result.
 func mockRPC(t *testing.T, handlers map[string]func(params []json.RawMessage) (json.RawMessage, error)) *httptest.Server {
 	t.Helper()
+
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonrpcReq
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Logf("mock rpc: decode error: %v", err)
-			http.Error(w, "bad request", 400)
+			http.Error(w, "bad request", http.StatusBadRequest)
+
 			return
 		}
 
@@ -54,6 +57,7 @@ func mockRPC(t *testing.T, handlers map[string]func(params []json.RawMessage) (j
 				Error:   json.RawMessage(`{"code":-32601,"message":"method not found"}`),
 			}
 			json.NewEncoder(w).Encode(resp)
+
 			return
 		}
 
@@ -65,6 +69,7 @@ func mockRPC(t *testing.T, handlers map[string]func(params []json.RawMessage) (j
 				Error:   json.RawMessage(fmt.Sprintf(`{"code":-32000,"message":"%s"}`, err.Error())),
 			}
 			json.NewEncoder(w).Encode(resp)
+
 			return
 		}
 
@@ -89,6 +94,7 @@ func TestNewClient(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -98,6 +104,7 @@ func TestNewClient(t *testing.T) {
 	if client.chainID.Int64() != BaseSepoliaChainID {
 		t.Errorf("chain ID = %d, want %d", client.chainID.Int64(), BaseSepoliaChainID)
 	}
+
 	if client.address != common.HexToAddress(IdentityRegistryBaseSepolia) {
 		t.Errorf("address = %s, want %s", client.address.Hex(), IdentityRegistryBaseSepolia)
 	}
@@ -112,7 +119,7 @@ func TestRegister(t *testing.T) {
 
 	// Build a fake Registered event log.
 	// Registered(uint256 indexed agentId, string agentURI, address indexed owner)
-	registeredABI, _ := json.Marshal([]interface{}{})
+	registeredABI, _ := json.Marshal([]any{})
 	_ = registeredABI
 
 	parsedABI, err := parseABI()
@@ -131,7 +138,9 @@ func TestRegister(t *testing.T) {
 	}
 
 	fakeTxHash := common.HexToHash("0xaabbccdd")
+
 	var nonceMu sync.Mutex
+
 	nonce := uint64(0)
 
 	handlers := map[string]func([]json.RawMessage) (json.RawMessage, error){
@@ -151,8 +160,10 @@ func TestRegister(t *testing.T) {
 		"eth_getTransactionCount": func(_ []json.RawMessage) (json.RawMessage, error) {
 			nonceMu.Lock()
 			defer nonceMu.Unlock()
+
 			result := fmt.Sprintf(`"0x%x"`, nonce)
 			nonce++
+
 			return json.RawMessage(result), nil
 		},
 		"eth_estimateGas": func(_ []json.RawMessage) (json.RawMessage, error) {
@@ -187,7 +198,7 @@ func TestRegister(t *testing.T) {
 					"logIndex": "0x0",
 					"removed": false
 				}],
-				"logsBloom": "0x` + strings.Repeat("0", 512) + `",
+				"logsBloom": "0x`+strings.Repeat("0", 512)+`",
 				"type": "0x2",
 				"effectiveGasPrice": "0x3b9aca00"
 			}`,
@@ -197,6 +208,7 @@ func TestRegister(t *testing.T) {
 				hex.EncodeToString(uriEncoded),
 				fakeTxHash.Hex(),
 			)
+
 			return json.RawMessage(receipt), nil
 		},
 		"eth_blockNumber": func(_ []json.RawMessage) (json.RawMessage, error) {
@@ -233,6 +245,7 @@ func TestRegister(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -276,6 +289,7 @@ func TestGetMetadata(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -299,6 +313,7 @@ func TestTokenURI(t *testing.T) {
 	}
 
 	expectedURI := "https://example.com/.well-known/agent-registration.json"
+
 	encoded, err := parsedABI.Methods["tokenURI"].Outputs.Pack(expectedURI)
 	if err != nil {
 		t.Fatalf("pack: %v", err)
@@ -317,6 +332,7 @@ func TestTokenURI(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -338,6 +354,7 @@ func TestTokenURI(t *testing.T) {
 // sendRawTransaction, receipt (status 0x1, empty logs), and block data.
 func txMockHandlers(fakeTxHash common.Hash) map[string]func([]json.RawMessage) (json.RawMessage, error) {
 	var nonceMu sync.Mutex
+
 	nonce := uint64(0)
 
 	return map[string]func([]json.RawMessage) (json.RawMessage, error){
@@ -356,8 +373,10 @@ func txMockHandlers(fakeTxHash common.Hash) map[string]func([]json.RawMessage) (
 		"eth_getTransactionCount": func(_ []json.RawMessage) (json.RawMessage, error) {
 			nonceMu.Lock()
 			defer nonceMu.Unlock()
+
 			result := fmt.Sprintf(`"0x%x"`, nonce)
 			nonce++
+
 			return json.RawMessage(result), nil
 		},
 		"eth_estimateGas": func(_ []json.RawMessage) (json.RawMessage, error) {
@@ -381,6 +400,7 @@ func txMockHandlers(fakeTxHash common.Hash) map[string]func([]json.RawMessage) (
 				"type": "0x2",
 				"effectiveGasPrice": "0x3b9aca00"
 			}`, fakeTxHash.Hex())
+
 			return json.RawMessage(receipt), nil
 		},
 		"eth_blockNumber": func(_ []json.RawMessage) (json.RawMessage, error) {
@@ -427,6 +447,7 @@ func TestSetAgentURI(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -452,6 +473,7 @@ func TestSetMetadata(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -487,6 +509,7 @@ func TestRegister_NoRegisteredEvent(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -497,6 +520,7 @@ func TestRegister_NoRegisteredEvent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when Registered event not found, got nil")
 	}
+
 	if !strings.Contains(err.Error(), "Registered event not found") {
 		t.Errorf("error = %q, want it to contain 'Registered event not found'", err.Error())
 	}
@@ -512,13 +536,14 @@ func TestRegister_TxError(t *testing.T) {
 	handlers := txMockHandlers(fakeTxHash)
 	// Override sendRawTransaction to return an error.
 	handlers["eth_sendRawTransaction"] = func(_ []json.RawMessage) (json.RawMessage, error) {
-		return nil, fmt.Errorf("insufficient funds")
+		return nil, errors.New("insufficient funds")
 	}
 
 	srv := mockRPC(t, handlers)
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -556,6 +581,7 @@ func TestGetMetadata_EmptyResult(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
+
 	client, err := NewClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -566,6 +592,7 @@ func TestGetMetadata_EmptyResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
+
 	if len(result) != 0 {
 		t.Errorf("expected empty bytes, got %q", result)
 	}

--- a/internal/erc8004/types.go
+++ b/internal/erc8004/types.go
@@ -13,15 +13,15 @@ package erc8004
 //
 // Spec: https://eips.ethereum.org/EIPS/eip-8004
 type AgentRegistration struct {
-	Type           string        `json:"type"`                      // REQUIRED
-	Name           string        `json:"name"`                      // REQUIRED
-	Description    string        `json:"description,omitempty"`     // REQUIRED (omitempty for parsing)
-	Image          string        `json:"image,omitempty"`           // REQUIRED (omitempty for parsing)
-	Services       []ServiceDef  `json:"services"`                  // REQUIRED (>=1)
-	X402Support    bool          `json:"x402Support"`               // REQUIRED
-	Active         bool          `json:"active"`                    // REQUIRED
-	Registrations  []OnChainReg  `json:"registrations,omitempty"`   // REQUIRED (>=1, omitempty for parsing)
-	SupportedTrust []string      `json:"supportedTrust,omitempty"`  // OPTIONAL
+	Type           string       `json:"type"`                     // REQUIRED
+	Name           string       `json:"name"`                     // REQUIRED
+	Description    string       `json:"description,omitempty"`    // REQUIRED (omitempty for parsing)
+	Image          string       `json:"image,omitempty"`          // REQUIRED (omitempty for parsing)
+	Services       []ServiceDef `json:"services"`                 // REQUIRED (>=1)
+	X402Support    bool         `json:"x402Support"`              // REQUIRED
+	Active         bool         `json:"active"`                   // REQUIRED
+	Registrations  []OnChainReg `json:"registrations,omitempty"`  // REQUIRED (>=1, omitempty for parsing)
+	SupportedTrust []string     `json:"supportedTrust,omitempty"` // OPTIONAL
 }
 
 // RegistrationType is the canonical type URI for ERC-8004 registration v1.
@@ -32,10 +32,10 @@ const RegistrationType = "https://eips.ethereum.org/EIPS/eip-8004#registration-v
 // taxonomy for agent discovery. See https://schema.oasf.outshift.com/
 type ServiceDef struct {
 	Name     string   `json:"name"`               // e.g., "web", "A2A", "MCP", "OASF"
-	Endpoint string   `json:"endpoint,omitempty"`  // full URL (omitempty for OASF entries)
-	Version  string   `json:"version,omitempty"`   // protocol version (SHOULD per spec)
-	Skills   []string `json:"skills,omitempty"`    // OASF skill taxonomy paths
-	Domains  []string `json:"domains,omitempty"`   // OASF domain taxonomy paths
+	Endpoint string   `json:"endpoint,omitempty"` // full URL (omitempty for OASF entries)
+	Version  string   `json:"version,omitempty"`  // protocol version (SHOULD per spec)
+	Skills   []string `json:"skills,omitempty"`   // OASF skill taxonomy paths
+	Domains  []string `json:"domains,omitempty"`  // OASF domain taxonomy paths
 }
 
 // OnChainReg links the registration to its on-chain record.

--- a/internal/erc8004/types_test.go
+++ b/internal/erc8004/types_test.go
@@ -66,33 +66,43 @@ func TestAgentRegistration_UnmarshalJSON(t *testing.T) {
 	if reg.Type != RegistrationType {
 		t.Errorf("Type = %q, want %q", reg.Type, RegistrationType)
 	}
+
 	if reg.Name != "my-agent" {
 		t.Errorf("Name = %q, want %q", reg.Name, "my-agent")
 	}
+
 	if reg.Description != "An AI agent" {
 		t.Errorf("Description = %q, want %q", reg.Description, "An AI agent")
 	}
+
 	if !reg.X402Support {
 		t.Error("X402Support = false, want true")
 	}
+
 	if !reg.Active {
 		t.Error("Active = false, want true")
 	}
+
 	if len(reg.Services) != 1 {
 		t.Fatalf("len(Services) = %d, want 1", len(reg.Services))
 	}
+
 	if reg.Services[0].Name != "A2A" {
 		t.Errorf("Services[0].Name = %q, want %q", reg.Services[0].Name, "A2A")
 	}
+
 	if reg.Services[0].Version != "0.2.1" {
 		t.Errorf("Services[0].Version = %q, want %q", reg.Services[0].Version, "0.2.1")
 	}
+
 	if len(reg.Registrations) != 1 {
 		t.Fatalf("len(Registrations) = %d, want 1", len(reg.Registrations))
 	}
+
 	if reg.Registrations[0].AgentID != 7 {
 		t.Errorf("Registrations[0].AgentID = %d, want 7", reg.Registrations[0].AgentID)
 	}
+
 	if len(reg.SupportedTrust) != 2 {
 		t.Errorf("len(SupportedTrust) = %d, want 2", len(reg.SupportedTrust))
 	}
@@ -153,6 +163,7 @@ func TestServiceDef_VersionOptional(t *testing.T) {
 
 	// With version set, it should appear.
 	svc.Version = "2.0"
+
 	data, err = json.Marshal(svc)
 	if err != nil {
 		t.Fatalf("Marshal with version: %v", err)
@@ -162,6 +173,7 @@ func TestServiceDef_VersionOptional(t *testing.T) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+
 	if _, ok := m["version"]; !ok {
 		t.Error("version should be present when set")
 	}
@@ -199,6 +211,7 @@ func TestOnChainReg_AgentIDNumeric(t *testing.T) {
 	if err := json.Unmarshal(data, &back); err != nil {
 		t.Fatalf("round-trip Unmarshal: %v", err)
 	}
+
 	if back.AgentID != 42 {
 		t.Errorf("round-trip AgentID = %d, want 42", back.AgentID)
 	}

--- a/internal/inference/client.go
+++ b/internal/inference/client.go
@@ -64,6 +64,7 @@ func NewClient(ctx context.Context, gatewayURL string) (*Client, error) {
 	if _, err := c.fetchPubkey(ctx); err != nil {
 		return nil, err
 	}
+
 	return c, nil
 }
 
@@ -80,9 +81,11 @@ func (c *Client) EnableEncryptedReplies(tag string) error {
 	if err != nil {
 		return fmt.Errorf("inference client: generate reply key: %w", err)
 	}
+
 	c.mu.Lock()
 	c.replyKey = k
 	c.mu.Unlock()
+
 	return nil
 }
 
@@ -91,6 +94,7 @@ func (c *Client) EnableEncryptedReplies(tag string) error {
 func (c *Client) Pubkey() []byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
 	return c.pubkey
 }
 
@@ -106,6 +110,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Read and encrypt the body.
 	plain, err := io.ReadAll(req.Body)
 	req.Body.Close()
+
 	if err != nil {
 		return nil, fmt.Errorf("inference client: read body: %w", err)
 	}
@@ -130,6 +135,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 	c.mu.RLock()
 	rk := c.replyKey
 	c.mu.RUnlock()
+
 	if rk != nil {
 		out.Header.Set(headerReplyPubkey, hex.EncodeToString(rk.PublicKeyBytes()))
 	}
@@ -142,14 +148,17 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Decrypt an encrypted response.
 	if rk != nil && resp.Header.Get("Content-Type") == contentTypeEncrypted {
 		defer resp.Body.Close()
+
 		enc, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("inference client: read encrypted response: %w", err)
 		}
+
 		plainResp, err := rk.Decrypt(enc)
 		if err != nil {
 			return nil, fmt.Errorf("inference client: decrypt response: %w", err)
 		}
+
 		resp = &http.Response{
 			Status:     resp.Status,
 			StatusCode: resp.StatusCode,
@@ -173,16 +182,20 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // if not yet available.
 func (c *Client) fetchPubkey(ctx context.Context) ([]byte, error) {
 	c.mu.RLock()
+
 	if c.pubkey != nil {
 		pk := c.pubkey
 		c.mu.RUnlock()
+
 		return pk, nil
 	}
+
 	c.mu.RUnlock()
 
 	// Fetch under write lock to avoid thundering herd.
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if c.pubkey != nil { // double-check after acquiring write lock
 		return c.pubkey, nil
 	}
@@ -191,6 +204,7 @@ func (c *Client) fetchPubkey(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("inference client: build pubkey request: %w", err)
 	}
+
 	resp, err := c.transport().RoundTrip(req)
 	if err != nil {
 		return nil, fmt.Errorf("inference client: fetch pubkey: %w", err)
@@ -205,11 +219,14 @@ func (c *Client) fetchPubkey(ctx context.Context) ([]byte, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return nil, fmt.Errorf("inference client: decode pubkey response: %w", err)
 	}
+
 	pk, err := hex.DecodeString(body.Pubkey)
 	if err != nil {
 		return nil, fmt.Errorf("inference client: decode pubkey hex: %w", err)
 	}
+
 	c.pubkey = pk
+
 	return pk, nil
 }
 
@@ -217,5 +234,6 @@ func (c *Client) transport() http.RoundTripper {
 	if c.HTTP != nil {
 		return c.HTTP
 	}
+
 	return http.DefaultTransport
 }

--- a/internal/inference/client.go
+++ b/internal/inference/client.go
@@ -200,7 +200,7 @@ func (c *Client) fetchPubkey(ctx context.Context) ([]byte, error) {
 		return c.pubkey, nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.GatewayURL+"/v1/enclave/pubkey", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.GatewayURL+"/v1/enclave/pubkey", nil) //nolint:gosec // G704: URL from user-configured GatewayURL, not tainted input
 	if err != nil {
 		return nil, fmt.Errorf("inference client: build pubkey request: %w", err)
 	}

--- a/internal/inference/client_test.go
+++ b/internal/inference/client_test.go
@@ -21,7 +21,9 @@ import (
 // endpoint that decrypts incoming encrypted bodies.
 func startEnclaveGateway(t *testing.T, tag string) (*httptest.Server, enclave.Key) {
 	t.Helper()
+
 	_ = enclave.DeleteKey(tag)
+
 	t.Cleanup(func() { _ = enclave.DeleteKey(tag) })
 
 	seKey, err := enclave.NewKey(tag)
@@ -39,6 +41,7 @@ func startEnclaveGateway(t *testing.T, tag string) (*httptest.Server, enclave.Ke
 			"persistent": seKey.Persistent(),
 			"algorithm":  "ECIES-P256-HKDF-SHA256-AES256GCM",
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(body)
 	})
@@ -49,8 +52,10 @@ func startEnclaveGateway(t *testing.T, tag string) (*httptest.Server, enclave.Ke
 		body, _ := io.ReadAll(r.Body)
 
 		var plain []byte
+
 		if ct == "application/x-obol-encrypted" {
 			var err error
+
 			plain, err = seKey.Decrypt(body)
 			if err != nil {
 				http.Error(w, "decrypt failed: "+err.Error(), http.StatusBadRequest)
@@ -68,13 +73,16 @@ func startEnclaveGateway(t *testing.T, tag string) (*httptest.Server, enclave.Ke
 				http.Error(w, "bad reply pubkey", http.StatusBadRequest)
 				return
 			}
+
 			enc, err := enclave.Encrypt(replyPubkey, plain)
 			if err != nil {
 				http.Error(w, "encrypt reply failed: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
+
 			w.Header().Set("Content-Type", "application/x-obol-encrypted")
 			_, _ = w.Write(enc)
+
 			return
 		}
 
@@ -84,6 +92,7 @@ func startEnclaveGateway(t *testing.T, tag string) (*httptest.Server, enclave.Ke
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
+
 	return srv, seKey
 }
 
@@ -101,6 +110,7 @@ func TestClientFetchesPubkey(t *testing.T) {
 	if len(pk) != 65 {
 		t.Fatalf("expected 65-byte pubkey, got %d bytes", len(pk))
 	}
+
 	if hex.EncodeToString(pk) != hex.EncodeToString(seKey.PublicKeyBytes()) {
 		t.Errorf("pubkey mismatch")
 	}
@@ -117,7 +127,7 @@ func TestClientEncryptsRequest(t *testing.T) {
 	}
 
 	want := `{"model":"llama3","messages":[{"role":"user","content":"hello"}]}`
-	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/echo", strings.NewReader(want))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/echo", strings.NewReader(want))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.Do(req)
@@ -142,10 +152,12 @@ func TestClientPassthroughNoBody(t *testing.T) {
 	called := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
+
 		ct := r.Header.Get("Content-Type")
 		if ct == "application/x-obol-encrypted" {
 			t.Errorf("GET request should not be encrypted, got Content-Type: %s", ct)
 		}
+
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -156,6 +168,7 @@ func TestClientPassthroughNoBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewKey: %v", err)
 	}
+
 	t.Cleanup(func() { _ = enclave.DeleteKey("com.obol.inference.test.client-noencrypt") })
 
 	c := &inference.Client{
@@ -165,12 +178,15 @@ func TestClientPassthroughNoBody(t *testing.T) {
 	// Manually inject pubkey so fetchPubkey doesn't try to hit a missing endpoint.
 	_ = fakeKey // pubkey unused — GET has no body so encrypt path is skipped
 
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/health", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/health", nil)
+
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
+
 	resp.Body.Close()
+
 	if !called {
 		t.Error("upstream handler was not called")
 	}
@@ -181,7 +197,9 @@ func TestClientPassthroughNoBody(t *testing.T) {
 // client's ephemeral key → client decrypts → plaintext response.
 func TestClientEncryptedReply(t *testing.T) {
 	const replyTag = "com.obol.inference.test.client-reply"
+
 	_ = enclave.DeleteKey(replyTag)
+
 	t.Cleanup(func() { _ = enclave.DeleteKey(replyTag) })
 
 	srv, _ := startEnclaveGateway(t, "com.obol.inference.test.client-reply-gw")
@@ -190,12 +208,13 @@ func TestClientEncryptedReply(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
+
 	if err := c.EnableEncryptedReplies(replyTag); err != nil {
 		t.Fatalf("EnableEncryptedReplies: %v", err)
 	}
 
 	want := `{"model":"llama3","messages":[{"role":"user","content":"secret question"}]}`
-	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/echo", strings.NewReader(want))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/echo", strings.NewReader(want))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.Do(req)
@@ -207,6 +226,7 @@ func TestClientEncryptedReply(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status: %s", resp.Status)
 	}
+
 	got, _ := io.ReadAll(resp.Body)
 	if strings.TrimSpace(string(got)) != want {
 		t.Errorf("round-trip body mismatch:\n  want: %s\n  got:  %s", want, got)

--- a/internal/inference/container.go
+++ b/internal/inference/container.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -45,24 +46,29 @@ type ContainerManager struct {
 // kept; the result is truncated to 63 chars.
 func sanitizeContainerName(deploymentName string) string {
 	name := strings.ToLower(deploymentName)
+
 	var b strings.Builder
+
 	for _, c := range name {
 		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
 			b.WriteRune(c)
 		}
 	}
+
 	s := b.String()
 	// Trim leading hyphens.
 	s = strings.TrimLeft(s, "-")
 	if s == "" {
 		s = "default"
 	}
+
 	full := "obol-inference-" + s
 	if len(full) > 63 {
 		full = full[:63]
 	}
 	// Trim trailing hyphens after truncation.
 	full = strings.TrimRight(full, "-")
+
 	return full
 }
 
@@ -72,9 +78,11 @@ func newContainerManager(binary, deploymentName string, hostPort int) *Container
 	if binary == "" {
 		binary = "container"
 	}
+
 	if hostPort == 0 {
 		hostPort = defaultContainerHostPort
 	}
+
 	return &ContainerManager{
 		binary: binary,
 		name:   sanitizeContainerName(deploymentName),
@@ -91,14 +99,17 @@ func (m *ContainerManager) UpstreamURL() string {
 // Safe to call when the daemon is already running.
 func (m *ContainerManager) EnsureSystemRunning(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, m.binary, "system", "start", "--enable-kernel-install")
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s := strings.ToLower(string(out))
 		if strings.Contains(s, "already running") || strings.Contains(s, "already started") {
 			return nil
 		}
+
 		return fmt.Errorf("container system start: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+
 	return nil
 }
 
@@ -110,9 +121,11 @@ func (m *ContainerManager) Start(ctx context.Context, image string, cpus, memory
 	if image == "" {
 		image = defaultContainerImage
 	}
+
 	if cpus == 0 {
 		cpus = defaultContainerCPUs
 	}
+
 	if memoryMB == 0 {
 		memoryMB = defaultContainerMemoryMB
 	}
@@ -131,6 +144,7 @@ func (m *ContainerManager) Start(ctx context.Context, image string, cpus, memory
 	log.Printf("container: pulling image %s (first run may take several minutes)...", image)
 	pullCmd := exec.CommandContext(ctx, m.binary, "pull", image)
 	pullCmd.Stdout = os.Stdout
+
 	pullCmd.Stderr = os.Stderr
 	if err := pullCmd.Run(); err != nil {
 		return fmt.Errorf("container pull %s: %w", image, err)
@@ -143,7 +157,7 @@ func (m *ContainerManager) Start(ctx context.Context, image string, cpus, memory
 		"--name", m.name,
 		"--detach",
 		"--publish", fmt.Sprintf("127.0.0.1:%d:11434", m.port),
-		"--cpus", fmt.Sprintf("%d", cpus),
+		"--cpus", strconv.Itoa(cpus),
 		"--memory", fmt.Sprintf("%dM", memoryMB),
 		image,
 	}
@@ -158,6 +172,7 @@ func (m *ContainerManager) Start(ctx context.Context, image string, cpus, memory
 	}
 
 	log.Printf("container: %q ready at %s", m.name, m.UpstreamURL())
+
 	return nil
 }
 
@@ -165,6 +180,7 @@ func (m *ContainerManager) Start(ctx context.Context, image string, cpus, memory
 // Returns nil if the container does not exist.
 func (m *ContainerManager) Stop(ctx context.Context) error {
 	stopCmd := exec.CommandContext(ctx, m.binary, "stop", m.name)
+
 	out, err := stopCmd.CombinedOutput()
 	if err != nil {
 		s := strings.ToLower(string(out))
@@ -181,8 +197,10 @@ func (m *ContainerManager) Stop(ctx context.Context) error {
 		if strings.Contains(s, "not found") || strings.Contains(s, "does not exist") {
 			return nil
 		}
+
 		return fmt.Errorf("container rm %s: %w: %s", m.name, err, strings.TrimSpace(string(out)))
 	}
+
 	return nil
 }
 
@@ -199,6 +217,7 @@ func (m *ContainerManager) waitReady(ctx context.Context) error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("ollama in container %q not ready after %s", m.name, containerReadyTimeout)
 		}
+
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -208,6 +227,7 @@ func (m *ContainerManager) waitReady(ctx context.Context) error {
 			resp.Body.Close()
 			return nil
 		}
+
 		if resp != nil {
 			resp.Body.Close()
 		}

--- a/internal/inference/enclave_middleware.go
+++ b/internal/inference/enclave_middleware.go
@@ -63,6 +63,7 @@ func newEnclaveMiddleware(tag string) (*enclaveMiddleware, error) {
 	if err != nil {
 		return nil, fmt.Errorf("enclave middleware: %w", err)
 	}
+
 	return &enclaveMiddleware{key: k}, nil
 }
 
@@ -94,7 +95,9 @@ func (m *enclaveMiddleware) handlePubkey(w http.ResponseWriter, _ *http.Request)
 		Persistent: m.key.Persistent(),
 		Algorithm:  "ECIES-P256-HKDF-SHA256-AES256GCM",
 	}
+
 	w.Header().Set("Content-Type", "application/json")
+
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		log.Printf("enclave pubkey handler: encode error: %v", err)
 	}
@@ -121,6 +124,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 			http.Error(w, "failed to read request body", http.StatusBadRequest)
 			return
 		}
+
 		_ = r.Body.Close()
 
 		// Decrypt via the SE private key.
@@ -128,6 +132,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 		if err != nil {
 			log.Printf("enclave middleware: decrypt error: %q", err)
 			http.Error(w, "decryption failed", http.StatusBadRequest)
+
 			return
 		}
 
@@ -154,6 +159,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 				fmt.Sprintf("invalid %s header: must be hex-encoded 65-byte uncompressed P-256 public key", headerReplyPubkey),
 				http.StatusBadRequest,
 			)
+
 			return
 		}
 
@@ -164,6 +170,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 		if rec.overflow {
 			log.Printf("enclave middleware: upstream response exceeded %d byte capture limit", maxResponseCapture)
 			http.Error(w, "response too large to encrypt", http.StatusBadGateway)
+
 			return
 		}
 
@@ -171,6 +178,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 		if err != nil {
 			log.Printf("enclave middleware: response encrypt error: %v", err)
 			http.Error(w, "response encryption failed", http.StatusInternalServerError)
+
 			return
 		}
 
@@ -181,6 +189,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 		w.Header().Del("Content-Encoding")
 		w.Header().Del("ETag")
 		w.WriteHeader(rec.code())
+
 		if _, err := w.Write(encResp); err != nil {
 			log.Printf("enclave middleware: write encrypted response: %v", err)
 		}
@@ -202,10 +211,12 @@ func (c *responseCapture) Write(b []byte) (int, error) {
 	if c.overflow {
 		return 0, fmt.Errorf("response body exceeds %d byte limit", maxResponseCapture)
 	}
+
 	if c.body.Len()+len(b) > maxResponseCapture {
 		c.overflow = true
 		return 0, fmt.Errorf("response body exceeds %d byte limit", maxResponseCapture)
 	}
+
 	return c.body.Write(b)
 }
 
@@ -220,5 +231,6 @@ func (c *responseCapture) code() int {
 	if c.statusCode == 0 {
 		return http.StatusOK
 	}
+
 	return c.statusCode
 }

--- a/internal/inference/enclave_middleware.go
+++ b/internal/inference/enclave_middleware.go
@@ -190,7 +190,7 @@ func (m *enclaveMiddleware) wrap(next http.Handler) http.Handler {
 		w.Header().Del("ETag")
 		w.WriteHeader(rec.code())
 
-		if _, err := w.Write(encResp); err != nil {
+		if _, err := w.Write(encResp); err != nil { //nolint:gosec // G705: writing encrypted binary, not user-controlled HTML
 			log.Printf("enclave middleware: write encrypted response: %v", err)
 		}
 	})

--- a/internal/inference/enclave_middleware_test.go
+++ b/internal/inference/enclave_middleware_test.go
@@ -20,7 +20,9 @@ func testEnclaveTag(t *testing.T) string {
 	t.Helper()
 	tag := "com.obol.inference.test." + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "."))
 	t.Cleanup(func() { _ = enclave.DeleteKey(tag) })
+
 	_ = enclave.DeleteKey(tag)
+
 	return tag
 }
 
@@ -28,7 +30,9 @@ func testReplyTag(t *testing.T) string {
 	t.Helper()
 	tag := testEnclaveTag(t) + ".reply"
 	t.Cleanup(func() { _ = enclave.DeleteKey(tag) })
+
 	_ = enclave.DeleteKey(tag)
+
 	return tag
 }
 
@@ -54,12 +58,15 @@ func TestEnclavePubkeyEndpoint(t *testing.T) {
 	if got.Tag != em.key.Tag() {
 		t.Fatalf("tag mismatch: want %q, got %q", em.key.Tag(), got.Tag)
 	}
+
 	if got.Algorithm != "ECIES-P256-HKDF-SHA256-AES256GCM" {
 		t.Fatalf("algorithm mismatch: got %q", got.Algorithm)
 	}
+
 	if _, err := hex.DecodeString(got.Pubkey); err != nil {
 		t.Fatalf("pubkey is not valid hex: %v", err)
 	}
+
 	if got.Pubkey != hex.EncodeToString(em.key.PublicKeyBytes()) {
 		t.Fatalf("pubkey mismatch")
 	}
@@ -72,6 +79,7 @@ func TestEnclaveWrapDecryptsEncryptedRequest(t *testing.T) {
 	}
 
 	plaintextReq := `{"model":"llama3","messages":[{"role":"user","content":"hello"}]}`
+
 	encReq, err := enclave.Encrypt(em.key.PublicKeyBytes(), []byte(plaintextReq))
 	if err != nil {
 		t.Fatalf("encrypt request: %v", err)
@@ -82,18 +90,22 @@ func TestEnclaveWrapDecryptsEncryptedRequest(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
+
 		if got := string(body); got != plaintextReq {
 			t.Fatalf("plaintext mismatch: want %s got %s", plaintextReq, got)
 		}
+
 		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 			t.Fatalf("unexpected content-type: %q", ct)
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(encReq))
 	req.Header.Set("Content-Type", contentTypeEncrypted)
+
 	rr := httptest.NewRecorder()
 
 	em.wrap(next).ServeHTTP(rr, req)
@@ -101,6 +113,7 @@ func TestEnclaveWrapDecryptsEncryptedRequest(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status: want 200, got %d", rr.Code)
 	}
+
 	if got := strings.TrimSpace(rr.Body.String()); got != plaintextReq {
 		t.Fatalf("response mismatch: want %s got %s", plaintextReq, got)
 	}
@@ -116,21 +129,26 @@ func TestEnclaveWrapPassesPlaintextThrough(t *testing.T) {
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
+
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
+
 		if got := string(body); got != want {
 			t.Fatalf("body mismatch: want %s got %s", want, got)
 		}
+
 		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 			t.Fatalf("unexpected content-type: %q", ct)
 		}
+
 		w.WriteHeader(http.StatusAccepted)
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(want))
 	req.Header.Set("Content-Type", "application/json")
+
 	rr := httptest.NewRecorder()
 
 	em.wrap(next).ServeHTTP(rr, req)
@@ -138,6 +156,7 @@ func TestEnclaveWrapPassesPlaintextThrough(t *testing.T) {
 	if !called {
 		t.Fatal("next handler was not called")
 	}
+
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("status: want 202, got %d", rr.Code)
 	}
@@ -148,6 +167,7 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newEnclaveMiddleware: %v", err)
 	}
+
 	replyKey, err := enclave.NewKey(testReplyTag(t))
 	if err != nil {
 		t.Fatalf("reply NewKey: %v", err)
@@ -155,6 +175,7 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 
 	plaintextReq := `{"model":"llama3","messages":[{"role":"user","content":"secret"}]}`
 	plaintextResp := `{"choices":[{"message":{"content":"42"}}]}`
+
 	encReq, err := enclave.Encrypt(em.key.PublicKeyBytes(), []byte(plaintextReq))
 	if err != nil {
 		t.Fatalf("encrypt request: %v", err)
@@ -164,6 +185,7 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 		if v := r.Header.Get(headerReplyPubkey); v != "" {
 			t.Fatalf("reply pubkey header should be stripped before upstream, got %q", v)
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Length", strconv.Itoa(len(plaintextResp)))
 		w.Header().Set("Content-Encoding", "identity")
@@ -175,6 +197,7 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(encReq))
 	req.Header.Set("Content-Type", contentTypeEncrypted)
 	req.Header.Set(headerReplyPubkey, hex.EncodeToString(replyKey.PublicKeyBytes()))
+
 	rr := httptest.NewRecorder()
 
 	em.wrap(next).ServeHTTP(rr, req)
@@ -182,15 +205,19 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status: want 201, got %d", rr.Code)
 	}
+
 	if got := rr.Header().Get("Content-Type"); got != contentTypeEncrypted {
 		t.Fatalf("content-type: want %q, got %q", contentTypeEncrypted, got)
 	}
+
 	if rr.Header().Get("Content-Encoding") != "" {
 		t.Fatalf("content-encoding should be cleared, got %q", rr.Header().Get("Content-Encoding"))
 	}
+
 	if rr.Header().Get("ETag") != "" {
 		t.Fatalf("etag should be cleared, got %q", rr.Header().Get("ETag"))
 	}
+
 	wantLen := strconv.Itoa(rr.Body.Len())
 	if got := rr.Header().Get("Content-Length"); got != wantLen {
 		t.Fatalf("content-length: want %q, got %q", wantLen, got)
@@ -200,6 +227,7 @@ func TestEnclaveWrapEncryptsReplyAndRefreshesHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decrypt response: %v", err)
 	}
+
 	if got := string(decrypted); got != plaintextResp {
 		t.Fatalf("decrypted response mismatch: want %s got %s", plaintextResp, got)
 	}
@@ -224,6 +252,7 @@ func TestEnclaveWrapRejectsInvalidReplyPubkey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(encReq))
 	req.Header.Set("Content-Type", contentTypeEncrypted)
 	req.Header.Set(headerReplyPubkey, "not-hex")
+
 	rr := httptest.NewRecorder()
 
 	em.wrap(next).ServeHTTP(rr, req)
@@ -231,6 +260,7 @@ func TestEnclaveWrapRejectsInvalidReplyPubkey(t *testing.T) {
 	if called {
 		t.Fatal("next handler should not run when reply pubkey is invalid")
 	}
+
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status: want 400, got %d", rr.Code)
 	}

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -113,20 +114,25 @@ type Gateway struct {
 // NewGateway creates a new inference gateway with the given configuration.
 func NewGateway(cfg GatewayConfig) (*Gateway, error) {
 	if cfg.TEEType != "" && cfg.EnclaveTag != "" {
-		return nil, fmt.Errorf("TEEType and EnclaveTag are mutually exclusive: set one or neither")
+		return nil, errors.New("TEEType and EnclaveTag are mutually exclusive: set one or neither")
 	}
+
 	if cfg.ListenAddr == "" {
 		cfg.ListenAddr = ":8402"
 	}
+
 	if cfg.FacilitatorURL == "" {
 		cfg.FacilitatorURL = "https://facilitator.x402.rs"
 	}
+
 	if err := x402verifier.ValidateFacilitatorURL(cfg.FacilitatorURL); err != nil {
 		return nil, err
 	}
+
 	if cfg.Chain.NetworkID == "" {
 		cfg.Chain = x402.BaseSepolia
 	}
+
 	if cfg.PricePerRequest == "" {
 		cfg.PricePerRequest = "0.001"
 	}
@@ -172,6 +178,7 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 
 	// Initialise key backend: TEE (Linux) or SE (macOS), mutually exclusive.
 	var em *enclaveMiddleware
+
 	switch {
 	case g.config.TEEType != "":
 		// Linux TEE path — generate key inside TEE (or stub).
@@ -179,10 +186,12 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 		if deployName == "" {
 			deployName = "com.obol.inference.default"
 		}
+
 		seKey, keyErr := tee.NewKey(deployName, g.config.ModelHash)
 		if keyErr != nil {
 			return nil, fmt.Errorf("tee key: %w", keyErr)
 		}
+
 		g.seKey = seKey
 		em = &enclaveMiddleware{key: seKey}
 		log.Printf("  tee:       type=%s tag=%q pubkey=%x...",
@@ -193,10 +202,12 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 		if err := enclave.CheckSIP(); err != nil {
 			return nil, fmt.Errorf("enclave SIP check failed: %w", err)
 		}
+
 		em, err = newEnclaveMiddleware(g.config.EnclaveTag)
 		if err != nil {
 			return nil, fmt.Errorf("enclave middleware: %w", err)
 		}
+
 		g.seKey = em.key
 		log.Printf("  enclave:   tag=%q persistent=%v pubkey=%x...",
 			em.key.Tag(), em.key.Persistent(), em.key.PublicKeyBytes()[:8])
@@ -218,9 +229,11 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 		if em != nil {
 			h = em.wrap(h)
 		}
+
 		if !g.config.NoPaymentGate {
 			h = paymentMiddleware(h)
 		}
+
 		return h
 	}
 
@@ -248,8 +261,10 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 			if err != nil {
 				log.Printf("attestation error: %v", err)
 				http.Error(w, "attestation unavailable", http.StatusInternalServerError)
+
 				return
 			}
+
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(report)
 		})
@@ -277,16 +292,18 @@ func (g *Gateway) Start() error {
 		// Use deployment name from enclave tag suffix if available.
 		if g.config.EnclaveTag != "" {
 			const prefix = "com.obol.inference."
-			if strings.HasPrefix(g.config.EnclaveTag, prefix) {
+			if after, ok := strings.CutPrefix(g.config.EnclaveTag, prefix); ok {
 				cm = newContainerManager(g.config.VMBinary,
-					strings.TrimPrefix(g.config.EnclaveTag, prefix),
+					after,
 					g.config.VMHostPort)
 			}
 		}
+
 		ctx := context.Background()
 		if err := cm.Start(ctx, g.config.VMImage, g.config.VMCPUs, g.config.VMMemoryMB); err != nil {
 			return fmt.Errorf("container start: %w", err)
 		}
+
 		g.container = cm
 		upstreamURL = cm.UpstreamURL()
 		log.Printf("  container:   %s → %s", cm.name, cm.UpstreamURL())
@@ -314,6 +331,7 @@ func (g *Gateway) Start() error {
 	log.Printf("  price:       %s USDC/request", g.config.PricePerRequest)
 	log.Printf("  chain:       %s", g.config.Chain.NetworkID)
 	log.Printf("  facilitator: %s", g.config.FacilitatorURL)
+
 	if g.config.TEEType != "" {
 		log.Printf("  tee:         %s (model_hash=%s)", g.config.TEEType, g.config.ModelHash)
 	} else if g.config.EnclaveTag == "" {
@@ -326,15 +344,18 @@ func (g *Gateway) Start() error {
 // Stop gracefully shuts down the gateway and any managed container.
 func (g *Gateway) Stop() error {
 	var serverErr error
+
 	if g.server != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
 		serverErr = g.server.Shutdown(ctx)
 	}
 
 	if g.container != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
+
 		if err := g.container.Stop(ctx); err != nil {
 			log.Printf("container stop: %v", err)
 		}

--- a/internal/inference/gateway_test.go
+++ b/internal/inference/gateway_test.go
@@ -21,6 +21,7 @@ type mockFacilitatorOpts struct {
 
 type mockFacilitator struct {
 	*httptest.Server
+
 	verifyCalls  atomic.Int32
 	settleCalls  atomic.Int32
 	supportCalls atomic.Int32
@@ -28,6 +29,7 @@ type mockFacilitator struct {
 
 func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator {
 	t.Helper()
+
 	mf := &mockFacilitator{}
 
 	mux := http.NewServeMux()
@@ -41,10 +43,12 @@ func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator
 	mux.HandleFunc("/verify", func(w http.ResponseWriter, r *http.Request) {
 		mf.verifyCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
+
 		if opts.rejectPayment {
 			fmt.Fprintf(w, `{"isValid":false,"invalidReason":"mock rejection"}`)
 			return
 		}
+
 		fmt.Fprintf(w, `{"isValid":true,"payer":"0xmockpayer"}`)
 	})
 
@@ -55,7 +59,8 @@ func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator
 	})
 
 	mf.Server = httptest.NewServer(mux)
-	t.Cleanup(mf.Server.Close)
+	t.Cleanup(mf.Close)
+
 	return mf
 }
 
@@ -63,6 +68,7 @@ func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator
 
 func newMockOllama(t *testing.T) *httptest.Server {
 	t.Helper()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/chat/completions":
@@ -76,6 +82,7 @@ func newMockOllama(t *testing.T) *httptest.Server {
 		}
 	}))
 	t.Cleanup(srv.Close)
+
 	return srv
 }
 
@@ -86,6 +93,7 @@ func newMockOllama(t *testing.T) *httptest.Server {
 // The mock facilitator accepts any payload so no real signature is needed.
 func testPaymentHeader(t *testing.T) string {
 	t.Helper()
+
 	p := x402.PaymentPayload{
 		X402Version: 1,
 		Scheme:      "exact",
@@ -102,10 +110,12 @@ func testPaymentHeader(t *testing.T) string {
 			},
 		},
 	}
+
 	data, err := json.Marshal(p)
 	if err != nil {
 		t.Fatalf("marshal payment: %v", err)
 	}
+
 	return base64.StdEncoding.EncodeToString(data)
 }
 
@@ -113,6 +123,7 @@ func testPaymentHeader(t *testing.T) string {
 // using httptest.NewServer. VMMode and EnclaveTag are always disabled.
 func newTestGateway(t *testing.T, facilitatorURL, upstreamURL string, verifyOnly bool) *httptest.Server {
 	t.Helper()
+
 	gw, err := NewGateway(GatewayConfig{
 		UpstreamURL:     upstreamURL,
 		WalletAddress:   "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -124,12 +135,15 @@ func newTestGateway(t *testing.T, facilitatorURL, upstreamURL string, verifyOnly
 	if err != nil {
 		t.Fatalf("NewGateway: %v", err)
 	}
+
 	handler, err := gw.buildHandler(upstreamURL)
 	if err != nil {
 		t.Fatalf("buildHandler: %v", err)
 	}
+
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
+
 	return ts
 }
 
@@ -166,6 +180,7 @@ func TestGateway_NoPayment_Returns402(t *testing.T) {
 	if resp.StatusCode != http.StatusPaymentRequired {
 		t.Errorf("expected 402, got %d", resp.StatusCode)
 	}
+
 	if fac.verifyCalls.Load() != 0 {
 		t.Error("facilitator verify should not be called without X-PAYMENT header")
 	}
@@ -179,7 +194,7 @@ func TestGateway_ValidPayment_Returns200(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, gw.URL+"/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3.2","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -190,9 +205,11 @@ func TestGateway_ValidPayment_Returns200(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
+
 	if fac.verifyCalls.Load() != 1 {
 		t.Errorf("expected 1 verify call, got %d", fac.verifyCalls.Load())
 	}
+
 	if fac.settleCalls.Load() != 1 {
 		t.Errorf("expected 1 settle call, got %d", fac.settleCalls.Load())
 	}
@@ -206,7 +223,7 @@ func TestGateway_VerifyOnly_SkipsSettle(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, gw.URL+"/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3.2","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -217,9 +234,11 @@ func TestGateway_VerifyOnly_SkipsSettle(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
+
 	if fac.verifyCalls.Load() != 1 {
 		t.Errorf("expected 1 verify call, got %d", fac.verifyCalls.Load())
 	}
+
 	if fac.settleCalls.Load() != 0 {
 		t.Errorf("expected 0 settle calls (verifyOnly), got %d", fac.settleCalls.Load())
 	}
@@ -233,7 +252,7 @@ func TestGateway_FacilitatorRejects_Returns402(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, gw.URL+"/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3.2","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -244,6 +263,7 @@ func TestGateway_FacilitatorRejects_Returns402(t *testing.T) {
 	if resp.StatusCode != http.StatusPaymentRequired {
 		t.Errorf("expected 402 on rejected payment, got %d", resp.StatusCode)
 	}
+
 	if fac.settleCalls.Load() != 0 {
 		t.Error("settle should not be called when verify fails")
 	}
@@ -262,7 +282,7 @@ func TestGateway_UpstreamDown_Returns502(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, gw.URL+"/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3.2","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -286,6 +306,7 @@ func TestGateway_UnprotectedPassthrough(t *testing.T) {
 		t.Fatalf("GET /v1/models: %v", err)
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusPaymentRequired {
 		t.Errorf("GET /v1/models without payment: expected 402, got %d", resp.StatusCode)
 	}
@@ -297,7 +318,7 @@ func TestGateway_ModelsEndpoint_WithPayment(t *testing.T) {
 	gw := newTestGateway(t, fac.URL, ollama.URL, true)
 
 	req, _ := http.NewRequest(http.MethodGet, gw.URL+"/v1/models", nil)
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -315,6 +336,7 @@ func TestGateway_ModelsEndpoint_WithPayment(t *testing.T) {
 // newTestGatewayTEE starts a gateway with TEE stub mode enabled.
 func newTestGatewayTEE(t *testing.T, facilitatorURL, upstreamURL string) *httptest.Server {
 	t.Helper()
+
 	gw, err := NewGateway(GatewayConfig{
 		UpstreamURL:     upstreamURL,
 		WalletAddress:   "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -328,12 +350,15 @@ func newTestGatewayTEE(t *testing.T, facilitatorURL, upstreamURL string) *httpte
 	if err != nil {
 		t.Fatalf("NewGateway: %v", err)
 	}
+
 	handler, err := gw.buildHandler(upstreamURL)
 	if err != nil {
 		t.Fatalf("buildHandler: %v", err)
 	}
+
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
+
 	return ts
 }
 
@@ -366,15 +391,19 @@ func TestGateway_TEE_Attestation(t *testing.T) {
 	if report.TEEType != "stub" {
 		t.Errorf("tee_type = %q, want %q", report.TEEType, "stub")
 	}
+
 	if report.Pubkey == "" {
 		t.Error("pubkey should not be empty")
 	}
+
 	if report.ModelHash == "" {
 		t.Error("model_hash should not be empty")
 	}
+
 	if len(report.Quote) == 0 {
 		t.Error("quote should not be empty")
 	}
+
 	if report.Timestamp == 0 {
 		t.Error("timestamp should not be zero")
 	}
@@ -402,6 +431,7 @@ func TestGateway_TEE_PubkeyEndpoint(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&pk); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
+
 	if pk.Pubkey == "" {
 		t.Error("pubkey should not be empty")
 	}
@@ -418,6 +448,7 @@ func TestGateway_TEE_ECIES_RoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
+
 	var pk struct {
 		Pubkey string `json:"pubkey"`
 	}

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -123,6 +123,7 @@ func ValidateName(name string) error {
 	if !validDeploymentName.MatchString(name) {
 		return fmt.Errorf("invalid deployment name %q: must be 1-63 alphanumeric chars, hyphens, or underscores", name)
 	}
+
 	return nil
 }
 
@@ -153,6 +154,7 @@ func (s *Store) Create(d *Deployment, force bool) error {
 	if err := ValidateName(d.Name); err != nil {
 		return err
 	}
+
 	if _, err := os.Stat(s.configPath(d.Name)); err == nil && !force {
 		return fmt.Errorf("%w: %s", ErrDeploymentExists, d.Name)
 	}
@@ -161,25 +163,32 @@ func (s *Store) Create(d *Deployment, force bool) error {
 	if d.EnclaveTag == "" {
 		d.EnclaveTag = "com.obol.inference." + d.Name
 	}
+
 	if d.ListenAddr == "" {
 		d.ListenAddr = ":8402"
 	}
+
 	if d.UpstreamURL == "" {
 		d.UpstreamURL = "http://localhost:11434"
 	}
+
 	if d.PricePerRequest == "" {
 		d.PricePerRequest = "0.001"
 	}
+
 	if d.Chain == "" {
 		d.Chain = "base-sepolia"
 	}
+
 	if d.FacilitatorURL == "" {
 		d.FacilitatorURL = "https://facilitator.x402.rs"
 	}
+
 	now := time.Now().UTC().Format(time.RFC3339)
 	if d.CreatedAt == "" {
 		d.CreatedAt = now
 	}
+
 	d.UpdatedAt = now
 
 	if err := os.MkdirAll(s.dir(d.Name), 0o700); err != nil {
@@ -190,9 +199,11 @@ func (s *Store) Create(d *Deployment, force bool) error {
 	if err != nil {
 		return fmt.Errorf("inference store: marshal: %w", err)
 	}
+
 	if err := os.WriteFile(s.configPath(d.Name), data, 0o600); err != nil {
 		return fmt.Errorf("inference store: write: %w", err)
 	}
+
 	return nil
 }
 
@@ -201,17 +212,21 @@ func (s *Store) Get(name string) (*Deployment, error) {
 	if err := ValidateName(name); err != nil {
 		return nil, err
 	}
+
 	data, err := os.ReadFile(s.configPath(name))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("%w: %s", ErrDeploymentNotFound, name)
 		}
+
 		return nil, fmt.Errorf("inference store: read %s: %w", name, err)
 	}
+
 	var d Deployment
 	if err := json.Unmarshal(data, &d); err != nil {
 		return nil, fmt.Errorf("inference store: parse %s: %w", name, err)
 	}
+
 	return &d, nil
 }
 
@@ -222,20 +237,25 @@ func (s *Store) List() ([]*Deployment, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil // empty — not an error
 		}
+
 		return nil, fmt.Errorf("inference store: list: %w", err)
 	}
 
 	var deployments []*Deployment
+
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
+
 		d, err := s.Get(e.Name())
 		if err != nil {
 			continue // skip malformed entries
 		}
+
 		deployments = append(deployments, d)
 	}
+
 	return deployments, nil
 }
 
@@ -246,12 +266,15 @@ func (s *Store) Delete(name string) error {
 	if err := ValidateName(name); err != nil {
 		return err
 	}
+
 	if _, err := s.Get(name); err != nil {
 		return err
 	}
+
 	if err := os.RemoveAll(s.dir(name)); err != nil {
 		return fmt.Errorf("inference store: delete %s: %w", name, err)
 	}
+
 	return nil
 }
 
@@ -260,10 +283,13 @@ func (s *Store) Update(d *Deployment) error {
 	if _, err := s.Get(d.Name); err != nil {
 		return err
 	}
+
 	d.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
 	data, err := json.MarshalIndent(d, "", "  ")
 	if err != nil {
 		return fmt.Errorf("inference store: marshal: %w", err)
 	}
+
 	return os.WriteFile(s.configPath(d.Name), data, 0o600)
 }

--- a/internal/inference/store_test.go
+++ b/internal/inference/store_test.go
@@ -25,9 +25,11 @@ func TestStoreCreateAndGet(t *testing.T) {
 	if d.EnclaveTag == "" {
 		t.Error("EnclaveTag should have been set by Create")
 	}
+
 	if d.Chain == "" {
 		t.Error("Chain should have been set by Create")
 	}
+
 	if d.CreatedAt == "" {
 		t.Error("CreatedAt should have been set by Create")
 	}
@@ -36,12 +38,15 @@ func TestStoreCreateAndGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
+
 	if got.Name != "test-deploy" {
 		t.Errorf("Name mismatch: %s", got.Name)
 	}
+
 	if got.WalletAddress != "0xdeadbeef" {
 		t.Errorf("WalletAddress mismatch: %s", got.WalletAddress)
 	}
+
 	if got.EnclaveTag != "com.obol.inference.test-deploy" {
 		t.Errorf("unexpected EnclaveTag: %s", got.EnclaveTag)
 	}
@@ -67,12 +72,15 @@ func TestStoreCreate_PersistsPerMTokMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
+
 	if got.PricePerRequest != "0.0005" {
 		t.Errorf("PricePerRequest = %q, want %q", got.PricePerRequest, "0.0005")
 	}
+
 	if got.PricePerMTok != "0.50" {
 		t.Errorf("PricePerMTok = %q, want %q", got.PricePerMTok, "0.50")
 	}
+
 	if got.ApproxTokensPerRequest != 1000 {
 		t.Errorf("ApproxTokensPerRequest = %d, want %d", got.ApproxTokensPerRequest, 1000)
 	}
@@ -103,24 +111,31 @@ func TestStoreCreate_PersistsCanonicalProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
+
 	if got.Provenance == nil {
 		t.Fatal("Provenance should be persisted")
 	}
+
 	if got.Provenance.Framework != "autoresearch" {
 		t.Errorf("Framework = %q, want %q", got.Provenance.Framework, "autoresearch")
 	}
+
 	if got.Provenance.MetricName != "val_bpb" {
 		t.Errorf("MetricName = %q, want %q", got.Provenance.MetricName, "val_bpb")
 	}
+
 	if got.Provenance.MetricValue != "0.9973" {
 		t.Errorf("MetricValue = %q, want %q", got.Provenance.MetricValue, "0.9973")
 	}
+
 	if got.Provenance.ExperimentID != "abc123" {
 		t.Errorf("ExperimentID = %q, want %q", got.Provenance.ExperimentID, "abc123")
 	}
+
 	if got.Provenance.TrainHash != "sha256:deadbeef" {
 		t.Errorf("TrainHash = %q, want %q", got.Provenance.TrainHash, "sha256:deadbeef")
 	}
+
 	if got.Provenance.ParamCount != "50000000" {
 		t.Errorf("ParamCount = %q, want %q", got.Provenance.ParamCount, "50000000")
 	}
@@ -162,6 +177,7 @@ func TestStoreList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
+
 	if len(list) != len(names) {
 		t.Fatalf("List returned %d deployments, want %d", len(list), len(names))
 	}
@@ -175,6 +191,7 @@ func TestStoreListEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List on empty store: %v", err)
 	}
+
 	if len(list) != 0 {
 		t.Fatalf("expected empty list, got %d items", len(list))
 	}
@@ -187,9 +204,11 @@ func TestStoreDelete(t *testing.T) {
 	if err := store.Create(&inference.Deployment{Name: "todelete"}, false); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+
 	if err := store.Delete("todelete"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
+
 	if _, err := store.Get("todelete"); !errors.Is(err, inference.ErrDeploymentNotFound) {
 		t.Fatalf("expected ErrDeploymentNotFound after delete, got %v", err)
 	}
@@ -223,9 +242,11 @@ func TestStoreUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get after update: %v", err)
 	}
+
 	if got.Chain != "polygon" {
 		t.Errorf("Chain not updated: %s", got.Chain)
 	}
+
 	if got.UpdatedAt == "" {
 		t.Error("UpdatedAt should be set after Update")
 	}
@@ -243,10 +264,12 @@ func TestStoreDirPermissions(t *testing.T) {
 
 	// Config file should be 0600.
 	cfgPath := dir + "/inference/perm-test/config.json"
+
 	info, err := os.Stat(cfgPath)
 	if err != nil {
 		t.Fatalf("stat config: %v", err)
 	}
+
 	if mode := info.Mode().Perm(); mode != 0o600 {
 		t.Errorf("config.json permissions: want 0600, got %04o", mode)
 	}

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -6,6 +6,7 @@ package kubectl
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,8 +21,9 @@ import (
 func EnsureCluster(cfg *config.Config) error {
 	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
+
 	return nil
 }
 
@@ -35,17 +37,23 @@ func Paths(cfg *config.Config) (binary, kubeconfig string) {
 // capturing stderr. The error message includes stderr output on failure.
 func Run(binary, kubeconfig string, args ...string) error {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
+
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -53,16 +61,21 @@ func Run(binary, kubeconfig string, args ...string) error {
 // and included in the returned error on failure.
 func RunSilent(binary, kubeconfig string, args ...string) error {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -70,34 +83,45 @@ func RunSilent(binary, kubeconfig string, args ...string) error {
 // captured and included in the returned error on failure.
 func Output(binary, kubeconfig string, args ...string) (string, error) {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stdout, stderr bytes.Buffer
+
 	cmd.Stdout = &stdout
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return "", fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return "", err
 	}
+
 	return stdout.String(), nil
 }
 
 // Apply pipes the given data into kubectl apply -f -.
 func Apply(binary, kubeconfig string, data []byte) error {
 	cmd := exec.Command(binary, "apply", "-f", "-")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
 	cmd.Stdin = bytes.NewReader(data)
 	cmd.Stdout = os.Stdout
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return fmt.Errorf("kubectl apply: %w: %s", err, errMsg)
 		}
+
 		return fmt.Errorf("kubectl apply: %w", err)
 	}
+
 	return nil
 }

--- a/internal/kubectl/kubectl_test.go
+++ b/internal/kubectl/kubectl_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestEnsureCluster_Missing(t *testing.T) {
 	cfg := &config.Config{ConfigDir: t.TempDir()}
+
 	err := EnsureCluster(cfg)
 	if err == nil {
 		t.Fatal("expected error when kubeconfig missing")
@@ -18,9 +19,10 @@ func TestEnsureCluster_Missing(t *testing.T) {
 
 func TestEnsureCluster_Exists(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+
 	cfg := &config.Config{ConfigDir: dir}
 	if err := EnsureCluster(cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -32,10 +34,12 @@ func TestPaths(t *testing.T) {
 		BinDir:    "/usr/local/bin",
 		ConfigDir: "/home/user/.config/obol",
 	}
+
 	bin, kc := Paths(cfg)
 	if bin != "/usr/local/bin/kubectl" {
 		t.Errorf("binary = %q, want /usr/local/bin/kubectl", bin)
 	}
+
 	if kc != "/home/user/.config/obol/kubeconfig.yaml" {
 		t.Errorf("kubeconfig = %q, want /home/user/.config/obol/kubeconfig.yaml", kc)
 	}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	encoding_base64 "encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -91,6 +92,7 @@ func HasConfiguredModels(cfg *config.Config) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -125,6 +127,7 @@ func HasProviderConfigured(cfg *config.Config, provider string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -133,27 +136,33 @@ func HasProviderConfigured(cfg *config.Config, provider string) bool {
 // Skips comments (#) and blank lines. Does not call os.Setenv.
 func LoadDotEnv(path string) map[string]string {
 	result := make(map[string]string)
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return result
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
+
 		idx := strings.IndexByte(line, '=')
 		if idx < 1 {
 			continue
 		}
+
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
 		// Strip surrounding quotes
 		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
 			val = val[1 : len(val)-1]
 		}
+
 		result[key] = val
 	}
+
 	return result
 }
 
@@ -166,6 +175,7 @@ func ConfigureLiteLLM(cfg *config.Config, u *ui.UI, provider, apiKey string, mod
 	if err := PatchLiteLLMProvider(cfg, u, provider, apiKey, models); err != nil {
 		return err
 	}
+
 	return RestartLiteLLM(cfg, u, provider)
 }
 
@@ -177,13 +187,14 @@ func PatchLiteLLMProvider(cfg *config.Config, u *ui.UI, provider, apiKey string,
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	// 1. Patch Secret with API key (if cloud provider)
 	envVar := ProviderEnvVar(provider)
 	if envVar != "" && apiKey != "" {
 		u.Infof("Setting %s API key", provider)
+
 		patchJSON := fmt.Sprintf(`{"stringData":{"%s":"%s"}}`, envVar, apiKey)
 		if err := kubectl.Run(kubectlBinary, kubeconfigPath,
 			"patch", "secret", secretName, "-n", namespace,
@@ -200,6 +211,7 @@ func PatchLiteLLMProvider(cfg *config.Config, u *ui.UI, provider, apiKey string,
 
 	// 3. Patch ConfigMap with new model_list entries
 	u.Infof("Adding %d model(s) to LiteLLM config", len(entries))
+
 	if err := patchLiteLLMConfig(kubectlBinary, kubeconfigPath, entries); err != nil {
 		return fmt.Errorf("failed to update LiteLLM config: %w", err)
 	}
@@ -213,13 +225,14 @@ func RestartLiteLLM(cfg *config.Config, u *ui.UI, provider string) error {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	u.Info("Restarting LiteLLM")
+
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "restart", fmt.Sprintf("deployment/%s", deployName), "-n", namespace); err != nil {
+		"rollout", "restart", "deployment/"+deployName, "-n", namespace); err != nil {
 		return fmt.Errorf("failed to restart LiteLLM: %w", err)
 	}
 
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "status", fmt.Sprintf("deployment/%s", deployName), "-n", namespace,
+		"rollout", "status", "deployment/"+deployName, "-n", namespace,
 		"--timeout=90s"); err != nil {
 		u.Warnf("LiteLLM rollout not confirmed: %v", err)
 		u.Print("The deployment may still be rolling out.")
@@ -236,7 +249,7 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	// Read current config
@@ -253,12 +266,15 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 
 	// Find and remove matching entries
 	var kept []ModelEntry
+
 	removed := 0
+
 	for _, entry := range litellmConfig.ModelList {
 		if entry.ModelName == modelName {
 			removed++
 			continue
 		}
+
 		kept = append(kept, entry)
 	}
 
@@ -279,9 +295,11 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to escape YAML: %w", err)
 	}
+
 	patchJSON := fmt.Sprintf(`{"data":{"config.yaml":%s}}`, escapedYAML)
 
 	u.Infof("Removing model %q from LiteLLM config", modelName)
+
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
 		"patch", "configmap", configMapName, "-n", namespace,
 		"-p", patchJSON, "--type=merge"); err != nil {
@@ -290,13 +308,14 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 
 	// Restart deployment
 	u.Info("Restarting LiteLLM")
+
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "restart", fmt.Sprintf("deployment/%s", deployName), "-n", namespace); err != nil {
+		"rollout", "restart", "deployment/"+deployName, "-n", namespace); err != nil {
 		return fmt.Errorf("failed to restart LiteLLM: %w", err)
 	}
 
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "status", fmt.Sprintf("deployment/%s", deployName), "-n", namespace,
+		"rollout", "status", "deployment/"+deployName, "-n", namespace,
 		"--timeout=90s"); err != nil {
 		u.Warnf("LiteLLM rollout not confirmed: %v", err)
 	} else {
@@ -313,18 +332,21 @@ func AddCustomEndpoint(cfg *config.Config, u *ui.UI, name, endpoint, modelName, 
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	// Validate the endpoint from the host (use localhost-reachable URL)
 	u.Info("Validating custom endpoint...")
+
 	validationEndpoint := endpoint
 	// If the user gave a k3d-internal URL, translate for host validation
 	validationEndpoint = strings.Replace(validationEndpoint, "host.k3d.internal", "localhost", 1)
+
 	validationEndpoint = strings.Replace(validationEndpoint, "host.docker.internal", "localhost", 1)
 	if err := ValidateCustomEndpoint(validationEndpoint, modelName, apiKey); err != nil {
 		return fmt.Errorf("endpoint validation failed: %w", err)
 	}
+
 	u.Success("Endpoint validated successfully")
 
 	// For the cluster ConfigMap, translate localhost to k3d-internal
@@ -336,6 +358,7 @@ func AddCustomEndpoint(cfg *config.Config, u *ui.UI, name, endpoint, modelName, 
 	// Build model entry
 	litellmModel := "openai/" + modelName
 	modelID := fmt.Sprintf("custom/%s/%s", name, modelName)
+
 	entry := ModelEntry{
 		ModelName: modelID,
 		LiteLLMParams: LiteLLMParams{
@@ -350,18 +373,21 @@ func AddCustomEndpoint(cfg *config.Config, u *ui.UI, name, endpoint, modelName, 
 
 	// Patch config
 	u.Infof("Adding custom endpoint %q to LiteLLM config", name)
+
 	if err := patchLiteLLMConfig(kubectlBinary, kubeconfigPath, []ModelEntry{entry}); err != nil {
 		return fmt.Errorf("failed to update LiteLLM config: %w", err)
 	}
 
 	// Restart
 	u.Info("Restarting LiteLLM")
+
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "restart", fmt.Sprintf("deployment/%s", deployName), "-n", namespace); err != nil {
+		"rollout", "restart", "deployment/"+deployName, "-n", namespace); err != nil {
 		return fmt.Errorf("failed to restart LiteLLM: %w", err)
 	}
+
 	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
-		"rollout", "status", fmt.Sprintf("deployment/%s", deployName), "-n", namespace,
+		"rollout", "status", "deployment/"+deployName, "-n", namespace,
 		"--timeout=90s"); err != nil {
 		u.Warnf("LiteLLM rollout not confirmed: %v", err)
 	} else {
@@ -377,6 +403,7 @@ func AddCustomEndpoint(cfg *config.Config, u *ui.UI, name, endpoint, modelName, 
 // list the loaded model in /models but accept it for inference.
 func ValidateCustomEndpoint(endpoint, modelName, apiKey string) error {
 	client := &http.Client{Timeout: 60 * time.Second}
+
 	authHeader := ""
 	if apiKey != "" {
 		authHeader = "Bearer " + apiKey
@@ -385,24 +412,30 @@ func ValidateCustomEndpoint(endpoint, modelName, apiKey string) error {
 	// Step 1: Reachability check — try /models, /health, or / (in that order)
 	base := strings.TrimRight(endpoint, "/")
 	reachable := false
+
 	for _, path := range []string{"/models", "/health", ""} {
-		req, err := http.NewRequest("GET", base+path, nil)
+		req, err := http.NewRequest(http.MethodGet, base+path, nil)
 		if err != nil {
 			continue
 		}
+
 		if authHeader != "" {
 			req.Header.Set("Authorization", authHeader)
 		}
+
 		resp, err := client.Do(req)
 		if err != nil {
 			continue
 		}
+
 		resp.Body.Close()
+
 		if resp.StatusCode < 500 {
 			reachable = true
 			break
 		}
 	}
+
 	if !reachable {
 		return fmt.Errorf("endpoint unreachable — cannot connect to %s", base)
 	}
@@ -414,19 +447,24 @@ func ValidateCustomEndpoint(endpoint, modelName, apiKey string) error {
 		"max_tokens": 1,
 	})
 	completionsURL := strings.TrimRight(endpoint, "/") + "/chat/completions"
-	probeReq, err := http.NewRequest("POST", completionsURL, bytes.NewReader(probePayload))
+
+	probeReq, err := http.NewRequest(http.MethodPost, completionsURL, bytes.NewReader(probePayload))
 	if err != nil {
 		return fmt.Errorf("failed to build inference probe: %w", err)
 	}
+
 	probeReq.Header.Set("Content-Type", "application/json")
+
 	if authHeader != "" {
 		probeReq.Header.Set("Authorization", authHeader)
 	}
+
 	probeResp, err := client.Do(probeReq)
 	if err != nil {
 		return fmt.Errorf("inference probe failed — cannot reach %s: %w", completionsURL, err)
 	}
 	defer probeResp.Body.Close()
+
 	if probeResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("inference probe failed — %s returned %d", completionsURL, probeResp.StatusCode)
 	}
@@ -441,8 +479,9 @@ func ValidateCustomEndpoint(endpoint, modelName, apiKey string) error {
 	if err := json.NewDecoder(probeResp.Body).Decode(&chatResp); err != nil {
 		return fmt.Errorf("inference probe returned invalid response: %w", err)
 	}
+
 	if len(chatResp.Choices) == 0 {
-		return fmt.Errorf("inference probe returned empty choices array")
+		return errors.New("inference probe returned empty choices array")
 	}
 
 	return nil
@@ -456,9 +495,10 @@ func GetAvailableProviders(_ *config.Config) ([]ProviderInfo, error) {
 // GetProviderStatus reads LiteLLM config and returns provider status.
 func GetProviderStatus(cfg *config.Config) (map[string]ProviderStatus, error) {
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return nil, errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	// Read config.yaml from ConfigMap
@@ -492,7 +532,9 @@ func buildProviderStatus(configYAML, secretJSON []byte) (map[string]ProviderStat
 	if err := json.Unmarshal(secretJSON, &secret); err != nil {
 		return nil, fmt.Errorf("failed to parse secret: %w", err)
 	}
+
 	secretKeys := make(map[string]bool)
+
 	for k, v := range secret.Data {
 		if strings.TrimSpace(v) != "" {
 			secretKeys[k] = true
@@ -501,6 +543,7 @@ func buildProviderStatus(configYAML, secretJSON []byte) (map[string]ProviderStat
 
 	// Build status from model_list
 	status := make(map[string]ProviderStatus)
+
 	for _, entry := range litellmConfig.ModelList {
 		provider := detectProvider(entry)
 		st := status[provider]
@@ -512,13 +555,16 @@ func buildProviderStatus(configYAML, secretJSON []byte) (map[string]ProviderStat
 	// Add env var info and API key status
 	for _, p := range knownProviders {
 		st := status[p.ID]
+
 		st.EnvVar = p.EnvVar
 		if p.EnvVar != "" && secretKeys[p.EnvVar] {
 			st.HasAPIKey = true
 		}
+
 		if p.ID == "ollama" {
 			st.HasAPIKey = true // Ollama doesn't need a key
 		}
+
 		status[p.ID] = st
 	}
 
@@ -528,9 +574,10 @@ func buildProviderStatus(configYAML, secretJSON []byte) (map[string]ProviderStat
 // GetMasterKey reads the LiteLLM master key from the cluster Secret.
 func GetMasterKey(cfg *config.Config) (string, error) {
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("cluster not running")
+		return "", errors.New("cluster not running")
 	}
 
 	key, err := kubectl.Output(kubectlBinary, kubeconfigPath,
@@ -544,6 +591,7 @@ func GetMasterKey(cfg *config.Config) (string, error) {
 	if err != nil {
 		return key, nil // If not base64, return raw
 	}
+
 	return decoded, nil
 }
 
@@ -553,9 +601,10 @@ func GetMasterKey(cfg *config.Config) (string, error) {
 // baked-in WellKnownModels list if the cluster is unreachable.
 func GetConfiguredModels(cfg *config.Config) ([]string, error) {
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster not running")
+		return nil, errors.New("cluster not running")
 	}
 
 	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
@@ -573,12 +622,15 @@ func GetConfiguredModels(cfg *config.Config) ([]string, error) {
 	liveModels := queryLiteLLMModels(kubectlBinary, kubeconfigPath)
 
 	var models []string
+
 	seen := make(map[string]bool)
+
 	for _, entry := range litellmConfig.ModelList {
 		name := entry.ModelName
-		if strings.HasSuffix(name, "/*") {
+		if before, ok := strings.CutSuffix(name, "/*"); ok {
 			// Expand wildcard: prefer live models, fall back to well-known
-			provider := strings.TrimSuffix(name, "/*")
+			provider := before
+
 			expanded := expandWildcard(provider, liveModels)
 			for _, m := range expanded {
 				if !seen[m] {
@@ -586,13 +638,16 @@ func GetConfiguredModels(cfg *config.Config) ([]string, error) {
 					seen[m] = true
 				}
 			}
+
 			continue
 		}
+
 		if !seen[name] {
 			models = append(models, name)
 			seen[name] = true
 		}
 	}
+
 	return models, nil
 }
 
@@ -601,11 +656,12 @@ func GetConfiguredModels(cfg *config.Config) ([]string, error) {
 func queryLiteLLMModels(kubectlBinary, kubeconfigPath string) []string {
 	// Use kubectl exec to query from inside the cluster (avoids port-forward)
 	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
-		"exec", "-n", namespace, fmt.Sprintf("deployment/%s", deployName), "--",
+		"exec", "-n", namespace, "deployment/"+deployName, "--",
 		"curl", "-sf", "http://localhost:4000/v1/models")
 	if err != nil {
 		return nil
 	}
+
 	var resp struct {
 		Data []struct {
 			ID string `json:"id"`
@@ -614,10 +670,12 @@ func queryLiteLLMModels(kubectlBinary, kubeconfigPath string) []string {
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		return nil
 	}
+
 	var models []string
 	for _, m := range resp.Data {
 		models = append(models, m.ID)
 	}
+
 	return models
 }
 
@@ -627,12 +685,14 @@ func expandWildcard(provider string, liveModels []string) []string {
 	// Filter live models that match this provider
 	if len(liveModels) > 0 {
 		var matched []string
+
 		for _, m := range liveModels {
 			p := ProviderFromModelName(m)
 			if p == provider {
 				matched = append(matched, m)
 			}
 		}
+
 		if len(matched) > 0 {
 			return matched
 		}
@@ -641,6 +701,7 @@ func expandWildcard(provider string, liveModels []string) []string {
 	if known, ok := WellKnownModels[provider]; ok {
 		return known
 	}
+
 	return nil
 }
 
@@ -649,9 +710,11 @@ func ProviderFromModelName(name string) string {
 	if strings.Contains(name, "claude") {
 		return "anthropic"
 	}
+
 	if strings.HasPrefix(name, "gpt") || strings.HasPrefix(name, "o1") || strings.HasPrefix(name, "o3") || strings.HasPrefix(name, "o4") {
 		return "openai"
 	}
+
 	return ""
 }
 
@@ -665,18 +728,22 @@ func ResolveAPIKey(provider string) (key, envVarUsed string) {
 		if p.ID != provider {
 			continue
 		}
+
 		if p.EnvVar != "" {
 			if v := os.Getenv(p.EnvVar); v != "" {
 				return v, p.EnvVar
 			}
 		}
+
 		for _, alt := range p.AltEnvVars {
 			if v := os.Getenv(alt); v != "" {
 				return v, alt
 			}
 		}
+
 		return "", ""
 	}
+
 	return "", ""
 }
 
@@ -687,6 +754,7 @@ func ProviderEnvVar(provider string) string {
 			return p.EnvVar
 		}
 	}
+
 	return strings.ToUpper(provider) + "_API_KEY"
 }
 
@@ -715,6 +783,7 @@ var WellKnownModels = map[string][]string{
 // (wildcards are broken for ollama_chat/).
 func buildModelEntries(provider string, models []string) []ModelEntry {
 	var entries []ModelEntry
+
 	switch provider {
 	case "ollama":
 		// Explicit entries — ollama_chat/* wildcards are broken in LiteLLM
@@ -762,6 +831,7 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 			})
 		}
 	}
+
 	return entries
 }
 
@@ -785,6 +855,7 @@ func patchLiteLLMConfig(kubectlBinary, kubeconfigPath string, entries []ModelEnt
 	for i, e := range litellmConfig.ModelList {
 		existing[e.ModelName] = i
 	}
+
 	for _, entry := range entries {
 		if idx, ok := existing[entry.ModelName]; ok {
 			litellmConfig.ModelList[idx] = entry
@@ -804,6 +875,7 @@ func patchLiteLLMConfig(kubectlBinary, kubeconfigPath string, entries []ModelEnt
 	if err != nil {
 		return fmt.Errorf("failed to escape YAML: %w", err)
 	}
+
 	patchJSON := fmt.Sprintf(`{"data":{"config.yaml":%s}}`, escapedYAML)
 
 	return kubectl.Run(kubectlBinary, kubeconfigPath,
@@ -816,17 +888,21 @@ func detectProvider(entry ModelEntry) string {
 	if strings.HasPrefix(entry.ModelName, "custom/") {
 		return "custom"
 	}
+
 	if strings.HasPrefix(entry.ModelName, "paid/") {
 		return "paid"
 	}
+
 	model := entry.LiteLLMParams.Model
 	// Wildcard entries
 	if strings.HasPrefix(model, "anthropic/") {
 		return "anthropic"
 	}
+
 	if strings.HasPrefix(model, "ollama/") || strings.HasPrefix(model, "ollama_chat/") {
 		return "ollama"
 	}
+
 	if strings.HasPrefix(model, "openai/") {
 		return "openai"
 	}
@@ -834,18 +910,22 @@ func detectProvider(entry ModelEntry) string {
 	if strings.Contains(model, "claude") {
 		return "anthropic"
 	}
+
 	if strings.HasPrefix(model, "gpt") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") {
 		return "openai"
 	}
+
 	return "unknown"
 }
 
 func decodeBase64(s string) (string, error) {
 	decoded := make([]byte, len(s))
+
 	n, err := encoding_base64.StdEncoding.Decode(decoded, []byte(s))
 	if err != nil {
 		return "", err
 	}
+
 	return string(decoded[:n]), nil
 }
 
@@ -857,8 +937,10 @@ func WarnAndStripV1Suffix(endpoint string) string {
 	if strings.HasSuffix(trimmed, "/v1") {
 		fmt.Printf("  Warning: stripping trailing /v1 from endpoint URL (LiteLLM adds it automatically)\n")
 		fmt.Printf("  %s → %s\n", trimmed, strings.TrimSuffix(trimmed, "/v1"))
+
 		return strings.TrimSuffix(trimmed, "/v1")
 	}
+
 	return endpoint
 }
 
@@ -870,6 +952,7 @@ func localhostToClusterEndpoint(endpoint string) string {
 			return strings.Replace(endpoint, local, "host.k3d.internal", 1)
 		}
 	}
+
 	return endpoint
 }
 
@@ -882,8 +965,10 @@ func ollamaEndpoint() string {
 		if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 			host = "http://" + host
 		}
+
 		return strings.TrimRight(host, "/")
 	}
+
 	return "http://localhost:11434"
 }
 
@@ -898,12 +983,14 @@ type OllamaModel struct {
 // Returns nil and an error if Ollama is not reachable.
 func ListOllamaModels() ([]OllamaModel, error) {
 	endpoint := ollamaEndpoint()
+
 	tagsURL, err := url.JoinPath(endpoint, "api", "tags")
 	if err != nil {
 		return nil, fmt.Errorf("invalid Ollama endpoint: %w", err)
 	}
 
 	client := &http.Client{Timeout: 3 * time.Second}
+
 	resp, err := client.Get(tagsURL)
 	if err != nil {
 		return nil, fmt.Errorf("Ollama is not running at %s: %w", endpoint, err)
@@ -920,6 +1007,7 @@ func ListOllamaModels() ([]OllamaModel, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to parse Ollama response: %w", err)
 	}
+
 	return result.Models, nil
 }
 
@@ -927,6 +1015,7 @@ func ListOllamaModels() ([]OllamaModel, error) {
 // It streams progress to stdout, matching the UX of `ollama pull`.
 func PullOllamaModel(name string) error {
 	endpoint := ollamaEndpoint()
+
 	pullURL, err := url.JoinPath(endpoint, "api", "pull")
 	if err != nil {
 		return fmt.Errorf("invalid Ollama endpoint: %w", err)
@@ -934,14 +1023,16 @@ func PullOllamaModel(name string) error {
 
 	// Check Ollama is reachable first
 	client := &http.Client{Timeout: 3 * time.Second}
+
 	healthResp, err := client.Get(endpoint)
 	if err != nil {
 		return fmt.Errorf("Ollama is not running at %s — start it first", endpoint)
 	}
+
 	healthResp.Body.Close()
 
 	// POST /api/pull with streaming response
-	body, err := json.Marshal(map[string]interface{}{
+	body, err := json.Marshal(map[string]any{
 		"name":   name,
 		"stream": true,
 	})
@@ -951,6 +1042,7 @@ func PullOllamaModel(name string) error {
 
 	// Use a long timeout — model downloads can take a while
 	pullClient := &http.Client{Timeout: 0}
+
 	resp, err := pullClient.Post(pullURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to start pull: %w", err)
@@ -964,6 +1056,7 @@ func PullOllamaModel(name string) error {
 		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil && errBody.Error != "" {
 			return fmt.Errorf("pull failed: %s", errBody.Error)
 		}
+
 		return fmt.Errorf("pull failed with status %d", resp.StatusCode)
 	}
 
@@ -973,6 +1066,7 @@ func PullOllamaModel(name string) error {
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	var lastStatus string
+
 	for scanner.Scan() {
 		var progress struct {
 			Status    string `json:"status"`
@@ -997,10 +1091,12 @@ func PullOllamaModel(name string) error {
 			if lastStatus != "" {
 				fmt.Println()
 			}
+
 			fmt.Printf("  %s", progress.Status)
 			lastStatus = progress.Status
 		}
 	}
+
 	fmt.Println()
 
 	if err := scanner.Err(); err != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -25,13 +25,18 @@ const (
 	secretName    = "litellm-secrets"
 	configMapName = "litellm-config"
 	deployName    = "litellm"
+
+	// Provider name constants used in model routing and configuration.
+	ProviderOllama    = "ollama"
+	ProviderAnthropic = "anthropic"
+	ProviderOpenAI    = "openai"
 )
 
 // Known provider definitions — no need to query the running pod.
 var knownProviders = []ProviderInfo{
-	{ID: "anthropic", Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY", AltEnvVars: []string{"CLAUDE_CODE_OAUTH_TOKEN"}},
-	{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY"},
-	{ID: "ollama", Name: "Ollama (local)", EnvVar: ""},
+	{ID: ProviderAnthropic, Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY", AltEnvVars: []string{"CLAUDE_CODE_OAUTH_TOKEN"}},
+	{ID: ProviderOpenAI, Name: "OpenAI", EnvVar: "OPENAI_API_KEY"},
+	{ID: ProviderOllama, Name: "Ollama (local)", EnvVar: ""},
 }
 
 // ProviderInfo describes an LLM provider.
@@ -561,7 +566,7 @@ func buildProviderStatus(configYAML, secretJSON []byte) (map[string]ProviderStat
 			st.HasAPIKey = true
 		}
 
-		if p.ID == "ollama" {
+		if p.ID == ProviderOllama {
 			st.HasAPIKey = true // Ollama doesn't need a key
 		}
 
@@ -708,11 +713,11 @@ func expandWildcard(provider string, liveModels []string) []string {
 // ProviderFromModelName infers the provider from a model name string.
 func ProviderFromModelName(name string) string {
 	if strings.Contains(name, "claude") {
-		return "anthropic"
+		return ProviderAnthropic
 	}
 
 	if strings.HasPrefix(name, "gpt") || strings.HasPrefix(name, "o1") || strings.HasPrefix(name, "o3") || strings.HasPrefix(name, "o4") {
-		return "openai"
+		return ProviderOpenAI
 	}
 
 	return ""
@@ -762,13 +767,13 @@ func ProviderEnvVar(provider string) string {
 // Used to populate OpenClaw's model allowlist when a wildcard is configured
 // and the LiteLLM pod is not reachable for a live /v1/models query.
 var WellKnownModels = map[string][]string{
-	"anthropic": {
+	ProviderAnthropic: {
 		"claude-opus-4-6",
 		"claude-sonnet-4-6",
 		"claude-haiku-4-5-20251001",
 		"claude-sonnet-4-5-20250929",
 	},
-	"openai": {
+	ProviderOpenAI: {
 		"gpt-5.4",
 		"gpt-4.1",
 		"gpt-4.1-mini",
@@ -785,7 +790,7 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 	var entries []ModelEntry
 
 	switch provider {
-	case "ollama":
+	case ProviderOllama:
 		// Explicit entries — ollama_chat/* wildcards are broken in LiteLLM
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
@@ -796,7 +801,7 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 				},
 			})
 		}
-	case "anthropic":
+	case ProviderAnthropic:
 		// Wildcard: routes any anthropic model without explicit registration
 		entries = append(entries, ModelEntry{
 			ModelName:     "anthropic/*",
@@ -809,7 +814,7 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 				LiteLLMParams: LiteLLMParams{Model: m, APIKey: "os.environ/ANTHROPIC_API_KEY"},
 			})
 		}
-	case "openai":
+	case ProviderOpenAI:
 		entries = append(entries, ModelEntry{
 			ModelName:     "openai/*",
 			LiteLLMParams: LiteLLMParams{Model: "openai/*", APIKey: "os.environ/OPENAI_API_KEY"},
@@ -895,24 +900,24 @@ func detectProvider(entry ModelEntry) string {
 
 	model := entry.LiteLLMParams.Model
 	// Wildcard entries
-	if strings.HasPrefix(model, "anthropic/") {
-		return "anthropic"
+	if strings.HasPrefix(model, ProviderAnthropic+"/") {
+		return ProviderAnthropic
 	}
 
-	if strings.HasPrefix(model, "ollama/") || strings.HasPrefix(model, "ollama_chat/") {
-		return "ollama"
+	if strings.HasPrefix(model, ProviderOllama+"/") || strings.HasPrefix(model, "ollama_chat/") {
+		return ProviderOllama
 	}
 
-	if strings.HasPrefix(model, "openai/") {
-		return "openai"
+	if strings.HasPrefix(model, ProviderOpenAI+"/") {
+		return ProviderOpenAI
 	}
 	// Anthropic models without prefix
 	if strings.Contains(model, "claude") {
-		return "anthropic"
+		return ProviderAnthropic
 	}
 
 	if strings.HasPrefix(model, "gpt") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") {
-		return "openai"
+		return ProviderOpenAI
 	}
 
 	return "unknown"

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -441,7 +441,7 @@ func ValidateCustomEndpoint(endpoint, modelName, apiKey string) error {
 	}
 
 	// Step 2: Inference probe — the definitive test
-	probePayload, _ := json.Marshal(map[string]any{
+	probePayload, _ := json.Marshal(map[string]any{ //nolint:errchkjson // map[string]any is safe, keys/values are controlled
 		"model":      modelName,
 		"messages":   []map[string]string{{"role": "user", "content": "ping"}},
 		"max_tokens": 1,
@@ -589,7 +589,7 @@ func GetMasterKey(cfg *config.Config) (string, error) {
 	// The value is base64-encoded in .data
 	decoded, err := decodeBase64(strings.TrimSpace(key))
 	if err != nil {
-		return key, nil // If not base64, return raw
+		return key, nil //nolint:nilerr // secret may be stored unencoded; fall back to raw value
 	}
 
 	return decoded, nil
@@ -993,12 +993,12 @@ func ListOllamaModels() ([]OllamaModel, error) {
 
 	resp, err := client.Get(tagsURL)
 	if err != nil {
-		return nil, fmt.Errorf("Ollama is not running at %s: %w", endpoint, err)
+		return nil, fmt.Errorf("ollama is not running at %s: %w", endpoint, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Ollama returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("ollama returned status %d", resp.StatusCode)
 	}
 
 	var result struct {
@@ -1026,7 +1026,7 @@ func PullOllamaModel(name string) error {
 
 	healthResp, err := client.Get(endpoint)
 	if err != nil {
-		return fmt.Errorf("Ollama is not running at %s — start it first", endpoint)
+		return fmt.Errorf("ollama is not running at %s — start it first", endpoint)
 	}
 
 	healthResp.Body.Close()

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -17,12 +17,15 @@ func TestBuildModelEntries(t *testing.T) {
 		if len(entries) != 2 {
 			t.Fatalf("got %d entries, want 2", len(entries))
 		}
+
 		if entries[0].LiteLLMParams.Model != "ollama_chat/qwen3.5:35b" {
 			t.Errorf("model = %q, want ollama_chat/qwen3.5:35b", entries[0].LiteLLMParams.Model)
 		}
+
 		if entries[0].LiteLLMParams.APIBase != "http://ollama.llm.svc.cluster.local:11434" {
 			t.Errorf("api_base = %q", entries[0].LiteLLMParams.APIBase)
 		}
+
 		if entries[0].LiteLLMParams.APIKey != "" {
 			t.Errorf("ollama should not have api_key, got %q", entries[0].LiteLLMParams.APIKey)
 		}
@@ -37,6 +40,7 @@ func TestBuildModelEntries(t *testing.T) {
 		if entries[0].ModelName != "anthropic/*" {
 			t.Errorf("entries[0].ModelName = %q, want anthropic/*", entries[0].ModelName)
 		}
+
 		if entries[0].LiteLLMParams.Model != "anthropic/*" {
 			t.Errorf("entries[0].Model = %q, want anthropic/*", entries[0].LiteLLMParams.Model)
 		}
@@ -44,6 +48,7 @@ func TestBuildModelEntries(t *testing.T) {
 		if entries[1].ModelName != "claude-sonnet-4-5-20250929" {
 			t.Errorf("entries[1].ModelName = %q", entries[1].ModelName)
 		}
+
 		if entries[1].LiteLLMParams.APIKey != "os.environ/ANTHROPIC_API_KEY" {
 			t.Errorf("api_key = %q, want os.environ/ANTHROPIC_API_KEY", entries[1].LiteLLMParams.APIKey)
 		}
@@ -54,9 +59,11 @@ func TestBuildModelEntries(t *testing.T) {
 		if len(entries) != 2 {
 			t.Fatalf("got %d entries, want 2 (wildcard + explicit)", len(entries))
 		}
+
 		if entries[0].ModelName != "openai/*" {
 			t.Errorf("entries[0].ModelName = %q, want openai/*", entries[0].ModelName)
 		}
+
 		if entries[1].LiteLLMParams.Model != "openai/gpt-4o" {
 			t.Errorf("entries[1].Model = %q, want openai/gpt-4o", entries[1].LiteLLMParams.Model)
 		}
@@ -67,6 +74,7 @@ func TestBuildModelEntries(t *testing.T) {
 		if len(entries) != 1 {
 			t.Fatalf("got %d entries, want 1 (wildcard only)", len(entries))
 		}
+
 		if entries[0].ModelName != "anthropic/*" {
 			t.Errorf("ModelName = %q, want anthropic/*", entries[0].ModelName)
 		}
@@ -83,6 +91,7 @@ func TestBuildModelEntries(t *testing.T) {
 func TestExpandWildcard(t *testing.T) {
 	t.Run("uses live models when available", func(t *testing.T) {
 		live := []string{"claude-sonnet-4-6", "claude-opus-4", "gpt-4o"}
+
 		got := expandWildcard("anthropic", live)
 		if len(got) != 2 {
 			t.Fatalf("got %d models, want 2 (claude only)", len(got))
@@ -126,6 +135,7 @@ func TestDetectProvider(t *testing.T) {
 				ModelName:     tt.name,
 				LiteLLMParams: LiteLLMParams{Model: tt.model},
 			}
+
 			got := detectProvider(entry)
 			if got != tt.wantProv {
 				t.Errorf("detectProvider(%q) = %q, want %q", tt.model, got, tt.wantProv)
@@ -206,10 +216,12 @@ func TestResolveAPIKey(t *testing.T) {
 	t.Run("primary env var found", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "sk-ant-primary")
 		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
 		key, envVar := ResolveAPIKey("anthropic")
 		if key != "sk-ant-primary" {
 			t.Errorf("key = %q, want sk-ant-primary", key)
 		}
+
 		if envVar != "ANTHROPIC_API_KEY" {
 			t.Errorf("envVar = %q, want ANTHROPIC_API_KEY", envVar)
 		}
@@ -218,10 +230,12 @@ func TestResolveAPIKey(t *testing.T) {
 	t.Run("fallback env var found", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "")
 		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-123")
+
 		key, envVar := ResolveAPIKey("anthropic")
 		if key != "oauth-token-123" {
 			t.Errorf("key = %q, want oauth-token-123", key)
 		}
+
 		if envVar != "CLAUDE_CODE_OAUTH_TOKEN" {
 			t.Errorf("envVar = %q, want CLAUDE_CODE_OAUTH_TOKEN", envVar)
 		}
@@ -230,10 +244,12 @@ func TestResolveAPIKey(t *testing.T) {
 	t.Run("primary takes precedence over fallback", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "sk-ant-primary")
 		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-123")
+
 		key, envVar := ResolveAPIKey("anthropic")
 		if key != "sk-ant-primary" {
 			t.Errorf("key = %q, want sk-ant-primary (primary should win)", key)
 		}
+
 		if envVar != "ANTHROPIC_API_KEY" {
 			t.Errorf("envVar = %q, want ANTHROPIC_API_KEY", envVar)
 		}
@@ -242,10 +258,12 @@ func TestResolveAPIKey(t *testing.T) {
 	t.Run("neither found", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "")
 		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
 		key, envVar := ResolveAPIKey("anthropic")
 		if key != "" {
 			t.Errorf("key = %q, want empty", key)
 		}
+
 		if envVar != "" {
 			t.Errorf("envVar = %q, want empty", envVar)
 		}
@@ -253,10 +271,12 @@ func TestResolveAPIKey(t *testing.T) {
 
 	t.Run("provider with no alt env vars", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "sk-openai-123")
+
 		key, envVar := ResolveAPIKey("openai")
 		if key != "sk-openai-123" {
 			t.Errorf("key = %q, want sk-openai-123", key)
 		}
+
 		if envVar != "OPENAI_API_KEY" {
 			t.Errorf("envVar = %q, want OPENAI_API_KEY", envVar)
 		}
@@ -281,12 +301,15 @@ func TestProviderEnvVar(t *testing.T) {
 	if got := ProviderEnvVar("anthropic"); got != "ANTHROPIC_API_KEY" {
 		t.Errorf("got %q, want ANTHROPIC_API_KEY", got)
 	}
+
 	if got := ProviderEnvVar("openai"); got != "OPENAI_API_KEY" {
 		t.Errorf("got %q, want OPENAI_API_KEY", got)
 	}
+
 	if got := ProviderEnvVar("ollama"); got != "" {
 		t.Errorf("got %q, want empty string for ollama", got)
 	}
+
 	if got := ProviderEnvVar("custom_thing"); got != "CUSTOM_THING_API_KEY" {
 		t.Errorf("got %q, want CUSTOM_THING_API_KEY", got)
 	}
@@ -319,10 +342,12 @@ func TestLoadDotEnv(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, ".env")
 		os.WriteFile(path, []byte("FOO=bar\nBAZ=qux\n"), 0o644)
+
 		m := LoadDotEnv(path)
 		if m["FOO"] != "bar" {
 			t.Errorf("FOO = %q, want bar", m["FOO"])
 		}
+
 		if m["BAZ"] != "qux" {
 			t.Errorf("BAZ = %q, want qux", m["BAZ"])
 		}
@@ -339,6 +364,7 @@ func TestLoadDotEnv(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, ".env")
 		os.WriteFile(path, []byte("# comment\n\nKEY=val\n"), 0o644)
+
 		m := LoadDotEnv(path)
 		if len(m) != 1 || m["KEY"] != "val" {
 			t.Errorf("expected {KEY:val}, got %v", m)
@@ -349,10 +375,12 @@ func TestLoadDotEnv(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, ".env")
 		os.WriteFile(path, []byte(`KEY="hello world"`+"\n"+`KEY2='single'`+"\n"), 0o644)
+
 		m := LoadDotEnv(path)
 		if m["KEY"] != "hello world" {
 			t.Errorf("KEY = %q, want 'hello world'", m["KEY"])
 		}
+
 		if m["KEY2"] != "single" {
 			t.Errorf("KEY2 = %q, want 'single'", m["KEY2"])
 		}
@@ -363,6 +391,7 @@ func TestValidateCustomEndpoint(t *testing.T) {
 	t.Run("full validation success", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
+
 			switch r.URL.Path {
 			case "/v1/models":
 				fmt.Fprint(w, `{"data":[{"id":"test-model"},{"id":"other-model"}]}`)
@@ -383,13 +412,14 @@ func TestValidateCustomEndpoint(t *testing.T) {
 	t.Run("inference probe returns empty choices", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
+
 			switch {
 			case strings.HasSuffix(r.URL.Path, "/models"):
 				fmt.Fprint(w, `{"data":[{"id":"other-model"}]}`)
 			case strings.HasSuffix(r.URL.Path, "/chat/completions"):
 				fmt.Fprint(w, `{"choices":[]}`)
 			default:
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}
 		}))
 		defer srv.Close()
@@ -398,6 +428,7 @@ func TestValidateCustomEndpoint(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for empty choices")
 		}
+
 		if !strings.Contains(err.Error(), "empty choices") {
 			t.Errorf("error should mention 'empty choices', got: %v", err)
 		}
@@ -413,11 +444,12 @@ func TestValidateCustomEndpoint(t *testing.T) {
 	t.Run("inference probe fails", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
+
 			switch r.URL.Path {
 			case "/v1/models":
 				fmt.Fprint(w, `{"data":[{"id":"test-model"}]}`)
 			case "/v1/chat/completions":
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprint(w, `{"error":"internal server error"}`)
 			}
 		}))
@@ -457,6 +489,7 @@ func TestFormatBytes(t *testing.T) {
 func TestOllamaEndpoint(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "")
+
 		got := ollamaEndpoint()
 		if got != "http://localhost:11434" {
 			t.Errorf("got %q, want http://localhost:11434", got)
@@ -465,6 +498,7 @@ func TestOllamaEndpoint(t *testing.T) {
 
 	t.Run("custom host:port", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "myhost:9999")
+
 		got := ollamaEndpoint()
 		if got != "http://myhost:9999" {
 			t.Errorf("got %q, want http://myhost:9999", got)
@@ -473,6 +507,7 @@ func TestOllamaEndpoint(t *testing.T) {
 
 	t.Run("full URL", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "https://ollama.example.com/")
+
 		got := ollamaEndpoint()
 		if got != "https://ollama.example.com" {
 			t.Errorf("got %q, want https://ollama.example.com", got)
@@ -487,6 +522,7 @@ func TestListOllamaModels_MockServer(t *testing.T) {
 				http.NotFound(w, r)
 				return
 			}
+
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"models":[
 				{"name":"llama3.2:3b","size":2000000000,"modified_at":"2025-01-01T00:00:00Z"},
@@ -496,16 +532,20 @@ func TestListOllamaModels_MockServer(t *testing.T) {
 		defer srv.Close()
 
 		t.Setenv("OLLAMA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
 		models, err := ListOllamaModels()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(models) != 2 {
 			t.Fatalf("got %d models, want 2", len(models))
 		}
+
 		if models[0].Name != "llama3.2:3b" {
 			t.Errorf("models[0].Name = %q, want llama3.2:3b", models[0].Name)
 		}
+
 		if models[1].Size != 4700000000 {
 			t.Errorf("models[1].Size = %d, want 4700000000", models[1].Size)
 		}
@@ -519,10 +559,12 @@ func TestListOllamaModels_MockServer(t *testing.T) {
 		defer srv.Close()
 
 		t.Setenv("OLLAMA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
 		models, err := ListOllamaModels()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(models) != 0 {
 			t.Fatalf("got %d models, want 0", len(models))
 		}
@@ -530,10 +572,12 @@ func TestListOllamaModels_MockServer(t *testing.T) {
 
 	t.Run("server not running", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "localhost:19999")
+
 		_, err := ListOllamaModels()
 		if err == nil {
 			t.Fatal("expected error when server is not running")
 		}
+
 		if !strings.Contains(err.Error(), "not running") {
 			t.Errorf("error should mention 'not running', got: %v", err)
 		}
@@ -543,36 +587,41 @@ func TestListOllamaModels_MockServer(t *testing.T) {
 func TestPullOllamaModel_MockServer(t *testing.T) {
 	t.Run("successful pull", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/api/pull" && r.Method == "POST" {
+			if r.URL.Path == "/api/pull" && r.Method == http.MethodPost {
 				var req struct {
 					Name   string `json:"name"`
 					Stream bool   `json:"stream"`
 				}
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					http.Error(w, err.Error(), 500)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
+
 				if req.Name != "llama3.2:3b" {
-					http.Error(w, "unexpected model", 400)
+					http.Error(w, "unexpected model", http.StatusBadRequest)
 					return
 				}
+
 				w.Header().Set("Content-Type", "application/x-ndjson")
 				fmt.Fprintln(w, `{"status":"pulling manifest"}`)
 				fmt.Fprintln(w, `{"status":"pulling abc123","total":1000,"completed":500}`)
 				fmt.Fprintln(w, `{"status":"pulling abc123","total":1000,"completed":1000}`)
 				fmt.Fprintln(w, `{"status":"success"}`)
+
 				return
 			}
 			// Health check endpoint
 			if r.URL.Path == "/" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				return
 			}
+
 			http.NotFound(w, r)
 		}))
 		defer srv.Close()
 
 		t.Setenv("OLLAMA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
 		err := PullOllamaModel("llama3.2:3b")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -585,17 +634,21 @@ func TestPullOllamaModel_MockServer(t *testing.T) {
 				w.Header().Set("Content-Type", "application/x-ndjson")
 				fmt.Fprintln(w, `{"status":"pulling manifest"}`)
 				fmt.Fprintln(w, `{"error":"model not found"}`)
+
 				return
 			}
-			w.WriteHeader(200)
+
+			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
 
 		t.Setenv("OLLAMA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
 		err := PullOllamaModel("nonexistent:latest")
 		if err == nil {
 			t.Fatal("expected error for nonexistent model")
 		}
+
 		if !strings.Contains(err.Error(), "model not found") {
 			t.Errorf("error should contain 'model not found', got: %v", err)
 		}
@@ -603,6 +656,7 @@ func TestPullOllamaModel_MockServer(t *testing.T) {
 
 	t.Run("server not running", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "localhost:19999")
+
 		err := PullOllamaModel("llama3.2:3b")
 		if err == nil {
 			t.Fatal("expected error when server is not running")

--- a/internal/network/chainlist.go
+++ b/internal/network/chainlist.go
@@ -29,10 +29,10 @@ type RPCEndpoint struct {
 
 // ChainEntry represents a single chain entry from the ChainList API.
 type ChainEntry struct {
-	Name    string        `json:"name"`
-	Chain   string        `json:"chain"`
-	ChainID int           `json:"chainId"`
-	RPC     []interface{} `json:"rpc"` // mix of strings and objects
+	Name    string `json:"name"`
+	Chain   string `json:"chain"`
+	ChainID int    `json:"chainId"`
+	RPC     []any  `json:"rpc"` // mix of strings and objects
 }
 
 // chainNames maps common chain names/aliases to chain IDs.
@@ -81,7 +81,9 @@ func ResolveChainID(nameOrID string) (int, string, error) {
 	for name := range chainNames {
 		names = append(names, name)
 	}
+
 	sort.Strings(names)
+
 	return 0, "", fmt.Errorf("unknown chain %q. Known chains: %s\nOr use a numeric chain ID (e.g., 8453)", nameOrID, strings.Join(names, ", "))
 }
 
@@ -91,6 +93,7 @@ type ChainListFetcher func() ([]byte, error)
 // DefaultChainListFetcher fetches from the real ChainList API.
 func DefaultChainListFetcher() ([]byte, error) {
 	client := &http.Client{Timeout: chainListTimeout}
+
 	resp, err := client.Get(chainListURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch ChainList data: %w", err)
@@ -136,27 +139,32 @@ func ParseAndFilterRPCs(data []byte, chainID, maxRPCs int) ([]RPCEndpoint, strin
 
 	// Find the chain entry.
 	var target *ChainEntry
+
 	for i := range chains {
 		if chains[i].ChainID == chainID {
 			target = &chains[i]
 			break
 		}
 	}
+
 	if target == nil {
 		return nil, "", fmt.Errorf("chain ID %d not found in ChainList data", chainID)
 	}
 
 	// Parse RPCs — the RPC field is a mix of strings and objects.
 	var endpoints []RPCEndpoint
+
 	for _, raw := range target.RPC {
 		var ep RPCEndpoint
+
 		switch v := raw.(type) {
 		case string:
 			ep = RPCEndpoint{URL: v, Tracking: "unknown"}
-		case map[string]interface{}:
+		case map[string]any:
 			if url, ok := v["url"].(string); ok {
 				ep.URL = url
 			}
+
 			if tracking, ok := v["tracking"].(string); ok {
 				ep.Tracking = tracking
 			} else {
@@ -186,6 +194,7 @@ func ParseAndFilterRPCs(data []byte, chainID, maxRPCs int) ([]RPCEndpoint, strin
 // FilterFreeRPCs filters RPC endpoints to only include free, HTTPS, non-tracking endpoints.
 func FilterFreeRPCs(endpoints []RPCEndpoint) []RPCEndpoint {
 	var result []RPCEndpoint
+
 	for _, ep := range endpoints {
 		// HTTPS only.
 		if !strings.HasPrefix(ep.URL, "https://") {
@@ -209,6 +218,7 @@ func FilterFreeRPCs(endpoints []RPCEndpoint) []RPCEndpoint {
 
 		result = append(result, ep)
 	}
+
 	return result
 }
 

--- a/internal/network/chainlist_test.go
+++ b/internal/network/chainlist_test.go
@@ -229,12 +229,15 @@ func TestResolveChainID(t *testing.T) {
 			if err == nil {
 				t.Errorf("ResolveChainID(%q): expected error, got chainID=%d", tt.input, chainID)
 			}
+
 			continue
 		}
+
 		if err != nil {
 			t.Errorf("ResolveChainID(%q): unexpected error: %v", tt.input, err)
 			continue
 		}
+
 		if chainID != tt.wantChainID {
 			t.Errorf("ResolveChainID(%q): got chainID=%d, want %d", tt.input, chainID, tt.wantChainID)
 		}

--- a/internal/network/erpc.go
+++ b/internal/network/erpc.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -76,6 +77,7 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return err
 	}
+
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap
@@ -87,34 +89,37 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 	}
 
 	// Parse the YAML config
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		return fmt.Errorf("could not parse eRPC config: %w", err)
 	}
 
 	// Navigate to projects[0].upstreams
-	projects, ok := erpcConfig["projects"].([]interface{})
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
-		return fmt.Errorf("eRPC config has no projects")
-	}
-	project, ok := projects[0].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("eRPC config project[0] is not a map")
+		return errors.New("eRPC config has no projects")
 	}
 
-	upstreams, _ := project["upstreams"].([]interface{})
+	project, ok := projects[0].(map[string]any)
+	if !ok {
+		return errors.New("eRPC config project[0] is not a map")
+	}
+
+	upstreams, _ := project["upstreams"].([]any)
 
 	// Remove existing upstream with this ID (idempotent)
-	filtered := make([]interface{}, 0, len(upstreams))
+	filtered := make([]any, 0, len(upstreams))
 	for _, u := range upstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			filtered = append(filtered, u)
 			continue
 		}
+
 		if um["id"] == upstreamID {
 			continue // remove it
 		}
+
 		filtered = append(filtered, u)
 	}
 
@@ -126,18 +131,18 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 		// Write methods are blocked on local nodes so transactions are
 		// always routed through the designated write upstream (e.g.
 		// obol-rpc-mainnet) rather than leaking to the public mempool.
-		newUpstream := map[string]interface{}{
+		newUpstream := map[string]any{
 			"id":       upstreamID,
 			"endpoint": endpoint,
-			"evm": map[string]interface{}{
+			"evm": map[string]any{
 				"chainId": chainID,
 			},
-			"ignoreMethods": []interface{}{
+			"ignoreMethods": []any{
 				"eth_sendRawTransaction",
 				"eth_sendTransaction",
 			},
 		}
-		filtered = append([]interface{}{newUpstream}, filtered...)
+		filtered = append([]any{newUpstream}, filtered...)
 	}
 
 	project["upstreams"] = filtered
@@ -149,34 +154,39 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 	// array order, so inserting the local node at position 0 is sufficient
 	// for local-first routing with automatic remote fallback.
 	if add {
-		networks, _ := project["networks"].([]interface{})
+		networks, _ := project["networks"].([]any)
 		found := false
+
 		for _, n := range networks {
-			nm, ok := n.(map[string]interface{})
+			nm, ok := n.(map[string]any)
 			if !ok {
 				continue
 			}
-			evm, _ := nm["evm"].(map[string]interface{})
+
+			evm, _ := nm["evm"].(map[string]any)
 			if evm == nil {
 				continue
 			}
+
 			if cid, _ := evm["chainId"].(int); cid == chainID {
 				found = true
 				break
 			}
 		}
+
 		if !found {
-			newNetwork := map[string]interface{}{
+			newNetwork := map[string]any{
 				"architecture": "evm",
-				"evm":          map[string]interface{}{"chainId": chainID},
-				"failsafe": map[string]interface{}{
-					"timeout": map[string]interface{}{"duration": "30s"},
-					"retry":   map[string]interface{}{"maxAttempts": 2, "delay": "100ms"},
+				"evm":          map[string]any{"chainId": chainID},
+				"failsafe": map[string]any{
+					"timeout": map[string]any{"duration": "30s"},
+					"retry":   map[string]any{"maxAttempts": 2, "delay": "100ms"},
 				},
 			}
 			if networkAlias != "" {
 				newNetwork["alias"] = networkAlias
 			}
+
 			networks = append(networks, newNetwork)
 			project["networks"] = networks
 		}
@@ -189,11 +199,12 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 	}
 
 	// Patch the ConfigMap
-	patchData := map[string]interface{}{
+	patchData := map[string]any{
 		"data": map[string]string{
 			erpcConfigKey: string(updatedYAML),
 		},
 	}
+
 	patchJSON, err := json.Marshal(patchData)
 	if err != nil {
 		return fmt.Errorf("could not marshal patch: %w", err)
@@ -207,7 +218,7 @@ func patchERPCUpstream(cfg *config.Config, upstreamID, endpoint string, chainID 
 
 	// Restart eRPC to pick up new config
 	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
-		"rollout", "restart", fmt.Sprintf("deployment/%s", erpcDeployment), "-n", erpcNamespace); err != nil {
+		"rollout", "restart", "deployment/"+erpcDeployment, "-n", erpcNamespace); err != nil {
 		return fmt.Errorf("could not restart eRPC: %w", err)
 	}
 

--- a/internal/network/erpc_test.go
+++ b/internal/network/erpc_test.go
@@ -27,47 +27,48 @@ projects:
             duration: 30s
 `
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		t.Fatalf("failed to parse test config: %v", err)
 	}
 
-	projects := erpcConfig["projects"].([]interface{})
-	project := projects[0].(map[string]interface{})
+	projects := erpcConfig["projects"].([]any)
+	project := projects[0].(map[string]any)
 
 	// Add a local upstream at position 0 (highest priority)
-	upstreams := project["upstreams"].([]interface{})
-	newUpstream := map[string]interface{}{
+	upstreams := project["upstreams"].([]any)
+	newUpstream := map[string]any{
 		"id":       "local-ethereum-test",
 		"endpoint": "http://ethereum-execution.ethereum-test.svc.cluster.local:8545",
-		"evm":      map[string]interface{}{"chainId": 1},
-		"ignoreMethods": []interface{}{
+		"evm":      map[string]any{"chainId": 1},
+		"ignoreMethods": []any{
 			"eth_sendRawTransaction",
 			"eth_sendTransaction",
 		},
 	}
-	upstreams = append([]interface{}{newUpstream}, upstreams...)
+	upstreams = append([]any{newUpstream}, upstreams...)
 	project["upstreams"] = upstreams
 
 	// Verify local upstream is first (eRPC tries in order for reads)
-	if len(project["upstreams"].([]interface{})) != 2 {
-		t.Errorf("expected 2 upstreams, got %d", len(project["upstreams"].([]interface{})))
+	if len(project["upstreams"].([]any)) != 2 {
+		t.Errorf("expected 2 upstreams, got %d", len(project["upstreams"].([]any)))
 	}
 
-	first := project["upstreams"].([]interface{})[0].(map[string]interface{})
+	first := project["upstreams"].([]any)[0].(map[string]any)
 	if first["id"] != "local-ethereum-test" {
 		t.Errorf("first upstream should be local, got %v", first["id"])
 	}
 	// Local upstream must block write methods
-	ignored, ok := first["ignoreMethods"].([]interface{})
+	ignored, ok := first["ignoreMethods"].([]any)
 	if !ok || len(ignored) != 2 {
 		t.Fatal("local upstream must have ignoreMethods for write methods")
 	}
+
 	if ignored[0] != "eth_sendRawTransaction" {
 		t.Errorf("ignoreMethods[0] = %v, want eth_sendRawTransaction", ignored[0])
 	}
 
-	second := project["upstreams"].([]interface{})[1].(map[string]interface{})
+	second := project["upstreams"].([]any)[1].(map[string]any)
 	if second["id"] != "obol-rpc-mainnet" {
 		t.Errorf("second upstream should be remote (write-capable), got %v", second["id"])
 	}
@@ -87,30 +88,34 @@ func TestPatchERPCConfig_RemoveUpstream(t *testing.T) {
           chainId: 1
 `
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		t.Fatalf("failed to parse: %v", err)
 	}
 
-	projects := erpcConfig["projects"].([]interface{})
-	project := projects[0].(map[string]interface{})
-	upstreams := project["upstreams"].([]interface{})
+	projects := erpcConfig["projects"].([]any)
+	project := projects[0].(map[string]any)
+	upstreams := project["upstreams"].([]any)
 
 	// Filter out the local upstream
-	var filtered []interface{}
+	var filtered []any
+
 	for _, u := range upstreams {
-		um := u.(map[string]interface{})
+		um := u.(map[string]any)
 		if um["id"] == "local-ethereum-test" {
 			continue
 		}
+
 		filtered = append(filtered, u)
 	}
+
 	project["upstreams"] = filtered
 
 	if len(filtered) != 1 {
 		t.Errorf("expected 1 upstream after removal, got %d", len(filtered))
 	}
-	remaining := filtered[0].(map[string]interface{})
+
+	remaining := filtered[0].(map[string]any)
 	if remaining["id"] != "obol-rpc-mainnet" {
 		t.Errorf("remaining upstream should be obol-rpc-mainnet, got %v", remaining["id"])
 	}
@@ -130,42 +135,45 @@ func TestPatchERPCConfig_Idempotent(t *testing.T) {
           chainId: 1
 `
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		t.Fatalf("failed to parse: %v", err)
 	}
 
-	projects := erpcConfig["projects"].([]interface{})
-	project := projects[0].(map[string]interface{})
-	upstreams := project["upstreams"].([]interface{})
+	projects := erpcConfig["projects"].([]any)
+	project := projects[0].(map[string]any)
+	upstreams := project["upstreams"].([]any)
 
 	// Remove existing, then add updated (same as patchERPCUpstream logic)
-	var filtered []interface{}
+	var filtered []any
+
 	for _, u := range upstreams {
-		um := u.(map[string]interface{})
+		um := u.(map[string]any)
 		if um["id"] == "local-ethereum-test" {
 			continue
 		}
+
 		filtered = append(filtered, u)
 	}
 
-	newUpstream := map[string]interface{}{
+	newUpstream := map[string]any{
 		"id":       "local-ethereum-test",
 		"endpoint": "http://new-endpoint:8545",
-		"evm":      map[string]interface{}{"chainId": 1},
-		"ignoreMethods": []interface{}{
+		"evm":      map[string]any{"chainId": 1},
+		"ignoreMethods": []any{
 			"eth_sendRawTransaction",
 			"eth_sendTransaction",
 		},
 	}
-	filtered = append([]interface{}{newUpstream}, filtered...)
+	filtered = append([]any{newUpstream}, filtered...)
 	project["upstreams"] = filtered
 
 	// Should still be 2 upstreams (not 3)
 	if len(filtered) != 2 {
 		t.Errorf("expected 2 upstreams (idempotent), got %d", len(filtered))
 	}
-	first := filtered[0].(map[string]interface{})
+
+	first := filtered[0].(map[string]any)
 	if first["endpoint"] != "http://new-endpoint:8545" {
 		t.Errorf("endpoint should be updated, got %v", first["endpoint"])
 	}
@@ -199,53 +207,58 @@ func TestPatchERPCConfig_PreservesWriteOnlySelectionPolicy(t *testing.T) {
             }
 `
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		t.Fatalf("failed to parse: %v", err)
 	}
 
-	projects := erpcConfig["projects"].([]interface{})
-	project := projects[0].(map[string]interface{})
+	projects := erpcConfig["projects"].([]any)
+	project := projects[0].(map[string]any)
 
 	// Simulate what patchERPCUpstream does: add local upstream at front
 	// with write methods blocked
-	upstreams := project["upstreams"].([]interface{})
-	newUpstream := map[string]interface{}{
+	upstreams := project["upstreams"].([]any)
+	newUpstream := map[string]any{
 		"id":       "local-ethereum-prod",
 		"endpoint": "http://ethereum-execution.ethereum-prod.svc.cluster.local:8545",
-		"evm":      map[string]interface{}{"chainId": 1},
-		"ignoreMethods": []interface{}{
+		"evm":      map[string]any{"chainId": 1},
+		"ignoreMethods": []any{
 			"eth_sendRawTransaction",
 			"eth_sendTransaction",
 		},
 	}
-	upstreams = append([]interface{}{newUpstream}, upstreams...)
+	upstreams = append([]any{newUpstream}, upstreams...)
 	project["upstreams"] = upstreams
 
 	// Verify: selectionPolicy must be UNTOUCHED
-	networks := project["networks"].([]interface{})
-	mainnet := networks[0].(map[string]interface{})
-	sp, ok := mainnet["selectionPolicy"].(map[string]interface{})
+	networks := project["networks"].([]any)
+	mainnet := networks[0].(map[string]any)
+
+	sp, ok := mainnet["selectionPolicy"].(map[string]any)
 	if !ok {
 		t.Fatal("selectionPolicy was removed")
 	}
+
 	if sp["evalPerMethod"] != true {
 		t.Error("evalPerMethod should still be true")
 	}
+
 	fn, ok := sp["evalFunction"].(string)
 	if !ok || !strings.Contains(fn, "obol-rpc-mainnet") {
 		t.Error("evalFunction should still route writes to obol-rpc-mainnet")
 	}
 
 	// Verify: 2 upstreams (local + obol), local first for reads
-	if len(project["upstreams"].([]interface{})) != 2 {
-		t.Errorf("expected 2 upstreams, got %d", len(project["upstreams"].([]interface{})))
+	if len(project["upstreams"].([]any)) != 2 {
+		t.Errorf("expected 2 upstreams, got %d", len(project["upstreams"].([]any)))
 	}
-	first := project["upstreams"].([]interface{})[0].(map[string]interface{})
+
+	first := project["upstreams"].([]any)[0].(map[string]any)
 	if first["id"] != "local-ethereum-prod" {
 		t.Errorf("local upstream should be first (for reads), got %v", first["id"])
 	}
-	second := project["upstreams"].([]interface{})[1].(map[string]interface{})
+
+	second := project["upstreams"].([]any)[1].(map[string]any)
 	if second["id"] != "obol-rpc-mainnet" {
 		t.Errorf("obol-rpc-mainnet should be second (protected write target), got %v", second["id"])
 	}
@@ -269,6 +282,7 @@ func TestNetworkChainIDs(t *testing.T) {
 			t.Errorf("networkChainIDs missing %q", tt.network)
 			continue
 		}
+
 		if got != tt.chainID {
 			t.Errorf("networkChainIDs[%q] = %d, want %d", tt.network, got, tt.chainID)
 		}

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,7 +13,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/embed"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
-	"github.com/dustinkirkland/golang-petname"
+	petname "github.com/dustinkirkland/golang-petname"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,9 +30,11 @@ func List(cfg *config.Config, u *ui.UI) error {
 	}
 
 	u.Bold("Available networks:")
+
 	for _, network := range availableNetworks {
 		u.Printf("  • %s", network)
 	}
+
 	u.Blank()
 	u.Dim(fmt.Sprintf("Total: %d network(s) available", len(availableNetworks)))
 
@@ -68,11 +71,13 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 				id = networkValue
 			}
 		}
+
 		if id == "" {
 			id = petname.Generate(2, "-")
 		}
+
 		overrides["id"] = id
-		u.Detail("Deployment ID", fmt.Sprintf("%s (generated)", id))
+		u.Detail("Deployment ID", id+" (generated)")
 	} else {
 		u.Detail("Deployment ID", id)
 	}
@@ -85,6 +90,7 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 				"Directory: %s\n"+
 				"Use --force or -f to overwrite the existing configuration", network, id, deploymentDir)
 		}
+
 		u.Warnf("Overwriting existing deployment at %s", deploymentDir)
 	}
 
@@ -99,7 +105,7 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 
 	u.Blank()
 	u.Print("Configuration:")
-	u.Detail("deployment id", fmt.Sprintf("%s (from directory structure)", id))
+	u.Detail("deployment id", id+" (from directory structure)")
 
 	// Process parsed fields
 	for _, field := range fields {
@@ -111,7 +117,7 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 		} else if field.Required && value == "" {
 			return fmt.Errorf("missing required flag: --%s", field.FlagName)
 		} else if value != "" {
-			u.Detail(field.Name, fmt.Sprintf("%s (default)", value))
+			u.Detail(field.Name, value+" (default)")
 		} else {
 			u.Detail(field.Name, "(empty, optional)")
 		}
@@ -137,7 +143,7 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 	}
 
 	// Validate that the generated content is valid YAML
-	var yamlCheck interface{}
+	var yamlCheck any
 	if err := yaml.Unmarshal(buf.Bytes(), &yamlCheck); err != nil {
 		return fmt.Errorf("generated values.yaml contains invalid YAML syntax: %w\n"+
 			"This may be caused by special characters in your input values.\n"+
@@ -145,13 +151,13 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 	}
 
 	// Create deployment directory
-	if err := os.MkdirAll(deploymentDir, 0755); err != nil {
+	if err := os.MkdirAll(deploymentDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create deployment directory: %w", err)
 	}
 
 	// Write the templated values.yaml
 	valuesPath := filepath.Join(deploymentDir, "values.yaml")
-	if err := os.WriteFile(valuesPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(valuesPath, buf.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
 
@@ -176,34 +182,42 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 // SyncAll syncs all installed network deployments found in the config directory.
 func SyncAll(cfg *config.Config, u *ui.UI) error {
 	networksDir := filepath.Join(cfg.ConfigDir, "networks")
+
 	networkDirs, err := os.ReadDir(networksDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			u.Print("No networks installed.")
 			return nil
 		}
+
 		return fmt.Errorf("could not read networks directory: %w", err)
 	}
 
 	var synced int
+
 	for _, networkDir := range networkDirs {
 		if !networkDir.IsDir() {
 			continue
 		}
+
 		deployments, err := os.ReadDir(filepath.Join(networksDir, networkDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, deployment := range deployments {
 			if !deployment.IsDir() {
 				continue
 			}
+
 			identifier := fmt.Sprintf("%s/%s", networkDir.Name(), deployment.Name())
 			u.Infof("Syncing %s", identifier)
+
 			if err := Sync(cfg, u, identifier); err != nil {
 				u.Warnf("Failed to sync %s: %v", identifier, err)
 				continue
 			}
+
 			synced++
 		}
 	}
@@ -213,6 +227,7 @@ func SyncAll(cfg *config.Config, u *ui.UI) error {
 	} else {
 		u.Successf("Synced %d network deployment(s)", synced)
 	}
+
 	return nil
 }
 
@@ -224,15 +239,17 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	if strings.Contains(deploymentIdentifier, "/") {
 		parts := strings.SplitN(deploymentIdentifier, "/", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
+			return errors.New("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
 		}
+
 		networkName = parts[0]
 		deploymentID = parts[1]
 	} else {
 		parts := strings.SplitN(deploymentIdentifier, "-", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
+			return errors.New("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
 		}
+
 		networkName = parts[0]
 		deploymentID = parts[1]
 	}
@@ -261,7 +278,7 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	// Check kubeconfig (cluster must be running)
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
@@ -272,10 +289,11 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	// Execute helmfile sync
 	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync",
 		"--state-values-file", valuesPath,
-		"--state-values-set", fmt.Sprintf("id=%s", deploymentID))
+		"--state-values-set", "id="+deploymentID)
 	cmd.Dir = deploymentDir
+
 	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath),
+		"KUBECONFIG="+kubeconfigPath,
 	)
 
 	if err := u.Exec(ui.ExecConfig{
@@ -308,15 +326,17 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	if strings.Contains(deploymentIdentifier, "/") {
 		parts := strings.SplitN(deploymentIdentifier, "/", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
+			return errors.New("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
 		}
+
 		networkName = parts[0]
 		deploymentID = parts[1]
 	} else {
 		parts := strings.SplitN(deploymentIdentifier, "-", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
+			return errors.New("invalid deployment identifier format. Use: <network>/<id> or <network>-<id>")
 		}
+
 		networkName = parts[0]
 		deploymentID = parts[1]
 	}
@@ -334,11 +354,13 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 
 	// Check if namespace exists in cluster
 	namespaceExists := false
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); err == nil {
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		cmd := exec.Command(kubectlBinary, "get", "namespace", namespaceName)
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 		if err := cmd.Run(); err == nil {
 			namespaceExists = true
 		}
@@ -359,9 +381,10 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	if namespaceExists {
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		cmd := exec.Command(kubectlBinary, "delete", "namespace", namespaceName, "--force", "--grace-period=0")
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 		if err := u.Exec(ui.ExecConfig{
-			Name: fmt.Sprintf("Deleting namespace %s", namespaceName),
+			Name: "Deleting namespace " + namespaceName,
 			Cmd:  cmd,
 		}); err != nil {
 			return fmt.Errorf("failed to delete namespace: %w", err)
@@ -373,10 +396,12 @@ func Delete(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 		if err := os.RemoveAll(deploymentDir); err != nil {
 			return fmt.Errorf("failed to delete config directory: %w", err)
 		}
+
 		u.Success("Configuration deleted")
 
 		// Clean up empty parent directory
 		networkDir := filepath.Join(cfg.ConfigDir, "networks", networkName)
+
 		entries, err := os.ReadDir(networkDir)
 		if err == nil && len(entries) == 0 {
 			os.Remove(networkDir)

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -49,8 +49,8 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 	// Default to the network name (e.g., "mainnet", "hoodi", "sepolia") so that
 	// the first install of each network type gets a human-readable ID. If that
 	// directory already exists, fall back to a petname.
-	id, hasId := overrides["id"]
-	if !hasId || id == "" {
+	id, hasID := overrides["id"]
+	if !hasID || id == "" {
 		// Resolve the network name from --network flag or template default.
 		networkValue := overrides["network"]
 		if networkValue == "" {

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -157,7 +157,7 @@ func Install(cfg *config.Config, u *ui.UI, network string, overrides map[string]
 
 	// Write the templated values.yaml
 	valuesPath := filepath.Join(deploymentDir, "values.yaml")
-	if err := os.WriteFile(valuesPath, buf.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(valuesPath, buf.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to write values.yaml: %w", err)
 	}
 

--- a/internal/network/parser.go
+++ b/internal/network/parser.go
@@ -35,6 +35,7 @@ func extractTemplateFields(content string) (map[string]int, error) {
 
 	// Walk the template AST to find field references
 	var walkNodes func(node parse.Node)
+
 	walkNodes = func(node parse.Node) {
 		if node == nil {
 			return
@@ -82,8 +83,8 @@ func extractTemplateFields(content string) (map[string]int, error) {
 	}
 
 	// Walk the template tree
-	if tmpl.Tree != nil && tmpl.Tree.Root != nil {
-		walkNodes(tmpl.Tree.Root)
+	if tmpl.Tree != nil && tmpl.Root != nil {
+		walkNodes(tmpl.Root)
 	}
 
 	return fields, nil
@@ -92,12 +93,15 @@ func extractTemplateFields(content string) (map[string]int, error) {
 // parseAnnotationsFromLines extracts annotations from comment lines preceding a field
 // Returns enum values, default value, description, and whether a default was specified
 func parseAnnotationsFromLines(lines []string, fieldLineNum int) ([]string, string, string, bool) {
-	var enumValues []string
-	var defaultValue string
-	var description string
-	var hasDefault bool
+	var (
+		enumValues   []string
+		defaultValue string
+		description  string
+		hasDefault   bool
+	)
 
 	// Look backwards from the field line to find annotations
+
 	for i := fieldLineNum - 1; i >= 0; i-- {
 		line := lines[i]
 		trimmed := strings.TrimSpace(line)
@@ -110,6 +114,7 @@ func parseAnnotationsFromLines(lines []string, fieldLineNum int) ([]string, stri
 		// Parse @enum annotation
 		if enumMatch := regexp.MustCompile(`#\s*@enum\s+(.+)`).FindStringSubmatch(line); enumMatch != nil {
 			enumStr := strings.TrimSpace(enumMatch[1])
+
 			enumValues = strings.Split(enumStr, ",")
 			for j := range enumValues {
 				enumValues[j] = strings.TrimSpace(enumValues[j])
@@ -153,10 +158,12 @@ func ParseTemplateFields(networkName string) ([]TemplateField, error) {
 		name string
 		line int
 	}
+
 	sortedFields := make([]fieldWithLine, 0, len(fieldMap))
 	for fieldName, lineNum := range fieldMap {
 		sortedFields = append(sortedFields, fieldWithLine{name: fieldName, line: lineNum})
 	}
+
 	sort.Slice(sortedFields, func(i, j int) bool {
 		return sortedFields[i].line < sortedFields[j].line
 	})
@@ -192,10 +199,12 @@ func ParseTemplateFields(networkName string) ([]TemplateField, error) {
 func fieldNameToFlagName(fieldName string) string {
 	// Insert hyphen before uppercase letters (except first)
 	var result strings.Builder
+
 	for i, r := range fieldName {
 		if i > 0 && r >= 'A' && r <= 'Z' {
 			result.WriteRune('-')
 		}
+
 		result.WriteRune(r)
 	}
 

--- a/internal/network/resolve.go
+++ b/internal/network/resolve.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,24 +20,29 @@ func ListInstanceIDs(cfg *config.Config) ([]string, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, fmt.Errorf("failed to read networks directory: %w", err)
 	}
 
 	var ids []string
+
 	for _, networkDir := range networkDirs {
 		if !networkDir.IsDir() {
 			continue
 		}
+
 		deployments, err := os.ReadDir(filepath.Join(networksDir, networkDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, deployment := range deployments {
 			if deployment.IsDir() {
 				ids = append(ids, fmt.Sprintf("%s/%s", networkDir.Name(), deployment.Name()))
 			}
 		}
 	}
+
 	return ids, nil
 }
 
@@ -55,7 +61,7 @@ func ResolveInstance(cfg *config.Config, args []string) (identifier string, rema
 
 	switch len(instances) {
 	case 0:
-		return "", nil, fmt.Errorf("no network deployments found — run 'obol network install <network>' to create one")
+		return "", nil, errors.New("no network deployments found — run 'obol network install <network>' to create one")
 	case 1:
 		return instances[0], args, nil
 	default:
@@ -68,15 +74,18 @@ func ResolveInstance(cfg *config.Config, args []string) (identifier string, rema
 			}
 			// Type-prefix match: "ethereum" → auto-select if only one of that type
 			var prefixMatches []string
+
 			for _, inst := range instances {
 				if typ, _, ok := strings.Cut(inst, "/"); ok && typ == args[0] {
 					prefixMatches = append(prefixMatches, inst)
 				}
 			}
+
 			if len(prefixMatches) == 1 {
 				return prefixMatches[0], args[1:], nil
 			}
 		}
+
 		return "", nil, fmt.Errorf("multiple network deployments found, specify one: %s", strings.Join(instances, ", "))
 	}
 }

--- a/internal/network/resolve_test.go
+++ b/internal/network/resolve_test.go
@@ -11,10 +11,12 @@ import (
 func TestListInstanceIDs(t *testing.T) {
 	t.Run("no networks directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -22,12 +24,13 @@ func TestListInstanceIDs(t *testing.T) {
 
 	t.Run("empty directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
-		os.MkdirAll(filepath.Join(cfg.ConfigDir, "networks"), 0755)
+		os.MkdirAll(filepath.Join(cfg.ConfigDir, "networks"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -35,15 +38,17 @@ func TestListInstanceIDs(t *testing.T) {
 
 	t.Run("single network single deployment", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
-		os.MkdirAll(filepath.Join(cfg.ConfigDir, "networks", "ethereum", "my-node"), 0755)
+		os.MkdirAll(filepath.Join(cfg.ConfigDir, "networks", "ethereum", "my-node"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 1 {
 			t.Fatalf("expected 1 instance, got %d", len(ids))
 		}
+
 		if ids[0] != "ethereum/my-node" {
 			t.Fatalf("expected 'ethereum/my-node', got '%s'", ids[0])
 		}
@@ -52,14 +57,15 @@ func TestListInstanceIDs(t *testing.T) {
 	t.Run("multiple networks multiple deployments", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
 		base := filepath.Join(cfg.ConfigDir, "networks")
-		os.MkdirAll(filepath.Join(base, "ethereum", "my-node"), 0755)
-		os.MkdirAll(filepath.Join(base, "ethereum", "hoodi-prod"), 0755)
-		os.MkdirAll(filepath.Join(base, "aztec", "testnet"), 0755)
+		os.MkdirAll(filepath.Join(base, "ethereum", "my-node"), 0o755)
+		os.MkdirAll(filepath.Join(base, "ethereum", "hoodi-prod"), 0o755)
+		os.MkdirAll(filepath.Join(base, "aztec", "testnet"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 3 {
 			t.Fatalf("expected 3 instances, got %d", len(ids))
 		}
@@ -68,13 +74,14 @@ func TestListInstanceIDs(t *testing.T) {
 	t.Run("ignores non-directory entries", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
 		base := filepath.Join(cfg.ConfigDir, "networks", "ethereum")
-		os.MkdirAll(filepath.Join(base, "my-node"), 0755)
-		os.WriteFile(filepath.Join(base, "some-file.txt"), []byte("test"), 0644)
+		os.MkdirAll(filepath.Join(base, "my-node"), 0o755)
+		os.WriteFile(filepath.Join(base, "some-file.txt"), []byte("test"), 0o644)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 1 {
 			t.Fatalf("expected 1 instance, got %d", len(ids))
 		}
@@ -86,19 +93,23 @@ func TestResolveInstance(t *testing.T) {
 	setupInstances := func(t *testing.T, identifiers ...string) *config.Config {
 		t.Helper()
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		base := filepath.Join(cfg.ConfigDir, "networks")
 		for _, id := range identifiers {
-			os.MkdirAll(filepath.Join(base, id), 0755)
+			os.MkdirAll(filepath.Join(base, id), 0o755)
 		}
+
 		return cfg
 	}
 
 	t.Run("zero instances returns error", func(t *testing.T) {
 		cfg := setupInstances(t)
+
 		_, _, err := ResolveInstance(cfg, []string{"ethereum/my-node"})
 		if err == nil {
 			t.Fatal("expected error for zero instances")
 		}
+
 		if got := err.Error(); got != "no network deployments found — run 'obol network install <network>' to create one" {
 			t.Fatalf("unexpected error: %s", got)
 		}
@@ -106,13 +117,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance auto-selects", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"extra-arg"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "ethereum/my-node" {
 			t.Fatalf("expected id 'ethereum/my-node', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra-arg" {
 			t.Fatalf("expected remaining args [extra-arg], got %v", remaining)
 		}
@@ -120,13 +134,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance with no args", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/happy-otter")
+
 		id, remaining, err := ResolveInstance(cfg, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "ethereum/happy-otter" {
 			t.Fatalf("expected id 'ethereum/happy-otter', got '%s'", id)
 		}
+
 		if len(remaining) != 0 {
 			t.Fatalf("expected no remaining args, got %v", remaining)
 		}
@@ -134,13 +151,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with valid name", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node", "ethereum/hoodi-prod")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"ethereum/hoodi-prod", "extra"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "ethereum/hoodi-prod" {
 			t.Fatalf("expected id 'ethereum/hoodi-prod', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra" {
 			t.Fatalf("expected remaining [extra], got %v", remaining)
 		}
@@ -148,6 +168,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances without name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node", "aztec/testnet")
+
 		_, _, err := ResolveInstance(cfg, nil)
 		if err == nil {
 			t.Fatal("expected error for multiple instances without name")
@@ -156,6 +177,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with unknown name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node", "aztec/testnet")
+
 		_, _, err := ResolveInstance(cfg, []string{"helios/nonexistent"})
 		if err == nil {
 			t.Fatal("expected error for unknown instance name")
@@ -164,13 +186,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("type prefix selects sole instance of that type", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node", "aztec/testnet")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"ethereum", "extra"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "ethereum/my-node" {
 			t.Fatalf("expected id 'ethereum/my-node', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra" {
 			t.Fatalf("expected remaining [extra], got %v", remaining)
 		}
@@ -178,6 +203,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("type prefix errors when multiple of same type", func(t *testing.T) {
 		cfg := setupInstances(t, "ethereum/my-node", "ethereum/hoodi-prod")
+
 		_, _, err := ResolveInstance(cfg, []string{"ethereum"})
 		if err == nil {
 			t.Fatal("expected error when type prefix matches multiple instances")

--- a/internal/network/rpc.go
+++ b/internal/network/rpc.go
@@ -387,7 +387,7 @@ func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int
 	// Read config for upstream counts.
 	erpcConfig, readErr := readERPCConfig(cfg)
 	if readErr != nil {
-		return podStatus, nil, nil
+		return podStatus, nil, nil //nolint:nilerr // config unreadable; return pod status without upstream counts
 	}
 
 	upstreamCounts = make(map[int]int)

--- a/internal/network/rpc.go
+++ b/internal/network/rpc.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -19,6 +20,7 @@ func sanitizeAlias(name string) string {
 	s := strings.ToLower(strings.TrimSpace(name))
 	s = nonAlphanumeric.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-")
+
 	return s
 }
 
@@ -43,29 +45,34 @@ func ListRPCNetworks(cfg *config.Config) ([]RPCNetworkInfo, error) {
 		return nil, err
 	}
 
-	projects, ok := erpcConfig["projects"].([]interface{})
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
-		return nil, fmt.Errorf("eRPC config has no projects")
+		return nil, errors.New("eRPC config has no projects")
 	}
-	project, ok := projects[0].(map[string]interface{})
+
+	project, ok := projects[0].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("eRPC config project[0] is not a map")
+		return nil, errors.New("eRPC config project[0] is not a map")
 	}
 
 	// Build upstream lookup by chain ID.
-	upstreams, _ := project["upstreams"].([]interface{})
+	upstreams, _ := project["upstreams"].([]any)
 	upstreamsByChain := make(map[int][]RPCUpstreamInfo)
+
 	for _, u := range upstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			continue
 		}
+
 		id, _ := um["id"].(string)
 		endpoint, _ := um["endpoint"].(string)
+
 		var chainID int
-		if evm, ok := um["evm"].(map[string]interface{}); ok {
+		if evm, ok := um["evm"].(map[string]any); ok {
 			chainID = yamlInt(evm["chainId"])
 		}
+
 		if chainID > 0 {
 			upstreamsByChain[chainID] = append(upstreamsByChain[chainID], RPCUpstreamInfo{
 				ID:       id,
@@ -76,17 +83,21 @@ func ListRPCNetworks(cfg *config.Config) ([]RPCNetworkInfo, error) {
 	}
 
 	// Build network list.
-	networks, _ := project["networks"].([]interface{})
+	networks, _ := project["networks"].([]any)
+
 	var result []RPCNetworkInfo
+
 	for _, n := range networks {
-		nm, ok := n.(map[string]interface{})
+		nm, ok := n.(map[string]any)
 		if !ok {
 			continue
 		}
+
 		var chainID int
-		if evm, ok := nm["evm"].(map[string]interface{}); ok {
+		if evm, ok := nm["evm"].(map[string]any); ok {
 			chainID = yamlInt(evm["chainId"])
 		}
+
 		alias, _ := nm["alias"].(string)
 		if chainID > 0 {
 			result = append(result, RPCNetworkInfo{
@@ -101,7 +112,7 @@ func ListRPCNetworks(cfg *config.Config) ([]RPCNetworkInfo, error) {
 }
 
 // writeMethods are blocked by default on remote upstreams when readOnly is true.
-var writeMethods = []interface{}{"eth_sendRawTransaction", "eth_sendTransaction"}
+var writeMethods = []any{"eth_sendRawTransaction", "eth_sendTransaction"}
 
 // AddCustomRPC adds a single custom RPC endpoint for a chain to the eRPC ConfigMap.
 // Uses the "custom-" prefix to distinguish from ChainList-sourced upstreams.
@@ -112,68 +123,76 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string, r
 		return err
 	}
 
-	projects, ok := erpcConfig["projects"].([]interface{})
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
-		return fmt.Errorf("eRPC config has no projects")
+		return errors.New("eRPC config has no projects")
 	}
-	project, ok := projects[0].(map[string]interface{})
+
+	project, ok := projects[0].(map[string]any)
 	if !ok {
-		return fmt.Errorf("eRPC config project[0] is not a map")
+		return errors.New("eRPC config project[0] is not a map")
 	}
 
 	// Remove any existing custom upstream for this chain ID.
-	existingUpstreams, _ := project["upstreams"].([]interface{})
-	filtered := make([]interface{}, 0, len(existingUpstreams))
+	existingUpstreams, _ := project["upstreams"].([]any)
+
+	filtered := make([]any, 0, len(existingUpstreams))
 	for _, u := range existingUpstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			filtered = append(filtered, u)
 			continue
 		}
+
 		id, _ := um["id"].(string)
 		if strings.HasPrefix(id, fmt.Sprintf("custom-%d-", chainID)) {
 			continue
 		}
+
 		filtered = append(filtered, u)
 	}
 
 	// Add the custom upstream.
-	upstream := map[string]interface{}{
+	upstream := map[string]any{
 		"id":       fmt.Sprintf("custom-%d-0", chainID),
 		"endpoint": endpoint,
-		"evm": map[string]interface{}{
+		"evm": map[string]any{
 			"chainId": chainID,
 		},
 	}
 	if readOnly {
 		upstream["ignoreMethods"] = writeMethods
 	}
+
 	filtered = append(filtered, upstream)
 	project["upstreams"] = filtered
 
 	// Ensure a network entry exists for this chain ID.
-	networksList, _ := project["networks"].([]interface{})
+	networksList, _ := project["networks"].([]any)
 	found := false
+
 	for _, n := range networksList {
-		nm, ok := n.(map[string]interface{})
+		nm, ok := n.(map[string]any)
 		if !ok {
 			continue
 		}
-		if evm, ok := nm["evm"].(map[string]interface{}); ok {
+
+		if evm, ok := nm["evm"].(map[string]any); ok {
 			if yamlInt(evm["chainId"]) == chainID {
 				found = true
 				break
 			}
 		}
 	}
+
 	if !found {
-		networksList = append(networksList, map[string]interface{}{
+		networksList = append(networksList, map[string]any{
 			"architecture": "evm",
-			"evm":          map[string]interface{}{"chainId": chainID},
+			"evm":          map[string]any{"chainId": chainID},
 			"alias":        sanitizeAlias(chainName),
-			"failsafe": map[string]interface{}{
-				"timeout": map[string]interface{}{"duration": "30s"},
-				"retry":   map[string]interface{}{"maxAttempts": 2, "delay": "100ms"},
+			"failsafe": map[string]any{
+				"timeout": map[string]any{"duration": "30s"},
+				"retry":   map[string]any{"maxAttempts": 2, "delay": "100ms"},
 			},
 		})
 		project["networks"] = networksList
@@ -188,6 +207,7 @@ func AddPublicRPCs(cfg *config.Config, chainID int, chainName string, endpoints 
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return err
 	}
+
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap.
@@ -198,75 +218,84 @@ func AddPublicRPCs(cfg *config.Config, chainID int, chainName string, endpoints 
 		return fmt.Errorf("could not read eRPC config: %w", err)
 	}
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		return fmt.Errorf("could not parse eRPC config: %w", err)
 	}
 
-	projects, ok := erpcConfig["projects"].([]interface{})
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
-		return fmt.Errorf("eRPC config has no projects")
+		return errors.New("eRPC config has no projects")
 	}
-	project, ok := projects[0].(map[string]interface{})
+
+	project, ok := projects[0].(map[string]any)
 	if !ok {
-		return fmt.Errorf("eRPC config project[0] is not a map")
+		return errors.New("eRPC config project[0] is not a map")
 	}
 
 	// Remove any existing chainlist- upstreams for this chain ID.
-	existingUpstreams, _ := project["upstreams"].([]interface{})
-	filtered := make([]interface{}, 0, len(existingUpstreams))
+	existingUpstreams, _ := project["upstreams"].([]any)
+
+	filtered := make([]any, 0, len(existingUpstreams))
 	for _, u := range existingUpstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			filtered = append(filtered, u)
 			continue
 		}
+
 		id, _ := um["id"].(string)
 		if strings.HasPrefix(id, fmt.Sprintf("chainlist-%d-", chainID)) {
 			continue // remove old chainlist entries for this chain
 		}
+
 		filtered = append(filtered, u)
 	}
 
 	// Add new ChainList upstreams.
 	for i, ep := range endpoints {
-		newUpstream := map[string]interface{}{
+		newUpstream := map[string]any{
 			"id":       fmt.Sprintf("chainlist-%d-%d", chainID, i),
 			"endpoint": ep.URL,
-			"evm": map[string]interface{}{
+			"evm": map[string]any{
 				"chainId": chainID,
 			},
 		}
 		if readOnly {
 			newUpstream["ignoreMethods"] = writeMethods
 		}
+
 		filtered = append(filtered, newUpstream)
 	}
+
 	project["upstreams"] = filtered
 
 	// Ensure a network entry exists for this chain ID.
-	networksList, _ := project["networks"].([]interface{})
+	networksList, _ := project["networks"].([]any)
 	found := false
+
 	for _, n := range networksList {
-		nm, ok := n.(map[string]interface{})
+		nm, ok := n.(map[string]any)
 		if !ok {
 			continue
 		}
-		if evm, ok := nm["evm"].(map[string]interface{}); ok {
+
+		if evm, ok := nm["evm"].(map[string]any); ok {
 			if yamlInt(evm["chainId"]) == chainID {
 				found = true
 				break
 			}
 		}
 	}
+
 	if !found {
-		newNetwork := map[string]interface{}{
+		newNetwork := map[string]any{
 			"architecture": "evm",
-			"evm":          map[string]interface{}{"chainId": chainID},
+			"evm":          map[string]any{"chainId": chainID},
 			"alias":        sanitizeAlias(chainName),
-			"failsafe": map[string]interface{}{
-				"timeout": map[string]interface{}{"duration": "30s"},
-				"retry":   map[string]interface{}{"maxAttempts": 2, "delay": "100ms"},
+			"failsafe": map[string]any{
+				"timeout": map[string]any{"duration": "30s"},
+				"retry":   map[string]any{"maxAttempts": 2, "delay": "100ms"},
 			},
 		}
 		networksList = append(networksList, newNetwork)
@@ -282,6 +311,7 @@ func RemovePublicRPCs(cfg *config.Config, chainID int) error {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return err
 	}
+
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Read current eRPC config from ConfigMap.
@@ -292,35 +322,39 @@ func RemovePublicRPCs(cfg *config.Config, chainID int) error {
 		return fmt.Errorf("could not read eRPC config: %w", err)
 	}
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		return fmt.Errorf("could not parse eRPC config: %w", err)
 	}
 
-	projects, ok := erpcConfig["projects"].([]interface{})
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
-		return fmt.Errorf("eRPC config has no projects")
+		return errors.New("eRPC config has no projects")
 	}
-	project, ok := projects[0].(map[string]interface{})
+
+	project, ok := projects[0].(map[string]any)
 	if !ok {
-		return fmt.Errorf("eRPC config project[0] is not a map")
+		return errors.New("eRPC config project[0] is not a map")
 	}
 
 	// Remove chainlist- upstreams for this chain ID.
-	existingUpstreams, _ := project["upstreams"].([]interface{})
-	filtered := make([]interface{}, 0, len(existingUpstreams))
+	existingUpstreams, _ := project["upstreams"].([]any)
+	filtered := make([]any, 0, len(existingUpstreams))
 	removed := 0
+
 	for _, u := range existingUpstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			filtered = append(filtered, u)
 			continue
 		}
+
 		id, _ := um["id"].(string)
 		if strings.HasPrefix(id, fmt.Sprintf("chainlist-%d-", chainID)) {
 			removed++
 			continue
 		}
+
 		filtered = append(filtered, u)
 	}
 
@@ -338,6 +372,7 @@ func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return "", nil, err
 	}
+
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	// Get pod status.
@@ -356,22 +391,25 @@ func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int
 	}
 
 	upstreamCounts = make(map[int]int)
-	projects, ok := erpcConfig["projects"].([]interface{})
+
+	projects, ok := erpcConfig["projects"].([]any)
 	if !ok || len(projects) == 0 {
 		return podStatus, upstreamCounts, nil
 	}
-	project, ok := projects[0].(map[string]interface{})
+
+	project, ok := projects[0].(map[string]any)
 	if !ok {
 		return podStatus, upstreamCounts, nil
 	}
 
-	upstreams, _ := project["upstreams"].([]interface{})
+	upstreams, _ := project["upstreams"].([]any)
 	for _, u := range upstreams {
-		um, ok := u.(map[string]interface{})
+		um, ok := u.(map[string]any)
 		if !ok {
 			continue
 		}
-		if evm, ok := um["evm"].(map[string]interface{}); ok {
+
+		if evm, ok := um["evm"].(map[string]any); ok {
 			chainID := yamlInt(evm["chainId"])
 			if chainID > 0 {
 				upstreamCounts[chainID]++
@@ -383,10 +421,11 @@ func GetERPCStatus(cfg *config.Config) (podStatus string, upstreamCounts map[int
 }
 
 // readERPCConfig reads and parses the eRPC ConfigMap YAML.
-func readERPCConfig(cfg *config.Config) (map[string]interface{}, error) {
+func readERPCConfig(cfg *config.Config) (map[string]any, error) {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return nil, err
 	}
+
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	configYAML, err := kubectl.Output(kubectlBin, kubeconfigPath,
@@ -396,7 +435,7 @@ func readERPCConfig(cfg *config.Config) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("could not read eRPC config: %w", err)
 	}
 
-	var erpcConfig map[string]interface{}
+	var erpcConfig map[string]any
 	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
 		return nil, fmt.Errorf("could not parse eRPC config: %w", err)
 	}
@@ -405,7 +444,7 @@ func readERPCConfig(cfg *config.Config) (map[string]interface{}, error) {
 }
 
 // writeERPCConfig serializes the eRPC config and patches the ConfigMap, then restarts eRPC.
-func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) error {
+func writeERPCConfig(cfg *config.Config, erpcConfig map[string]any) error {
 	kubectlBin, kubeconfigPath := kubectl.Paths(cfg)
 
 	updatedYAML, err := yaml.Marshal(erpcConfig)
@@ -413,11 +452,12 @@ func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) erro
 		return fmt.Errorf("could not serialize eRPC config: %w", err)
 	}
 
-	patchData := map[string]interface{}{
+	patchData := map[string]any{
 		"data": map[string]string{
 			erpcConfigKey: string(updatedYAML),
 		},
 	}
+
 	patchJSON, err := json.Marshal(patchData)
 	if err != nil {
 		return fmt.Errorf("could not marshal patch: %w", err)
@@ -431,7 +471,7 @@ func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) erro
 
 	// Restart eRPC to pick up new config.
 	if err := kubectl.RunSilent(kubectlBin, kubeconfigPath,
-		"rollout", "restart", fmt.Sprintf("deployment/%s", erpcDeployment), "-n", erpcNamespace); err != nil {
+		"rollout", "restart", "deployment/"+erpcDeployment, "-n", erpcNamespace); err != nil {
 		return fmt.Errorf("could not restart eRPC: %w", err)
 	}
 
@@ -440,7 +480,7 @@ func writeERPCConfig(cfg *config.Config, erpcConfig map[string]interface{}) erro
 
 // yamlInt extracts an int from a YAML-parsed interface{} value,
 // handling both int and float64 (JSON numbers).
-func yamlInt(v interface{}) int {
+func yamlInt(v any) int {
 	switch n := v.(type) {
 	case int:
 		return n

--- a/internal/network/validate.go
+++ b/internal/network/validate.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,15 +16,17 @@ func validateInstallOptions(networkName string, values map[string]string) error 
 	if err != nil {
 		return fmt.Errorf("invalid --reth-indexer-enabled value %q: %w", values["RethIndexerEnabled"], err)
 	}
+
 	if !rethIndexerEnabled {
 		return nil
 	}
 
 	if values["ExecutionClient"] != "reth" {
-		return fmt.Errorf("the embedded ERC-8004 indexer requires --execution-client reth")
+		return errors.New("the embedded ERC-8004 indexer requires --execution-client reth")
 	}
+
 	if strings.TrimSpace(values["RethImageRepository"]) == "" || strings.TrimSpace(values["RethImageTag"]) == "" {
-		return fmt.Errorf("the embedded ERC-8004 indexer requires both --reth-image-repository and --reth-image-tag")
+		return errors.New("the embedded ERC-8004 indexer requires both --reth-image-repository and --reth-image-tag")
 	}
 
 	port := strings.TrimSpace(values["RethIndexerPort"])
@@ -35,10 +38,11 @@ func validateInstallOptions(networkName string, values map[string]string) error 
 	}
 
 	if strings.TrimSpace(values["RethIndexerDbPath"]) == "" {
-		return fmt.Errorf("the embedded ERC-8004 indexer requires --reth-indexer-db-path")
+		return errors.New("the embedded ERC-8004 indexer requires --reth-indexer-db-path")
 	}
+
 	if strings.TrimSpace(values["RethIndexerRegistryAddress"]) == "" {
-		return fmt.Errorf("the embedded ERC-8004 indexer requires --reth-indexer-registry-address")
+		return errors.New("the embedded ERC-8004 indexer requires --reth-indexer-registry-address")
 	}
 
 	if backfill := strings.TrimSpace(values["RethIndexerBackfillFromBlock"]); backfill != "" {
@@ -57,6 +61,6 @@ func parseBoolString(value string) (bool, error) {
 	case "true", "1", "yes":
 		return true, nil
 	default:
-		return false, fmt.Errorf("expected true/false")
+		return false, errors.New("expected true/false")
 	}
 }

--- a/internal/network/validate.go
+++ b/internal/network/validate.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func validateInstallOptions(networkName string, values map[string]string) error {
+func validateInstallOptions(networkName string, values map[string]string) error { //nolint:unparam // networkName will vary when more networks gain validation
 	if networkName != "ethereum" {
 		return nil
 	}

--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -100,7 +100,7 @@ type openclawModel struct {
 func DetectExistingConfig() (*ImportResult, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, nil
+		return nil, nil //nolint:nilerr,nilnil // home dir unavailable; treat as no existing config
 	}
 
 	return detectExistingConfigAt(home)
@@ -114,7 +114,7 @@ func detectExistingConfigAt(home string) (*ImportResult, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil //nolint:nilnil // file absent means no prior config; not an error
 		}
 
 		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)

--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -102,6 +102,7 @@ func DetectExistingConfig() (*ImportResult, error) {
 	if err != nil {
 		return nil, nil
 	}
+
 	return detectExistingConfigAt(home)
 }
 
@@ -109,11 +110,13 @@ func DetectExistingConfig() (*ImportResult, error) {
 // Extracted from DetectExistingConfig for testability.
 func detectExistingConfigAt(home string) (*ImportResult, error) {
 	configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
 	}
 
@@ -134,6 +137,7 @@ func detectExistingConfigAt(home string) (*ImportResult, error) {
 		if p.API != "" && sanitized == "" {
 			fmt.Printf("  Note: unknown API type '%s' for provider '%s', will auto-detect\n", p.API, name)
 		}
+
 		ip := ImportedProvider{
 			Name:         name,
 			BaseURL:      p.BaseURL,
@@ -150,9 +154,11 @@ func detectExistingConfigAt(home string) (*ImportResult, error) {
 				fmt.Printf("  Note: provider '%s' uses an env-var reference for its API key (will need manual configuration)\n", name)
 			}
 		}
+
 		for _, m := range p.Models {
-			ip.Models = append(ip.Models, ImportedModel{ID: m.ID, Name: m.Name})
+			ip.Models = append(ip.Models, ImportedModel(m))
 		}
+
 		result.Providers = append(result.Providers, ip)
 	}
 
@@ -163,6 +169,7 @@ func detectExistingConfigAt(home string) (*ImportResult, error) {
 			fmt.Printf("  Note: Telegram bot token uses env-var reference (will need manual configuration)\n")
 		}
 	}
+
 	if cfg.Channels.Discord != nil && cfg.Channels.Discord.BotToken != "" {
 		if !isEnvVarRef(cfg.Channels.Discord.BotToken) {
 			result.Channels.Discord = &ImportedDiscord{BotToken: cfg.Channels.Discord.BotToken}
@@ -170,8 +177,10 @@ func detectExistingConfigAt(home string) (*ImportResult, error) {
 			fmt.Printf("  Note: Discord bot token uses env-var reference (will need manual configuration)\n")
 		}
 	}
+
 	if cfg.Channels.Slack != nil {
 		botToken := cfg.Channels.Slack.BotToken
+
 		appToken := cfg.Channels.Slack.AppToken
 		if botToken != "" && !isEnvVarRef(botToken) {
 			result.Channels.Slack = &ImportedSlack{
@@ -200,42 +209,51 @@ func TranslateToOverlayYAML(result *ImportResult) string {
 	var b strings.Builder
 
 	if result.AgentModel != "" {
-		b.WriteString(fmt.Sprintf("openclaw:\n  agentModel: %s\n\n", result.AgentModel))
+		fmt.Fprintf(&b, "openclaw:\n  agentModel: %s\n\n", result.AgentModel)
 	}
 
 	if len(result.Providers) > 0 {
 		b.WriteString("models:\n")
+
 		for _, p := range result.Providers {
-			b.WriteString(fmt.Sprintf("  %s:\n", p.Name))
+			fmt.Fprintf(&b, "  %s:\n", p.Name)
+
 			if p.Disabled {
 				b.WriteString("    enabled: false\n")
 				continue
 			}
+
 			b.WriteString("    enabled: true\n")
+
 			if p.BaseURL != "" {
-				b.WriteString(fmt.Sprintf("    baseUrl: %s\n", p.BaseURL))
+				fmt.Fprintf(&b, "    baseUrl: %s\n", p.BaseURL)
 			}
 			// Always emit api to override any stale base chart value.
 			// Empty string makes the Helm template omit it from JSON,
 			// letting OpenClaw auto-detect the protocol.
 			if p.API != "" {
-				b.WriteString(fmt.Sprintf("    api: %s\n", p.API))
+				fmt.Fprintf(&b, "    api: %s\n", p.API)
 			} else {
 				b.WriteString("    api: \"\"\n")
 			}
+
 			if p.APIKeyEnvVar != "" {
-				b.WriteString(fmt.Sprintf("    apiKeyEnvVar: %s\n", p.APIKeyEnvVar))
+				fmt.Fprintf(&b, "    apiKeyEnvVar: %s\n", p.APIKeyEnvVar)
 			}
+
 			if len(p.Models) > 0 {
 				b.WriteString("    models:\n")
+
 				for _, m := range p.Models {
-					b.WriteString(fmt.Sprintf("      - id: %s\n", m.ID))
+					fmt.Fprintf(&b, "      - id: %s\n", m.ID)
+
 					if m.Name != "" {
-						b.WriteString(fmt.Sprintf("        name: %s\n", m.Name))
+						fmt.Fprintf(&b, "        name: %s\n", m.Name)
 					}
 				}
 			}
 		}
+
 		b.WriteString("\n")
 	}
 
@@ -243,18 +261,22 @@ func TranslateToOverlayYAML(result *ImportResult) string {
 	hasChannels := result.Channels.Telegram != nil || result.Channels.Discord != nil || result.Channels.Slack != nil
 	if hasChannels {
 		b.WriteString("channels:\n")
+
 		if result.Channels.Telegram != nil {
 			b.WriteString("  telegram:\n")
 			b.WriteString("    enabled: true\n")
 		}
+
 		if result.Channels.Discord != nil {
 			b.WriteString("  discord:\n")
 			b.WriteString("    enabled: true\n")
 		}
+
 		if result.Channels.Slack != nil {
 			b.WriteString("  slack:\n")
 			b.WriteString("    enabled: true\n")
 		}
+
 		b.WriteString("\n")
 	}
 
@@ -268,26 +290,34 @@ func PrintImportSummary(result *ImportResult) {
 	}
 
 	fmt.Println("Detected existing OpenClaw installation (~/.openclaw/):")
+
 	if len(result.Providers) > 0 {
 		fmt.Printf("  Providers: ")
+
 		names := make([]string, 0, len(result.Providers))
 		for _, p := range result.Providers {
 			names = append(names, p.Name)
 		}
+
 		fmt.Println(strings.Join(names, ", "))
 	}
+
 	if result.AgentModel != "" {
 		fmt.Printf("  Agent model: %s\n", result.AgentModel)
 	}
+
 	if result.Channels.Telegram != nil {
 		fmt.Println("  Telegram: configured")
 	}
+
 	if result.Channels.Discord != nil {
 		fmt.Println("  Discord: configured")
 	}
+
 	if result.Channels.Slack != nil {
 		fmt.Println("  Slack: configured")
 	}
+
 	if result.WorkspaceDir != "" {
 		files := detectWorkspaceFiles(result.WorkspaceDir)
 		fmt.Printf("  Workspace: %s (%s)\n", result.WorkspaceDir, strings.Join(files, ", "))
@@ -320,6 +350,7 @@ func detectWorkspace(home, configWorkspace string) string {
 
 	// Directory exists but has no marker files
 	fmt.Printf("  Note: workspace at %s has no marker files (SOUL.md, AGENTS.md, IDENTITY.md)\n", wsDir)
+
 	return ""
 }
 
@@ -329,7 +360,9 @@ func detectWorkspaceFiles(wsDir string) []string {
 		"SOUL.md", "AGENTS.md", "IDENTITY.md", "USER.md",
 		"TOOLS.md", "MEMORY.md",
 	}
+
 	var found []string
+
 	for _, name := range candidates {
 		if _, err := os.Stat(filepath.Join(wsDir, name)); err == nil {
 			found = append(found, name)
@@ -339,6 +372,7 @@ func detectWorkspaceFiles(wsDir string) []string {
 	if info, err := os.Stat(filepath.Join(wsDir, "memory")); err == nil && info.IsDir() {
 		found = append(found, "memory/")
 	}
+
 	return found
 }
 
@@ -361,6 +395,7 @@ func sanitizeModelAPI(api string) string {
 	if validModelAPIs[api] {
 		return api
 	}
+
 	return ""
 }
 
@@ -374,6 +409,7 @@ func defaultProviderAPIKeyEnvVar(provider string) string {
 		return "OLLAMA_API_KEY"
 	default:
 		var out []rune
+
 		for _, r := range strings.ToUpper(provider) {
 			if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
 				out = append(out, r)
@@ -381,10 +417,12 @@ func defaultProviderAPIKeyEnvVar(provider string) string {
 				out = append(out, '_')
 			}
 		}
+
 		s := strings.Trim(string(out), "_")
 		if s == "" {
 			return "MODEL_API_KEY"
 		}
+
 		return s + "_API_KEY"
 	}
 }
@@ -394,13 +432,16 @@ func extractEnvVarName(s string) (string, bool) {
 	if !strings.HasPrefix(s, "${") || !strings.HasSuffix(s, "}") {
 		return "", false
 	}
+
 	body := strings.TrimSuffix(strings.TrimPrefix(s, "${"), "}")
 	if body == "" {
 		return "", false
 	}
+
 	if i := strings.Index(body, ":"); i > 0 {
 		body = body[:i]
 	}
+
 	return body, body != ""
 }
 

--- a/internal/openclaw/import.go
+++ b/internal/openclaw/import.go
@@ -6,6 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/model"
+)
+
+// API key environment variable names for known providers.
+const (
+	envAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	envOpenAIAPIKey    = "OPENAI_API_KEY"
 )
 
 // ImportResult holds the parsed configuration from ~/.openclaw/openclaw.json
@@ -401,11 +409,11 @@ func sanitizeModelAPI(api string) string {
 
 func defaultProviderAPIKeyEnvVar(provider string) string {
 	switch provider {
-	case "anthropic":
-		return "ANTHROPIC_API_KEY"
-	case "openai":
-		return "OPENAI_API_KEY"
-	case "ollama":
+	case model.ProviderAnthropic:
+		return envAnthropicAPIKey
+	case model.ProviderOpenAI:
+		return envOpenAIAPIKey
+	case model.ProviderOllama:
 		return "OLLAMA_API_KEY"
 	default:
 		var out []rune

--- a/internal/openclaw/import_test.go
+++ b/internal/openclaw/import_test.go
@@ -101,8 +101,8 @@ func TestDetectWorkspace(t *testing.T) {
 	t.Run("dir with SOUL.md marker", func(t *testing.T) {
 		home := t.TempDir()
 		wsDir := filepath.Join(home, ".openclaw", "workspace")
-		os.MkdirAll(wsDir, 0755)
-		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0644)
+		os.MkdirAll(wsDir, 0o755)
+		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0o644)
 
 		got := detectWorkspace(home, "")
 		if got != wsDir {
@@ -113,8 +113,8 @@ func TestDetectWorkspace(t *testing.T) {
 	t.Run("dir with AGENTS.md marker only", func(t *testing.T) {
 		home := t.TempDir()
 		wsDir := filepath.Join(home, ".openclaw", "workspace")
-		os.MkdirAll(wsDir, 0755)
-		os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("test"), 0644)
+		os.MkdirAll(wsDir, 0o755)
+		os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("test"), 0o644)
 
 		got := detectWorkspace(home, "")
 		if got != wsDir {
@@ -125,8 +125,8 @@ func TestDetectWorkspace(t *testing.T) {
 	t.Run("dir with IDENTITY.md marker only", func(t *testing.T) {
 		home := t.TempDir()
 		wsDir := filepath.Join(home, ".openclaw", "workspace")
-		os.MkdirAll(wsDir, 0755)
-		os.WriteFile(filepath.Join(wsDir, "IDENTITY.md"), []byte("test"), 0644)
+		os.MkdirAll(wsDir, 0o755)
+		os.WriteFile(filepath.Join(wsDir, "IDENTITY.md"), []byte("test"), 0o644)
 
 		got := detectWorkspace(home, "")
 		if got != wsDir {
@@ -137,8 +137,8 @@ func TestDetectWorkspace(t *testing.T) {
 	t.Run("dir exists but no marker files", func(t *testing.T) {
 		home := t.TempDir()
 		wsDir := filepath.Join(home, ".openclaw", "workspace")
-		os.MkdirAll(wsDir, 0755)
-		os.WriteFile(filepath.Join(wsDir, "readme.txt"), []byte("test"), 0644)
+		os.MkdirAll(wsDir, 0o755)
+		os.WriteFile(filepath.Join(wsDir, "readme.txt"), []byte("test"), 0o644)
 
 		got := detectWorkspace(home, "")
 		if got != "" {
@@ -148,6 +148,7 @@ func TestDetectWorkspace(t *testing.T) {
 
 	t.Run("dir does not exist", func(t *testing.T) {
 		home := t.TempDir()
+
 		got := detectWorkspace(home, "")
 		if got != "" {
 			t.Errorf("detectWorkspace() = %q, want empty", got)
@@ -157,8 +158,8 @@ func TestDetectWorkspace(t *testing.T) {
 	t.Run("custom workspace path from config", func(t *testing.T) {
 		home := t.TempDir()
 		customWs := filepath.Join(t.TempDir(), "my-workspace")
-		os.MkdirAll(customWs, 0755)
-		os.WriteFile(filepath.Join(customWs, "SOUL.md"), []byte("test"), 0644)
+		os.MkdirAll(customWs, 0o755)
+		os.WriteFile(filepath.Join(customWs, "SOUL.md"), []byte("test"), 0o644)
 
 		got := detectWorkspace(home, customWs)
 		if got != customWs {
@@ -171,9 +172,10 @@ func TestDetectWorkspaceFiles(t *testing.T) {
 	t.Run("all files present", func(t *testing.T) {
 		wsDir := t.TempDir()
 		for _, f := range []string{"SOUL.md", "AGENTS.md", "IDENTITY.md", "USER.md", "TOOLS.md", "MEMORY.md"} {
-			os.WriteFile(filepath.Join(wsDir, f), []byte("test"), 0644)
+			os.WriteFile(filepath.Join(wsDir, f), []byte("test"), 0o644)
 		}
-		os.Mkdir(filepath.Join(wsDir, "memory"), 0755)
+
+		os.Mkdir(filepath.Join(wsDir, "memory"), 0o755)
 
 		got := detectWorkspaceFiles(wsDir)
 		if len(got) != 7 {
@@ -183,7 +185,7 @@ func TestDetectWorkspaceFiles(t *testing.T) {
 
 	t.Run("only SOUL.md", func(t *testing.T) {
 		wsDir := t.TempDir()
-		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0644)
+		os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("test"), 0o644)
 
 		got := detectWorkspaceFiles(wsDir)
 		if len(got) != 1 || got[0] != "SOUL.md" {
@@ -193,7 +195,7 @@ func TestDetectWorkspaceFiles(t *testing.T) {
 
 	t.Run("memory dir included", func(t *testing.T) {
 		wsDir := t.TempDir()
-		os.Mkdir(filepath.Join(wsDir, "memory"), 0755)
+		os.Mkdir(filepath.Join(wsDir, "memory"), 0o755)
 
 		got := detectWorkspaceFiles(wsDir)
 		if len(got) != 1 || got[0] != "memory/" {
@@ -203,6 +205,7 @@ func TestDetectWorkspaceFiles(t *testing.T) {
 
 	t.Run("empty dir", func(t *testing.T) {
 		wsDir := t.TempDir()
+
 		got := detectWorkspaceFiles(wsDir)
 		if len(got) != 0 {
 			t.Errorf("detectWorkspaceFiles() = %v, want empty", got)
@@ -221,10 +224,12 @@ func TestTranslateToOverlayYAML_AgentModelOnly(t *testing.T) {
 	result := &ImportResult{
 		AgentModel: "claude-sonnet-4-6",
 	}
+
 	got := TranslateToOverlayYAML(result)
 	if !strings.Contains(got, "agentModel: claude-sonnet-4-6") {
 		t.Errorf("YAML missing agentModel, got:\n%s", got)
 	}
+
 	if strings.Contains(got, "models:") {
 		t.Errorf("YAML should not contain models section, got:\n%s", got)
 	}
@@ -271,6 +276,7 @@ func TestTranslateToOverlayYAML_DisabledProvider(t *testing.T) {
 	if !strings.Contains(got, "openai:\n    enabled: false") {
 		t.Errorf("YAML missing disabled openai, got:\n%s", got)
 	}
+
 	if strings.Contains(got, "enabled: true") {
 		t.Errorf("YAML should not contain enabled: true for disabled provider, got:\n%s", got)
 	}
@@ -313,6 +319,7 @@ func TestTranslateToOverlayYAML_Channels(t *testing.T) {
 			t.Errorf("YAML missing %q, got:\n%s", check, got)
 		}
 	}
+
 	for _, unexpected := range []string{"botToken:", "appToken:"} {
 		if strings.Contains(got, unexpected) {
 			t.Errorf("YAML should not contain %q, got:\n%s", unexpected, got)
@@ -342,12 +349,15 @@ func TestTranslateToOverlayYAML_FullConfig(t *testing.T) {
 	if !strings.Contains(got, "agentModel: claude-sonnet-4-6") {
 		t.Errorf("YAML missing agentModel, got:\n%s", got)
 	}
+
 	if !strings.Contains(got, "anthropic:\n    enabled: true") {
 		t.Errorf("YAML missing enabled anthropic, got:\n%s", got)
 	}
+
 	if !strings.Contains(got, "openai:\n    enabled: false") {
 		t.Errorf("YAML missing disabled openai, got:\n%s", got)
 	}
+
 	if !strings.Contains(got, "telegram:\n    enabled: true") {
 		t.Errorf("YAML missing telegram channel, got:\n%s", got)
 	}
@@ -356,21 +366,25 @@ func TestTranslateToOverlayYAML_FullConfig(t *testing.T) {
 // writeTestOpenclawConfig creates a test openclaw.json at the expected path
 func writeTestOpenclawConfig(t *testing.T, home string, cfg *openclawConfig) {
 	t.Helper()
+
 	dir := filepath.Join(home, ".openclaw")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "openclaw.json"), data, 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.json"), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDetectExistingConfigAt_FileNotFound(t *testing.T) {
 	home := t.TempDir()
+
 	result, err := detectExistingConfigAt(home)
 	if result != nil || err != nil {
 		t.Errorf("expected (nil, nil), got (%v, %v)", result, err)
@@ -380,16 +394,18 @@ func TestDetectExistingConfigAt_FileNotFound(t *testing.T) {
 func TestDetectExistingConfigAt_InvalidJSON(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, ".openclaw")
-	os.MkdirAll(dir, 0755)
-	os.WriteFile(filepath.Join(dir, "openclaw.json"), []byte("{invalid json"), 0644)
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "openclaw.json"), []byte("{invalid json"), 0o644)
 
 	result, err := detectExistingConfigAt(home)
 	if result != nil {
 		t.Errorf("expected nil result, got %v", result)
 	}
+
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
+
 	if !strings.Contains(err.Error(), "failed to parse") {
 		t.Errorf("error should mention parsing, got: %v", err)
 	}
@@ -413,6 +429,7 @@ func TestDetectExistingConfigAt_ValidConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -420,22 +437,28 @@ func TestDetectExistingConfigAt_ValidConfig(t *testing.T) {
 	if result.AgentModel != "claude-sonnet-4-6" {
 		t.Errorf("AgentModel = %q, want %q", result.AgentModel, "claude-sonnet-4-6")
 	}
+
 	if len(result.Providers) != 1 {
 		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
 	}
+
 	p := result.Providers[0]
 	if p.Name != "anthropic" {
 		t.Errorf("Provider.Name = %q, want %q", p.Name, "anthropic")
 	}
+
 	if p.APIKey != "sk-ant-test-key" {
 		t.Errorf("Provider.APIKey = %q, want %q", p.APIKey, "sk-ant-test-key")
 	}
+
 	if p.API != "anthropic-messages" {
 		t.Errorf("Provider.API = %q, want %q", p.API, "anthropic-messages")
 	}
+
 	if p.APIKeyEnvVar != "ANTHROPIC_API_KEY" {
 		t.Errorf("Provider.APIKeyEnvVar = %q, want %q", p.APIKeyEnvVar, "ANTHROPIC_API_KEY")
 	}
+
 	if len(p.Models) != 1 || p.Models[0].ID != "claude-sonnet-4-6" {
 		t.Errorf("Provider.Models = %v", p.Models)
 	}
@@ -458,6 +481,7 @@ func TestDetectExistingConfigAt_EnvVarKeySkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -465,9 +489,11 @@ func TestDetectExistingConfigAt_EnvVarKeySkipped(t *testing.T) {
 	if len(result.Providers) != 1 {
 		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
 	}
+
 	if result.Providers[0].APIKey != "" {
 		t.Errorf("Provider.APIKey = %q, want empty (env-var should be skipped)", result.Providers[0].APIKey)
 	}
+
 	if result.Providers[0].APIKeyEnvVar != "OPENAI_API_KEY" {
 		t.Errorf("Provider.APIKeyEnvVar = %q, want OPENAI_API_KEY", result.Providers[0].APIKeyEnvVar)
 	}
@@ -496,9 +522,11 @@ func TestDetectExistingConfigAt_ChannelImport(t *testing.T) {
 	if result.Channels.Telegram == nil || result.Channels.Telegram.BotToken != "123456:ABCDEF" {
 		t.Errorf("Telegram = %v", result.Channels.Telegram)
 	}
+
 	if result.Channels.Discord == nil || result.Channels.Discord.BotToken != "MTIzNDU2" {
 		t.Errorf("Discord = %v", result.Channels.Discord)
 	}
+
 	if result.Channels.Slack == nil || result.Channels.Slack.BotToken != "xoxb-test" || result.Channels.Slack.AppToken != "xapp-test" {
 		t.Errorf("Slack = %v", result.Channels.Slack)
 	}
@@ -525,8 +553,8 @@ func TestDetectExistingConfigAt_ChannelEnvVarSkipped(t *testing.T) {
 func TestDetectExistingConfigAt_WorkspaceDetection(t *testing.T) {
 	home := t.TempDir()
 	wsDir := filepath.Join(home, ".openclaw", "workspace")
-	os.MkdirAll(wsDir, 0755)
-	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("I am an agent"), 0644)
+	os.MkdirAll(wsDir, 0o755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("I am an agent"), 0o644)
 
 	cfg := &openclawConfig{}
 	writeTestOpenclawConfig(t, home, cfg)
@@ -561,6 +589,7 @@ func TestDetectExistingConfigAt_UnknownAPISanitized(t *testing.T) {
 	if len(result.Providers) != 1 {
 		t.Fatalf("len(Providers) = %d, want 1", len(result.Providers))
 	}
+
 	if result.Providers[0].API != "" {
 		t.Errorf("Provider.API = %q, want empty (unknown API should be sanitized)", result.Providers[0].API)
 	}
@@ -575,12 +604,15 @@ func TestDetectExistingConfigAt_EmptyConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if result == nil {
 		t.Fatal("expected non-nil result for valid but empty config")
 	}
+
 	if len(result.Providers) != 0 {
 		t.Errorf("len(Providers) = %d, want 0", len(result.Providers))
 	}
+
 	if result.AgentModel != "" {
 		t.Errorf("AgentModel = %q, want empty", result.AgentModel)
 	}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -172,7 +172,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 			namespace := fmt.Sprintf("%s-%s", appName, id)
 
 			helmfileContent := generateHelmfile(id, namespace)
-			if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
+			if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o600); err != nil {
 				return fmt.Errorf("failed to update helmfile.yaml: %w", err)
 			}
 
@@ -285,7 +285,7 @@ agents:
 `
 	}
 
-	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0o600); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write overlay values: %w", err)
 	}
@@ -313,7 +313,7 @@ agents:
 
 	// Generate helmfile.yaml referencing obol/openclaw + remote-signer
 	helmfileContent := generateHelmfile(id, namespace)
-	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o600); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write helmfile.yaml: %w", err)
 	}
@@ -748,12 +748,12 @@ func copyDirRecursive(src, dst string) error {
 			return os.MkdirAll(targetPath, 0o755)
 		}
 
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) //nolint:gosec // G122: local skill files from embedded assets, no symlink risk
 		if err != nil {
 			return err
 		}
 
-		return os.WriteFile(targetPath, data, 0o644)
+		return os.WriteFile(targetPath, data, 0o600) //nolint:gosec // G703: targetPath from user's local config dir
 	})
 }
 
@@ -1073,7 +1073,7 @@ func Setup(cfg *config.Config, id string, _ SetupOptions, u *ui.UI) error {
 	namespace := fmt.Sprintf("%s-%s", appName, id)
 
 	helmfileContent := generateHelmfile(id, namespace)
-	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o600); err != nil {
 		return fmt.Errorf("failed to write helmfile.yaml: %w", err)
 	}
 
@@ -1088,7 +1088,7 @@ func Setup(cfg *config.Config, id string, _ SetupOptions, u *ui.UI) error {
 	overlay := generateOverlayValues(cfg, hostname, imported, len(secretData) > 0, nil, "")
 
 	overlayPath := filepath.Join(deploymentDir, "values-obol.yaml")
-	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o600); err != nil {
 		return fmt.Errorf("failed to write overlay values: %w", err)
 	}
 
@@ -1568,7 +1568,7 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 		// Update overlay YAML (for helm consistency on next sync)
 		updated, changed := patchOverlayModelList(content, models)
 		if changed {
-			if err := os.WriteFile(overlayPath, []byte(updated), 0o644); err != nil {
+			if err := os.WriteFile(overlayPath, []byte(updated), 0o600); err != nil { //nolint:gosec // G703: path from user's local config dir
 				u.Warnf("Failed to update overlay for %s: %v", id, err)
 			}
 		}
@@ -1769,7 +1769,7 @@ func patchAgentModelsJSON(cfg *config.Config, id string, models []string, master
 
 	data = append(data, '\n')
 
-	return os.WriteFile(modelsPath, data, 0o644)
+	return os.WriteFile(modelsPath, data, 0o600)
 }
 
 // patchOverlayModelList replaces the model list under the openai provider

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -2351,14 +2351,14 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 
 			return result, cloud, nil
 		case "4":
-			result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-sonnet-4-6", "Claude Sonnet 4.6")
+			result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", envAnthropicAPIKey, "claude-sonnet-4-6", "Claude Sonnet 4.6")
 			if err != nil {
 				return nil, nil, err
 			}
 
 			return result, nil, nil
 		case "5":
-			result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", "OPENAI_API_KEY", "gpt-5.2", "GPT-5.2")
+			result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", envOpenAIAPIKey, "gpt-5.2", "GPT-5.2")
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2413,14 +2413,14 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 
 		return result, cloud, nil
 	case "3":
-		result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-sonnet-4-6", "Claude Sonnet 4.6")
+		result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", envAnthropicAPIKey, "claude-sonnet-4-6", "Claude Sonnet 4.6")
 		if err != nil {
 			return nil, nil, err
 		}
 
 		return result, nil, nil
 	case "4":
-		result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", "OPENAI_API_KEY", "gpt-5.2", "GPT-5.2")
+		result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", envOpenAIAPIKey, "gpt-5.2", "GPT-5.2")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2543,7 +2543,7 @@ func promptForCustomProvider(reader *bufio.Reader) (*ImportResult, error) {
 
 	apiKeyEnvVar = strings.TrimSpace(apiKeyEnvVar)
 	if apiKeyEnvVar == "" {
-		apiKeyEnvVar = "OPENAI_API_KEY"
+		apiKeyEnvVar = envOpenAIAPIKey
 	}
 
 	fmt.Printf("API key (optional, leave empty to configure later): ")
@@ -2572,7 +2572,7 @@ func buildLiteLLMRoutedOverlay(cfg *config.Config, cloud *CloudProviderInfo) *Im
 				Name:         "openai",
 				BaseURL:      "http://litellm.llm.svc.cluster.local:4000/v1",
 				API:          "openai-completions",
-				APIKeyEnvVar: "OPENAI_API_KEY",
+				APIKeyEnvVar: envOpenAIAPIKey,
 				APIKey:       litellmMasterKey(cfg),
 				Models: []ImportedModel{
 					{ID: cloud.ModelID, Name: cloud.Display},
@@ -2590,18 +2590,18 @@ func buildDirectProviderOverlay(providerName, baseURL, api, apiKeyEnvVar, modelI
 	var agentPrefix string
 
 	switch providerName {
-	case "anthropic":
-		agentPrefix = "anthropic"
-	case "openai":
-		agentPrefix = "openai"
+	case model.ProviderAnthropic:
+		agentPrefix = model.ProviderAnthropic
+	case model.ProviderOpenAI:
+		agentPrefix = model.ProviderOpenAI
 	default:
 		agentPrefix = providerName
 	}
 
 	providers := []ImportedProvider{
-		{Name: "anthropic", Disabled: providerName != "anthropic"},
-		{Name: "openai", Disabled: providerName != "openai"},
-		{Name: "ollama", Disabled: providerName != "ollama"},
+		{Name: model.ProviderAnthropic, Disabled: providerName != model.ProviderAnthropic},
+		{Name: model.ProviderOpenAI, Disabled: providerName != model.ProviderOpenAI},
+		{Name: model.ProviderOllama, Disabled: providerName != model.ProviderOllama},
 	}
 	for i := range providers {
 		if providers[i].Name != providerName {

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,13 +63,15 @@ var openclawVersionRaw string
 // openclawImageTag returns the image tag derived from OPENCLAW_VERSION,
 // stripping the leading "v" and any whitespace/comments.
 func openclawImageTag() string {
-	for _, line := range strings.Split(openclawVersionRaw, "\n") {
+	for line := range strings.SplitSeq(openclawVersionRaw, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
+
 		return strings.TrimPrefix(line, "v")
 	}
+
 	return ""
 }
 
@@ -109,6 +112,7 @@ func SetupDefault(cfg *config.Config, u *ui.UI) error {
 	if importErr != nil {
 		u.Warnf("could not read existing config: %v", importErr)
 	}
+
 	hasImportedProviders := imported != nil && len(imported.Providers) > 0
 
 	// No imported providers — skip automatic deployment.
@@ -129,6 +133,7 @@ func SetupDefault(cfg *config.Config, u *ui.UI) error {
 			u.Warnf("Local Ollama not detected on host (%s)", ollamaEndpoint())
 			u.Print("  Skipping default OpenClaw model provider setup.")
 			u.Print("  Run 'obol model setup' to configure a provider later.")
+
 			return nil
 		}
 	}
@@ -148,6 +153,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 	if opts.IsDefault {
 		id = "obol-agent"
 	}
+
 	if id == "" {
 		id = petname.Generate(2, "-")
 		u.Infof("Generated deployment ID: %s", id)
@@ -164,10 +170,12 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 			// Always regenerate helmfile.yaml to pick up chart version bumps.
 			// values-obol.yaml (user config) is intentionally left unchanged.
 			namespace := fmt.Sprintf("%s-%s", appName, id)
+
 			helmfileContent := generateHelmfile(id, namespace)
-			if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
 				return fmt.Errorf("failed to update helmfile.yaml: %w", err)
 			}
+
 			if opts.Sync {
 				if err := doSync(cfg, id, u); err != nil {
 					return err
@@ -177,11 +185,14 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 				if importErr != nil {
 					u.Warnf("could not read existing config: %v", importErr)
 				}
+
 				if imported != nil && imported.WorkspaceDir != "" {
 					copyWorkspaceToVolume(cfg, id, imported.WorkspaceDir, u)
 				}
+
 				return nil
 			}
+
 			return nil
 		}
 	}
@@ -192,6 +203,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 				"Directory: %s\n"+
 				"Use --force or -f to overwrite", appName, id, deploymentDir)
 		}
+
 		u.Warnf("Overwriting existing deployment at %s", deploymentDir)
 	}
 
@@ -200,6 +212,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 	if err != nil {
 		u.Warnf("failed to read existing config: %v", err)
 	}
+
 	if imported != nil {
 		PrintImportSummary(imported)
 	}
@@ -210,6 +223,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 			u.Print("\nUsing detected configuration from ~/.openclaw/")
 		} else {
 			var cloudProvider *CloudProviderInfo
+
 			imported, cloudProvider, err = interactiveSetup(cfg, imported)
 			if err != nil {
 				return fmt.Errorf("interactive setup failed: %w", err)
@@ -223,7 +237,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 		}
 	}
 
-	if err := os.MkdirAll(deploymentDir, 0755); err != nil {
+	if err := os.MkdirAll(deploymentDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create deployment directory: %w", err)
 	}
 
@@ -236,6 +250,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 	if err := dns.EnsureHostsEntries(collectAllHostnames(cfg, hostname)); err != nil {
 		u.Warnf("Could not update /etc/hosts for %s: %v", hostname, err)
 	}
+
 	secretData := collectSensitiveData(imported)
 	if err := writeUserSecretsFile(deploymentDir, secretData); err != nil {
 		os.RemoveAll(deploymentDir)
@@ -243,6 +258,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 	}
 	// If running in agent mode, read tunnel state to inject AGENT_BASE_URL.
 	var agentBaseURL string
+
 	if opts.AgentMode {
 		st, _ := tunnel.LoadTunnelState(cfg)
 		if st != nil && st.Hostname != "" {
@@ -254,6 +270,7 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 			opts.OllamaModels = listOllamaModels()
 		}
 	}
+
 	overlay := generateOverlayValues(cfg, hostname, imported, len(secretData) > 0, opts.OllamaModels, agentBaseURL)
 
 	// Append heartbeat config for agent mode.
@@ -267,7 +284,8 @@ agents:
       target: "none"
 `
 	}
-	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(deploymentDir, "values-obol.yaml"), []byte(overlay), 0o644); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write overlay values: %w", err)
 	}
@@ -275,16 +293,19 @@ agents:
 	// Generate Ethereum signing wallet (key + remote-signer config).
 	u.Blank()
 	u.Info("Generating Ethereum wallet...")
+
 	wallet, err := GenerateWallet(cfg, id)
 	if err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to generate wallet: %w", err)
 	}
+
 	rsValues := generateRemoteSignerValues(wallet)
-	if err := os.WriteFile(filepath.Join(deploymentDir, "values-remote-signer.yaml"), []byte(rsValues), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "values-remote-signer.yaml"), []byte(rsValues), 0o600); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write remote-signer values: %w", err)
 	}
+
 	if err := WriteWalletMetadata(deploymentDir, wallet); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write wallet metadata: %w", err)
@@ -292,7 +313,7 @@ agents:
 
 	// Generate helmfile.yaml referencing obol/openclaw + remote-signer
 	helmfileContent := generateHelmfile(id, namespace)
-	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
 		os.RemoveAll(deploymentDir)
 		return fmt.Errorf("failed to write helmfile.yaml: %w", err)
 	}
@@ -310,9 +331,11 @@ agents:
 	u.Print("  - values-remote-signer.yaml  Remote-signer config (keystore password)")
 	u.Print("  - wallet.json                Wallet metadata (address, keystore UUID)")
 	u.Print("  - helmfile.yaml              Deployment configuration")
+
 	if len(secretData) > 0 {
 		u.Printf("  - %s  Local secret values (used to create %s in-cluster)", userSecretsFileName, userSecretsK8sSecretRef)
 	}
+
 	u.Blank()
 	u.Print("  Back up your signing key:")
 	u.Printf("    cp -r %s ~/obol-wallet-backup/", KeystoreVolumePath(cfg, id))
@@ -326,6 +349,7 @@ agents:
 		u.Blank()
 		u.Info("Deploying to cluster...")
 		u.Blank()
+
 		if err := doSync(cfg, id, u); err != nil {
 			return err
 		}
@@ -342,10 +366,12 @@ agents:
 		if imported != nil && imported.WorkspaceDir != "" {
 			copyWorkspaceToVolume(cfg, id, imported.WorkspaceDir, u)
 		}
+
 		return nil
 	}
 
 	u.Printf("\nTo deploy: obol openclaw sync %s", id)
+
 	return nil
 }
 
@@ -367,13 +393,14 @@ func doSync(cfg *config.Config, id string, u *ui.UI) error {
 
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
 	if _, err := os.Stat(helmfileBinary); os.IsNotExist(err) {
 		return fmt.Errorf("helmfile not found at %s", helmfileBinary)
 	}
+
 	namespace := fmt.Sprintf("%s-%s", appName, id)
 
 	if err := applyUserSecretsIfPresent(cfg, namespace, deploymentDir); err != nil {
@@ -401,8 +428,9 @@ func doSync(cfg *config.Config, id string, u *ui.UI) error {
 
 	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
 	cmd.Dir = deploymentDir
+
 	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath),
+		"KUBECONFIG="+kubeconfigPath,
 	)
 
 	if err := u.Exec(ui.ExecConfig{
@@ -427,7 +455,7 @@ func doSync(cfg *config.Config, id string, u *ui.UI) error {
 	u.Blank()
 	u.Success("OpenClaw installed successfully!")
 	u.Detail("Namespace", namespace)
-	u.Detail("URL", fmt.Sprintf("http://%s", hostname))
+	u.Detail("URL", "http://"+hostname)
 	u.Blank()
 	u.Dim("[Optional] Retrieve a gateway token:")
 	u.Printf("  obol openclaw token %s", id)
@@ -445,10 +473,11 @@ func refreshObolHelmRepo(cfg *config.Config) error {
 	}
 
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-	env := append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+	env := append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 	addCmd := exec.Command(helmBinary, "repo", "add", "obol", "https://obolnetwork.github.io/helm-charts/")
 	addCmd.Env = env
+
 	addOut, addErr := addCmd.CombinedOutput()
 	if addErr != nil && !strings.Contains(string(addOut), `"obol" already exists`) {
 		return fmt.Errorf("helm repo add obol failed: %w\n%s", addErr, string(addOut))
@@ -456,6 +485,7 @@ func refreshObolHelmRepo(cfg *config.Config) error {
 
 	updateCmd := exec.Command(helmBinary, "repo", "update", "obol")
 	updateCmd.Env = env
+
 	updateOut, updateErr := updateCmd.CombinedOutput()
 	if updateErr != nil {
 		return fmt.Errorf("helm repo update obol failed: %w\n%s", updateErr, string(updateOut))
@@ -470,6 +500,7 @@ func writeUserSecretsFile(deploymentDir string, secretData map[string]string) er
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+
 		return nil
 	}
 
@@ -477,16 +508,19 @@ func writeUserSecretsFile(deploymentDir string, secretData map[string]string) er
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, payload, 0600)
+
+	return os.WriteFile(path, payload, 0o600)
 }
 
 func loadUserSecretsFile(deploymentDir string) (map[string]string, error) {
 	path := filepath.Join(deploymentDir, userSecretsFileName)
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, err
 	}
 
@@ -494,6 +528,7 @@ func loadUserSecretsFile(deploymentDir string) (map[string]string, error) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", userSecretsFileName, err)
 	}
+
 	return out, nil
 }
 
@@ -502,6 +537,7 @@ func applyUserSecretsIfPresent(cfg *config.Config, namespace, deploymentDir stri
 	if err != nil {
 		return err
 	}
+
 	if len(secretData) == 0 {
 		return nil
 	}
@@ -513,7 +549,7 @@ func applyUserSecretsIfPresent(cfg *config.Config, namespace, deploymentDir stri
 		return err
 	}
 
-	manifest := map[string]interface{}{
+	manifest := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Secret",
 		"metadata": map[string]string{
@@ -523,39 +559,50 @@ func applyUserSecretsIfPresent(cfg *config.Config, namespace, deploymentDir stri
 		"type":       "Opaque",
 		"stringData": secretData,
 	}
+
 	raw, err := json.Marshal(manifest)
 	if err != nil {
 		return err
 	}
 
 	cmd := exec.Command(kubectlBinary, "apply", "-f", "-")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	cmd.Stdin = bytes.NewReader(raw)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%w\n%s", err, stderr.String())
 	}
+
 	return nil
 }
 
 func ensureNamespaceExists(kubectlBinary, kubeconfigPath, namespace string) error {
 	getCmd := exec.Command(kubectlBinary, "get", "namespace", namespace)
-	getCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	getCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	if err := getCmd.Run(); err == nil {
 		return nil
 	}
 
 	createCmd := exec.Command(kubectlBinary, "create", "namespace", namespace)
-	createCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	createCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 	var stderr bytes.Buffer
+
 	createCmd.Stderr = &stderr
 	if err := createCmd.Run(); err != nil {
 		if strings.Contains(stderr.String(), "AlreadyExists") {
 			return nil
 		}
+
 		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
 	}
+
 	return nil
 }
 
@@ -569,7 +616,7 @@ func copyWorkspaceToVolume(cfg *config.Config, id, workspaceDir string, u *ui.UI
 	u.Blank()
 	u.Infof("Importing workspace from %s...", workspaceDir)
 
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		u.Warnf("could not create workspace directory: %v", err)
 		return
 	}
@@ -593,7 +640,7 @@ func stageDefaultSkills(deploymentDir string, u *ui.UI) {
 		return
 	}
 
-	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		u.Warnf("could not create skills directory: %v", err)
 		return
 	}
@@ -634,6 +681,7 @@ func skillsVolumePath(cfg *config.Config, id string) string {
 // OpenClaw's file watcher detects new/changed skills at runtime.
 func injectSkillsToVolume(cfg *config.Config, id string, deploymentDir string, u *ui.UI) {
 	skillsSrc := filepath.Join(deploymentDir, "skills")
+
 	info, err := os.Stat(skillsSrc)
 	if err != nil || !info.IsDir() {
 		return
@@ -643,34 +691,41 @@ func injectSkillsToVolume(cfg *config.Config, id string, deploymentDir string, u
 	if err != nil {
 		return
 	}
+
 	hasSkills := false
+
 	for _, e := range entries {
 		if e.IsDir() {
 			hasSkills = true
 			break
 		}
 	}
+
 	if !hasSkills {
 		return
 	}
 
 	targetDir := skillsVolumePath(cfg, id)
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		u.Warnf("could not create skills volume directory: %v", err)
 		return
 	}
 
 	u.Info("Injecting skills to volume...")
+
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
+
 		src := filepath.Join(skillsSrc, e.Name())
+
 		dst := filepath.Join(targetDir, e.Name())
 		if err := copyDirRecursive(src, dst); err != nil {
 			u.Warnf("could not inject skill %s: %v", e.Name(), err)
 			continue
 		}
+
 		u.Successf("Injected skill: %s", e.Name())
 	}
 }
@@ -682,26 +737,30 @@ func copyDirRecursive(src, dst string) error {
 		if err != nil {
 			return err
 		}
+
 		relPath, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
 		}
+
 		targetPath := filepath.Join(dst, relPath)
 		if info.IsDir() {
-			return os.MkdirAll(targetPath, 0755)
+			return os.MkdirAll(targetPath, 0o755)
 		}
+
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(targetPath, data, 0644)
+
+		return os.WriteFile(targetPath, data, 0o644)
 	})
 }
 
 // waitForPod polls for a Running pod matching the openclaw label and returns its name.
 // Returns an error if no ready pod is found within timeoutSec seconds.
 func waitForPod(kubectlBinary, kubeconfigPath, namespace string, timeoutSec int) (string, error) {
-	labelSelector := fmt.Sprintf("app.kubernetes.io/name=%s", appName)
+	labelSelector := "app.kubernetes.io/name=" + appName
 
 	for i := 0; i < timeoutSec; i += 3 {
 		cmd := exec.Command(kubectlBinary, "get", "pods",
@@ -709,8 +768,11 @@ func waitForPod(kubectlBinary, kubeconfigPath, namespace string, timeoutSec int)
 			"-l", labelSelector,
 			"-o", "jsonpath={.items[?(@.status.phase=='Running')].metadata.name}",
 		)
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 		var stdout bytes.Buffer
+
 		cmd.Stdout = &stdout
 		cmd.Run()
 
@@ -720,6 +782,7 @@ func waitForPod(kubectlBinary, kubeconfigPath, namespace string, timeoutSec int)
 			if idx := strings.Index(podName, " "); idx > 0 {
 				podName = podName[:idx]
 			}
+
 			return podName, nil
 		}
 
@@ -735,16 +798,19 @@ func getToken(cfg *config.Config, id string) (string, error) {
 
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return "", errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 
 	cmd := exec.Command(kubectlBinary, "get", "secret", "-n", namespace,
-		"-l", fmt.Sprintf("app.kubernetes.io/name=%s", appName),
+		"-l", "app.kubernetes.io/name="+appName,
 		"-o", "json")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 	var stdout, stderr bytes.Buffer
+
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
@@ -771,6 +837,7 @@ func getToken(cfg *config.Config, id string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("failed to decode token: %w", err)
 			}
+
 			return string(decoded), nil
 		}
 	}
@@ -784,7 +851,9 @@ func Token(cfg *config.Config, id string, u *ui.UI) error {
 	if err != nil {
 		return err
 	}
+
 	u.Print(token)
+
 	return nil
 }
 
@@ -792,38 +861,45 @@ func Token(cfg *config.Config, id string, u *ui.UI) error {
 // then retrieves and returns the new token.
 func RegenerateToken(cfg *config.Config, id string, u *ui.UI) (string, error) {
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return "", errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 
 	// Delete the existing secret so a fresh token is generated on restart.
 	u.Info("Deleting existing gateway token...")
+
 	deleteCmd := exec.Command(kubectlBinary, "delete", "secret",
 		"-n", namespace,
-		"-l", fmt.Sprintf("app.kubernetes.io/name=%s", appName),
+		"-l", "app.kubernetes.io/name="+appName,
 		"--ignore-not-found")
-	deleteCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	deleteCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	if out, err := deleteCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to delete secret: %w\n%s", err, string(out))
 	}
 
 	// Restart the deployment to regenerate the token.
 	u.Info("Restarting OpenClaw to regenerate token...")
+
 	restartCmd := exec.Command(kubectlBinary, "rollout", "restart",
 		"deployment/openclaw", "-n", namespace)
-	restartCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	restartCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	if out, err := restartCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to restart deployment: %w\n%s", err, string(out))
 	}
 
 	// Wait for rollout to complete.
 	u.Info("Waiting for new pod to start...")
+
 	waitCmd := exec.Command(kubectlBinary, "rollout", "status",
 		"deployment/openclaw", "-n", namespace, "--timeout=120s")
-	waitCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	waitCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	if out, err := waitCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("rollout not confirmed: %w\n%s", err, string(out))
 	}
@@ -838,6 +914,7 @@ func RegenerateToken(cfg *config.Config, id string, u *ui.UI) (string, error) {
 	}
 
 	u.Success("Token regenerated successfully")
+
 	return newToken, nil
 }
 
@@ -847,11 +924,13 @@ func findOpenClawBinary(cfg *config.Config) (string, error) {
 	if p, err := exec.LookPath("openclaw"); err == nil {
 		return p, nil
 	}
+
 	candidate := filepath.Join(cfg.BinDir, "openclaw")
 	if _, err := os.Stat(candidate); err == nil {
 		return candidate, nil
 	}
-	return "", fmt.Errorf("openclaw CLI not found.\n\nInstall with one of:\n  obolup.sh                                    (re-run bootstrap installer)\n  curl -fsSL https://openclaw.ai/install.sh | bash\n  npm install -g openclaw                      (requires Node.js 22+)")
+
+	return "", errors.New("openclaw CLI not found.\n\nInstall with one of:\n  obolup.sh                                    (re-run bootstrap installer)\n  curl -fsSL https://openclaw.ai/install.sh | bash\n  npm install -g openclaw                      (requires Node.js 22+)")
 }
 
 // portForwarder manages a background kubectl port-forward process.
@@ -867,7 +946,7 @@ type portForwarder struct {
 func startPortForward(cfg *config.Config, namespace string, localPort int) (*portForwarder, error) {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return nil, errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
@@ -879,8 +958,9 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, kubectlBinary, "port-forward",
-		fmt.Sprintf("svc/%s", appName), portArg, "-n", namespace)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+		"svc/"+appName, portArg, "-n", namespace)
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 	// kubectl prints "Forwarding from ..." to stdout (not stderr)
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -895,6 +975,7 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 	}
 
 	done := make(chan error, 1)
+
 	go func() {
 		done <- cmd.Wait()
 	}()
@@ -902,6 +983,7 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 	// Parse the "Forwarding from 127.0.0.1:<port>" line from stdout
 	parsedPort := make(chan int, 1)
 	parseErr := make(chan error, 1)
+
 	go func() {
 		scanner := bufio.NewScanner(stdoutPipe)
 		for scanner.Scan() {
@@ -911,17 +993,20 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 				parts := strings.Split(line, ":")
 				if len(parts) >= 2 {
 					portPart := strings.Fields(parts[len(parts)-1])[0]
+
 					var p int
 					if _, err := fmt.Sscanf(portPart, "%d", &p); err == nil {
 						parsedPort <- p
 						// Continue draining to prevent pipe blocking
 						io.Copy(io.Discard, stdoutPipe)
+
 						return
 					}
 				}
 			}
 		}
-		parseErr <- fmt.Errorf("port-forward exited without reporting a local port")
+
+		parseErr <- errors.New("port-forward exited without reporting a local port")
 	}()
 
 	select {
@@ -932,19 +1017,22 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 		return nil, err
 	case err := <-done:
 		cancel()
+
 		if err != nil {
 			return nil, fmt.Errorf("port-forward process exited unexpectedly: %w", err)
 		}
-		return nil, fmt.Errorf("port-forward process exited unexpectedly")
+
+		return nil, errors.New("port-forward process exited unexpectedly")
 	case <-time.After(30 * time.Second):
 		cancel()
-		return nil, fmt.Errorf("timed out waiting for port-forward to become ready")
+		return nil, errors.New("timed out waiting for port-forward to become ready")
 	}
 }
 
 // Stop terminates the port-forward process gracefully.
 func (pf *portForwarder) Stop() {
 	pf.cancel()
+
 	select {
 	case <-pf.done:
 	case <-time.After(5 * time.Second):
@@ -983,26 +1071,31 @@ func Setup(cfg *config.Config, id string, _ SetupOptions, u *ui.UI) error {
 
 	// Regenerate helmfile to pick up any chart version bumps
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	helmfileContent := generateHelmfile(id, namespace)
-	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deploymentDir, "helmfile.yaml"), []byte(helmfileContent), 0o644); err != nil {
 		return fmt.Errorf("failed to write helmfile.yaml: %w", err)
 	}
 
 	// Regenerate overlay values with the selected provider
 	hostname := fmt.Sprintf("openclaw-%s.%s", id, defaultDomain)
+
 	secretData := collectSensitiveData(imported)
 	if err := writeUserSecretsFile(deploymentDir, secretData); err != nil {
 		return fmt.Errorf("failed to write OpenClaw secrets metadata: %w", err)
 	}
+
 	overlay := generateOverlayValues(cfg, hostname, imported, len(secretData) > 0, nil, "")
+
 	overlayPath := filepath.Join(deploymentDir, "values-obol.yaml")
-	if err := os.WriteFile(overlayPath, []byte(overlay), 0644); err != nil {
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
 		return fmt.Errorf("failed to write overlay values: %w", err)
 	}
 
 	u.Blank()
 	u.Info("Applying configuration...")
 	u.Blank()
+
 	if err := doSync(cfg, id, u); err != nil {
 		return err
 	}
@@ -1012,6 +1105,7 @@ func Setup(cfg *config.Config, id string, _ SetupOptions, u *ui.UI) error {
 
 	u.Blank()
 	u.Info("Waiting for the OpenClaw gateway to be ready...")
+
 	if _, err := waitForPod(kubectlBinary, kubeconfigPath, namespace, 90); err != nil {
 		u.Warnf("pod not ready yet: %v", err)
 		u.Printf("The deployment may still be rolling out. Check with: obol kubectl get pods -n %s", namespace)
@@ -1021,6 +1115,7 @@ func Setup(cfg *config.Config, id string, _ SetupOptions, u *ui.UI) error {
 		u.Success("Setup complete!")
 		u.Print("  Access the OpenClaw dashboard from http://obol.stack")
 	}
+
 	return nil
 }
 
@@ -1066,6 +1161,7 @@ func Dashboard(cfg *config.Config, id string, opts DashboardOptions, onReady fun
 	}
 
 	sigCh := make(chan os.Signal, 1)
+
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
@@ -1089,6 +1185,7 @@ func List(cfg *config.Config, u *ui.UI) error {
 	if _, err := os.Stat(appsDir); os.IsNotExist(err) {
 		u.Print("No OpenClaw instances installed")
 		u.Print("\nTo create one: obol openclaw up")
+
 		return nil
 	}
 
@@ -1106,21 +1203,25 @@ func List(cfg *config.Config, u *ui.UI) error {
 	u.Blank()
 
 	count := 0
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
+
 		id := entry.Name()
 		namespace := fmt.Sprintf("%s-%s", appName, id)
 		hostname := fmt.Sprintf("openclaw-%s.%s", id, defaultDomain)
 		u.Bold("  " + id)
 		u.Detail("  Namespace", namespace)
-		u.Detail("  URL", fmt.Sprintf("http://%s", hostname))
+		u.Detail("  URL", "http://"+hostname)
 		u.Blank()
+
 		count++
 	}
 
 	u.Printf("Total: %d instance(s)", count)
+
 	return nil
 }
 
@@ -1138,11 +1239,13 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 	}
 
 	namespaceExists := false
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); err == nil {
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		cmd := exec.Command(kubectlBinary, "get", "namespace", namespace)
-		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 		if err := cmd.Run(); err == nil {
 			namespaceExists = true
 		}
@@ -1154,11 +1257,13 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 
 	u.Blank()
 	u.Print("Resources to be deleted:")
+
 	if namespaceExists {
 		u.Printf("  [x] Kubernetes namespace: %s", namespace)
 	} else {
 		u.Printf("  [ ] Kubernetes namespace: %s (not found)", namespace)
 	}
+
 	if configExists {
 		u.Printf("  [x] Configuration: %s", deploymentDir)
 	}
@@ -1174,15 +1279,17 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 		// Run helmfile destroy first to cleanly remove Helm releases.
 		// This ensures StatefulSet PVCs are properly cleaned up before namespace deletion.
 		helmfilePath := filepath.Join(deploymentDir, "helmfile.yaml")
+
 		helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
 		if _, err := os.Stat(helmfilePath); err == nil {
 			if _, err := os.Stat(helmfileBinary); err == nil {
 				destroyCmd := exec.Command(helmfileBinary, "-f", helmfilePath, "destroy")
 				destroyCmd.Dir = deploymentDir
-				destroyCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+				destroyCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 				if err := u.Exec(ui.ExecConfig{
-					Name: fmt.Sprintf("Removing Helm releases from %s", namespace),
+					Name: "Removing Helm releases from " + namespace,
 					Cmd:  destroyCmd,
 				}); err != nil {
 					u.Warnf("helmfile destroy failed (will force-delete namespace): %v", err)
@@ -1193,10 +1300,11 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 		kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 		deleteCmd := exec.Command(kubectlBinary, "delete", "namespace", namespace,
 			"--force", "--grace-period=0")
-		deleteCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+		deleteCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 		if err := u.Exec(ui.ExecConfig{
-			Name: fmt.Sprintf("Deleting namespace %s", namespace),
+			Name: "Deleting namespace " + namespace,
 			Cmd:  deleteCmd,
 		}); err != nil {
 			u.Warnf("namespace deletion may still be in progress: %v", err)
@@ -1205,12 +1313,15 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 
 	if configExists {
 		u.Info("Deleting configuration...")
+
 		if err := os.RemoveAll(deploymentDir); err != nil {
 			return fmt.Errorf("failed to delete config directory: %w", err)
 		}
+
 		u.Success("Configuration deleted")
 
 		parentDir := filepath.Join(cfg.ConfigDir, "applications", appName)
+
 		entries, err := os.ReadDir(parentDir)
 		if err == nil && len(entries) == 0 {
 			os.Remove(parentDir)
@@ -1219,6 +1330,7 @@ func Delete(cfg *config.Config, id string, force bool, u *ui.UI) error {
 
 	u.Blank()
 	u.Successf("OpenClaw %s deleted successfully!", id)
+
 	return nil
 }
 
@@ -1234,7 +1346,7 @@ func SkillsSync(cfg *config.Config, id, skillsDir string, u *ui.UI) error {
 
 	u.Infof("Syncing skills from %s to volume...", skillsDir)
 
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create skills volume directory: %w", err)
 	}
 
@@ -1247,15 +1359,19 @@ func SkillsSync(cfg *config.Config, id, skillsDir string, u *ui.UI) error {
 		if !e.IsDir() {
 			continue
 		}
+
 		src := filepath.Join(skillsDir, e.Name())
+
 		dst := filepath.Join(targetDir, e.Name())
 		if err := copyDirRecursive(src, dst); err != nil {
 			return fmt.Errorf("failed to copy skill %s: %w", e.Name(), err)
 		}
+
 		u.Successf("Synced skill: %s", e.Name())
 	}
 
 	u.Success("Skills synced to volume (file watcher will reload)")
+
 	return nil
 }
 
@@ -1264,6 +1380,7 @@ func SkillsSync(cfg *config.Config, id, skillsDir string, u *ui.UI) error {
 func SkillAdd(cfg *config.Config, id string, args []string, u *ui.UI) error {
 	_ = u // interactive passthrough — subprocess owns stdout/stderr
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	return cliViaKubectlExec(cfg, namespace, append([]string{"skills", "add"}, args...))
 }
 
@@ -1272,6 +1389,7 @@ func SkillAdd(cfg *config.Config, id string, args []string, u *ui.UI) error {
 func SkillRemove(cfg *config.Config, id string, args []string, u *ui.UI) error {
 	_ = u // interactive passthrough — subprocess owns stdout/stderr
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	return cliViaKubectlExec(cfg, namespace, append([]string{"skills", "remove"}, args...))
 }
 
@@ -1280,6 +1398,7 @@ func SkillRemove(cfg *config.Config, id string, args []string, u *ui.UI) error {
 func SkillList(cfg *config.Config, id string, u *ui.UI) error {
 	_ = u // interactive passthrough — subprocess owns stdout/stderr
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	return cliViaKubectlExec(cfg, namespace, []string{"skills", "list"})
 }
 
@@ -1296,6 +1415,7 @@ var remoteCapableCommands = map[string]bool{
 // others are executed via kubectl exec into the pod.
 func CLI(cfg *config.Config, id string, args []string, u *ui.UI) error {
 	_ = u // interactive passthrough — subprocess owns stdout/stderr
+
 	deploymentDir := DeploymentPath(cfg, id)
 	if _, err := os.Stat(deploymentDir); os.IsNotExist(err) {
 		return fmt.Errorf("deployment not found: %s/%s\nRun 'obol openclaw up' first", appName, id)
@@ -1315,6 +1435,7 @@ func CLI(cfg *config.Config, id string, args []string, u *ui.UI) error {
 	if remoteCapableCommands[firstArg] {
 		return cliViaPortForward(cfg, id, namespace, args)
 	}
+
 	return cliViaKubectlExec(cfg, namespace, args)
 }
 
@@ -1347,6 +1468,7 @@ func cliViaPortForward(cfg *config.Config, id, namespace string, args []string) 
 
 	// Handle signals to clean up port-forward
 	sigCh := make(chan os.Signal, 1)
+
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
@@ -1356,13 +1478,16 @@ func cliViaPortForward(cfg *config.Config, id, namespace string, args []string) 
 	}()
 
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				os.Exit(status.ExitStatus())
 			}
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -1370,7 +1495,7 @@ func cliViaPortForward(cfg *config.Config, id, namespace string, args []string) 
 func cliViaKubectlExec(cfg *config.Config, namespace string, args []string) error {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
 
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
@@ -1389,19 +1514,23 @@ func cliViaKubectlExec(cfg *config.Config, namespace string, args []string) erro
 	execArgs = append(execArgs, args...)
 
 	cmd := exec.Command(kubectlBinary, execArgs...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				os.Exit(status.ExitStatus())
 			}
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -1423,10 +1552,12 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 
 	for _, id := range ids {
 		overlayPath := filepath.Join(DeploymentPath(cfg, id), "values-obol.yaml")
+
 		data, err := os.ReadFile(overlayPath)
 		if err != nil {
 			continue
 		}
+
 		content := string(data)
 
 		// Only patch instances that use the LiteLLM gateway pattern
@@ -1437,7 +1568,7 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 		// Update overlay YAML (for helm consistency on next sync)
 		updated, changed := patchOverlayModelList(content, models)
 		if changed {
-			if err := os.WriteFile(overlayPath, []byte(updated), 0644); err != nil {
+			if err := os.WriteFile(overlayPath, []byte(updated), 0o644); err != nil {
 				u.Warnf("Failed to update overlay for %s: %v", id, err)
 			}
 		}
@@ -1455,6 +1586,7 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 
 		u.Infof("Updated models for OpenClaw %s (%d models, primary: %s)", id, len(models), primary)
 	}
+
 	return nil
 }
 
@@ -1468,6 +1600,7 @@ func rankModels(models []string) (primary string, fallbacks []string) {
 
 	// Partition into cloud and local
 	var cloud, local []string
+
 	for _, m := range models {
 		if isCloudModel(m) {
 			cloud = append(cloud, m)
@@ -1487,9 +1620,11 @@ func rankModels(models []string) (primary string, fallbacks []string) {
 
 	// Prefix with openai/ for LiteLLM routing
 	primary = "openai/" + primary
+
 	for i, f := range fallbacks {
 		fallbacks[i] = "openai/" + f
 	}
+
 	return primary, fallbacks
 }
 
@@ -1498,9 +1633,11 @@ func isCloudModel(name string) bool {
 	if strings.Contains(name, "claude") {
 		return true
 	}
+
 	if strings.HasPrefix(name, "gpt") || strings.HasPrefix(name, "o1") || strings.HasPrefix(name, "o3") {
 		return true
 	}
+
 	return false
 }
 
@@ -1515,36 +1652,41 @@ func patchModelHierarchy(cfg *config.Config, id, primary string, fallbacks []str
 	// Read current ConfigMap
 	getCmd := exec.Command(kubectlBinary, "get", "configmap", "openclaw-config",
 		"-n", namespace, "-o", "jsonpath={.data.openclaw\\.json}")
-	getCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	getCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 	var out bytes.Buffer
+
 	getCmd.Stdout = &out
 	if err := getCmd.Run(); err != nil {
 		return // ConfigMap may not exist yet
 	}
 
-	var cfgJSON map[string]interface{}
+	var cfgJSON map[string]any
 	if err := json.Unmarshal(out.Bytes(), &cfgJSON); err != nil {
 		return
 	}
 
 	// Navigate to agents.defaults.model
-	agents, ok := cfgJSON["agents"].(map[string]interface{})
+	agents, ok := cfgJSON["agents"].(map[string]any)
 	if !ok {
-		agents = map[string]interface{}{}
+		agents = map[string]any{}
 		cfgJSON["agents"] = agents
 	}
-	defaults, ok := agents["defaults"].(map[string]interface{})
+
+	defaults, ok := agents["defaults"].(map[string]any)
 	if !ok {
-		defaults = map[string]interface{}{}
+		defaults = map[string]any{}
 		agents["defaults"] = defaults
 	}
 
-	modelCfg := map[string]interface{}{
+	modelCfg := map[string]any{
 		"primary": primary,
 	}
 	if len(fallbacks) > 0 {
 		modelCfg["fallbacks"] = fallbacks
 	}
+
 	defaults["model"] = modelCfg
 
 	// Re-serialize and apply
@@ -1553,10 +1695,10 @@ func patchModelHierarchy(cfg *config.Config, id, primary string, fallbacks []str
 		return
 	}
 
-	applyPayload := map[string]interface{}{
+	applyPayload := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "openclaw-config",
 			"namespace": namespace,
 		},
@@ -1568,7 +1710,9 @@ func patchModelHierarchy(cfg *config.Config, id, primary string, fallbacks []str
 
 	applyCmd := exec.Command(kubectlBinary, "apply", "-f", "-",
 		"--server-side", "--field-manager=helm", "--force-conflicts")
-	applyCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	applyCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 	applyCmd.Stdin = bytes.NewReader(applyRaw)
 	if err := applyCmd.Run(); err != nil {
 		u.Warnf("Failed to patch model hierarchy in ConfigMap: %v", err)
@@ -1594,6 +1738,7 @@ func patchAgentModelsJSON(cfg *config.Config, id string, models []string, master
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
+
 	type provider struct {
 		BaseURL string       `json:"baseUrl"`
 		APIKey  string       `json:"apiKey"`
@@ -1606,8 +1751,8 @@ func patchAgentModelsJSON(cfg *config.Config, id string, models []string, master
 		entries = append(entries, modelEntry{ID: m, Name: m})
 	}
 
-	modelsJSON := map[string]interface{}{
-		"providers": map[string]interface{}{
+	modelsJSON := map[string]any{
+		"providers": map[string]any{
 			"openai": provider{
 				BaseURL: "http://litellm.llm.svc.cluster.local:4000/v1",
 				APIKey:  masterKey,
@@ -1621,9 +1766,10 @@ func patchAgentModelsJSON(cfg *config.Config, id string, models []string, master
 	if err != nil {
 		return fmt.Errorf("failed to marshal models.json: %w", err)
 	}
+
 	data = append(data, '\n')
 
-	return os.WriteFile(modelsPath, data, 0644)
+	return os.WriteFile(modelsPath, data, 0o644)
 }
 
 // patchOverlayModelList replaces the model list under the openai provider
@@ -1639,7 +1785,9 @@ func patchOverlayModelList(content string, models []string) (string, bool) {
 	//         - id: <model>
 	//           name: <display>
 	lines := strings.Split(content, "\n")
+
 	var result []string
+
 	inOpenAI := false
 	inModelList := false
 	modelListIndent := ""
@@ -1652,7 +1800,9 @@ func patchOverlayModelList(content string, models []string) (string, bool) {
 		// Track when we enter the openai provider section
 		if trimmed == "openai:" && strings.Contains(content, "litellm.llm.svc") {
 			inOpenAI = true
+
 			result = append(result, line)
+
 			continue
 		}
 
@@ -1678,15 +1828,19 @@ func patchOverlayModelList(content string, models []string) (string, bool) {
 			if trimmed == "models: []" {
 				continue
 			}
+
 			for i+1 < len(lines) {
 				next := lines[i+1]
+
 				nextTrimmed := strings.TrimSpace(next)
 				if nextTrimmed == "" || (strings.HasPrefix(next, modelListIndent+"  ") && (strings.HasPrefix(nextTrimmed, "- id:") || strings.HasPrefix(nextTrimmed, "name:"))) {
 					i++
 					continue
 				}
+
 				break
 			}
+
 			continue
 		}
 
@@ -1701,6 +1855,7 @@ func patchOverlayModelList(content string, models []string) (string, bool) {
 	if !replaced {
 		return content, false
 	}
+
 	return strings.Join(result, "\n"), true
 }
 
@@ -1715,10 +1870,12 @@ func DeploymentPath(cfg *config.Config, id string) string {
 // litellmMasterKey returns the LiteLLM master key derived from the cluster's stack ID.
 func litellmMasterKey(cfg *config.Config) string {
 	stackIDPath := filepath.Join(cfg.ConfigDir, ".stack-id")
+
 	data, err := os.ReadFile(stackIDPath)
 	if err != nil {
 		return "sk-obol-default" // fallback if stack ID not found
 	}
+
 	return "sk-obol-" + strings.TrimSpace(string(data))
 }
 
@@ -1733,7 +1890,7 @@ httpRoute:
   enabled: true
   hostnames:
 `)
-	b.WriteString(fmt.Sprintf("    - %s\n", hostname))
+	fmt.Fprintf(&b, "    - %s\n", hostname)
 	b.WriteString(`  parentRefs:
     - name: traefik-gateway
       namespace: traefik
@@ -1751,7 +1908,7 @@ rbac:
 
 	// Override chart default image tag when the binary pins a newer version.
 	if tag := openclawImageTag(); tag != "" {
-		b.WriteString(fmt.Sprintf("# Override chart default image tag (chart ships %s)\nimage:\n  tag: \"%s\"\n\n", chartVersion, tag))
+		fmt.Fprintf(&b, "# Override chart default image tag (chart ships %s)\nimage:\n  tag: \"%s\"\n\n", chartVersion, tag)
 	}
 
 	// Provider and agent model configuration.
@@ -1781,9 +1938,11 @@ rbac:
 
 	b.WriteString("# All models route through LiteLLM gateway (openai provider slot).\n")
 	b.WriteString("openclaw:\n")
+
 	if agentModel != "" {
-		b.WriteString(fmt.Sprintf("  agentModel: %s\n", agentModel))
+		fmt.Fprintf(&b, "  agentModel: %s\n", agentModel)
 	}
+
 	b.WriteString(`  gateway:
     # Allow control UI over HTTP behind Traefik (local dev stack).
     # dangerouslyDisableDeviceAuth is needed because Traefik proxies from
@@ -1802,16 +1961,18 @@ models:
     api: openai-completions
     apiKeyEnvVar: OPENAI_API_KEY
 `)
-	b.WriteString(fmt.Sprintf("    apiKeyValue: %s\n", litellmMasterKey(cfg)))
+	fmt.Fprintf(&b, "    apiKeyValue: %s\n", litellmMasterKey(cfg))
 
 	if len(ollamaModels) > 0 {
 		b.WriteString("    models:\n")
+
 		for _, m := range ollamaModels {
-			b.WriteString(fmt.Sprintf("      - id: %s\n        name: %s\n", m, ollamaModelDisplayName(m)))
+			fmt.Fprintf(&b, "      - id: %s\n        name: %s\n", m, ollamaModelDisplayName(m))
 		}
 	} else {
 		b.WriteString("    models: []\n")
 	}
+
 	b.WriteString("\n")
 
 	// Append non-model imported config (channels, etc.)
@@ -1820,8 +1981,11 @@ models:
 		// Strip the openclaw: and models: sections — we already wrote those above.
 		// Keep only channel config and other non-provider settings.
 		lines := strings.Split(importedOverlay, "\n")
+
 		var kept []string
+
 		skip := false
+
 		for _, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			// Skip openclaw: block (agentModel) and models: block (providers)
@@ -1833,10 +1997,12 @@ models:
 			if skip && len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
 				skip = false
 			}
+
 			if !skip {
 				kept = append(kept, line)
 			}
 		}
+
 		extra := strings.TrimSpace(strings.Join(kept, "\n"))
 		if extra != "" {
 			b.WriteString("# Imported from ~/.openclaw/openclaw.json\n")
@@ -1855,11 +2021,13 @@ extraEnv:
   - name: REMOTE_SIGNER_URL
     value: http://remote-signer:9000
 `)
+
 	if agentBaseURL != "" {
-		b.WriteString(fmt.Sprintf(`  - name: AGENT_BASE_URL
+		fmt.Fprintf(&b, `  - name: AGENT_BASE_URL
     value: %s
-`, agentBaseURL))
+`, agentBaseURL)
 	}
+
 	b.WriteString(`
 # Skills: injected directly to the host-side PVC path at
 # $DATA_DIR/openclaw-<id>/openclaw-data/.openclaw/skills/
@@ -1890,6 +2058,7 @@ secrets:
 func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 	// Read values-obol.yaml to check for heartbeat config.
 	valuesPath := filepath.Join(deploymentDir, "values-obol.yaml")
+
 	valuesRaw, err := os.ReadFile(valuesPath)
 	if err != nil {
 		return // No values file, nothing to patch.
@@ -1902,17 +2071,20 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 
 	// Extract heartbeat every/target from YAML (simple parsing, not full YAML).
 	var every, target string
-	for _, line := range strings.Split(string(valuesRaw), "\n") {
+
+	for line := range strings.SplitSeq(string(valuesRaw), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "every:") {
-			every = strings.TrimSpace(strings.TrimPrefix(trimmed, "every:"))
+		if after, ok := strings.CutPrefix(trimmed, "every:"); ok {
+			every = strings.TrimSpace(after)
 			every = strings.Trim(every, "\"'")
 		}
-		if strings.HasPrefix(trimmed, "target:") {
-			target = strings.TrimSpace(strings.TrimPrefix(trimmed, "target:"))
+
+		if after, ok := strings.CutPrefix(trimmed, "target:"); ok {
+			target = strings.TrimSpace(after)
 			target = strings.Trim(target, "\"'")
 		}
 	}
+
 	if every == "" {
 		return // No heartbeat interval configured.
 	}
@@ -1924,8 +2096,11 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 	// Read current ConfigMap.
 	getCmd := exec.Command(kubectlBinary, "get", "configmap", "openclaw-config",
 		"-n", namespace, "-o", "jsonpath={.data.openclaw\\.json}")
-	getCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	getCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+
 	var out bytes.Buffer
+
 	getCmd.Stdout = &out
 	if err := getCmd.Run(); err != nil {
 		fmt.Printf("Warning: could not read openclaw-config ConfigMap: %v\n", err)
@@ -1933,30 +2108,32 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 	}
 
 	// Parse JSON config.
-	var cfgJSON map[string]interface{}
+	var cfgJSON map[string]any
 	if err := json.Unmarshal(out.Bytes(), &cfgJSON); err != nil {
 		fmt.Printf("Warning: could not parse openclaw.json: %v\n", err)
 		return
 	}
 
 	// Navigate to agents.defaults, inject heartbeat.
-	agents, ok := cfgJSON["agents"].(map[string]interface{})
+	agents, ok := cfgJSON["agents"].(map[string]any)
 	if !ok {
-		agents = map[string]interface{}{}
+		agents = map[string]any{}
 		cfgJSON["agents"] = agents
 	}
-	defaults, ok := agents["defaults"].(map[string]interface{})
+
+	defaults, ok := agents["defaults"].(map[string]any)
 	if !ok {
-		defaults = map[string]interface{}{}
+		defaults = map[string]any{}
 		agents["defaults"] = defaults
 	}
 
-	heartbeat := map[string]interface{}{
+	heartbeat := map[string]any{
 		"every": every,
 	}
 	if target != "" {
 		heartbeat["target"] = target
 	}
+
 	defaults["heartbeat"] = heartbeat
 
 	// Re-serialize.
@@ -1968,10 +2145,10 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 
 	// Apply via kubectl apply --server-side with Helm's field manager so that
 	// subsequent helm upgrade doesn't conflict on data.openclaw.json.
-	applyPayload := map[string]interface{}{
+	applyPayload := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "openclaw-config",
 			"namespace": namespace,
 		},
@@ -1983,9 +2160,12 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 
 	applyCmd := exec.Command(kubectlBinary, "apply", "-f", "-",
 		"--server-side", "--field-manager=helm", "--force-conflicts")
-	applyCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	applyCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	applyCmd.Stdin = bytes.NewReader(applyRaw)
+
 	var applyErr bytes.Buffer
+
 	applyCmd.Stderr = &applyErr
 	if err := applyCmd.Run(); err != nil {
 		fmt.Printf("Warning: could not patch heartbeat config: %v\n%s\n", err, applyErr.String())
@@ -2003,8 +2183,10 @@ func ollamaEndpoint() string {
 		if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 			host = "http://" + host
 		}
+
 		return strings.TrimRight(host, "/")
 	}
+
 	return "http://localhost:11434"
 }
 
@@ -2013,17 +2195,21 @@ func ollamaEndpoint() string {
 // server responds with HTTP 200.
 func detectOllama() bool {
 	endpoint := ollamaEndpoint()
+
 	tagsURL, err := url.JoinPath(endpoint, "api", "tags")
 	if err != nil {
 		return false
 	}
 
 	client := &http.Client{Timeout: 2 * time.Second}
+
 	resp, err := client.Get(tagsURL)
 	if err != nil {
 		return false
 	}
+
 	resp.Body.Close()
+
 	return resp.StatusCode == http.StatusOK
 }
 
@@ -2031,19 +2217,24 @@ func detectOllama() bool {
 // Returns nil if Ollama is not reachable, empty slice if reachable but no models pulled.
 func listOllamaModels() []string {
 	endpoint := ollamaEndpoint()
+
 	tagsURL, err := url.JoinPath(endpoint, "api", "tags")
 	if err != nil {
 		return nil
 	}
+
 	client := &http.Client{Timeout: 3 * time.Second}
+
 	resp, err := client.Get(tagsURL)
 	if err != nil {
 		return nil
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil
 	}
+
 	var result struct {
 		Models []struct {
 			Name string `json:"name"`
@@ -2052,11 +2243,13 @@ func listOllamaModels() []string {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil
 	}
+
 	names := make([]string, 0, len(result.Models))
 	for _, m := range result.Models {
 		name := strings.TrimSuffix(m.Name, ":latest")
 		names = append(names, name)
 	}
+
 	return names
 }
 
@@ -2068,6 +2261,7 @@ func preferredOllamaModel(models []string) string {
 	if len(models) > 0 {
 		return models[0]
 	}
+
 	return ""
 }
 
@@ -2075,13 +2269,16 @@ func preferredOllamaModel(models []string) string {
 // into a human-friendly display name (e.g. "Llama3.2 3b").
 func ollamaModelDisplayName(name string) string {
 	parts := strings.SplitN(name, ":", 2)
+
 	display := parts[0]
 	if len(display) > 0 {
 		display = strings.ToUpper(display[:1]) + display[1:]
 	}
+
 	if len(parts) > 1 {
 		display += " " + parts[1]
 	}
+
 	return display
 }
 
@@ -2094,7 +2291,9 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 
 	if imported != nil {
 		fmt.Print("\nUse detected configuration? [Y/n]: ")
+
 		line, _ := reader.ReadString('\n')
+
 		line = strings.TrimSpace(strings.ToLower(line))
 		if line == "" || line == "y" || line == "yes" {
 			fmt.Println("Using detected configuration.")
@@ -2121,6 +2320,7 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 		fmt.Print("\nChoice [1]: ")
 
 		line, _ := reader.ReadString('\n')
+
 		choice := strings.TrimSpace(line)
 		if choice == "" {
 			choice = "1"
@@ -2135,32 +2335,39 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 			if err != nil {
 				return nil, nil, err
 			}
+
 			result := buildLiteLLMRoutedOverlay(cfg, cloud)
+
 			return result, cloud, nil
 		case "3":
 			cloud, err := promptForCloudProvider(reader, "openai", "OpenAI", "gpt-5.2", "GPT-5.2")
 			if err != nil {
 				return nil, nil, err
 			}
+
 			result := buildLiteLLMRoutedOverlay(cfg, cloud)
+
 			return result, cloud, nil
 		case "4":
 			result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-sonnet-4-6", "Claude Sonnet 4.6")
 			if err != nil {
 				return nil, nil, err
 			}
+
 			return result, nil, nil
 		case "5":
 			result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", "OPENAI_API_KEY", "gpt-5.2", "GPT-5.2")
 			if err != nil {
 				return nil, nil, err
 			}
+
 			return result, nil, nil
 		case "6":
 			result, err := promptForCustomProvider(reader)
 			if err != nil {
 				return nil, nil, err
 			}
+
 			return result, nil, nil
 		default:
 			fmt.Printf("Unknown choice '%s', using global Ollama route.\n", choice)
@@ -2178,6 +2385,7 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 	fmt.Print("\nChoice [1]: ")
 
 	line, _ := reader.ReadString('\n')
+
 	choice := strings.TrimSpace(line)
 	if choice == "" {
 		choice = "1"
@@ -2189,32 +2397,39 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 		if err != nil {
 			return nil, nil, err
 		}
+
 		result := buildLiteLLMRoutedOverlay(cfg, cloud)
+
 		return result, cloud, nil
 	case "2":
 		cloud, err := promptForCloudProvider(reader, "openai", "OpenAI", "gpt-5.2", "GPT-5.2")
 		if err != nil {
 			return nil, nil, err
 		}
+
 		result := buildLiteLLMRoutedOverlay(cfg, cloud)
+
 		return result, cloud, nil
 	case "3":
 		result, err := promptForDirectProvider(reader, "anthropic", "Anthropic", "https://api.anthropic.com", "anthropic-messages", "ANTHROPIC_API_KEY", "claude-sonnet-4-6", "Claude Sonnet 4.6")
 		if err != nil {
 			return nil, nil, err
 		}
+
 		return result, nil, nil
 	case "4":
 		result, err := promptForDirectProvider(reader, "openai", "OpenAI", "https://api.openai.com/v1", "openai-completions", "OPENAI_API_KEY", "gpt-5.2", "GPT-5.2")
 		if err != nil {
 			return nil, nil, err
 		}
+
 		return result, nil, nil
 	case "5":
 		result, err := promptForCustomProvider(reader)
 		if err != nil {
 			return nil, nil, err
 		}
+
 		return result, nil, nil
 	default:
 		return nil, nil, fmt.Errorf("unknown choice '%s'; please select a valid model provider", choice)
@@ -2225,7 +2440,9 @@ func interactiveSetup(cfg *config.Config, imported *ImportResult) (*ImportResult
 // The actual overlay (ImportResult) is built separately via buildLiteLLMRoutedOverlay.
 func promptForCloudProvider(reader *bufio.Reader, name, display, modelID, modelName string) (*CloudProviderInfo, error) {
 	fmt.Printf("\n%s API key: ", display)
+
 	apiKey, _ := reader.ReadString('\n')
+
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("%s API key is required", display)
@@ -2242,73 +2459,95 @@ func promptForCloudProvider(reader *bufio.Reader, name, display, modelID, modelN
 // promptForDirectProvider asks for direct-provider settings for an instance-local override.
 func promptForDirectProvider(reader *bufio.Reader, providerName, display, defaultBaseURL, defaultAPI, defaultAPIKeyEnvVar, defaultModelID, defaultModelName string) (*ImportResult, error) {
 	fmt.Printf("\n%s API key (instance-local): ", display)
+
 	apiKey, _ := reader.ReadString('\n')
+
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("%s API key is required", display)
 	}
 
 	fmt.Printf("%s model ID [%s]: ", display, defaultModelID)
+
 	modelID, _ := reader.ReadString('\n')
+
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
 		modelID = defaultModelID
 	}
 
 	fmt.Printf("%s model display name [%s]: ", display, defaultModelName)
+
 	modelName, _ := reader.ReadString('\n')
+
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
 		modelName = defaultModelName
 	}
 
 	fmt.Printf("%s base URL [%s]: ", display, defaultBaseURL)
+
 	baseURL, _ := reader.ReadString('\n')
+
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
+
 	return buildDirectProviderOverlay(providerName, baseURL, defaultAPI, defaultAPIKeyEnvVar, modelID, modelName, apiKey), nil
 }
 
 // promptForCustomProvider asks for an OpenAI-compatible custom endpoint override.
 func promptForCustomProvider(reader *bufio.Reader) (*ImportResult, error) {
 	fmt.Printf("\nCustom base URL (OpenAI-compatible, e.g. https://example.com/v1): ")
+
 	baseURL, _ := reader.ReadString('\n')
+
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
-		return nil, fmt.Errorf("custom base URL is required")
+		return nil, errors.New("custom base URL is required")
 	}
+
 	fmt.Printf("Custom model ID: ")
+
 	modelID, _ := reader.ReadString('\n')
+
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
-		return nil, fmt.Errorf("custom model ID is required")
+		return nil, errors.New("custom model ID is required")
 	}
 
 	fmt.Printf("Custom model display name [%s]: ", modelID)
+
 	modelName, _ := reader.ReadString('\n')
+
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
 		modelName = modelID
 	}
 
 	fmt.Printf("Custom API type [openai-completions]: ")
+
 	apiType, _ := reader.ReadString('\n')
+
 	apiType = strings.TrimSpace(apiType)
 	if apiType == "" {
 		apiType = "openai-completions"
 	}
 
 	fmt.Printf("API key env var [OPENAI_API_KEY]: ")
+
 	apiKeyEnvVar, _ := reader.ReadString('\n')
+
 	apiKeyEnvVar = strings.TrimSpace(apiKeyEnvVar)
 	if apiKeyEnvVar == "" {
 		apiKeyEnvVar = "OPENAI_API_KEY"
 	}
 
 	fmt.Printf("API key (optional, leave empty to configure later): ")
+
 	apiKey, _ := reader.ReadString('\n')
+
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		fmt.Println("  Note: no API key provided; set it later via the OpenClaw user secret.")
@@ -2347,6 +2586,7 @@ func buildLiteLLMRoutedOverlay(cfg *config.Config, cloud *CloudProviderInfo) *Im
 // Provider name must be one of anthropic/openai/ollama due current chart constraints.
 func buildDirectProviderOverlay(providerName, baseURL, api, apiKeyEnvVar, modelID, modelName, apiKey string) *ImportResult {
 	var agentPrefix string
+
 	switch providerName {
 	case "anthropic":
 		agentPrefix = "anthropic"
@@ -2365,6 +2605,7 @@ func buildDirectProviderOverlay(providerName, baseURL, api, apiKeyEnvVar, modelI
 		if providers[i].Name != providerName {
 			continue
 		}
+
 		providers[i].Disabled = false
 		providers[i].BaseURL = baseURL
 		providers[i].API = api
@@ -2395,11 +2636,13 @@ func collectSensitiveData(imported *ImportResult) map[string]string {
 		if p.APIKey == "" {
 			continue
 		}
+
 		envVar := p.APIKeyEnvVar
 		if envVar == "" {
 			envVar = defaultProviderAPIKeyEnvVar(p.Name)
 			p.APIKeyEnvVar = envVar
 		}
+
 		secretData[envVar] = p.APIKey
 		p.APIKey = ""
 	}
@@ -2408,15 +2651,18 @@ func collectSensitiveData(imported *ImportResult) map[string]string {
 		secretData["TELEGRAM_BOT_TOKEN"] = imported.Channels.Telegram.BotToken
 		imported.Channels.Telegram.BotToken = ""
 	}
+
 	if imported.Channels.Discord != nil && imported.Channels.Discord.BotToken != "" {
 		secretData["DISCORD_BOT_TOKEN"] = imported.Channels.Discord.BotToken
 		imported.Channels.Discord.BotToken = ""
 	}
+
 	if imported.Channels.Slack != nil {
 		if imported.Channels.Slack.BotToken != "" {
 			secretData["SLACK_BOT_TOKEN"] = imported.Channels.Slack.BotToken
 			imported.Channels.Slack.BotToken = ""
 		}
+
 		if imported.Channels.Slack.AppToken != "" {
 			secretData["SLACK_APP_TOKEN"] = imported.Channels.Slack.AppToken
 			imported.Channels.Slack.AppToken = ""
@@ -2426,6 +2672,7 @@ func collectSensitiveData(imported *ImportResult) map[string]string {
 	if len(secretData) == 0 {
 		return nil
 	}
+
 	return secretData
 }
 
@@ -2462,20 +2709,25 @@ releases:
 func collectAllHostnames(cfg *config.Config, newHostname string) []string {
 	hostnames := []string{newHostname}
 	appsDir := filepath.Join(cfg.ConfigDir, "applications", appName)
+
 	entries, err := os.ReadDir(appsDir)
 	if err != nil {
 		return hostnames
 	}
+
 	seen := map[string]bool{newHostname: true}
+
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
+
 		h := fmt.Sprintf("openclaw-%s.%s", e.Name(), defaultDomain)
 		if !seen[h] {
 			hostnames = append(hostnames, h)
 			seen[h] = true
 		}
 	}
+
 	return hostnames
 }

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -518,7 +518,7 @@ func loadUserSecretsFile(deploymentDir string) (map[string]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil //nolint:nilnil // file absent means no user secrets; not an error
 		}
 
 		return nil, err
@@ -774,7 +774,7 @@ func waitForPod(kubectlBinary, kubeconfigPath, namespace string, timeoutSec int)
 		var stdout bytes.Buffer
 
 		cmd.Stdout = &stdout
-		cmd.Run()
+		_ = cmd.Run()
 
 		podName := strings.TrimSpace(stdout.String())
 		if podName != "" {
@@ -998,7 +998,7 @@ func startPortForward(cfg *config.Config, namespace string, localPort int) (*por
 					if _, err := fmt.Sscanf(portPart, "%d", &p); err == nil {
 						parsedPort <- p
 						// Continue draining to prevent pipe blocking
-						io.Copy(io.Discard, stdoutPipe)
+						_, _ = io.Copy(io.Discard, stdoutPipe)
 
 						return
 					}
@@ -1037,7 +1037,7 @@ func (pf *portForwarder) Stop() {
 	case <-pf.done:
 	case <-time.After(5 * time.Second):
 		if pf.cmd.Process != nil {
-			pf.cmd.Process.Kill()
+			_ = pf.cmd.Process.Kill()
 		}
 	}
 }
@@ -1459,7 +1459,7 @@ func cliViaPortForward(cfg *config.Config, id, namespace string, args []string) 
 
 	// Append --url and --token to the args
 	wsURL := fmt.Sprintf("ws://localhost:%d", pf.localPort)
-	fullArgs := append(args, "--url", wsURL, "--token", token)
+	fullArgs := append(append([]string{}, args...), "--url", wsURL, "--token", token)
 
 	cmd := exec.Command(openclawBinary, fullArgs...)
 	cmd.Stdin = os.Stdin
@@ -1481,7 +1481,7 @@ func cliViaPortForward(cfg *config.Config, id, namespace string, args []string) 
 		exitErr := &exec.ExitError{}
 		if errors.As(err, &exitErr) {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				os.Exit(status.ExitStatus())
+				os.Exit(status.ExitStatus()) //nolint:gocritic // intentional exit to propagate child exit code; defers handle cleanup
 			}
 		}
 
@@ -1545,7 +1545,7 @@ func cliViaKubectlExec(cfg *config.Config, namespace string, args []string) erro
 func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 	ids, err := ListInstanceIDs(cfg)
 	if err != nil || len(ids) == 0 {
-		return nil
+		return nil //nolint:nilerr // no instances to sync; not an error
 	}
 
 	masterKey := litellmMasterKey(cfg)
@@ -1612,7 +1612,7 @@ func rankModels(models []string) (primary string, fallbacks []string) {
 	// Best cloud model is primary; rest are fallbacks (cloud first, then local)
 	if len(cloud) > 0 {
 		primary = cloud[0]
-		fallbacks = append(cloud[1:], local...)
+		fallbacks = append(append([]string{}, cloud[1:]...), local...)
 	} else {
 		primary = local[0]
 		fallbacks = local[1:]
@@ -1706,7 +1706,7 @@ func patchModelHierarchy(cfg *config.Config, id, primary string, fallbacks []str
 			"openclaw.json": string(patched),
 		},
 	}
-	applyRaw, _ := json.Marshal(applyPayload)
+	applyRaw, _ := json.Marshal(applyPayload) //nolint:errchkjson // map[string]any is safe, keys/values are controlled
 
 	applyCmd := exec.Command(kubectlBinary, "apply", "-f", "-",
 		"--server-side", "--field-manager=helm", "--force-conflicts")
@@ -1790,8 +1790,10 @@ func patchOverlayModelList(content string, models []string) (string, bool) {
 
 	inOpenAI := false
 	inModelList := false
-	modelListIndent := ""
-	replaced := false
+
+	var modelListIndent string
+
+	var replaced bool
 
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
@@ -2156,7 +2158,7 @@ func patchHeartbeatConfig(cfg *config.Config, id, deploymentDir string) {
 			"openclaw.json": string(patched),
 		},
 	}
-	applyRaw, _ := json.Marshal(applyPayload)
+	applyRaw, _ := json.Marshal(applyPayload) //nolint:errchkjson // map[string]any is safe, keys/values are controlled
 
 	applyCmd := exec.Command(kubectlBinary, "apply", "-f", "-",
 		"--server-side", "--field-manager=helm", "--force-conflicts")

--- a/internal/openclaw/overlay_test.go
+++ b/internal/openclaw/overlay_test.go
@@ -14,7 +14,8 @@ import (
 func testConfig(t *testing.T) *config.Config {
 	t.Helper()
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, ".stack-id"), []byte("test-cluster"), 0644)
+	os.WriteFile(filepath.Join(dir, ".stack-id"), []byte("test-cluster"), 0o644)
+
 	return &config.Config{ConfigDir: dir, DataDir: dir, BinDir: dir}
 }
 
@@ -42,18 +43,23 @@ func TestBuildLiteLLMRoutedOverlay_Anthropic(t *testing.T) {
 	if openai.Name != "openai" || openai.Disabled {
 		t.Errorf("openai: name=%q disabled=%v, want openai/false", openai.Name, openai.Disabled)
 	}
+
 	if openai.BaseURL != "http://litellm.llm.svc.cluster.local:4000/v1" {
 		t.Errorf("openai.BaseURL = %q", openai.BaseURL)
 	}
+
 	if openai.APIKeyEnvVar != "OPENAI_API_KEY" {
 		t.Errorf("openai.APIKeyEnvVar = %q, want OPENAI_API_KEY", openai.APIKeyEnvVar)
 	}
+
 	if openai.APIKey != "sk-obol-test-cluster" {
 		t.Errorf("openai.APIKey = %q, want sk-obol-test-cluster", openai.APIKey)
 	}
+
 	if openai.API != "openai-completions" {
 		t.Errorf("openai.API = %q, want openai-completions", openai.API)
 	}
+
 	if len(openai.Models) != 1 || openai.Models[0].ID != "claude-sonnet-4-5-20250929" {
 		t.Errorf("openai.Models = %v", openai.Models)
 	}
@@ -64,9 +70,11 @@ func TestBuildLiteLLMRoutedOverlay_Anthropic(t *testing.T) {
 			t.Errorf("Providers[%d] (%s) should be disabled", idx, result.Providers[idx].Name)
 		}
 	}
+
 	if result.Providers[1].Name != "anthropic" {
 		t.Errorf("Providers[1].Name = %q, want anthropic", result.Providers[1].Name)
 	}
+
 	if result.Providers[2].Name != "ollama" {
 		t.Errorf("Providers[2].Name = %q, want ollama", result.Providers[2].Name)
 	}
@@ -111,6 +119,7 @@ func TestOverlayYAML_LiteLLMRouted(t *testing.T) {
 	if !strings.Contains(yaml, "openai:\n    enabled: true") {
 		t.Errorf("YAML missing enabled openai provider, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "baseUrl: http://litellm.llm.svc.cluster.local:4000/v1") {
 		t.Errorf("YAML missing LiteLLM baseUrl, got:\n%s", yaml)
 	}
@@ -139,6 +148,7 @@ func TestOverlayYAML_LiteLLMRouted(t *testing.T) {
 	if !strings.Contains(yaml, "anthropic:\n    enabled: false") {
 		t.Errorf("YAML missing disabled anthropic, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "ollama:\n    enabled: false") {
 		t.Errorf("YAML missing disabled ollama, got:\n%s", yaml)
 	}
@@ -152,12 +162,15 @@ func TestGenerateOverlayValues_OllamaDefaultWithModels(t *testing.T) {
 	if !strings.Contains(yaml, "agentModel: openai/llama3.2:3b") {
 		t.Errorf("default overlay missing ollama agentModel, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "baseUrl: http://litellm.llm.svc.cluster.local:4000/v1") {
 		t.Errorf("default overlay missing LiteLLM baseUrl, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "id: llama3.2:3b") {
 		t.Errorf("default overlay missing first model, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "id: mistral:7b") {
 		t.Errorf("default overlay missing second model, got:\n%s", yaml)
 	}
@@ -170,9 +183,11 @@ func TestGenerateOverlayValues_OllamaDefaultNoModels(t *testing.T) {
 	if strings.Contains(yaml, "agentModel:") {
 		t.Errorf("default overlay should not set agentModel when no models available, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "models: []") {
 		t.Errorf("default overlay should have empty models list, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "baseUrl: http://litellm.llm.svc.cluster.local:4000/v1") {
 		t.Errorf("default overlay missing LiteLLM baseUrl, got:\n%s", yaml)
 	}
@@ -183,6 +198,7 @@ func TestGenerateOverlayValues_ExternalSecrets(t *testing.T) {
 	if !strings.Contains(yaml, "extraEnvFromSecrets") {
 		t.Errorf("overlay missing extraEnvFromSecrets, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "openclaw-user-secrets") {
 		t.Errorf("overlay missing external secret ref, got:\n%s", yaml)
 	}
@@ -195,6 +211,7 @@ func TestGenerateOverlayValues_AgentBaseURL(t *testing.T) {
 	if !strings.Contains(yaml, "AGENT_BASE_URL") {
 		t.Errorf("overlay missing AGENT_BASE_URL, got:\n%s", yaml)
 	}
+
 	if !strings.Contains(yaml, "value: https://mystack.example.com") {
 		t.Errorf("overlay missing AGENT_BASE_URL value, got:\n%s", yaml)
 	}
@@ -231,12 +248,15 @@ func TestCollectSensitiveData_StripsLiterals(t *testing.T) {
 	if data["OPENAI_API_KEY"] != "sk-test" {
 		t.Fatalf("missing OPENAI_API_KEY in extracted data: %+v", data)
 	}
+
 	if data["TELEGRAM_BOT_TOKEN"] != "tg-token" {
 		t.Fatalf("missing TELEGRAM_BOT_TOKEN in extracted data: %+v", data)
 	}
+
 	if imported.Providers[0].APIKey != "" {
 		t.Fatalf("provider API key was not stripped from overlay data")
 	}
+
 	if imported.Channels.Telegram.BotToken != "" {
 		t.Fatalf("telegram token was not stripped from overlay data")
 	}
@@ -256,18 +276,23 @@ func TestBuildDirectProviderOverlay_OpenAI(t *testing.T) {
 	if result.AgentModel != "openai/gpt-5.2" {
 		t.Fatalf("AgentModel = %q, want openai/gpt-5.2", result.AgentModel)
 	}
+
 	foundEnabled := false
+
 	for _, p := range result.Providers {
 		if p.Name == "openai" {
 			foundEnabled = true
+
 			if p.Disabled {
 				t.Fatalf("openai provider should be enabled")
 			}
+
 			if p.APIKeyEnvVar != "OPENAI_API_KEY" {
 				t.Fatalf("openai APIKeyEnvVar = %q", p.APIKeyEnvVar)
 			}
 		}
 	}
+
 	if !foundEnabled {
 		t.Fatalf("openai provider not found in overlay")
 	}
@@ -287,30 +312,39 @@ func TestBuildDirectProviderOverlay_Anthropic(t *testing.T) {
 	if result.AgentModel != "anthropic/claude-sonnet-4-6" {
 		t.Fatalf("AgentModel = %q, want anthropic/claude-sonnet-4-6", result.AgentModel)
 	}
+
 	foundEnabled := false
+
 	for _, p := range result.Providers {
 		if p.Name == "anthropic" {
 			foundEnabled = true
+
 			if p.Disabled {
 				t.Fatalf("anthropic provider should be enabled")
 			}
+
 			if p.BaseURL != "https://api.anthropic.com" {
 				t.Fatalf("anthropic BaseURL = %q, want https://api.anthropic.com (no /v1 suffix)", p.BaseURL)
 			}
+
 			if p.API != "anthropic-messages" {
 				t.Fatalf("anthropic API = %q, want anthropic-messages", p.API)
 			}
+
 			if p.APIKeyEnvVar != "ANTHROPIC_API_KEY" {
 				t.Fatalf("anthropic APIKeyEnvVar = %q", p.APIKeyEnvVar)
 			}
 		}
+
 		if p.Name == "openai" && !p.Disabled {
 			t.Fatalf("openai provider should be disabled for anthropic direct")
 		}
+
 		if p.Name == "ollama" && !p.Disabled {
 			t.Fatalf("ollama provider should be disabled for anthropic direct")
 		}
 	}
+
 	if !foundEnabled {
 		t.Fatalf("anthropic provider not found in overlay")
 	}
@@ -339,14 +373,17 @@ models:
 erpc:
   url: http://erpc.erpc.svc.cluster.local/rpc
 `
+
 	t.Run("add models", func(t *testing.T) {
 		updated, changed := patchOverlayModelList(overlay, []string{"llama3.2:3b", "claude-sonnet-4-5-20250929", "gpt-4o"})
 		if !changed {
 			t.Fatal("expected change")
 		}
+
 		if !strings.Contains(updated, "id: claude-sonnet-4-5-20250929") {
 			t.Errorf("missing claude model in updated overlay:\n%s", updated)
 		}
+
 		if !strings.Contains(updated, "id: gpt-4o") {
 			t.Errorf("missing gpt model in updated overlay:\n%s", updated)
 		}
@@ -361,6 +398,7 @@ erpc:
 		if !changed {
 			t.Fatal("expected change")
 		}
+
 		if !strings.Contains(updated, "models: []") {
 			t.Errorf("expected empty models list:\n%s", updated)
 		}
@@ -372,6 +410,7 @@ erpc:
     enabled: true
     baseUrl: https://api.anthropic.com
 `
+
 		_, changed := patchOverlayModelList(nonLiteLLM, []string{"claude-sonnet-4-5-20250929"})
 		if changed {
 			t.Fatal("should not patch non-LiteLLM overlay")
@@ -382,10 +421,12 @@ erpc:
 		emptyOverlay := strings.Replace(overlay,
 			"    models:\n      - id: llama3.2:3b\n        name: Llama 3.2 3B",
 			"    models: []", 1)
+
 		updated, changed := patchOverlayModelList(emptyOverlay, []string{"llama3.2:3b"})
 		if !changed {
 			t.Fatal("expected change")
 		}
+
 		if !strings.Contains(updated, "id: llama3.2:3b") {
 			t.Errorf("missing model in updated overlay:\n%s", updated)
 		}
@@ -398,9 +439,10 @@ func TestPatchAgentModelsJSON(t *testing.T) {
 		id := "test"
 		namespace := fmt.Sprintf("%s-%s", appName, id)
 		agentDir := filepath.Join(cfg.DataDir, namespace, "openclaw-data", ".openclaw", "agents", "main", "agent")
-		os.MkdirAll(agentDir, 0755)
+		os.MkdirAll(agentDir, 0o755)
 
 		models := []string{"claude-sonnet-4-6", "gpt-4o", "llama3.2:3b"}
+
 		err := patchAgentModelsJSON(cfg, id, models, "sk-obol-test")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -415,9 +457,11 @@ func TestPatchAgentModelsJSON(t *testing.T) {
 		if !strings.Contains(content, "claude-sonnet-4-6") {
 			t.Errorf("missing claude model in models.json")
 		}
+
 		if !strings.Contains(content, "litellm.llm.svc.cluster.local:4000") {
 			t.Errorf("missing LiteLLM URL in models.json")
 		}
+
 		if !strings.Contains(content, "sk-obol-test") {
 			t.Errorf("missing master key in models.json")
 		}
@@ -425,6 +469,7 @@ func TestPatchAgentModelsJSON(t *testing.T) {
 		if strings.Contains(content, "llmspy") {
 			t.Errorf("models.json should not contain llmspy")
 		}
+
 		if strings.Contains(content, "ollama") {
 			t.Errorf("models.json should not contain stale ollama provider")
 		}
@@ -432,6 +477,7 @@ func TestPatchAgentModelsJSON(t *testing.T) {
 
 	t.Run("skips when agent dir does not exist", func(t *testing.T) {
 		cfg := testConfig(t)
+
 		err := patchAgentModelsJSON(cfg, "nonexistent", []string{"model"}, "key")
 		if err != nil {
 			t.Fatalf("should skip gracefully, got error: %v", err)

--- a/internal/openclaw/resolve.go
+++ b/internal/openclaw/resolve.go
@@ -1,6 +1,7 @@
 package openclaw
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,15 +20,18 @@ func ListInstanceIDs(cfg *config.Config) ([]string, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, fmt.Errorf("failed to read OpenClaw instances: %w", err)
 	}
 
 	var ids []string
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			ids = append(ids, entry.Name())
 		}
 	}
+
 	return ids, nil
 }
 
@@ -46,7 +50,7 @@ func ResolveInstance(cfg *config.Config, args []string) (id string, remaining []
 
 	switch len(instances) {
 	case 0:
-		return "", nil, fmt.Errorf("no OpenClaw instances found — run 'obol agent init' to create one")
+		return "", nil, errors.New("no OpenClaw instances found — run 'obol agent init' to create one")
 	case 1:
 		return instances[0], args, nil
 	default:
@@ -57,6 +61,7 @@ func ResolveInstance(cfg *config.Config, args []string) (id string, remaining []
 				}
 			}
 		}
+
 		return "", nil, fmt.Errorf("multiple OpenClaw instances found, specify one: %s", strings.Join(instances, ", "))
 	}
 }

--- a/internal/openclaw/resolve_test.go
+++ b/internal/openclaw/resolve_test.go
@@ -11,10 +11,12 @@ import (
 func TestListInstanceIDs(t *testing.T) {
 	t.Run("no instances directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -22,12 +24,13 @@ func TestListInstanceIDs(t *testing.T) {
 
 	t.Run("empty directory", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
-		os.MkdirAll(filepath.Join(cfg.ConfigDir, "applications", "openclaw"), 0755)
+		os.MkdirAll(filepath.Join(cfg.ConfigDir, "applications", "openclaw"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 0 {
 			t.Fatalf("expected 0 instances, got %d", len(ids))
 		}
@@ -36,13 +39,14 @@ func TestListInstanceIDs(t *testing.T) {
 	t.Run("multiple instances", func(t *testing.T) {
 		cfg := &config.Config{ConfigDir: t.TempDir()}
 		base := filepath.Join(cfg.ConfigDir, "applications", "openclaw")
-		os.MkdirAll(filepath.Join(base, "default"), 0755)
-		os.MkdirAll(filepath.Join(base, "prod"), 0755)
+		os.MkdirAll(filepath.Join(base, "default"), 0o755)
+		os.MkdirAll(filepath.Join(base, "prod"), 0o755)
 
 		ids, err := ListInstanceIDs(cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if len(ids) != 2 {
 			t.Fatalf("expected 2 instances, got %d", len(ids))
 		}
@@ -53,19 +57,23 @@ func TestResolveInstance(t *testing.T) {
 	setupInstances := func(t *testing.T, names ...string) *config.Config {
 		t.Helper()
 		cfg := &config.Config{ConfigDir: t.TempDir()}
+
 		base := filepath.Join(cfg.ConfigDir, "applications", "openclaw")
 		for _, name := range names {
-			os.MkdirAll(filepath.Join(base, name), 0755)
+			os.MkdirAll(filepath.Join(base, name), 0o755)
 		}
+
 		return cfg
 	}
 
 	t.Run("zero instances returns error", func(t *testing.T) {
 		cfg := setupInstances(t)
+
 		_, _, err := ResolveInstance(cfg, []string{"sync"})
 		if err == nil {
 			t.Fatal("expected error for zero instances")
 		}
+
 		if got := err.Error(); got != "no OpenClaw instances found — run 'obol agent init' to create one" {
 			t.Fatalf("unexpected error: %s", got)
 		}
@@ -73,13 +81,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance auto-selects", func(t *testing.T) {
 		cfg := setupInstances(t, "default")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"extra-arg"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "default" {
 			t.Fatalf("expected id 'default', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra-arg" {
 			t.Fatalf("expected remaining args [extra-arg], got %v", remaining)
 		}
@@ -87,13 +98,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("single instance with no args", func(t *testing.T) {
 		cfg := setupInstances(t, "happy-otter")
+
 		id, remaining, err := ResolveInstance(cfg, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "happy-otter" {
 			t.Fatalf("expected id 'happy-otter', got '%s'", id)
 		}
+
 		if len(remaining) != 0 {
 			t.Fatalf("expected no remaining args, got %v", remaining)
 		}
@@ -101,13 +115,16 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with valid name", func(t *testing.T) {
 		cfg := setupInstances(t, "default", "prod")
+
 		id, remaining, err := ResolveInstance(cfg, []string{"prod", "extra"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
 		if id != "prod" {
 			t.Fatalf("expected id 'prod', got '%s'", id)
 		}
+
 		if len(remaining) != 1 || remaining[0] != "extra" {
 			t.Fatalf("expected remaining [extra], got %v", remaining)
 		}
@@ -115,6 +132,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances without name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "default", "prod")
+
 		_, _, err := ResolveInstance(cfg, nil)
 		if err == nil {
 			t.Fatal("expected error for multiple instances without name")
@@ -123,6 +141,7 @@ func TestResolveInstance(t *testing.T) {
 
 	t.Run("multiple instances with unknown name errors", func(t *testing.T) {
 		cfg := setupInstances(t, "default", "prod")
+
 		_, _, err := ResolveInstance(cfg, []string{"nonexistent"})
 		if err == nil {
 			t.Fatal("expected error for unknown instance name")

--- a/internal/openclaw/skills_injection_test.go
+++ b/internal/openclaw/skills_injection_test.go
@@ -12,6 +12,7 @@ import (
 func TestSkillsVolumePath(t *testing.T) {
 	cfg := &config.Config{DataDir: "/data/obol"}
 	got := skillsVolumePath(cfg, "default")
+
 	want := filepath.Join("/data/obol", "openclaw-default", "openclaw-data", ".openclaw", "skills")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -44,11 +45,12 @@ func TestStageDefaultSkillsSkipsExisting(t *testing.T) {
 
 	// Pre-create skills directory with custom content
 	skillsDir := filepath.Join(deploymentDir, "skills")
-	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+
 	marker := filepath.Join(skillsDir, "custom-marker.txt")
-	if err := os.WriteFile(marker, []byte("keep"), 0644); err != nil {
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/internal/openclaw/version_test.go
+++ b/internal/openclaw/version_test.go
@@ -19,21 +19,31 @@ import (
 // If this test fails, update all three in the same commit.
 func TestOpenClawVersionConsistency(t *testing.T) {
 	// 1. Read the canonical version file.
-	_, thisFile, _, _ := runtime.Caller(0)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
 	versionFile := filepath.Join(filepath.Dir(thisFile), "OPENCLAW_VERSION")
+
 	raw, err := os.ReadFile(versionFile)
 	if err != nil {
 		t.Fatalf("cannot read OPENCLAW_VERSION: %v", err)
 	}
+
 	var fileVersion string
-	for _, line := range strings.Split(string(raw), "\n") {
+
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
+
 		fileVersion = strings.TrimPrefix(line, "v")
+
 		break
 	}
+
 	if fileVersion == "" {
 		t.Fatal("OPENCLAW_VERSION file has no version line")
 	}
@@ -46,15 +56,19 @@ func TestOpenClawVersionConsistency(t *testing.T) {
 
 	// 3. Check obolup.sh constant matches.
 	obolupPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "obolup.sh")
+
 	obolupRaw, err := os.ReadFile(obolupPath)
 	if err != nil {
 		t.Fatalf("cannot read obolup.sh: %v", err)
 	}
+
 	re := regexp.MustCompile(`(?m)^readonly OPENCLAW_VERSION="([^"]+)"`)
+
 	matches := re.FindSubmatch(obolupRaw)
 	if matches == nil {
 		t.Fatal("obolup.sh does not contain OPENCLAW_VERSION constant")
 	}
+
 	shellVersion := string(matches[1])
 	if shellVersion != fileVersion {
 		t.Errorf("obolup.sh OPENCLAW_VERSION = %q, want %q (from OPENCLAW_VERSION file)", shellVersion, fileVersion)

--- a/internal/openclaw/wallet.go
+++ b/internal/openclaw/wallet.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -25,10 +26,10 @@ import (
 // WalletInfo holds generated wallet metadata returned from GenerateWallet.
 type WalletInfo struct {
 	Address      string `json:"address"`       // 0x-prefixed Ethereum address
-	PublicKey    string `json:"publicKey"`      // 0x-prefixed uncompressed public key (130 hex chars)
+	PublicKey    string `json:"publicKey"`     // 0x-prefixed uncompressed public key (130 hex chars)
 	KeystoreUUID string `json:"keystore_uuid"` // UUID of the V3 keystore file
 	KeystorePath string `json:"keystore_path"` // Absolute host path to keystore JSON
-	CreatedAt    string `json:"createdAt"`      // ISO 8601 timestamp
+	CreatedAt    string `json:"createdAt"`     // ISO 8601 timestamp
 	Password     string `json:"-"`             // Keystore password (not serialized)
 }
 
@@ -63,9 +64,9 @@ type kdfParams struct {
 
 // scrypt parameters matching go-ethereum defaults.
 const (
-	scryptN    = 262144
-	scryptR    = 8
-	scryptP    = 1
+	scryptN     = 262144
+	scryptR     = 8
+	scryptP     = 1
 	scryptDKLen = 32
 )
 
@@ -145,6 +146,7 @@ func toChecksumAddress(addr string) string {
 
 	var result strings.Builder
 	result.WriteString("0x")
+
 	for i, c := range addr {
 		if c >= '0' && c <= '9' {
 			result.WriteRune(c)
@@ -158,6 +160,7 @@ func toChecksumAddress(addr string) string {
 			}
 		}
 	}
+
 	return result.String()
 }
 
@@ -170,6 +173,7 @@ func encryptToV3Keystore(privKey, pubKey []byte, password string) ([]byte, strin
 	if _, err := rand.Read(salt); err != nil {
 		return nil, "", fmt.Errorf("salt generation: %w", err)
 	}
+
 	iv := make([]byte, 16)
 	if _, err := rand.Read(iv); err != nil {
 		return nil, "", fmt.Errorf("iv generation: %w", err)
@@ -186,6 +190,7 @@ func encryptToV3Keystore(privKey, pubKey []byte, password string) ([]byte, strin
 	if err != nil {
 		return nil, "", fmt.Errorf("aes cipher: %w", err)
 	}
+
 	cipherText := make([]byte, len(privKey))
 	stream := cipher.NewCTR(block, iv)
 	stream.XORKeyStream(cipherText, privKey)
@@ -244,14 +249,17 @@ func decryptV3Keystore(keystoreJSON []byte, password string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode salt: %w", err)
 	}
+
 	iv, err := hex.DecodeString(ks.Crypto.CipherParams.IV)
 	if err != nil {
 		return nil, fmt.Errorf("decode iv: %w", err)
 	}
+
 	cipherText, err := hex.DecodeString(ks.Crypto.CipherText)
 	if err != nil {
 		return nil, fmt.Errorf("decode ciphertext: %w", err)
 	}
+
 	storedMAC, err := hex.DecodeString(ks.Crypto.MAC)
 	if err != nil {
 		return nil, fmt.Errorf("decode mac: %w", err)
@@ -266,9 +274,10 @@ func decryptV3Keystore(keystoreJSON []byte, password string) ([]byte, error) {
 	mac := sha3.NewLegacyKeccak256()
 	mac.Write(derivedKey[16:32])
 	mac.Write(cipherText)
+
 	computedMAC := mac.Sum(nil)
 	if !hmacEqual(computedMAC, storedMAC) {
-		return nil, fmt.Errorf("MAC mismatch: wrong password or corrupted keystore")
+		return nil, errors.New("MAC mismatch: wrong password or corrupted keystore")
 	}
 
 	// Decrypt.
@@ -276,6 +285,7 @@ func decryptV3Keystore(keystoreJSON []byte, password string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("aes cipher: %w", err)
 	}
+
 	plaintext := make([]byte, len(cipherText))
 	stream := cipher.NewCTR(block, iv)
 	stream.XORKeyStream(plaintext, cipherText)
@@ -288,10 +298,12 @@ func hmacEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
 	}
+
 	var result byte
 	for i := range a {
 		result |= a[i] ^ b[i]
 	}
+
 	return result == 0
 }
 
@@ -299,6 +311,7 @@ func hmacEqual(a, b []byte) bool {
 // alphanumeric characters (a-z, A-Z, 0-9).
 func generateRandomPassword(length int) (string, error) {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
 	charsetLen := big.NewInt(int64(len(charset)))
 
 	result := make([]byte, length)
@@ -307,8 +320,10 @@ func generateRandomPassword(length int) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("random int: %w", err)
 		}
+
 		result[i] = charset[n.Int64()]
 	}
+
 	return string(result), nil
 }
 
@@ -325,13 +340,14 @@ func KeystoreVolumePath(cfg *config.Config, id string) string {
 // written keystore file.
 func provisionKeystoreToVolume(cfg *config.Config, id, keystoreID string, keystoreJSON []byte) (string, error) {
 	dir := KeystoreVolumePath(cfg, id)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("create keystore directory: %w", err)
 	}
 
 	filename := keystoreID + ".json"
+
 	path := filepath.Join(dir, filename)
-	if err := os.WriteFile(path, keystoreJSON, 0600); err != nil {
+	if err := os.WriteFile(path, keystoreJSON, 0o600); err != nil {
 		return "", fmt.Errorf("write keystore: %w", err)
 	}
 
@@ -366,7 +382,8 @@ func WriteWalletMetadata(deploymentDir string, wallet *WalletInfo) error {
 	if err != nil {
 		return fmt.Errorf("marshal wallet metadata: %w", err)
 	}
-	return os.WriteFile(walletMetadataPath(deploymentDir), data, 0644)
+
+	return os.WriteFile(walletMetadataPath(deploymentDir), data, 0o644)
 }
 
 // ReadWalletMetadata reads existing wallet metadata from the deployment directory.
@@ -375,10 +392,12 @@ func ReadWalletMetadata(deploymentDir string) (*WalletInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var wallet WalletInfo
 	if err := json.Unmarshal(data, &wallet); err != nil {
 		return nil, fmt.Errorf("unmarshal wallet metadata: %w", err)
 	}
+
 	return &wallet, nil
 }
 
@@ -399,6 +418,7 @@ func ensureWallet(cfg *config.Config, id, deploymentDir string) {
 
 	// No wallet yet — generate one.
 	fmt.Println("Generating Ethereum wallet for this instance...")
+
 	wallet, err := GenerateWallet(cfg, id)
 	if err != nil {
 		fmt.Printf("Warning: could not generate wallet: %v\n", err)
@@ -406,7 +426,7 @@ func ensureWallet(cfg *config.Config, id, deploymentDir string) {
 	}
 
 	values := generateRemoteSignerValues(wallet)
-	if err := os.WriteFile(valuesPath, []byte(values), 0644); err != nil {
+	if err := os.WriteFile(valuesPath, []byte(values), 0o644); err != nil {
 		fmt.Printf("Warning: could not write remote-signer values: %v\n", err)
 		return
 	}
@@ -433,14 +453,14 @@ func applyWalletMetadataConfigMap(cfg *config.Config, id, deploymentDir string) 
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 
 	// Build addresses.json matching the frontend's WalletMetadata type.
-	addressesJSON := map[string]interface{}{
+	addressesJSON := map[string]any{
 		"instanceId": id,
 		"addresses": []map[string]string{
 			{
 				"address":   wallet.Address,
 				"publicKey": wallet.PublicKey,
 				"createdAt": wallet.CreatedAt,
-				"label":     fmt.Sprintf("obol-agent-%s", id),
+				"label":     "obol-agent-" + id,
 			},
 		},
 		"count": 1,
@@ -452,10 +472,10 @@ func applyWalletMetadataConfigMap(cfg *config.Config, id, deploymentDir string) 
 		return
 	}
 
-	manifest := map[string]interface{}{
+	manifest := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "wallet-metadata",
 			"namespace": namespace,
 			"labels": map[string]string{
@@ -475,9 +495,12 @@ func applyWalletMetadataConfigMap(cfg *config.Config, id, deploymentDir string) 
 	}
 
 	cmd := exec.Command(kubectlBinary, "apply", "-f", "-")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	cmd.Stdin = bytes.NewReader(raw)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("Warning: could not apply wallet-metadata ConfigMap: %v\n%s", err, stderr.String())

--- a/internal/openclaw/wallet.go
+++ b/internal/openclaw/wallet.go
@@ -383,7 +383,7 @@ func WriteWalletMetadata(deploymentDir string, wallet *WalletInfo) error {
 		return fmt.Errorf("marshal wallet metadata: %w", err)
 	}
 
-	return os.WriteFile(walletMetadataPath(deploymentDir), data, 0o644)
+	return os.WriteFile(walletMetadataPath(deploymentDir), data, 0o600)
 }
 
 // ReadWalletMetadata reads existing wallet metadata from the deployment directory.
@@ -426,7 +426,7 @@ func ensureWallet(cfg *config.Config, id, deploymentDir string) {
 	}
 
 	values := generateRemoteSignerValues(wallet)
-	if err := os.WriteFile(valuesPath, []byte(values), 0o644); err != nil {
+	if err := os.WriteFile(valuesPath, []byte(values), 0o600); err != nil {
 		fmt.Printf("Warning: could not write remote-signer values: %v\n", err)
 		return
 	}

--- a/internal/openclaw/wallet_backup.go
+++ b/internal/openclaw/wallet_backup.go
@@ -391,7 +391,7 @@ persistence:
   size: 100Mi
 `, password)
 
-	return os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(content), 0o644)
+	return os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(content), 0o600)
 }
 
 // encryptBackup encrypts plaintext using AES-256-GCM with a scrypt-derived key.

--- a/internal/openclaw/wallet_backup.go
+++ b/internal/openclaw/wallet_backup.go
@@ -5,9 +5,11 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
@@ -39,17 +41,17 @@ type BackupWallet struct {
 
 // BackupWalletOptions holds options for the backup command.
 type BackupWalletOptions struct {
-	Output     string // Output file path (empty = auto-generate)
-	Passphrase string // Encryption passphrase (empty = no encryption)
-	HasPassFlag bool  // Whether --passphrase was explicitly set
+	Output      string // Output file path (empty = auto-generate)
+	Passphrase  string // Encryption passphrase (empty = no encryption)
+	HasPassFlag bool   // Whether --passphrase was explicitly set
 }
 
 // RestoreWalletOptions holds options for the restore command.
 type RestoreWalletOptions struct {
-	Input      string // Input file path
-	Passphrase string // Decryption passphrase
-	HasPassFlag bool  // Whether --passphrase was explicitly set
-	Force      bool   // Overwrite existing wallet
+	Input       string // Input file path
+	Passphrase  string // Decryption passphrase
+	HasPassFlag bool   // Whether --passphrase was explicitly set
+	Force       bool   // Overwrite existing wallet
 }
 
 // BackupWallet creates a backup of the wallet for the given instance.
@@ -64,6 +66,7 @@ func BackupWalletCmd(cfg *config.Config, id string, opts BackupWalletOptions, u 
 
 	// Read keystore JSON.
 	keystorePath := filepath.Join(KeystoreVolumePath(cfg, id), wallet.KeystoreUUID+".json")
+
 	keystoreData, err := os.ReadFile(keystorePath)
 	if err != nil {
 		return fmt.Errorf("failed to read keystore file: %w", err)
@@ -124,11 +127,12 @@ func BackupWalletCmd(cfg *config.Config, id string, opts BackupWalletOptions, u 
 		if err != nil {
 			return fmt.Errorf("encryption failed: %w", err)
 		}
-		if err := os.WriteFile(outputPath, ciphertext, 0600); err != nil {
+
+		if err := os.WriteFile(outputPath, ciphertext, 0o600); err != nil {
 			return fmt.Errorf("failed to write backup: %w", err)
 		}
 	} else {
-		if err := os.WriteFile(outputPath, backupJSON, 0600); err != nil {
+		if err := os.WriteFile(outputPath, backupJSON, 0o600); err != nil {
 			return fmt.Errorf("failed to write backup: %w", err)
 		}
 	}
@@ -136,6 +140,7 @@ func BackupWalletCmd(cfg *config.Config, id string, opts BackupWalletOptions, u 
 	u.Success("Wallet backup created")
 	u.Detail("Address", wallet.Address)
 	u.Detail("Output", outputPath)
+
 	if encrypted {
 		u.Detail("Encrypted", "yes (AES-256-GCM)")
 	} else {
@@ -156,6 +161,7 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 
 	// Detect format and decrypt if needed.
 	var backupJSON []byte
+
 	if isEncryptedBackup(raw) {
 		passphrase := opts.Passphrase
 		if !opts.HasPassFlag {
@@ -164,9 +170,11 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 				return fmt.Errorf("failed to read passphrase: %w", err)
 			}
 		}
+
 		if passphrase == "" {
-			return fmt.Errorf("passphrase required for encrypted backup")
+			return errors.New("passphrase required for encrypted backup")
 		}
+
 		backupJSON, err = decryptBackup(raw, passphrase)
 		if err != nil {
 			return fmt.Errorf("decryption failed (wrong passphrase?): %w", err)
@@ -180,11 +188,13 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 	if err := json.Unmarshal(backupJSON, &backup); err != nil {
 		return fmt.Errorf("invalid backup file: %w", err)
 	}
+
 	if backup.Version != 1 {
 		return fmt.Errorf("unsupported backup version %d (expected 1)", backup.Version)
 	}
+
 	if len(backup.Wallets) == 0 {
-		return fmt.Errorf("backup contains no wallets")
+		return errors.New("backup contains no wallets")
 	}
 
 	w := backup.Wallets[0]
@@ -203,11 +213,12 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 
 	// Write keystore file.
 	keystoreDir := KeystoreVolumePath(cfg, id)
-	if err := os.MkdirAll(keystoreDir, 0700); err != nil {
+	if err := os.MkdirAll(keystoreDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create keystore directory: %w", err)
 	}
+
 	keystorePath := filepath.Join(keystoreDir, w.KeystoreUUID+".json")
-	if err := os.WriteFile(keystorePath, []byte(w.Keystore), 0600); err != nil {
+	if err := os.WriteFile(keystorePath, []byte(w.Keystore), 0o600); err != nil {
 		return fmt.Errorf("failed to write keystore: %w", err)
 	}
 
@@ -235,6 +246,7 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 	// Restart the remote-signer so it picks up the new keystore.
 	// Best-effort: cluster may not be running.
 	namespace := fmt.Sprintf("%s-%s", appName, id)
+
 	kubectlBin, kubeconfig := kubectl.Paths(cfg)
 	if err := kubectl.RunSilent(kubectlBin, kubeconfig,
 		"rollout", "restart", "deployment/remote-signer", "-n", namespace,
@@ -257,10 +269,12 @@ func ListWallets(cfg *config.Config, id string, u *ui.UI) error {
 		ids = []string{id}
 	} else {
 		var err error
+
 		ids, err = ListInstanceIDs(cfg)
 		if err != nil {
 			return err
 		}
+
 		if len(ids) == 0 {
 			u.Info("No OpenClaw instances found")
 			return nil
@@ -268,25 +282,32 @@ func ListWallets(cfg *config.Config, id string, u *ui.UI) error {
 	}
 
 	found := false
+
 	for _, instanceID := range ids {
 		deployDir := DeploymentPath(cfg, instanceID)
+
 		wallet, err := ReadWalletMetadata(deployDir)
 		if err != nil {
 			continue
 		}
+
 		found = true
+
 		u.Detail("Instance", instanceID)
 		u.Detail("  Address", wallet.Address)
 		u.Detail("  Keystore UUID", wallet.KeystoreUUID)
+
 		if wallet.CreatedAt != "" {
 			u.Detail("  Created", wallet.CreatedAt)
 		}
+
 		u.Blank()
 	}
 
 	if !found {
 		u.Info("No wallets found")
 	}
+
 	return nil
 }
 
@@ -296,13 +317,16 @@ func FindInstancesWithWallets(cfg *config.Config) []string {
 	if err != nil {
 		return nil
 	}
+
 	var result []string
+
 	for _, id := range ids {
 		deployDir := DeploymentPath(cfg, id)
 		if _, err := ReadWalletMetadata(deployDir); err == nil {
 			result = append(result, id)
 		}
 	}
+
 	return result
 }
 
@@ -322,8 +346,9 @@ func resolvePassphrase(flagValue string, hasFlag bool, u *ui.UI) (string, error)
 		if err != nil {
 			return "", fmt.Errorf("failed to read confirmation: %w", err)
 		}
+
 		if passphrase != confirm {
-			return "", fmt.Errorf("passphrases do not match")
+			return "", errors.New("passphrases do not match")
 		}
 	}
 
@@ -345,9 +370,11 @@ func readKeystorePassword(deployDir string) (string, error) {
 	if err := yaml.Unmarshal(data, &values); err != nil {
 		return "", fmt.Errorf("failed to parse values-remote-signer.yaml: %w", err)
 	}
+
 	if values.KeystorePassword.Value == "" {
-		return "", fmt.Errorf("keystorePassword.value not found in values-remote-signer.yaml")
+		return "", errors.New("keystorePassword.value not found in values-remote-signer.yaml")
 	}
+
 	return values.KeystorePassword.Value, nil
 }
 
@@ -363,7 +390,8 @@ persistence:
   enabled: true
   size: 100Mi
 `, password)
-	return os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(content), 0644)
+
+	return os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(content), 0o644)
 }
 
 // encryptBackup encrypts plaintext using AES-256-GCM with a scrypt-derived key.
@@ -411,20 +439,22 @@ func encryptBackup(plaintext []byte, passphrase string) ([]byte, error) {
 func decryptBackup(data []byte, passphrase string) ([]byte, error) {
 	minLen := len(backupMagic) + 1 + 32 + 12 // magic + version + salt + nonce
 	if len(data) < minLen {
-		return nil, fmt.Errorf("encrypted file too short")
+		return nil, errors.New("encrypted file too short")
 	}
 
 	offset := 0
 
 	// Verify magic.
 	if string(data[offset:offset+len(backupMagic)]) != string(backupMagic) {
-		return nil, fmt.Errorf("not an encrypted backup file")
+		return nil, errors.New("not an encrypted backup file")
 	}
+
 	offset += len(backupMagic)
 
 	// Check version.
 	version := data[offset]
 	offset++
+
 	if version != backupVersion {
 		return nil, fmt.Errorf("unsupported encryption version %d", version)
 	}
@@ -452,13 +482,15 @@ func decryptBackup(data []byte, passphrase string) ([]byte, error) {
 	// Extract nonce.
 	nonceSize := gcm.NonceSize()
 	if len(data) < offset+nonceSize {
-		return nil, fmt.Errorf("encrypted file too short for nonce")
+		return nil, errors.New("encrypted file too short for nonce")
 	}
+
 	nonce := data[offset : offset+nonceSize]
 	offset += nonceSize
 
 	// Decrypt.
 	ciphertext := data[offset:]
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("decryption failed: %w", err)
@@ -472,20 +504,25 @@ func isEncryptedBackup(data []byte) bool {
 	if len(data) < len(backupMagic) {
 		return false
 	}
+
 	return string(data[:len(backupMagic)]) == string(backupMagic)
 }
 
 // walletAddressesForPurgeWarning returns addresses of wallets that would be lost.
 func walletAddressesForPurgeWarning(cfg *config.Config) []string {
 	ids := FindInstancesWithWallets(cfg)
+
 	var addresses []string
+
 	for _, id := range ids {
 		deployDir := DeploymentPath(cfg, id)
+
 		w, err := ReadWalletMetadata(deployDir)
 		if err == nil {
 			addresses = append(addresses, fmt.Sprintf("  %s (instance: %s)", w.Address, id))
 		}
 	}
+
 	return addresses
 }
 
@@ -498,7 +535,9 @@ func PromptBackupBeforePurge(cfg *config.Config, u *ui.UI) {
 	}
 
 	addresses := walletAddressesForPurgeWarning(cfg)
+
 	u.Warn("The following wallets will be destroyed:")
+
 	for _, a := range addresses {
 		u.Print(a)
 	}
@@ -510,6 +549,7 @@ func PromptBackupBeforePurge(cfg *config.Config, u *ui.UI) {
 	}
 
 	u.Blank()
+
 	if !u.Confirm("Back up wallets before purging?", true) {
 		return
 	}
@@ -533,4 +573,3 @@ func PromptBackupBeforePurge(cfg *config.Config, u *ui.UI) {
 
 	u.Blank()
 }
-

--- a/internal/openclaw/wallet_backup_test.go
+++ b/internal/openclaw/wallet_backup_test.go
@@ -21,8 +21,9 @@ func setupTestInstance(t *testing.T) (*config.Config, string, *WalletInfo) {
 	}
 
 	id := "test-instance"
+
 	deployDir := DeploymentPath(cfg, id)
-	if err := os.MkdirAll(deployDir, 0755); err != nil {
+	if err := os.MkdirAll(deployDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -39,7 +40,7 @@ func setupTestInstance(t *testing.T) (*config.Config, string, *WalletInfo) {
 
 	// Write values-remote-signer.yaml.
 	values := generateRemoteSignerValues(wallet)
-	if err := os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(values), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deployDir, "values-remote-signer.yaml"), []byte(values), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,6 +53,7 @@ func TestBackupRestorePlainRoundTrip(t *testing.T) {
 	// Backup (no encryption).
 	backupPath := filepath.Join(t.TempDir(), "backup.json")
 	u := testUI()
+
 	err := BackupWalletCmd(cfg, id, BackupWalletOptions{
 		Output:      backupPath,
 		Passphrase:  "",
@@ -66,28 +68,33 @@ func TestBackupRestorePlainRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var backup BackupFile
 	if err := json.Unmarshal(data, &backup); err != nil {
 		t.Fatalf("backup is not valid JSON: %v", err)
 	}
+
 	if backup.Version != 1 {
 		t.Errorf("version = %d, want 1", backup.Version)
 	}
+
 	if len(backup.Wallets) != 1 {
 		t.Fatalf("wallets count = %d, want 1", len(backup.Wallets))
 	}
+
 	if backup.Wallets[0].Address != origWallet.Address {
 		t.Errorf("address = %q, want %q", backup.Wallets[0].Address, origWallet.Address)
 	}
 
 	// Create a new instance to restore into.
 	restoreID := "restore-instance"
+
 	restoreDir := DeploymentPath(cfg, restoreID)
-	if err := os.MkdirAll(restoreDir, 0755); err != nil {
+	if err := os.MkdirAll(restoreDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Write a dummy values-remote-signer.yaml so deployment looks valid.
-	if err := os.WriteFile(filepath.Join(restoreDir, "values-remote-signer.yaml"), []byte("dummy: true\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(restoreDir, "values-remote-signer.yaml"), []byte("dummy: true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -107,9 +114,11 @@ func TestBackupRestorePlainRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if restored.Address != origWallet.Address {
 		t.Errorf("restored address = %q, want %q", restored.Address, origWallet.Address)
 	}
+
 	if restored.KeystoreUUID != origWallet.KeystoreUUID {
 		t.Errorf("restored UUID = %q, want %q", restored.KeystoreUUID, origWallet.KeystoreUUID)
 	}
@@ -125,6 +134,7 @@ func TestBackupRestorePlainRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if restoredPwd != origWallet.Password {
 		t.Errorf("restored password = %q, want %q", restoredPwd, origWallet.Password)
 	}
@@ -152,17 +162,20 @@ func TestBackupRestoreEncryptedRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if !isEncryptedBackup(data) {
 		t.Error("backup file should be encrypted")
 	}
 
 	// Restore.
 	restoreID := "restore-enc"
+
 	restoreDir := DeploymentPath(cfg, restoreID)
-	if err := os.MkdirAll(restoreDir, 0755); err != nil {
+	if err := os.MkdirAll(restoreDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(restoreDir, "values-remote-signer.yaml"), []byte("dummy: true\n"), 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(restoreDir, "values-remote-signer.yaml"), []byte("dummy: true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,6 +193,7 @@ func TestBackupRestoreEncryptedRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if restored.Address != origWallet.Address {
 		t.Errorf("address = %q, want %q", restored.Address, origWallet.Address)
 	}
@@ -187,6 +201,7 @@ func TestBackupRestoreEncryptedRoundTrip(t *testing.T) {
 
 func TestDecryptWrongPassphrase(t *testing.T) {
 	plaintext := []byte(`{"version":1,"instance":"test","wallets":[]}`)
+
 	encrypted, err := encryptBackup(plaintext, "correct-passphrase")
 	if err != nil {
 		t.Fatal(err)
@@ -244,6 +259,7 @@ func TestIsEncryptedBackup(t *testing.T) {
 
 func TestCorruptEncryptedFile(t *testing.T) {
 	plaintext := []byte(`{"version":1}`)
+
 	encrypted, err := encryptBackup(plaintext, "pass")
 	if err != nil {
 		t.Fatal(err)
@@ -263,6 +279,7 @@ func TestRestoreRequiresForceForExisting(t *testing.T) {
 
 	// Create a backup first.
 	backupPath := filepath.Join(t.TempDir(), "backup.json")
+
 	u := testUI()
 	if err := BackupWalletCmd(cfg, id, BackupWalletOptions{
 		Output:      backupPath,
@@ -297,8 +314,9 @@ func TestRestoreRequiresForceForExisting(t *testing.T) {
 
 func TestRestoreInvalidVersion(t *testing.T) {
 	backup := `{"version":99,"instance":"test","wallets":[{"address":"0x1234"}]}`
+
 	backupPath := filepath.Join(t.TempDir(), "backup.json")
-	if err := os.WriteFile(backupPath, []byte(backup), 0644); err != nil {
+	if err := os.WriteFile(backupPath, []byte(backup), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -307,12 +325,14 @@ func TestRestoreInvalidVersion(t *testing.T) {
 		ConfigDir: filepath.Join(tmpDir, "config"),
 		DataDir:   filepath.Join(tmpDir, "data"),
 	}
+
 	deployDir := DeploymentPath(cfg, "test")
-	if err := os.MkdirAll(deployDir, 0755); err != nil {
+	if err := os.MkdirAll(deployDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	u := testUI()
+
 	err := RestoreWalletCmd(cfg, "test", RestoreWalletOptions{
 		Input:       backupPath,
 		Passphrase:  "",
@@ -333,7 +353,7 @@ keystorePassword:
 persistence:
   enabled: true
 `
-	if err := os.WriteFile(filepath.Join(tmpDir, "values-remote-signer.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "values-remote-signer.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -341,6 +361,7 @@ persistence:
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if pwd != "my-password-123" {
 		t.Errorf("password = %q, want %q", pwd, "my-password-123")
 	}
@@ -356,7 +377,7 @@ func TestFindInstancesWithWallets(t *testing.T) {
 	// Create two instances, one with wallet, one without.
 	for _, id := range []string{"with-wallet", "no-wallet"} {
 		dir := DeploymentPath(cfg, id)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -373,6 +394,7 @@ func TestFindInstancesWithWallets(t *testing.T) {
 	if len(ids) != 1 {
 		t.Fatalf("expected 1 instance with wallet, got %d", len(ids))
 	}
+
 	if ids[0] != "with-wallet" {
 		t.Errorf("instance = %q, want %q", ids[0], "with-wallet")
 	}

--- a/internal/openclaw/wallet_test.go
+++ b/internal/openclaw/wallet_test.go
@@ -215,7 +215,7 @@ func TestGenerateRandomPassword(t *testing.T) {
 
 	// Verify charset (alphanumeric only).
 	for _, c := range p1 {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
 			t.Errorf("password contains non-alphanumeric character: %c", c)
 		}
 	}

--- a/internal/openclaw/wallet_test.go
+++ b/internal/openclaw/wallet_test.go
@@ -20,18 +20,21 @@ func TestGenerateKeypair(t *testing.T) {
 	if len(privKey) != 32 {
 		t.Errorf("private key length = %d, want 32", len(privKey))
 	}
+
 	if len(pubKey) != 64 {
 		t.Errorf("public key length = %d, want 64 (uncompressed without prefix)", len(pubKey))
 	}
 
 	// Keys should be non-zero.
 	allZero := true
+
 	for _, b := range privKey {
 		if b != 0 {
 			allZero = false
 			break
 		}
 	}
+
 	if allZero {
 		t.Error("private key is all zeros")
 	}
@@ -42,10 +45,12 @@ func TestGenerateKeypairUniqueness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	priv2, _, err := generateKeypair()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if hex.EncodeToString(priv1) == hex.EncodeToString(priv2) {
 		t.Error("two generated keys are identical")
 	}
@@ -64,6 +69,7 @@ func TestAddressFromPublicKey(t *testing.T) {
 	if !strings.HasPrefix(addr, "0x") {
 		t.Errorf("address should start with 0x, got %s", addr)
 	}
+
 	if len(addr) != 42 {
 		t.Errorf("address length = %d, want 42", len(addr))
 	}
@@ -99,6 +105,7 @@ func TestEncryptToV3Keystore(t *testing.T) {
 	}
 
 	password := "test-password-123"
+
 	keystoreJSON, keystoreID, err := encryptToV3Keystore(privKey, pubKey, password)
 	if err != nil {
 		t.Fatalf("encryptToV3Keystore: %v", err)
@@ -117,27 +124,35 @@ func TestEncryptToV3Keystore(t *testing.T) {
 	if ks.Version != 3 {
 		t.Errorf("version = %d, want 3", ks.Version)
 	}
+
 	if ks.Crypto.Cipher != "aes-128-ctr" {
 		t.Errorf("cipher = %q, want aes-128-ctr", ks.Crypto.Cipher)
 	}
+
 	if ks.Crypto.KDF != "scrypt" {
 		t.Errorf("kdf = %q, want scrypt", ks.Crypto.KDF)
 	}
+
 	if ks.Crypto.KDFParams.N != 262144 {
 		t.Errorf("scrypt N = %d, want 262144", ks.Crypto.KDFParams.N)
 	}
+
 	if ks.Crypto.KDFParams.R != 8 {
 		t.Errorf("scrypt r = %d, want 8", ks.Crypto.KDFParams.R)
 	}
+
 	if ks.Crypto.KDFParams.P != 1 {
 		t.Errorf("scrypt p = %d, want 1", ks.Crypto.KDFParams.P)
 	}
+
 	if ks.Crypto.KDFParams.DKLen != 32 {
 		t.Errorf("scrypt dklen = %d, want 32", ks.Crypto.KDFParams.DKLen)
 	}
+
 	if len(ks.Address) != 40 {
 		t.Errorf("address length = %d, want 40 (hex without 0x)", len(ks.Address))
 	}
+
 	if ks.ID != keystoreID {
 		t.Errorf("ID = %q, want %q", ks.ID, keystoreID)
 	}
@@ -150,6 +165,7 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	}
 
 	password := "round-trip-test-password"
+
 	keystoreJSON, _, err := encryptToV3Keystore(privKey, pubKey, password)
 	if err != nil {
 		t.Fatal(err)
@@ -181,6 +197,7 @@ func TestDecryptWrongPassword(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when decrypting with wrong password")
 	}
+
 	if !strings.Contains(err.Error(), "MAC mismatch") {
 		t.Errorf("expected MAC mismatch error, got: %v", err)
 	}
@@ -191,6 +208,7 @@ func TestGenerateRandomPassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if len(p1) != 32 {
 		t.Errorf("password length = %d, want 32", len(p1))
 	}
@@ -207,6 +225,7 @@ func TestGenerateRandomPassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if p1 == p2 {
 		t.Error("two generated passwords are identical")
 	}
@@ -217,6 +236,7 @@ func TestKeystoreVolumePath(t *testing.T) {
 		DataDir: "/test/data",
 	}
 	path := KeystoreVolumePath(cfg, "my-agent")
+
 	want := "/test/data/openclaw-my-agent/remote-signer-keystores"
 	if path != want {
 		t.Errorf("keystoreVolumePath = %q, want %q", path, want)
@@ -228,6 +248,7 @@ func TestProvisionKeystoreToVolume(t *testing.T) {
 	cfg := &config.Config{DataDir: tmpDir}
 
 	keystoreJSON := []byte(`{"version": 3, "test": true}`)
+
 	path, err := provisionKeystoreToVolume(cfg, "test-id", "my-uuid", keystoreJSON)
 	if err != nil {
 		t.Fatal(err)
@@ -238,6 +259,7 @@ func TestProvisionKeystoreToVolume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read keystore: %v", err)
 	}
+
 	if string(data) != string(keystoreJSON) {
 		t.Error("keystore content mismatch")
 	}
@@ -253,7 +275,8 @@ func TestProvisionKeystoreToVolume(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0700 {
+
+	if info.Mode().Perm() != 0o700 {
 		t.Errorf("keystore dir permissions = %o, want 0700", info.Mode().Perm())
 	}
 }
@@ -270,9 +293,11 @@ func TestGenerateRemoteSignerValues(t *testing.T) {
 	if !strings.Contains(values, `keystorePassword:`) {
 		t.Error("values should contain keystorePassword section")
 	}
+
 	if !strings.Contains(values, `value: "my-secret-password"`) {
 		t.Error("values should contain password value")
 	}
+
 	if !strings.Contains(values, "persistence:") {
 		t.Error("values should contain persistence section")
 	}
@@ -299,6 +324,7 @@ func TestWalletMetadataRoundTrip(t *testing.T) {
 	if recovered.Address != wallet.Address {
 		t.Errorf("address = %q, want %q", recovered.Address, wallet.Address)
 	}
+
 	if recovered.KeystoreUUID != wallet.KeystoreUUID {
 		t.Errorf("UUID = %q, want %q", recovered.KeystoreUUID, wallet.KeystoreUUID)
 	}

--- a/internal/schemas/payment.go
+++ b/internal/schemas/payment.go
@@ -23,9 +23,11 @@ const ApproxTokensPerRequest = 1000
 // autoresearch 5-minute experiment budget.
 const ApproxMinutesPerRequest = 5
 
-var approxTokensPerRequestDecimal = decimal.NewFromInt(ApproxTokensPerRequest)
-var minutesPerHour = decimal.NewFromInt(60)
-var approxMinutesPerRequestDecimal = decimal.NewFromInt(ApproxMinutesPerRequest)
+var (
+	approxTokensPerRequestDecimal  = decimal.NewFromInt(ApproxTokensPerRequest)
+	minutesPerHour                 = decimal.NewFromInt(60)
+	approxMinutesPerRequestDecimal = decimal.NewFromInt(ApproxMinutesPerRequest)
+)
 
 // PaymentTerms defines x402 payment requirements for a ServiceOffer.
 // Field names align with x402 PaymentRequirements (V2).
@@ -77,6 +79,7 @@ func (p PriceTable) EffectiveRequestPrice() string {
 	if err != nil {
 		return "0"
 	}
+
 	return price
 }
 
@@ -87,12 +90,15 @@ func (p PriceTable) EffectiveRequestPriceE() (string, error) {
 	if p.PerRequest != "" {
 		return p.PerRequest, nil
 	}
+
 	if p.PerMTok != "" {
 		return ApproximateRequestPriceFromPerMTok(p.PerMTok)
 	}
+
 	if p.PerHour != "" {
 		return ApproximateRequestPriceFromPerHour(p.PerHour)
 	}
+
 	return "0", nil
 }
 
@@ -103,6 +109,7 @@ func ApproximateRequestPriceFromPerMTok(perMTok string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return value.Div(approxTokensPerRequestDecimal).String(), nil
 }
 
@@ -115,5 +122,6 @@ func ApproximateRequestPriceFromPerHour(perHour string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return value.Mul(approxMinutesPerRequestDecimal).Div(minutesPerHour).String(), nil
 }

--- a/internal/schemas/payment_test.go
+++ b/internal/schemas/payment_test.go
@@ -40,6 +40,7 @@ func TestApproximateRequestPriceFromPerHour(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApproximateRequestPriceFromPerHour(6.00) error = %v", err)
 	}
+
 	if got6 != "0.5" {
 		t.Errorf("ApproximateRequestPriceFromPerHour(6.00) = %q, want %q", got6, "0.5")
 	}
@@ -74,6 +75,7 @@ func TestApproximateRequestPriceFromPerMTok(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApproximateRequestPriceFromPerMTok() error = %v", err)
 	}
+
 	if got != "0.00125" {
 		t.Errorf("ApproximateRequestPriceFromPerMTok() = %q, want %q", got, "0.00125")
 	}
@@ -110,18 +112,23 @@ func TestPaymentTerms_JSONRoundTrip(t *testing.T) {
 	if decoded.Network != original.Network {
 		t.Errorf("Network = %q, want %q", decoded.Network, original.Network)
 	}
+
 	if decoded.PayTo != original.PayTo {
 		t.Errorf("PayTo = %q, want %q", decoded.PayTo, original.PayTo)
 	}
+
 	if decoded.Scheme != original.Scheme {
 		t.Errorf("Scheme = %q, want %q", decoded.Scheme, original.Scheme)
 	}
+
 	if decoded.MaxTimeoutSeconds != original.MaxTimeoutSeconds {
 		t.Errorf("MaxTimeoutSeconds = %d, want %d", decoded.MaxTimeoutSeconds, original.MaxTimeoutSeconds)
 	}
+
 	if decoded.Price.PerRequest != original.Price.PerRequest {
 		t.Errorf("Price.PerRequest = %q, want %q", decoded.Price.PerRequest, original.Price.PerRequest)
 	}
+
 	if decoded.Price.PerMTok != original.Price.PerMTok {
 		t.Errorf("Price.PerMTok = %q, want %q", decoded.Price.PerMTok, original.Price.PerMTok)
 	}
@@ -152,18 +159,23 @@ func TestPaymentTerms_YAMLRoundTrip(t *testing.T) {
 	if decoded.Network != original.Network {
 		t.Errorf("Network = %q, want %q", decoded.Network, original.Network)
 	}
+
 	if decoded.PayTo != original.PayTo {
 		t.Errorf("PayTo = %q, want %q", decoded.PayTo, original.PayTo)
 	}
+
 	if decoded.Scheme != original.Scheme {
 		t.Errorf("Scheme = %q, want %q", decoded.Scheme, original.Scheme)
 	}
+
 	if decoded.MaxTimeoutSeconds != original.MaxTimeoutSeconds {
 		t.Errorf("MaxTimeoutSeconds = %d, want %d", decoded.MaxTimeoutSeconds, original.MaxTimeoutSeconds)
 	}
+
 	if decoded.Price.PerRequest != original.Price.PerRequest {
 		t.Errorf("Price.PerRequest = %q, want %q", decoded.Price.PerRequest, original.Price.PerRequest)
 	}
+
 	if decoded.Price.PerMTok != original.Price.PerMTok {
 		t.Errorf("Price.PerMTok = %q, want %q", decoded.Price.PerMTok, original.Price.PerMTok)
 	}
@@ -209,11 +221,13 @@ func TestPaymentTerms_JSONFieldNames(t *testing.T) {
 	if err := json.Unmarshal(raw["price"], &priceRaw); err != nil {
 		t.Fatalf("json.Unmarshal price to map failed: %v", err)
 	}
+
 	for _, expected := range []string{"perRequest", "perMTok"} {
 		if _, ok := priceRaw[expected]; !ok {
 			t.Errorf("expected price field %q not found in JSON output", expected)
 		}
 	}
+
 	for _, unexpected := range []string{"per_request", "per_mtok"} {
 		if _, ok := priceRaw[unexpected]; ok {
 			t.Errorf("unexpected snake_case field %q found in price JSON output", unexpected)
@@ -238,6 +252,7 @@ func TestPriceTable_OmitEmpty(t *testing.T) {
 	if _, ok := jsonMap["perRequest"]; !ok {
 		t.Error("expected perRequest in JSON output")
 	}
+
 	for _, field := range []string{"perMTok", "perHour", "perEpoch"} {
 		if _, ok := jsonMap[field]; ok {
 			t.Errorf("field %q should be omitted from JSON when empty", field)
@@ -250,7 +265,7 @@ func TestPriceTable_OmitEmpty(t *testing.T) {
 		t.Fatalf("yaml.Marshal failed: %v", err)
 	}
 
-	var yamlMap map[string]interface{}
+	var yamlMap map[string]any
 	if err := yaml.Unmarshal(yamlData, &yamlMap); err != nil {
 		t.Fatalf("yaml.Unmarshal to map failed: %v", err)
 	}
@@ -258,6 +273,7 @@ func TestPriceTable_OmitEmpty(t *testing.T) {
 	if _, ok := yamlMap["perRequest"]; !ok {
 		t.Error("expected perRequest in YAML output")
 	}
+
 	for _, field := range []string{"perMTok", "perHour", "perEpoch"} {
 		if _, ok := yamlMap[field]; ok {
 			t.Errorf("field %q should be omitted from YAML when empty", field)

--- a/internal/schemas/serviceoffer.go
+++ b/internal/schemas/serviceoffer.go
@@ -60,18 +60,18 @@ type UpstreamSpec struct {
 
 // ServiceOfferStatus is the Go representation of a ServiceOffer status.
 type ServiceOfferStatus struct {
-	Conditions         []Condition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	Endpoint           string      `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	AgentID            string      `json:"agentId,omitempty" yaml:"agentId,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"         yaml:"conditions,omitempty"`
+	Endpoint           string      `json:"endpoint,omitempty"           yaml:"endpoint,omitempty"`
+	AgentID            string      `json:"agentId,omitempty"            yaml:"agentId,omitempty"`
 	RegistrationTxHash string      `json:"registrationTxHash,omitempty" yaml:"registrationTxHash,omitempty"`
 	ObservedGeneration int64       `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 // Condition represents a ServiceOffer status condition.
 type Condition struct {
-	Type               string `json:"type" yaml:"type"`
-	Status             string `json:"status" yaml:"status"`
-	Reason             string `json:"reason,omitempty" yaml:"reason,omitempty"`
-	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
+	Type               string `json:"type"                         yaml:"type"`
+	Status             string `json:"status"                       yaml:"status"`
+	Reason             string `json:"reason,omitempty"             yaml:"reason,omitempty"`
+	Message            string `json:"message,omitempty"            yaml:"message,omitempty"`
 	LastTransitionTime string `json:"lastTransitionTime,omitempty" yaml:"lastTransitionTime,omitempty"`
 }

--- a/internal/schemas/serviceoffer_test.go
+++ b/internal/schemas/serviceoffer_test.go
@@ -11,6 +11,7 @@ func TestWorkloadType_Constants(t *testing.T) {
 	if WorkloadInference != "inference" {
 		t.Errorf("WorkloadInference = %q, want %q", WorkloadInference, "inference")
 	}
+
 	if WorkloadFineTuning != "fine-tuning" {
 		t.Errorf("WorkloadFineTuning = %q, want %q", WorkloadFineTuning, "fine-tuning")
 	}
@@ -64,6 +65,7 @@ func TestServiceOfferSpec_JSONRoundTrip(t *testing.T) {
 	if decoded.Type != original.Type {
 		t.Errorf("Type = %q, want %q", decoded.Type, original.Type)
 	}
+
 	if decoded.Path != original.Path {
 		t.Errorf("Path = %q, want %q", decoded.Path, original.Path)
 	}
@@ -72,9 +74,11 @@ func TestServiceOfferSpec_JSONRoundTrip(t *testing.T) {
 	if decoded.Model == nil {
 		t.Fatal("Model is nil after round-trip")
 	}
+
 	if decoded.Model.Name != original.Model.Name {
 		t.Errorf("Model.Name = %q, want %q", decoded.Model.Name, original.Model.Name)
 	}
+
 	if decoded.Model.Runtime != original.Model.Runtime {
 		t.Errorf("Model.Runtime = %q, want %q", decoded.Model.Runtime, original.Model.Runtime)
 	}
@@ -83,12 +87,15 @@ func TestServiceOfferSpec_JSONRoundTrip(t *testing.T) {
 	if decoded.Upstream.Service != original.Upstream.Service {
 		t.Errorf("Upstream.Service = %q, want %q", decoded.Upstream.Service, original.Upstream.Service)
 	}
+
 	if decoded.Upstream.Namespace != original.Upstream.Namespace {
 		t.Errorf("Upstream.Namespace = %q, want %q", decoded.Upstream.Namespace, original.Upstream.Namespace)
 	}
+
 	if decoded.Upstream.Port != original.Upstream.Port {
 		t.Errorf("Upstream.Port = %d, want %d", decoded.Upstream.Port, original.Upstream.Port)
 	}
+
 	if decoded.Upstream.HealthPath != original.Upstream.HealthPath {
 		t.Errorf("Upstream.HealthPath = %q, want %q", decoded.Upstream.HealthPath, original.Upstream.HealthPath)
 	}
@@ -97,9 +104,11 @@ func TestServiceOfferSpec_JSONRoundTrip(t *testing.T) {
 	if decoded.Payment.Network != original.Payment.Network {
 		t.Errorf("Payment.Network = %q, want %q", decoded.Payment.Network, original.Payment.Network)
 	}
+
 	if decoded.Payment.PayTo != original.Payment.PayTo {
 		t.Errorf("Payment.PayTo = %q, want %q", decoded.Payment.PayTo, original.Payment.PayTo)
 	}
+
 	if decoded.Payment.Price.PerRequest != original.Payment.Price.PerRequest {
 		t.Errorf("Payment.Price.PerRequest = %q, want %q", decoded.Payment.Price.PerRequest, original.Payment.Price.PerRequest)
 	}
@@ -108,15 +117,19 @@ func TestServiceOfferSpec_JSONRoundTrip(t *testing.T) {
 	if decoded.Registration == nil {
 		t.Fatal("Registration is nil after round-trip")
 	}
+
 	if decoded.Registration.Enabled != original.Registration.Enabled {
 		t.Errorf("Registration.Enabled = %v, want %v", decoded.Registration.Enabled, original.Registration.Enabled)
 	}
+
 	if decoded.Registration.Name != original.Registration.Name {
 		t.Errorf("Registration.Name = %q, want %q", decoded.Registration.Name, original.Registration.Name)
 	}
+
 	if len(decoded.Registration.Services) != len(original.Registration.Services) {
 		t.Fatalf("Registration.Services length = %d, want %d", len(decoded.Registration.Services), len(original.Registration.Services))
 	}
+
 	if decoded.Registration.Services[0].Name != original.Registration.Services[0].Name {
 		t.Errorf("Registration.Services[0].Name = %q, want %q", decoded.Registration.Services[0].Name, original.Registration.Services[0].Name)
 	}
@@ -219,33 +232,42 @@ func TestServiceOfferStatus_Conditions(t *testing.T) {
 	if len(decoded.Conditions) != len(original.Conditions) {
 		t.Fatalf("Conditions length = %d, want %d", len(decoded.Conditions), len(original.Conditions))
 	}
+
 	for i, c := range decoded.Conditions {
 		orig := original.Conditions[i]
 		if c.Type != orig.Type {
 			t.Errorf("Conditions[%d].Type = %q, want %q", i, c.Type, orig.Type)
 		}
+
 		if c.Status != orig.Status {
 			t.Errorf("Conditions[%d].Status = %q, want %q", i, c.Status, orig.Status)
 		}
+
 		if c.Reason != orig.Reason {
 			t.Errorf("Conditions[%d].Reason = %q, want %q", i, c.Reason, orig.Reason)
 		}
+
 		if c.Message != orig.Message {
 			t.Errorf("Conditions[%d].Message = %q, want %q", i, c.Message, orig.Message)
 		}
+
 		if c.LastTransitionTime != orig.LastTransitionTime {
 			t.Errorf("Conditions[%d].LastTransitionTime = %q, want %q", i, c.LastTransitionTime, orig.LastTransitionTime)
 		}
 	}
+
 	if decoded.Endpoint != original.Endpoint {
 		t.Errorf("Endpoint = %q, want %q", decoded.Endpoint, original.Endpoint)
 	}
+
 	if decoded.AgentID != original.AgentID {
 		t.Errorf("AgentID = %q, want %q", decoded.AgentID, original.AgentID)
 	}
+
 	if decoded.RegistrationTxHash != original.RegistrationTxHash {
 		t.Errorf("RegistrationTxHash = %q, want %q", decoded.RegistrationTxHash, original.RegistrationTxHash)
 	}
+
 	if decoded.ObservedGeneration != original.ObservedGeneration {
 		t.Errorf("ObservedGeneration = %d, want %d", decoded.ObservedGeneration, original.ObservedGeneration)
 	}
@@ -270,6 +292,7 @@ func TestRegistrationSpec_SupportedTrust(t *testing.T) {
 	if len(decoded.SupportedTrust) != len(original.SupportedTrust) {
 		t.Fatalf("SupportedTrust length = %d, want %d", len(decoded.SupportedTrust), len(original.SupportedTrust))
 	}
+
 	for i, v := range decoded.SupportedTrust {
 		if v != original.SupportedTrust[i] {
 			t.Errorf("SupportedTrust[%d] = %q, want %q", i, v, original.SupportedTrust[i])
@@ -302,14 +325,17 @@ func TestRegistrationSpec_Services(t *testing.T) {
 	if len(decoded.Services) != len(original.Services) {
 		t.Fatalf("Services length = %d, want %d", len(decoded.Services), len(original.Services))
 	}
+
 	for i, svc := range decoded.Services {
 		orig := original.Services[i]
 		if svc.Name != orig.Name {
 			t.Errorf("Services[%d].Name = %q, want %q", i, svc.Name, orig.Name)
 		}
+
 		if svc.Endpoint != orig.Endpoint {
 			t.Errorf("Services[%d].Endpoint = %q, want %q", i, svc.Endpoint, orig.Endpoint)
 		}
+
 		if svc.Version != orig.Version {
 			t.Errorf("Services[%d].Version = %q, want %q", i, svc.Version, orig.Version)
 		}

--- a/internal/stack/backend.go
+++ b/internal/stack/backend.go
@@ -76,7 +76,7 @@ func LoadBackend(cfg *config.Config) (Backend, error) {
 // SaveBackend persists the backend choice
 func SaveBackend(cfg *config.Config, name string) error {
 	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
-	return os.WriteFile(path, []byte(name), 0o644)
+	return os.WriteFile(path, []byte(name), 0o600)
 }
 
 // DetectExistingBackend reads the persisted backend choice without

--- a/internal/stack/backend.go
+++ b/internal/stack/backend.go
@@ -64,17 +64,19 @@ func NewBackend(name string) (Backend, error) {
 // Falls back to k3d if no file exists (backward compatibility).
 func LoadBackend(cfg *config.Config) (Backend, error) {
 	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return &K3dBackend{}, nil
 	}
+
 	return NewBackend(strings.TrimSpace(string(data)))
 }
 
 // SaveBackend persists the backend choice
 func SaveBackend(cfg *config.Config, name string) error {
 	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
-	return os.WriteFile(path, []byte(name), 0644)
+	return os.WriteFile(path, []byte(name), 0o644)
 }
 
 // DetectExistingBackend reads the persisted backend choice without
@@ -82,14 +84,17 @@ func SaveBackend(cfg *config.Config, name string) error {
 // which lets Init() apply its own default.
 func DetectExistingBackend(cfg *config.Config) string {
 	path := filepath.Join(cfg.ConfigDir, stackBackendFile)
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
+
 	name := strings.TrimSpace(string(data))
 	// Validate it's a known backend; return empty if corrupted
 	if _, err := NewBackend(name); err != nil {
 		return ""
 	}
+
 	return name
 }

--- a/internal/stack/backend.go
+++ b/internal/stack/backend.go
@@ -67,7 +67,7 @@ func LoadBackend(cfg *config.Config) (Backend, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return &K3dBackend{}, nil
+		return &K3dBackend{}, nil //nolint:nilerr // missing file means legacy install; default to k3d
 	}
 
 	return NewBackend(strings.TrimSpace(string(data)))

--- a/internal/stack/backend_k3d.go
+++ b/internal/stack/backend_k3d.go
@@ -68,7 +68,7 @@ func (b *K3dBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 	k3dConfig = strings.ReplaceAll(k3dConfig, "{{CONFIG_DIR}}", absConfigDir)
 
 	k3dConfigPath := filepath.Join(cfg.ConfigDir, k3dConfigFile)
-	if err := os.WriteFile(k3dConfigPath, []byte(k3dConfig), 0o644); err != nil {
+	if err := os.WriteFile(k3dConfigPath, []byte(k3dConfig), 0o600); err != nil {
 		return fmt.Errorf("failed to write k3d config: %w", err)
 	}
 

--- a/internal/stack/backend_k3d.go
+++ b/internal/stack/backend_k3d.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -34,9 +35,10 @@ func (b *K3dBackend) Prerequisites(cfg *config.Config) error {
 	// Check Docker is running
 	cmd := exec.Command("docker", "info")
 	cmd.Stdout = nil
+
 	cmd.Stderr = nil
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Docker is not running. k3d backend requires Docker.\nStart Docker and try again")
+		return errors.New("Docker is not running. k3d backend requires Docker.\nStart Docker and try again")
 	}
 
 	// Check k3d binary exists
@@ -44,6 +46,7 @@ func (b *K3dBackend) Prerequisites(cfg *config.Config) error {
 	if _, err := os.Stat(k3dPath); os.IsNotExist(err) {
 		return fmt.Errorf("k3d not found at %s\nRun obolup.sh to install dependencies", k3dPath)
 	}
+
 	return nil
 }
 
@@ -65,7 +68,7 @@ func (b *K3dBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 	k3dConfig = strings.ReplaceAll(k3dConfig, "{{CONFIG_DIR}}", absConfigDir)
 
 	k3dConfigPath := filepath.Join(cfg.ConfigDir, k3dConfigFile)
-	if err := os.WriteFile(k3dConfigPath, []byte(k3dConfig), 0644); err != nil {
+	if err := os.WriteFile(k3dConfigPath, []byte(k3dConfig), 0o644); err != nil {
 		return fmt.Errorf("failed to write k3d config: %w", err)
 	}
 
@@ -73,17 +76,19 @@ func (b *K3dBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 }
 
 func (b *K3dBackend) IsRunning(cfg *config.Config, stackID string) (bool, error) {
-	stackName := fmt.Sprintf("obol-stack-%s", stackID)
+	stackName := "obol-stack-" + stackID
 	listCmd := exec.Command(filepath.Join(cfg.BinDir, "k3d"), "cluster", "list", "--no-headers")
+
 	output, err := listCmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("k3d list command failed: %w", err)
 	}
+
 	return strings.Contains(string(output), stackName), nil
 }
 
 func (b *K3dBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, error) {
-	stackName := fmt.Sprintf("obol-stack-%s", stackID)
+	stackName := "obol-stack-" + stackID
 	k3dConfigPath := filepath.Join(cfg.ConfigDir, k3dConfigFile)
 
 	running, err := b.IsRunning(cfg, stackID)
@@ -93,6 +98,7 @@ func (b *K3dBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 
 	if running {
 		u.Warn("Cluster already exists, starting it")
+
 		startCmd := exec.Command(filepath.Join(cfg.BinDir, "k3d"), "cluster", "start", stackName)
 		if err := u.Exec(ui.ExecConfig{
 			Name: "Starting existing k3d cluster",
@@ -106,7 +112,8 @@ func (b *K3dBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get absolute path for data directory: %w", err)
 		}
-		if err := os.MkdirAll(absDataDir, 0755); err != nil {
+
+		if err := os.MkdirAll(absDataDir, 0o755); err != nil {
 			return nil, fmt.Errorf("failed to create data directory: %w", err)
 		}
 
@@ -126,6 +133,7 @@ func (b *K3dBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 
 	// Export kubeconfig
 	kubeconfigCmd := exec.Command(filepath.Join(cfg.BinDir, "k3d"), "kubeconfig", "get", stackName)
+
 	kubeconfigData, err := kubeconfigCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
@@ -149,15 +157,17 @@ func (b *K3dBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 func waitForAPIServer(u *ui.UI, kubeconfigData []byte) error {
 	// Extract the server URL from kubeconfig
 	var serverURL string
-	for _, line := range strings.Split(string(kubeconfigData), "\n") {
+
+	for line := range strings.SplitSeq(string(kubeconfigData), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "server:") {
-			serverURL = strings.TrimSpace(strings.TrimPrefix(trimmed, "server:"))
+		if after, ok := strings.CutPrefix(trimmed, "server:"); ok {
+			serverURL = strings.TrimSpace(after)
 			break
 		}
 	}
+
 	if serverURL == "" {
-		return fmt.Errorf("could not find server URL in kubeconfig")
+		return errors.New("could not find server URL in kubeconfig")
 	}
 
 	client := &http.Client{
@@ -173,18 +183,21 @@ func waitForAPIServer(u *ui.UI, kubeconfigData []byte) error {
 			resp, err := client.Get(serverURL + "/version")
 			if err == nil {
 				resp.Body.Close()
+
 				if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized {
 					return nil
 				}
 			}
+
 			time.Sleep(2 * time.Second)
 		}
+
 		return fmt.Errorf("timed out after 60s waiting for API server at %s", serverURL)
 	})
 }
 
 func (b *K3dBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
-	stackName := fmt.Sprintf("obol-stack-%s", stackID)
+	stackName := "obol-stack-" + stackID
 
 	u.Infof("Stopping stack: %s", stackName)
 
@@ -194,6 +207,7 @@ func (b *K3dBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 		Cmd:  stopCmd,
 	}); err != nil {
 		u.Warn("Graceful stop failed, forcing cluster deletion")
+
 		deleteCmd := exec.Command(filepath.Join(cfg.BinDir, "k3d"), "cluster", "delete", stackName)
 		if err := u.Exec(ui.ExecConfig{
 			Name: "Deleting k3d cluster",
@@ -207,7 +221,7 @@ func (b *K3dBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 }
 
 func (b *K3dBackend) Destroy(cfg *config.Config, u *ui.UI, stackID string) error {
-	stackName := fmt.Sprintf("obol-stack-%s", stackID)
+	stackName := "obol-stack-" + stackID
 
 	deleteCmd := exec.Command(filepath.Join(cfg.BinDir, "k3d"), "cluster", "delete", stackName)
 	if err := u.Exec(ui.ExecConfig{

--- a/internal/stack/backend_k3d.go
+++ b/internal/stack/backend_k3d.go
@@ -38,7 +38,7 @@ func (b *K3dBackend) Prerequisites(cfg *config.Config) error {
 
 	cmd.Stderr = nil
 	if err := cmd.Run(); err != nil {
-		return errors.New("Docker is not running. k3d backend requires Docker.\nStart Docker and try again")
+		return errors.New("docker is not running; k3d backend requires Docker — start Docker and try again")
 	}
 
 	// Check k3d binary exists

--- a/internal/stack/backend_k3s.go
+++ b/internal/stack/backend_k3s.go
@@ -65,7 +65,7 @@ func (b *K3sBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 	k3sConfig = strings.ReplaceAll(k3sConfig, "{{DATA_DIR}}", absDataDir)
 
 	k3sConfigPath := filepath.Join(cfg.ConfigDir, k3sConfigFile)
-	if err := os.WriteFile(k3sConfigPath, []byte(k3sConfig), 0o644); err != nil {
+	if err := os.WriteFile(k3sConfigPath, []byte(k3sConfig), 0o600); err != nil {
 		return fmt.Errorf("failed to write k3s config: %w", err)
 	}
 

--- a/internal/stack/backend_k3s.go
+++ b/internal/stack/backend_k3s.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,7 +29,7 @@ func (b *K3sBackend) Name() string { return BackendK3s }
 
 func (b *K3sBackend) Prerequisites(cfg *config.Config) error {
 	if runtime.GOOS != "linux" {
-		return fmt.Errorf("k3s backend is only supported on Linux")
+		return errors.New("k3s backend is only supported on Linux")
 	}
 
 	// Check sudo access: try non-interactive first (NOPASSWD), fall back to interactive prompt
@@ -36,9 +37,10 @@ func (b *K3sBackend) Prerequisites(cfg *config.Config) error {
 		cmd := exec.Command("sudo", "-v")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
+
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("k3s backend requires root/sudo access")
+			return errors.New("k3s backend requires root/sudo access")
 		}
 	}
 
@@ -63,7 +65,7 @@ func (b *K3sBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 	k3sConfig = strings.ReplaceAll(k3sConfig, "{{DATA_DIR}}", absDataDir)
 
 	k3sConfigPath := filepath.Join(cfg.ConfigDir, k3sConfigFile)
-	if err := os.WriteFile(k3sConfigPath, []byte(k3sConfig), 0644); err != nil {
+	if err := os.WriteFile(k3sConfigPath, []byte(k3sConfig), 0o644); err != nil {
 		return fmt.Errorf("failed to write k3s config: %w", err)
 	}
 
@@ -83,11 +85,14 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 	running, _ := b.IsRunning(cfg, stackID)
 	if running {
 		u.Warn("k3s is already running")
+
 		kubeconfigPath := filepath.Join(cfg.ConfigDir, kubeconfigFile)
+
 		data, err := os.ReadFile(kubeconfigPath)
 		if err != nil {
 			return nil, fmt.Errorf("k3s is running but kubeconfig not found: %w", err)
 		}
+
 		return data, nil
 	}
 
@@ -104,7 +109,8 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path for data directory: %w", err)
 	}
-	if err := os.MkdirAll(absDataDir, 0755); err != nil {
+
+	if err := os.MkdirAll(absDataDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create data directory: %w", err)
 	}
 
@@ -116,7 +122,7 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 	os.Remove(kubeconfigPath)
 
 	// Open log file for k3s output
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k3s log file: %w", err)
 	}
@@ -143,7 +149,7 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 
 	// Write PID file
 	pidPath := filepath.Join(cfg.ConfigDir, k3sPidFile)
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0600); err != nil {
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o600); err != nil {
 		logFile.Close()
 		return nil, fmt.Errorf("failed to write k3s PID file: %w", err)
 	}
@@ -157,19 +163,23 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 
 	// Wait for kubeconfig to be written by k3s
 	var kubeconfigData []byte
+
 	err = u.RunWithSpinner("Waiting for kubeconfig", func() error {
 		deadline := time.Now().Add(2 * time.Minute)
 		for time.Now().Before(deadline) {
 			if info, statErr := os.Stat(kubeconfigPath); statErr == nil && info.Size() > 0 {
 				exec.Command("sudo", "chown", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), kubeconfigPath).Run()
+
 				data, readErr := os.ReadFile(kubeconfigPath)
 				if readErr == nil && len(data) > 0 {
 					kubeconfigData = data
 					return nil
 				}
 			}
+
 			time.Sleep(2 * time.Second)
 		}
+
 		return fmt.Errorf("k3s did not write kubeconfig within timeout\nCheck logs: %s", logPath)
 	})
 	if err != nil {
@@ -179,15 +189,18 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 	// Wait for API server
 	err = u.RunWithSpinner("Waiting for API server", func() error {
 		kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+
 		deadline := time.Now().Add(90 * time.Second)
 		for time.Now().Before(deadline) {
 			probe := exec.Command(kubectlPath, "--kubeconfig", kubeconfigPath, "get", "nodes", "--no-headers")
 			if out, probeErr := probe.Output(); probeErr == nil && len(out) > 0 {
 				return nil
 			}
+
 			time.Sleep(3 * time.Second)
 		}
-		return fmt.Errorf("API server not ready after 90s")
+
+		return errors.New("API server not ready after 90s")
 	})
 	if err != nil {
 		u.Warn("API server not fully ready, proceeding anyway")
@@ -206,12 +219,14 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 	if !b.isProcessAlive(pid) {
 		u.Warn("k3s process not running, cleaning up PID file")
 		b.removePidFile(cfg)
+
 		return nil
 	}
 
 	u.Infof("Stopping k3s (pid: %d)", pid)
 
 	pidStr := strconv.Itoa(pid)
+
 	stopCmd := exec.Command("sudo", "kill", "-TERM", pidStr)
 	if err := u.Exec(ui.ExecConfig{
 		Name: "Sending SIGTERM to k3s",
@@ -227,6 +242,7 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 		if !b.isProcessAlive(pid) {
 			break
 		}
+
 		time.Sleep(1 * time.Second)
 	}
 
@@ -246,6 +262,7 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 
 	b.removePidFile(cfg)
 	u.Success("k3s stopped")
+
 	return nil
 }
 
@@ -255,6 +272,7 @@ func (b *K3sBackend) Destroy(cfg *config.Config, u *ui.UI, stackID string) error
 
 	// Clean up k3s state directories
 	absDataDir, _ := filepath.Abs(cfg.DataDir)
+
 	cleanDirs := []string{
 		"/var/lib/rancher/k3s",
 		"/etc/rancher/k3s",
@@ -262,7 +280,7 @@ func (b *K3sBackend) Destroy(cfg *config.Config, u *ui.UI, stackID string) error
 	}
 	for _, dir := range cleanDirs {
 		if _, err := os.Stat(dir); err == nil {
-			u.Dim(fmt.Sprintf("  Cleaning up: %s", dir))
+			u.Dim("  Cleaning up: " + dir)
 			exec.Command("sudo", "rm", "-rf", dir).Run()
 		}
 	}
@@ -288,17 +306,21 @@ func (b *K3sBackend) DataDir(cfg *config.Config) string {
 // readPid reads the k3s PID from the PID file
 func (b *K3sBackend) readPid(cfg *config.Config) (int, error) {
 	pidPath := filepath.Join(cfg.ConfigDir, k3sPidFile)
+
 	data, err := os.ReadFile(pidPath)
 	if err != nil {
 		return 0, err
 	}
+
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		return 0, fmt.Errorf("invalid PID in %s: %w", pidPath, err)
 	}
+
 	if pid <= 0 {
 		return 0, fmt.Errorf("invalid PID in %s: %d", pidPath, pid)
 	}
+
 	return pid, nil
 }
 
@@ -308,6 +330,7 @@ func (b *K3sBackend) cleanStalePid(cfg *config.Config, u *ui.UI) {
 	if err != nil {
 		return
 	}
+
 	if !b.isProcessAlive(pid) {
 		u.Dim(fmt.Sprintf("  Cleaning up stale PID file (pid %d no longer running)", pid))
 		b.removePidFile(cfg)

--- a/internal/stack/backend_k3s.go
+++ b/internal/stack/backend_k3s.go
@@ -75,7 +75,7 @@ func (b *K3sBackend) Init(cfg *config.Config, u *ui.UI, stackID string) error {
 func (b *K3sBackend) IsRunning(cfg *config.Config, stackID string) (bool, error) {
 	pid, err := b.readPid(cfg)
 	if err != nil {
-		return false, nil
+		return false, nil //nolint:nilerr // missing PID file means not running
 	}
 
 	return b.isProcessAlive(pid), nil
@@ -155,7 +155,8 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 	}
 
 	// Detach the process
-	cmd.Process.Release()
+	_ = cmd.Process.Release()
+
 	logFile.Close()
 
 	u.Detail("PID", strconv.Itoa(pid))
@@ -168,7 +169,7 @@ func (b *K3sBackend) Up(cfg *config.Config, u *ui.UI, stackID string) ([]byte, e
 		deadline := time.Now().Add(2 * time.Minute)
 		for time.Now().Before(deadline) {
 			if info, statErr := os.Stat(kubeconfigPath); statErr == nil && info.Size() > 0 {
-				exec.Command("sudo", "chown", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), kubeconfigPath).Run()
+				_ = exec.Command("sudo", "chown", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), kubeconfigPath).Run()
 
 				data, readErr := os.ReadFile(kubeconfigPath)
 				if readErr == nil && len(data) > 0 {
@@ -213,7 +214,7 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 	pid, err := b.readPid(cfg)
 	if err != nil {
 		u.Warn("k3s PID file not found, may not be running")
-		return nil
+		return nil //nolint:nilerr // missing PID file means nothing to stop
 	}
 
 	if !b.isProcessAlive(pid) {
@@ -233,7 +234,8 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 		Cmd:  stopCmd,
 	}); err != nil {
 		u.Warnf("SIGTERM failed, sending SIGKILL: %v", err)
-		exec.Command("sudo", "kill", "-9", pidStr).Run()
+
+		_ = exec.Command("sudo", "kill", "-9", pidStr).Run()
 	}
 
 	// Wait for process to exit
@@ -255,9 +257,11 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 			Cmd:  cleanCmd,
 		})
 	} else {
-		exec.Command("sudo", "pkill", "-TERM", "-f", "containerd-shim.*k3s").Run()
+		_ = exec.Command("sudo", "pkill", "-TERM", "-f", "containerd-shim.*k3s").Run()
+
 		time.Sleep(2 * time.Second)
-		exec.Command("sudo", "pkill", "-KILL", "-f", "containerd-shim.*k3s").Run()
+
+		_ = exec.Command("sudo", "pkill", "-KILL", "-f", "containerd-shim.*k3s").Run()
 	}
 
 	b.removePidFile(cfg)
@@ -268,7 +272,7 @@ func (b *K3sBackend) Down(cfg *config.Config, u *ui.UI, stackID string) error {
 
 func (b *K3sBackend) Destroy(cfg *config.Config, u *ui.UI, stackID string) error {
 	// Stop if running
-	b.Down(cfg, u, stackID)
+	_ = b.Down(cfg, u, stackID)
 
 	// Clean up k3s state directories
 	absDataDir, _ := filepath.Abs(cfg.DataDir)
@@ -281,7 +285,7 @@ func (b *K3sBackend) Destroy(cfg *config.Config, u *ui.UI, stackID string) error
 	for _, dir := range cleanDirs {
 		if _, err := os.Stat(dir); err == nil {
 			u.Dim("  Cleaning up: " + dir)
-			exec.Command("sudo", "rm", "-rf", dir).Run()
+			_ = exec.Command("sudo", "rm", "-rf", dir).Run()
 		}
 	}
 

--- a/internal/stack/backend_k3s_test.go
+++ b/internal/stack/backend_k3s_test.go
@@ -34,24 +34,29 @@ func TestK3sReadPid(t *testing.T) {
 			cfg := &config.Config{ConfigDir: tmpDir}
 
 			pidPath := filepath.Join(tmpDir, k3sPidFile)
-			if err := os.WriteFile(pidPath, []byte(tt.content), 0600); err != nil {
+			if err := os.WriteFile(pidPath, []byte(tt.content), 0o600); err != nil {
 				t.Fatalf("WriteFile error: %v", err)
 			}
 
 			b := &K3sBackend{}
+
 			pid, err := b.readPid(cfg)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("readPid() = %d, nil error; want error containing %q", pid, tt.errContains)
 				}
+
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("readPid() error = %q, want containing %q", err.Error(), tt.errContains)
 				}
+
 				return
 			}
+
 			if err != nil {
 				t.Fatalf("readPid() unexpected error: %v", err)
 			}
+
 			if pid != tt.wantPid {
 				t.Errorf("readPid() = %d, want %d", pid, tt.wantPid)
 			}
@@ -63,6 +68,7 @@ func TestK3sReadPid(t *testing.T) {
 		cfg := &config.Config{ConfigDir: tmpDir}
 
 		b := &K3sBackend{}
+
 		_, err := b.readPid(cfg)
 		if err == nil {
 			t.Fatal("readPid() with no file should return error")
@@ -75,7 +81,7 @@ func TestK3sRemovePidFile(t *testing.T) {
 	cfg := &config.Config{ConfigDir: tmpDir}
 
 	pidPath := filepath.Join(tmpDir, k3sPidFile)
-	if err := os.WriteFile(pidPath, []byte("12345"), 0600); err != nil {
+	if err := os.WriteFile(pidPath, []byte("12345"), 0o600); err != nil {
 		t.Fatalf("WriteFile error: %v", err)
 	}
 

--- a/internal/stack/backend_test.go
+++ b/internal/stack/backend_test.go
@@ -38,14 +38,18 @@ func TestNewBackend(t *testing.T) {
 				if err == nil {
 					t.Fatalf("NewBackend(%q) = nil error, want error containing %q", tt.input, tt.errContains)
 				}
+
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("NewBackend(%q) error = %q, want containing %q", tt.input, err.Error(), tt.errContains)
 				}
+
 				return
 			}
+
 			if err != nil {
 				t.Fatalf("NewBackend(%q) unexpected error: %v", tt.input, err)
 			}
+
 			if backend.Name() != tt.wantName {
 				t.Errorf("NewBackend(%q).Name() = %q, want %q", tt.input, backend.Name(), tt.wantName)
 			}
@@ -82,6 +86,7 @@ func TestK3dBackendDataDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &K3dBackend{}
+
 			cfg := &config.Config{DataDir: tt.dataDir}
 			if got := b.DataDir(cfg); got != "/data" {
 				t.Errorf("K3dBackend.DataDir() = %q, want %q (must always be /data for Docker mount)", got, "/data")
@@ -97,6 +102,7 @@ func TestK3sBackendDataDir(t *testing.T) {
 
 	t.Run("absolute path passthrough", func(t *testing.T) {
 		cfg := &config.Config{DataDir: "/home/user/.local/share/obol"}
+
 		got := b.DataDir(cfg)
 		if got != "/home/user/.local/share/obol" {
 			t.Errorf("K3sBackend.DataDir() = %q, want %q", got, "/home/user/.local/share/obol")
@@ -105,10 +111,12 @@ func TestK3sBackendDataDir(t *testing.T) {
 
 	t.Run("relative path resolved to absolute", func(t *testing.T) {
 		cfg := &config.Config{DataDir: "relative/path"}
+
 		got := b.DataDir(cfg)
 		if !filepath.IsAbs(got) {
 			t.Errorf("K3sBackend.DataDir() = %q, want absolute path", got)
 		}
+
 		if !strings.HasSuffix(got, "relative/path") {
 			t.Errorf("K3sBackend.DataDir() = %q, want suffix %q", got, "relative/path")
 		}
@@ -138,6 +146,7 @@ func TestSaveAndLoadBackend(t *testing.T) {
 			if err != nil {
 				t.Fatalf("LoadBackend() error: %v", err)
 			}
+
 			if backend.Name() != tt.wantName {
 				t.Errorf("LoadBackend().Name() = %q, want %q", backend.Name(), tt.wantName)
 			}
@@ -155,6 +164,7 @@ func TestLoadBackendFallsBackToK3d(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadBackend() error: %v", err)
 	}
+
 	if backend.Name() != BackendK3d {
 		t.Errorf("LoadBackend() with no file = %q, want %q (backward compat)", backend.Name(), BackendK3d)
 	}
@@ -166,7 +176,7 @@ func TestLoadBackendWithWhitespace(t *testing.T) {
 
 	// Write file with trailing newline and whitespace
 	path := filepath.Join(tmpDir, stackBackendFile)
-	if err := os.WriteFile(path, []byte("k3s\n  "), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("k3s\n  "), 0o644); err != nil {
 		t.Fatalf("WriteFile error: %v", err)
 	}
 
@@ -174,6 +184,7 @@ func TestLoadBackendWithWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadBackend() error: %v", err)
 	}
+
 	if backend.Name() != BackendK3s {
 		t.Errorf("LoadBackend() = %q, want %q", backend.Name(), BackendK3s)
 	}
@@ -184,7 +195,7 @@ func TestLoadBackendInvalidName(t *testing.T) {
 	cfg := &config.Config{ConfigDir: tmpDir}
 
 	path := filepath.Join(tmpDir, stackBackendFile)
-	if err := os.WriteFile(path, []byte("docker-swarm"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("docker-swarm"), 0o644); err != nil {
 		t.Fatalf("WriteFile error: %v", err)
 	}
 
@@ -192,6 +203,7 @@ func TestLoadBackendInvalidName(t *testing.T) {
 	if err == nil {
 		t.Fatal("LoadBackend() with invalid backend name should return error")
 	}
+
 	if !strings.Contains(err.Error(), "unknown backend") {
 		t.Errorf("LoadBackend() error = %q, want containing %q", err.Error(), "unknown backend")
 	}
@@ -205,6 +217,7 @@ func TestK3dBackendInit(t *testing.T) {
 	}
 
 	b := &K3dBackend{}
+
 	u := ui.New(false)
 	if err := b.Init(cfg, u, "test-stack"); err != nil {
 		t.Fatalf("K3dBackend.Init() error: %v", err)
@@ -212,6 +225,7 @@ func TestK3dBackendInit(t *testing.T) {
 
 	// Verify config file was written
 	configPath := filepath.Join(tmpDir, k3dConfigFile)
+
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to read generated config: %v", err)
@@ -223,9 +237,11 @@ func TestK3dBackendInit(t *testing.T) {
 	if strings.Contains(content, "{{STACK_ID}}") {
 		t.Error("Config still contains {{STACK_ID}} placeholder")
 	}
+
 	if strings.Contains(content, "{{DATA_DIR}}") {
 		t.Error("Config still contains {{DATA_DIR}} placeholder")
 	}
+
 	if strings.Contains(content, "{{CONFIG_DIR}}") {
 		t.Error("Config still contains {{CONFIG_DIR}} placeholder")
 	}
@@ -249,6 +265,7 @@ func TestK3sBackendInit(t *testing.T) {
 	}
 
 	b := &K3sBackend{}
+
 	u := ui.New(false)
 	if err := b.Init(cfg, u, "my-cluster"); err != nil {
 		t.Fatalf("K3sBackend.Init() error: %v", err)
@@ -256,6 +273,7 @@ func TestK3sBackendInit(t *testing.T) {
 
 	// Verify config file was written
 	configPath := filepath.Join(tmpDir, k3sConfigFile)
+
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to read generated config: %v", err)
@@ -267,6 +285,7 @@ func TestK3sBackendInit(t *testing.T) {
 	if strings.Contains(content, "{{STACK_ID}}") {
 		t.Error("Config still contains {{STACK_ID}} placeholder")
 	}
+
 	if strings.Contains(content, "{{DATA_DIR}}") {
 		t.Error("Config still contains {{DATA_DIR}} placeholder")
 	}
@@ -278,6 +297,7 @@ func TestK3sBackendInit(t *testing.T) {
 
 	// Verify data-dir uses absolute path
 	absDataDir, _ := filepath.Abs(filepath.Join(tmpDir, "data"))
+
 	expectedDataDir := absDataDir + "/k3s"
 	if !strings.Contains(content, expectedDataDir) {
 		t.Errorf("Config does not contain absolute data-dir %q", expectedDataDir)
@@ -292,6 +312,7 @@ func TestDetectExistingBackend(t *testing.T) {
 		if err := SaveBackend(cfg, "k3s"); err != nil {
 			t.Fatalf("SaveBackend() error: %v", err)
 		}
+
 		got := DetectExistingBackend(cfg)
 		if got != "k3s" {
 			t.Errorf("DetectExistingBackend() = %q, want %q", got, "k3s")
@@ -313,7 +334,7 @@ func TestDetectExistingBackend(t *testing.T) {
 		cfg := &config.Config{ConfigDir: tmpDir}
 
 		path := filepath.Join(tmpDir, stackBackendFile)
-		os.WriteFile(path, []byte("docker-swarm"), 0644)
+		os.WriteFile(path, []byte("docker-swarm"), 0o644)
 
 		got := DetectExistingBackend(cfg)
 		if got != "" {
@@ -329,7 +350,7 @@ func TestCleanupStaleBackendConfigs(t *testing.T) {
 
 		// Create k3d config file
 		k3dPath := filepath.Join(tmpDir, k3dConfigFile)
-		os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+		os.WriteFile(k3dPath, []byte("k3d config"), 0o644)
 
 		cleanupStaleBackendConfigs(cfg, BackendK3d)
 
@@ -344,7 +365,7 @@ func TestCleanupStaleBackendConfigs(t *testing.T) {
 
 		// Create k3s files
 		for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
-			os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0644)
+			os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0o644)
 		}
 
 		cleanupStaleBackendConfigs(cfg, BackendK3s)
@@ -362,7 +383,7 @@ func TestCleanupStaleBackendConfigs(t *testing.T) {
 
 		// Create k3s config but clean up k3d (should not touch k3s files)
 		k3sPath := filepath.Join(tmpDir, k3sConfigFile)
-		os.WriteFile(k3sPath, []byte("k3s config"), 0644)
+		os.WriteFile(k3sPath, []byte("k3s config"), 0o644)
 
 		cleanupStaleBackendConfigs(cfg, BackendK3d)
 
@@ -406,7 +427,7 @@ func TestGetStackID(t *testing.T) {
 			cfg := &config.Config{ConfigDir: tmpDir}
 
 			path := filepath.Join(tmpDir, stackIDFile)
-			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
 				t.Fatalf("WriteFile error: %v", err)
 			}
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -118,7 +118,7 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 	}
 
 	// Store stack ID
-	if err := os.WriteFile(stackIDPath, []byte(stackID), 0o644); err != nil {
+	if err := os.WriteFile(stackIDPath, []byte(stackID), 0o600); err != nil { //nolint:gosec // G703: path from user's local config dir
 		return fmt.Errorf("failed to write stack ID: %w", err)
 	}
 
@@ -772,5 +772,5 @@ func migrateDefaultsHTTPRouteHostnames(helmfilePath string) error {
 		return nil
 	}
 
-	return os.WriteFile(helmfilePath, []byte(updated), 0o644)
+	return os.WriteFile(helmfilePath, []byte(updated), 0o600) //nolint:gosec // G703: path from user's local config dir
 }

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -733,11 +733,10 @@ func checkPortsAvailable(ports []int) error {
 
 	if len(blocked) > 0 {
 		return fmt.Errorf(
-			"port(s) %s already in use\n\n"+
-				"Obol Stack needs these ports for HTTP/HTTPS access.\n"+
-				"Find what's using them with:\n"+
-				"  sudo lsof -i :%d\n\n"+
-				"Then stop the conflicting service and retry 'obol stack up'.",
+			"port(s) %s already in use — "+
+				"Obol Stack needs these ports for HTTP/HTTPS access; "+
+				"find what's using them with: sudo lsof -i :%d, "+
+				"then stop the conflicting service and retry 'obol stack up'",
 			formatPorts(blocked), blocked[0],
 		)
 	}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -37,6 +38,7 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 	if _, err := os.Stat(stackIDPath); err == nil {
 		hasExistingConfig = true
 	}
+
 	if _, err := os.Stat(backendFilePath); err == nil {
 		hasExistingConfig = true
 	}
@@ -49,7 +51,7 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 		return fmt.Errorf("stack configuration already exists at %s\nUse --force to overwrite", cfg.ConfigDir)
 	}
 
-	if err := os.MkdirAll(cfg.ConfigDir, 0755); err != nil {
+	if err := os.MkdirAll(cfg.ConfigDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create stack config dir: %w", err)
 	}
 
@@ -100,10 +102,12 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 	// Resolve {{OLLAMA_HOST_IP}} to a numeric IP for the Endpoints object:
 	// - Endpoints require an IP, not a hostname (ClusterIP+Endpoints pattern)
 	ollamaHost := ollamaHostForBackend(backendName)
+
 	ollamaHostIP, err := ollamaHostIPForBackend(backendName)
 	if err != nil {
 		return fmt.Errorf("failed to resolve Ollama host IP: %w", err)
 	}
+
 	defaultsDir := filepath.Join(cfg.ConfigDir, "defaults")
 	if err := embed.CopyDefaults(defaultsDir, map[string]string{
 		"{{OLLAMA_HOST}}":    ollamaHost,
@@ -114,7 +118,7 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 	}
 
 	// Store stack ID
-	if err := os.WriteFile(stackIDPath, []byte(stackID), 0644); err != nil {
+	if err := os.WriteFile(stackIDPath, []byte(stackID), 0o644); err != nil {
 		return fmt.Errorf("failed to write stack ID: %w", err)
 	}
 
@@ -124,6 +128,7 @@ func Init(cfg *config.Config, u *ui.UI, force bool, backendName string) error {
 	}
 
 	u.Success("Stack initialized")
+
 	return nil
 }
 
@@ -134,6 +139,7 @@ func destroyOldBackendIfSwitching(cfg *config.Config, u *ui.UI, newBackend, stac
 	if err != nil {
 		return
 	}
+
 	if oldBackend.Name() == newBackend {
 		return // same backend, nothing to clean up
 	}
@@ -155,12 +161,14 @@ func destroyOldBackendIfSwitching(cfg *config.Config, u *ui.UI, newBackend, stac
 // that would otherwise linger and confuse detection.
 func cleanupStaleBackendConfigs(cfg *config.Config, oldBackend string) {
 	var staleFiles []string
+
 	switch oldBackend {
 	case BackendK3d:
 		staleFiles = []string{k3dConfigFile}
 	case BackendK3s:
 		staleFiles = []string{k3sConfigFile, k3sPidFile, k3sLogFile}
 	}
+
 	for _, f := range staleFiles {
 		path := filepath.Join(cfg.ConfigDir, f)
 		if _, err := os.Stat(path); err == nil {
@@ -175,9 +183,11 @@ func ollamaHostForBackend(backendName string) string {
 	if backendName == BackendK3s {
 		return "127.0.0.1"
 	}
+
 	if runtime.GOOS == "darwin" {
 		return "host.docker.internal"
 	}
+
 	return "host.k3d.internal"
 }
 
@@ -216,7 +226,8 @@ func ollamaHostIPForBackend(backendName string) (string, error) {
 		if bridgeErr == nil {
 			return ip, nil
 		}
-		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w; docker0 fallback also failed: %v", host, err, bridgeErr)
+
+		return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w; docker0 fallback also failed: %w", host, err, bridgeErr)
 	}
 
 	return "", fmt.Errorf("cannot resolve Ollama host %q to IP: %w\n\tEnsure Docker Desktop is running", host, err)
@@ -241,23 +252,26 @@ func dockerBridgeGatewayIP() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("docker0 interface not found: %w", err)
 	}
+
 	addrs, err := iface.Addrs()
 	if err != nil {
 		return "", fmt.Errorf("cannot get docker0 addresses: %w", err)
 	}
+
 	for _, addr := range addrs {
 		if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
 			return ipNet.IP.String(), nil
 		}
 	}
-	return "", fmt.Errorf("no IPv4 address found on docker0 interface")
+
+	return "", errors.New("no IPv4 address found on docker0 interface")
 }
 
 // Up starts the cluster using the configured backend
 func Up(cfg *config.Config, u *ui.UI) error {
 	stackID := getStackID(cfg)
 	if stackID == "" {
-		return fmt.Errorf("stack ID not found, run 'obol stack init' first")
+		return errors.New("stack ID not found, run 'obol stack init' first")
 	}
 
 	backend, err := LoadBackend(cfg)
@@ -275,7 +289,7 @@ func Up(cfg *config.Config, u *ui.UI) error {
 	}
 
 	// Write kubeconfig
-	if err := os.WriteFile(kubeconfigPath, kubeconfigData, 0600); err != nil {
+	if err := os.WriteFile(kubeconfigPath, kubeconfigData, 0o600); err != nil {
 		return fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
 
@@ -298,6 +312,7 @@ func Up(cfg *config.Config, u *ui.UI) error {
 	u.Bold("Stack started successfully.")
 	u.Print("Visit http://obol.stack in your browser to get started.")
 	update.HintIfStale(cfg)
+
 	return nil
 }
 
@@ -305,7 +320,7 @@ func Up(cfg *config.Config, u *ui.UI) error {
 func Down(cfg *config.Config, u *ui.UI) error {
 	stackID := getStackID(cfg)
 	if stackID == "" {
-		return fmt.Errorf("stack ID not found, stack may not be initialized")
+		return errors.New("stack ID not found, stack may not be initialized")
 	}
 
 	backend, err := LoadBackend(cfg)
@@ -336,6 +351,7 @@ func Purge(cfg *config.Config, u *ui.UI, force bool) error {
 	// Destroy cluster if we have a stack ID
 	if stackID != "" {
 		u.Infof("Destroying cluster (id: %s)", stackID)
+
 		if err := backend.Destroy(cfg, u, stackID); err != nil {
 			u.Warnf("Failed to destroy cluster (may already be deleted): %v", err)
 		}
@@ -349,6 +365,7 @@ func Purge(cfg *config.Config, u *ui.UI, force bool) error {
 	if err := os.RemoveAll(cfg.ConfigDir); err != nil {
 		return fmt.Errorf("failed to remove stack config: %w", err)
 	}
+
 	u.Success("Removed cluster config")
 
 	// Remove data directory only if force flag is set.
@@ -356,6 +373,7 @@ func Purge(cfg *config.Config, u *ui.UI, force bool) error {
 	// which requires an interactive terminal (stdin connected).
 	if force {
 		rmCmd := exec.Command("sudo", "rm", "-rf", cfg.DataDir)
+
 		rmCmd.Stdin = os.Stdin
 		if err := u.Exec(ui.ExecConfig{
 			Name:        "Removing data directory",
@@ -364,6 +382,7 @@ func Purge(cfg *config.Config, u *ui.UI, force bool) error {
 		}); err != nil {
 			return fmt.Errorf("failed to remove data directory: %w", err)
 		}
+
 		u.Blank()
 		u.Bold("Cluster fully purged (binaries preserved)")
 	} else {
@@ -378,10 +397,12 @@ func Purge(cfg *config.Config, u *ui.UI, force bool) error {
 // getStackID reads the stored stack ID
 func getStackID(cfg *config.Config) string {
 	stackIDPath := filepath.Join(cfg.ConfigDir, stackIDFile)
+
 	data, err := os.ReadFile(stackIDPath)
 	if err != nil {
 		return ""
 	}
+
 	return strings.TrimSpace(string(data))
 }
 
@@ -409,7 +430,7 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	)
 	helmfileCmd.Env = append(os.Environ(),
 		"KUBECONFIG="+kubeconfigPath,
-		fmt.Sprintf("STACK_DATA_DIR=%s", dataDir),
+		"STACK_DATA_DIR="+dataDir,
 	)
 
 	// In development mode, build and import local Docker images that aren't
@@ -425,9 +446,11 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 		Cmd:  helmfileCmd,
 	}); err != nil {
 		u.Warn("Helmfile sync failed, stopping cluster")
+
 		if downErr := Down(cfg, u); downErr != nil {
 			u.Warnf("Failed to stop cluster during cleanup: %v", downErr)
 		}
+
 		return fmt.Errorf("failed to apply defaults helmfile: %w", err)
 	}
 
@@ -446,6 +469,7 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	// prompt (e.g. EnsureHostsEntries writing /etc/hosts).
 	u.Blank()
 	u.Info("Setting up default OpenClaw instance")
+
 	if err := openclaw.SetupDefault(cfg, u); err != nil {
 		u.Warnf("Failed to set up default OpenClaw: %v", err)
 		u.Dim("  You can manually set up OpenClaw later with: obol openclaw onboard")
@@ -455,6 +479,7 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	// Non-fatal: the user can always run `obol agent init` later.
 	u.Blank()
 	u.Info("Applying agent capabilities")
+
 	if err := agent.Init(cfg, u); err != nil {
 		u.Warnf("Failed to apply agent capabilities: %v", err)
 		u.Dim("  You can manually apply later with: obol agent init")
@@ -463,8 +488,10 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	// Start the Cloudflare tunnel only if a persistent DNS tunnel is provisioned.
 	// Quick tunnels are dormant by default and activate on first `obol sell`.
 	u.Blank()
+
 	if st, _ := tunnel.LoadTunnelState(cfg); st != nil && st.Mode == "dns" && st.Hostname != "" {
 		u.Info("Starting persistent Cloudflare tunnel")
+
 		if tunnelURL, err := tunnel.EnsureRunning(cfg, u); err != nil {
 			u.Warnf("Tunnel not started: %v", err)
 			u.Dim("  Start manually with: obol tunnel restart")
@@ -493,11 +520,13 @@ func autoConfigureLLM(cfg *config.Config, u *ui.UI) {
 		u.Infof("Ollama detected with %d model(s)", len(ollamaModels))
 
 		var names []string
+
 		for _, m := range ollamaModels {
 			name := m.Name
-			if strings.HasSuffix(name, ":latest") {
-				name = strings.TrimSuffix(name, ":latest")
+			if before, ok := strings.CutSuffix(name, ":latest"); ok {
+				name = before
 			}
+
 			names = append(names, name)
 		}
 
@@ -539,10 +568,11 @@ func autoDetectCloudProvider(cfg *config.Config, u *ui.UI) string {
 
 	// Extract provider and model name from "anthropic/claude-sonnet-4-6".
 	provider, modelName := "", agentModel
-	if i := strings.Index(agentModel, "/"); i >= 0 {
-		provider = agentModel[:i]
-		modelName = agentModel[i+1:]
+	if before, after, ok := strings.Cut(agentModel, "/"); ok {
+		provider = before
+		modelName = after
 	}
+
 	if provider == "" {
 		provider = model.ProviderFromModelName(agentModel)
 	}
@@ -561,6 +591,7 @@ func autoDetectCloudProvider(cfg *config.Config, u *ui.UI) string {
 	if apiKey == "" && os.Getenv("OBOL_DEVELOPMENT") == "true" {
 		envVar := model.ProviderEnvVar(provider)
 		dotEnv := model.LoadDotEnv(filepath.Join(".", ".env"))
+
 		apiKey = dotEnv[envVar]
 		if apiKey != "" {
 			envVarUsed = envVar + " (.env)"
@@ -569,14 +600,17 @@ func autoDetectCloudProvider(cfg *config.Config, u *ui.UI) string {
 
 	if apiKey == "" {
 		u.Blank()
+
 		primaryEnv := model.ProviderEnvVar(provider)
 		u.Warnf("Agent model %s detected but %s is not set", agentModel, primaryEnv)
 		u.Dim(fmt.Sprintf("  Set it in your environment: export %s=...", primaryEnv))
-		u.Dim(fmt.Sprintf("  Or configure after startup: obol model setup --provider %s", provider))
+		u.Dim("  Or configure after startup: obol model setup --provider " + provider)
+
 		return ""
 	}
 
 	u.Blank()
+
 	if envVarUsed != model.ProviderEnvVar(provider) {
 		u.Infof("Cloud model %s detected via %s — configuring %s provider", agentModel, envVarUsed, provider)
 	} else {
@@ -586,12 +620,12 @@ func autoDetectCloudProvider(cfg *config.Config, u *ui.UI) string {
 	if err := model.PatchLiteLLMProvider(cfg, u, provider, apiKey, []string{modelName}); err != nil {
 		u.Warnf("Auto-configure %s failed: %v", provider, err)
 		u.Dim(fmt.Sprintf("  Run 'obol model setup --provider %s' to configure manually.", provider))
+
 		return ""
 	}
 
 	return provider
 }
-
 
 // localImage describes a Docker image built from source in this repo.
 type localImage struct {
@@ -621,11 +655,12 @@ func buildAndImportLocalImages(cfg *config.Config) {
 		return
 	}
 
-	clusterName := fmt.Sprintf("obol-stack-%s", stackID)
+	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
 
 	for _, img := range localImages {
 		contextDir := projectRoot
+
 		dockerfilePath := filepath.Join(projectRoot, img.dockerfile)
 		if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 			continue // Dockerfile not present (production install without source)
@@ -638,6 +673,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 			contextDir,
 		)
 		buildCmd.Stdout = os.Stdout
+
 		buildCmd.Stderr = os.Stderr
 		if err := buildCmd.Run(); err != nil {
 			fmt.Printf("Warning: failed to build %s: %v\n", img.tag, err)
@@ -647,6 +683,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 		fmt.Printf("Importing %s into cluster %s...\n", img.tag, clusterName)
 		importCmd := exec.Command(k3dBinary, "image", "import", img.tag, "-c", clusterName)
 		importCmd.Stdout = os.Stdout
+
 		importCmd.Stderr = os.Stderr
 		if err := importCmd.Run(); err != nil {
 			fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
@@ -660,14 +697,17 @@ func findProjectRoot() string {
 	if err != nil {
 		return ""
 	}
+
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
 			return dir
 		}
+
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			return ""
 		}
+
 		dir = parent
 	}
 }
@@ -675,17 +715,22 @@ func findProjectRoot() string {
 // checkPortsAvailable verifies that all required ports can be bound.
 func checkPortsAvailable(ports []int) error {
 	var blocked []int
+
 	for _, port := range ports {
 		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {
 			if strings.Contains(err.Error(), "permission denied") {
 				continue
 			}
+
 			blocked = append(blocked, port)
+
 			continue
 		}
+
 		ln.Close()
 	}
+
 	if len(blocked) > 0 {
 		return fmt.Errorf(
 			"port(s) %s already in use\n\n"+
@@ -696,6 +741,7 @@ func checkPortsAvailable(ports []int) error {
 			formatPorts(blocked), blocked[0],
 		)
 	}
+
 	return nil
 }
 
@@ -704,6 +750,7 @@ func formatPorts(ports []int) string {
 	for i, p := range ports {
 		strs[i] = strconv.Itoa(p)
 	}
+
 	return strings.Join(strs, ", ")
 }
 
@@ -714,13 +761,16 @@ func migrateDefaultsHTTPRouteHostnames(helmfilePath string) error {
 	}
 
 	needle := "              hostnames:\n                - obol.stack\n"
+
 	s := string(data)
 	if !strings.Contains(s, needle) {
 		return nil
 	}
+
 	updated := strings.ReplaceAll(s, needle, "")
 	if updated == s {
 		return nil
 	}
-	return os.WriteFile(helmfilePath, []byte(updated), 0644)
+
+	return os.WriteFile(helmfilePath, []byte(updated), 0o644)
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,11 +1,11 @@
 package stack
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -39,13 +39,15 @@ func TestCheckPortsAvailable_BlockedPort(t *testing.T) {
 		t.Fatal("expected error for blocked port, got nil")
 	}
 
-	portStr := fmt.Sprintf("%d", blockedPort)
+	portStr := strconv.Itoa(blockedPort)
 	if !strings.Contains(err.Error(), portStr) {
 		t.Errorf("error should mention blocked port %d, got: %v", blockedPort, err)
 	}
+
 	if !strings.Contains(err.Error(), "already in use") {
 		t.Errorf("error should mention 'already in use', got: %v", err)
 	}
+
 	if !strings.Contains(err.Error(), "sudo lsof") {
 		t.Errorf("error should include remediation hint, got: %v", err)
 	}
@@ -66,6 +68,7 @@ func TestCheckPortsAvailable_MixedPorts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to bind second ephemeral port: %v", err)
 	}
+
 	freePort := ln2.Addr().(*net.TCPAddr).Port
 	ln2.Close()
 
@@ -75,7 +78,7 @@ func TestCheckPortsAvailable_MixedPorts(t *testing.T) {
 	}
 
 	// Should mention only the blocked port
-	blockedStr := fmt.Sprintf("%d", blockedPort)
+	blockedStr := strconv.Itoa(blockedPort)
 	if !strings.Contains(err.Error(), blockedStr) {
 		t.Errorf("error should mention blocked port %d, got: %v", blockedPort, err)
 	}
@@ -109,8 +112,9 @@ func TestDestroyOldBackendIfSwitching_CleansStaleConfigs(t *testing.T) {
 
 	// Write k3d as the current backend + its config file
 	SaveBackend(cfg, BackendK3d)
+
 	k3dPath := filepath.Join(tmpDir, k3dConfigFile)
-	os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+	os.WriteFile(k3dPath, []byte("k3d config"), 0o644)
 
 	// Switch to k3s — k3d config should be cleaned up
 	// (Destroy will fail because no real cluster, but cleanup should still work)
@@ -130,8 +134,9 @@ func TestDestroyOldBackendIfSwitching_NoopSameBackend(t *testing.T) {
 	}
 
 	SaveBackend(cfg, BackendK3d)
+
 	k3dPath := filepath.Join(tmpDir, k3dConfigFile)
-	os.WriteFile(k3dPath, []byte("k3d config"), 0644)
+	os.WriteFile(k3dPath, []byte("k3d config"), 0o644)
 
 	// Same backend — nothing should be cleaned up
 	destroyOldBackendIfSwitching(cfg, ui.New(false), BackendK3d, "test-id")
@@ -152,7 +157,7 @@ func TestDestroyOldBackendIfSwitching_K3sToK3d(t *testing.T) {
 	SaveBackend(cfg, BackendK3s)
 	// Create k3s state files
 	for _, f := range []string{k3sConfigFile, k3sPidFile, k3sLogFile} {
-		os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0644)
+		os.WriteFile(filepath.Join(tmpDir, f), []byte("data"), 0o644)
 	}
 
 	// Switch to k3d — k3s files should be cleaned up
@@ -185,6 +190,7 @@ func TestOllamaHostIPForBackend_K3s(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error for k3s backend: %v", err)
 	}
+
 	if ip != "127.0.0.1" {
 		t.Errorf("expected 127.0.0.1 for k3s backend, got %s", ip)
 	}
@@ -199,6 +205,7 @@ func TestOllamaHostIPForBackend_K3d(t *testing.T) {
 	if err != nil {
 		t.Skipf("skipping: resolution failed (expected in CI without Docker): %v", err)
 	}
+
 	if ip == "" {
 		t.Fatal("expected non-empty IP for k3d backend")
 	}
@@ -216,6 +223,7 @@ func TestOllamaHostIPForBackend_AlreadyIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if ip != "127.0.0.1" {
 		t.Errorf("expected pass-through of 127.0.0.1, got %s", ip)
 	}
@@ -227,13 +235,16 @@ func TestDockerBridgeGatewayIP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("docker0 interface only exists on Linux")
 	}
+
 	ip, err := dockerBridgeGatewayIP()
 	if err != nil {
 		t.Skipf("skipping: docker0 not available (expected without Docker): %v", err)
 	}
+
 	if net.ParseIP(ip) == nil {
 		t.Errorf("expected valid IP from docker0, got %q", ip)
 	}
+
 	t.Logf("docker0 gateway IP: %s", ip)
 }
 
@@ -247,17 +258,21 @@ func TestHelmfile_IncludesBuyerPodMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read helmfile: %v", err)
 	}
+
 	out := string(data)
 
 	if !strings.Contains(out, "kind: PodMonitor") {
 		t.Fatalf("helmfile missing PodMonitor:\n%s", out)
 	}
+
 	if !strings.Contains(out, "name: litellm-x402-buyer") {
 		t.Fatalf("helmfile missing buyer PodMonitor name:\n%s", out)
 	}
+
 	if !strings.Contains(out, "release: monitoring") {
 		t.Fatalf("helmfile missing monitoring label:\n%s", out)
 	}
+
 	if !strings.Contains(out, "port: buyer-http") || !strings.Contains(out, "path: /metrics") {
 		t.Fatalf("helmfile missing buyer metrics endpoint:\n%s", out)
 	}
@@ -273,6 +288,7 @@ func TestLLMTemplate_IncludesPaidRouteAndBuyerSidecar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read llm template: %v", err)
 	}
+
 	out := string(data)
 
 	for _, want := range []string{
@@ -290,6 +306,7 @@ func TestLLMTemplate_IncludesPaidRouteAndBuyerSidecar(t *testing.T) {
 			t.Fatalf("llm template missing %q:\n%s", want, out)
 		}
 	}
+
 	if strings.Contains(out, "custom_provider_map") {
 		t.Fatalf("llm template should not require a custom provider:\n%s", out)
 	}

--- a/internal/tee/attest_stub.go
+++ b/internal/tee/attest_stub.go
@@ -96,7 +96,7 @@ func NewKey(tag, modelHash string) (enclave.Key, error) {
 
 	// 65-byte uncompressed SEC1 public key.
 	pub := b.privKey.PublicKey
-	pubBytes := elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+	pubBytes := elliptic.Marshal(pub.Curve, pub.X, pub.Y) //nolint:staticcheck // elliptic.Marshal needed for raw SEC1 encoding, not ECDH
 
 	return &teeKey{
 		tag:       tag,

--- a/internal/tee/attest_stub.go
+++ b/internal/tee/attest_stub.go
@@ -53,14 +53,17 @@ func (b *stubBackend) sign(digest []byte) ([]byte, error) {
 
 func (b *stubBackend) ecdh(peerPubKeyBytes []byte) ([]byte, error) {
 	curve := ecdh.P256()
+
 	peerKey, err := curve.NewPublicKey(peerPubKeyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("tee/stub: invalid peer public key: %w", err)
 	}
+
 	shared, err := b.ecdhPriv.ECDH(peerKey)
 	if err != nil {
 		return nil, fmt.Errorf("tee/stub: ECDH failed: %w", err)
 	}
+
 	return shared, nil
 }
 
@@ -70,19 +73,13 @@ func (b *stubBackend) attest(userData []byte) ([]byte, error) {
 		"user_data": hex.EncodeToString(userData),
 		"timestamp": time.Now().Unix(),
 	}
+
 	return json.Marshal(doc)
 }
 
 func (b *stubBackend) delete() error {
 	// No persistent state to clean up.
 	return nil
-}
-
-// pubKeyBytes returns the 65-byte uncompressed SEC1 encoding.
-func (b *stubBackend) pubKeyBytes() []byte {
-	pub := b.privKey.PublicKey
-	return elliptic.MarshalCompressed(pub.Curve, pub.X, pub.Y)
-	// Actually we need uncompressed (65 bytes), not compressed.
 }
 
 // NewKey generates (or loads) a P-256 key inside the TEE (or stub) and
@@ -118,6 +115,7 @@ func marshalDER(r, s *big.Int) []byte {
 	if len(rb) > 0 && rb[0]&0x80 != 0 {
 		rb = append([]byte{0}, rb...)
 	}
+
 	if len(sb) > 0 && sb[0]&0x80 != 0 {
 		sb = append([]byte{0}, sb...)
 	}
@@ -131,5 +129,6 @@ func marshalDER(r, s *big.Int) []byte {
 	out := make([]byte, 0, 2+len(inner))
 	out = append(out, 0x30, byte(len(inner)))
 	out = append(out, inner...)
+
 	return out
 }

--- a/internal/tee/coco.go
+++ b/internal/tee/coco.go
@@ -48,6 +48,7 @@ func ParseCoCoRuntime(s string) (CoCoRuntimeClass, error) {
 	if s == "" || s == "none" {
 		return "", nil
 	}
+
 	switch CoCoRuntimeClass(s) {
 	case RuntimeQEMUCoCoDev, RuntimeQEMUSNP, RuntimeQEMUTDX:
 		return CoCoRuntimeClass(s), nil
@@ -59,21 +60,23 @@ func ParseCoCoRuntime(s string) (CoCoRuntimeClass, error) {
 
 func cocoRuntimeStrings() []string {
 	runtimes := ValidCoCoRuntimes()
+
 	ss := make([]string, len(runtimes))
 	for i, r := range runtimes {
 		ss[i] = string(r)
 	}
+
 	return ss
 }
 
 // CoCoStatus describes the installation state of the CoCo operator.
 type CoCoStatus struct {
-	Installed       bool     `json:"installed"`
-	Version         string   `json:"version,omitempty"`
-	Namespace       string   `json:"namespace,omitempty"`
-	RuntimeClasses  []string `json:"runtime_classes,omitempty"`
-	OperatorReady   bool     `json:"operator_ready"`
-	KVMAvailable    bool     `json:"kvm_available"`
+	Installed      bool     `json:"installed"`
+	Version        string   `json:"version,omitempty"`
+	Namespace      string   `json:"namespace,omitempty"`
+	RuntimeClasses []string `json:"runtime_classes,omitempty"`
+	OperatorReady  bool     `json:"operator_ready"`
+	KVMAvailable   bool     `json:"kvm_available"`
 }
 
 // CoCoInstallOpts configures the CoCo Helm install.
@@ -96,6 +99,7 @@ func (o *CoCoInstallOpts) helm() string {
 	if o != nil && o.HelmBin != "" {
 		return o.HelmBin
 	}
+
 	return "helm"
 }
 
@@ -103,6 +107,7 @@ func (o *CoCoInstallOpts) kubectl() string {
 	if o != nil && o.KubectlBin != "" {
 		return o.KubectlBin
 	}
+
 	return "kubectl"
 }
 
@@ -110,6 +115,7 @@ func (o *CoCoInstallOpts) kubeconfigArgs() []string {
 	if o != nil && o.Kubeconfig != "" {
 		return []string{"--kubeconfig", o.Kubeconfig}
 	}
+
 	return nil
 }
 
@@ -144,10 +150,12 @@ func InstallCoCo(ctx context.Context, opts *CoCoInstallOpts) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, opts.helm(), args...)
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("tee/coco: helm install failed: %w\n%s", err, string(out))
 	}
+
 	return string(out), nil
 }
 
@@ -164,10 +172,12 @@ func UninstallCoCo(ctx context.Context, opts *CoCoInstallOpts) (string, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, opts.helm(), args...)
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("tee/coco: helm uninstall failed: %w\n%s", err, string(out))
 	}
+
 	return string(out), nil
 }
 
@@ -189,6 +199,7 @@ func CheckCoCo(ctx context.Context, opts *CoCoInstallOpts) (*CoCoStatus, error) 
 	helmArgs = append(helmArgs, opts.kubeconfigArgs()...)
 
 	cmd := exec.CommandContext(ctx, opts.helm(), helmArgs...)
+
 	helmOut, err := cmd.CombinedOutput()
 	if err != nil {
 		// Not installed or helm error.
@@ -227,6 +238,7 @@ func listRuntimeClasses(ctx context.Context, opts *CoCoInstallOpts) ([]string, e
 	args = append(args, opts.kubeconfigArgs()...)
 
 	cmd := exec.CommandContext(ctx, opts.kubectl(), args...)
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("tee/coco: list runtimeclasses: %w", err)
@@ -235,11 +247,13 @@ func listRuntimeClasses(ctx context.Context, opts *CoCoInstallOpts) ([]string, e
 	names := strings.Fields(strings.TrimSpace(string(out)))
 	// Filter to only CoCo/Kata runtimes.
 	var result []string
+
 	for _, name := range names {
 		if strings.HasPrefix(name, "kata-") {
 			result = append(result, name)
 		}
 	}
+
 	return result, nil
 }
 
@@ -249,6 +263,8 @@ func checkKVM() bool {
 	if err != nil {
 		return false
 	}
+
 	cmd := exec.Command("test", "-c", "/dev/kvm")
+
 	return cmd.Run() == nil
 }

--- a/internal/tee/coco.go
+++ b/internal/tee/coco.go
@@ -204,7 +204,7 @@ func CheckCoCo(ctx context.Context, opts *CoCoInstallOpts) (*CoCoStatus, error) 
 	if err != nil {
 		// Not installed or helm error.
 		status.Installed = false
-		return status, nil
+		return status, nil //nolint:nilerr // helm failure means chart not installed; not an error
 	}
 
 	// Parse helm status JSON.

--- a/internal/tee/coco_test.go
+++ b/internal/tee/coco_test.go
@@ -42,6 +42,7 @@ func TestValidCoCoRuntimes(t *testing.T) {
 		if err != nil {
 			t.Errorf("ParseCoCoRuntime(%q) failed: %v", r, err)
 		}
+
 		if got != r {
 			t.Errorf("round-trip mismatch: %q != %q", got, r)
 		}
@@ -61,6 +62,7 @@ func TestInstallCoCo_DryRun(t *testing.T) {
 	if cmd == "" {
 		t.Fatal("expected non-empty command string")
 	}
+
 	for _, want := range []string{
 		CoCoChartOCI,
 		CoCoChartVersion,
@@ -106,5 +108,6 @@ func searchString(s, sub string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/tee/key.go
+++ b/internal/tee/key.go
@@ -36,8 +36,8 @@ type teeKey struct {
 var _ enclave.Key = (*teeKey)(nil)
 
 func (k *teeKey) PublicKeyBytes() []byte { return k.pubBytes }
-func (k *teeKey) Tag() string           { return k.tag }
-func (k *teeKey) Persistent() bool      { return true }
+func (k *teeKey) Tag() string            { return k.tag }
+func (k *teeKey) Persistent() bool       { return true }
 
 func (k *teeKey) Sign(digest []byte) ([]byte, error) {
 	return k.backend.sign(digest)
@@ -65,6 +65,7 @@ func (k *teeKey) Decrypt(ciphertext []byte) ([]byte, error) {
 	if len(ciphertext) < headerLen+tagLen {
 		return nil, fmt.Errorf("tee: ciphertext too short (%d bytes)", len(ciphertext))
 	}
+
 	if ciphertext[0] != 0x01 {
 		return nil, fmt.Errorf("tee: unsupported ciphertext version 0x%02x", ciphertext[0])
 	}
@@ -89,6 +90,7 @@ func (k *teeKey) Decrypt(ciphertext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tee: aes.NewCipher: %w", err)
 	}
+
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, fmt.Errorf("tee: cipher.NewGCM: %w", err)
@@ -98,6 +100,7 @@ func (k *teeKey) Decrypt(ciphertext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tee: AES-GCM decrypt failed: %w", err)
 	}
+
 	return plain, nil
 }
 
@@ -113,9 +116,11 @@ func deriveKey(sharedPoint, ephPubBytes, recipPubBytes []byte) ([]byte, error) {
 	info = append(info, recipPubBytes...)
 
 	kdf := hkdf.New(sha256.New, sharedPoint, nil, info)
+
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(kdf, key); err != nil {
 		return nil, fmt.Errorf("tee: HKDF: %w", err)
 	}
+
 	return key, nil
 }

--- a/internal/tee/tee.go
+++ b/internal/tee/tee.go
@@ -70,9 +70,11 @@ func UserData(pubkey []byte, modelHash string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tee: invalid model hash hex: %w", err)
 	}
+
 	h := sha256.New()
 	h.Write(pubkey)
 	h.Write(hashBytes)
+
 	return h.Sum(nil), nil
 }
 

--- a/internal/tee/tee_test.go
+++ b/internal/tee/tee_test.go
@@ -22,6 +22,7 @@ func TestNewKey_StubBackend(t *testing.T) {
 	if len(pub) != 65 {
 		t.Fatalf("expected 65-byte public key, got %d", len(pub))
 	}
+
 	if pub[0] != 0x04 {
 		t.Fatalf("expected 0x04 prefix, got 0x%02x", pub[0])
 	}
@@ -30,6 +31,7 @@ func TestNewKey_StubBackend(t *testing.T) {
 	if key.Tag() != "com.obol.test.tee" {
 		t.Errorf("expected tag %q, got %q", "com.obol.test.tee", key.Tag())
 	}
+
 	if !key.Persistent() {
 		t.Error("expected Persistent() == true")
 	}
@@ -40,12 +42,14 @@ func TestNewKey_UniqueKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	k2, err := NewKey("com.obol.test.k2", testModelHash)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pub1 := hex.EncodeToString(k1.PublicKeyBytes())
+
 	pub2 := hex.EncodeToString(k2.PublicKeyBytes())
 	if pub1 == pub2 {
 		t.Error("two separately generated keys should have different public keys")
@@ -95,6 +99,7 @@ func TestECIES_DecryptBadVersion(t *testing.T) {
 
 	// Corrupt the version byte.
 	ct[0] = 0xFF
+
 	_, err = key.Decrypt(ct)
 	if err == nil {
 		t.Error("expected error for bad version, got nil")
@@ -128,15 +133,19 @@ func TestAttest_Stub(t *testing.T) {
 	if report.TEEType != TEETypeStub {
 		t.Errorf("expected tee_type %q, got %q", TEETypeStub, report.TEEType)
 	}
+
 	if report.Pubkey != hex.EncodeToString(key.PublicKeyBytes()) {
 		t.Error("report pubkey doesn't match key's public key")
 	}
+
 	if report.ModelHash != testModelHash {
 		t.Errorf("report model_hash = %q, want %q", report.ModelHash, testModelHash)
 	}
+
 	if report.Timestamp == 0 {
 		t.Error("expected non-zero timestamp")
 	}
+
 	if len(report.Quote) == 0 {
 		t.Error("expected non-empty quote")
 	}
@@ -149,6 +158,7 @@ func TestAttest_Stub(t *testing.T) {
 	if err := json.Unmarshal(report.Quote, &stubDoc); err != nil {
 		t.Fatalf("failed to parse stub quote: %v", err)
 	}
+
 	if stubDoc.Type != "stub" {
 		t.Errorf("stub quote type = %q, want %q", stubDoc.Type, "stub")
 	}
@@ -158,6 +168,7 @@ func TestAttest_Stub(t *testing.T) {
 	h := sha256.New()
 	h.Write(key.PublicKeyBytes())
 	h.Write(modelHashBytes)
+
 	expectedUD := hex.EncodeToString(h.Sum(nil))
 	if stubDoc.UserData != expectedUD {
 		t.Errorf("user_data mismatch:\n  got:  %s\n  want: %s", stubDoc.UserData, expectedUD)
@@ -194,6 +205,7 @@ func TestVerifyBinding_WrongModel(t *testing.T) {
 
 	// Wrong model hash should fail.
 	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+
 	err = VerifyBinding(report.Quote, key.PublicKeyBytes(), wrongHash)
 	if err == nil {
 		t.Error("expected error for wrong model hash, got nil")
@@ -215,6 +227,7 @@ func TestExtractUserData_StubRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractUserData failed: %v", err)
 	}
+
 	if teeType != TEETypeStub {
 		t.Errorf("expected tee type %q, got %q", TEETypeStub, teeType)
 	}
@@ -232,10 +245,12 @@ func TestSign_Stub(t *testing.T) {
 	}
 
 	digest := sha256.Sum256([]byte("test message"))
+
 	sig, err := key.Sign(digest[:])
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
 	}
+
 	if len(sig) == 0 {
 		t.Error("expected non-empty signature")
 	}
@@ -305,6 +320,7 @@ func TestMarshalReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	report, err := Attest(key, testModelHash)
 	if err != nil {
 		t.Fatal(err)
@@ -320,6 +336,7 @@ func TestMarshalReport(t *testing.T) {
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("failed to unmarshal report JSON: %v", err)
 	}
+
 	if parsed.TEEType != TEETypeStub {
 		t.Errorf("round-trip tee_type = %q, want %q", parsed.TEEType, TEETypeStub)
 	}
@@ -367,13 +384,16 @@ func TestExtractUserData_RejectsUnknownFormat(t *testing.T) {
 
 func TestPadTo64(t *testing.T) {
 	input := []byte{0x01, 0x02, 0x03}
+
 	out := padTo64(input)
 	if len(out) != 64 {
 		t.Fatalf("expected 64 bytes, got %d", len(out))
 	}
+
 	if out[0] != 0x01 || out[1] != 0x02 || out[2] != 0x03 {
 		t.Error("first 3 bytes should match input")
 	}
+
 	for i := 3; i < 64; i++ {
 		if out[i] != 0 {
 			t.Errorf("byte %d should be zero, got 0x%02x", i, out[i])
@@ -392,9 +412,11 @@ func TestExtractUserData_SyntheticSNP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractUserData failed: %v", err)
 	}
+
 	if teeType != TEETypeSNP {
 		t.Errorf("expected TEE type %q, got %q", TEETypeSNP, teeType)
 	}
+
 	if !bytesEqual(extracted, userData) {
 		t.Errorf("user_data mismatch:\n  got:  %x\n  want: %x", extracted, userData)
 	}
@@ -419,9 +441,11 @@ func TestExtractUserData_SyntheticTDX(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractUserData failed: %v", err)
 	}
+
 	if teeType != TEETypeTDX {
 		t.Errorf("expected TEE type %q, got %q", TEETypeTDX, teeType)
 	}
+
 	if !bytesEqual(extracted, userData[:32]) {
 		t.Errorf("user_data mismatch:\n  got:  %x\n  want: %x", extracted, userData[:32])
 	}

--- a/internal/tee/verify.go
+++ b/internal/tee/verify.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,6 +37,7 @@ func ExtractUserData(quote []byte) ([]byte, TEEType, error) {
 		if err != nil {
 			return nil, TEETypeStub, fmt.Errorf("tee: invalid stub user_data hex: %w", err)
 		}
+
 		return ud, TEETypeStub, nil
 	}
 
@@ -51,6 +53,7 @@ func ExtractUserData(quote []byte) ([]byte, TEEType, error) {
 	// teeType=0x00000081 at offset 4.
 	if len(quote) > 48 {
 		version := binary.LittleEndian.Uint16(quote[0:2])
+
 		teeType := binary.LittleEndian.Uint32(quote[4:8])
 		if version == 4 && teeType == 0x00000081 {
 			// reportData is in the TD Quote Body at offset 568 from quote
@@ -143,6 +146,7 @@ func VerifyTDX(quote []byte, expectedUserData []byte) error {
 	}
 
 	_ = quoteV4 // available for callers who need measurements (MrTd, RTMRs)
+
 	return nil
 }
 
@@ -219,8 +223,9 @@ func VerifyNitro(doc []byte, expectedUserData []byte) error {
 	if err != nil {
 		return fmt.Errorf("tee/nitro: attestation verification failed: %w", err)
 	}
+
 	if !result.SignatureOK {
-		return fmt.Errorf("tee/nitro: COSE signature verification failed")
+		return errors.New("tee/nitro: COSE signature verification failed")
 	}
 
 	// Validate user_data binding.
@@ -243,21 +248,23 @@ func VerifyNitroWithPCR0(doc []byte, expectedUserData []byte, expectedPCR0 []byt
 	if err != nil {
 		return fmt.Errorf("tee/nitro: attestation verification failed: %w", err)
 	}
+
 	if !result.SignatureOK {
-		return fmt.Errorf("tee/nitro: COSE signature verification failed")
+		return errors.New("tee/nitro: COSE signature verification failed")
 	}
 
 	if expectedUserData != nil {
 		if !bytes.Equal(result.Document.UserData, expectedUserData) {
-			return fmt.Errorf("tee/nitro: user_data mismatch")
+			return errors.New("tee/nitro: user_data mismatch")
 		}
 	}
 
 	if expectedPCR0 != nil {
 		pcr0, ok := result.Document.PCRs[0]
 		if !ok {
-			return fmt.Errorf("tee/nitro: PCR0 not present in attestation")
+			return errors.New("tee/nitro: PCR0 not present in attestation")
 		}
+
 		if !bytes.Equal(pcr0, expectedPCR0) {
 			return fmt.Errorf("tee/nitro: PCR0 mismatch: expected %x, got %x",
 				expectedPCR0, pcr0)
@@ -279,6 +286,7 @@ func ComputeModelHash(modelID string) string {
 func padTo64(data []byte) []byte {
 	out := make([]byte, 64)
 	copy(out, data)
+
 	return out
 }
 
@@ -288,10 +296,12 @@ func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
 	}
+
 	for i := range a {
 		if a[i] != b[i] {
 			return false
 		}
 	}
+
 	return true
 }

--- a/internal/testutil/anvil.go
+++ b/internal/testutil/anvil.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,7 +22,6 @@ import (
 func jsonDecode(r io.Reader, v any) error {
 	return json.NewDecoder(r).Decode(v)
 }
-
 
 // AnvilFork represents a running Anvil instance forking a live chain.
 type AnvilFork struct {
@@ -83,6 +83,7 @@ func StartAnvilForkWithURL(t *testing.T, forkURL string) *AnvilFork {
 	if err != nil {
 		t.Fatalf("find free port: %v", err)
 	}
+
 	port := l.Addr().(*net.TCPAddr).Port
 	l.Close()
 
@@ -91,10 +92,12 @@ func StartAnvilForkWithURL(t *testing.T, forkURL string) *AnvilFork {
 	cmd := exec.CommandContext(ctx, "anvil",
 		"--fork-url", forkURL,
 		"--host", "0.0.0.0",
-		"--port", fmt.Sprintf("%d", port),
+		"--port", strconv.Itoa(port),
 		"--silent",
 	)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
@@ -112,6 +115,7 @@ func StartAnvilForkWithURL(t *testing.T, forkURL string) *AnvilFork {
 
 	t.Cleanup(func() {
 		cancel()
+
 		_ = cmd.Wait()
 	})
 
@@ -132,12 +136,15 @@ func (f *AnvilFork) waitReady(timeout time.Duration) error {
 		resp, err := http.Post(f.RPCURL, "application/json", strings.NewReader(body))
 		if err == nil {
 			resp.Body.Close()
+
 			if resp.StatusCode == http.StatusOK {
 				return nil
 			}
 		}
+
 		time.Sleep(200 * time.Millisecond)
 	}
+
 	return fmt.Errorf("anvil not ready after %v on port %d", timeout, f.Port)
 }
 
@@ -173,6 +180,7 @@ func (f *AnvilFork) MintUSDC(t *testing.T, to string, amount *big.Int) {
 	if err != nil {
 		t.Fatalf("anvil_setStorageAt failed: %v", err)
 	}
+
 	resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -185,14 +193,17 @@ func (f *AnvilFork) MintUSDC(t *testing.T, to string, amount *big.Int) {
 // FundETH sets the ETH balance for an address on the Anvil fork using anvil_setBalance.
 func (f *AnvilFork) FundETH(t *testing.T, addr string, amount *big.Int) {
 	t.Helper()
+
 	body := fmt.Sprintf(
 		`{"jsonrpc":"2.0","method":"anvil_setBalance","params":["%s","0x%x"],"id":1}`,
 		addr, amount,
 	)
+
 	resp, err := http.Post(f.RPCURL, "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("anvil_setBalance failed: %v", err)
 	}
+
 	resp.Body.Close()
 	t.Logf("funded %s with %s wei", addr, amount)
 }
@@ -202,14 +213,17 @@ func (f *AnvilFork) FundETH(t *testing.T, addr string, amount *big.Int) {
 // USDC's SignatureChecker sees code → tries EIP-1271 instead of ecrecover.
 func (f *AnvilFork) ClearCode(t *testing.T, addr string) {
 	t.Helper()
+
 	body := fmt.Sprintf(
 		`{"jsonrpc":"2.0","method":"anvil_setCode","params":["%s","0x"],"id":1}`,
 		addr,
 	)
+
 	resp, err := http.Post(f.RPCURL, "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("anvil_setCode failed: %v", err)
 	}
+
 	resp.Body.Close()
 }
 
@@ -224,6 +238,7 @@ func (f *AnvilFork) GetUSDCBalance(t *testing.T, addr string) *big.Int {
 		`{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"%s","data":"%s"},"latest"],"id":1}`,
 		USDCBaseSepolia, calldata,
 	)
+
 	resp, err := http.Post(f.RPCURL, "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("eth_call balanceOf failed: %v", err)
@@ -239,5 +254,6 @@ func (f *AnvilFork) GetUSDCBalance(t *testing.T, addr string) *big.Int {
 
 	balance := new(big.Int)
 	balance.SetString(strings.TrimPrefix(result.Result, "0x"), 16)
+
 	return balance
 }

--- a/internal/testutil/anvil.go
+++ b/internal/testutil/anvil.go
@@ -165,7 +165,7 @@ func (f *AnvilFork) MintUSDC(t *testing.T, to string, amount *big.Int) {
 	// abi.encode(address, uint256(9)) — both padded to 32 bytes.
 	key := common.LeftPadBytes(addr.Bytes(), 32)
 	slotBytes := common.LeftPadBytes(slot.Bytes(), 32)
-	packed := append(key, slotBytes...)
+	packed := append(append([]byte{}, key...), slotBytes...)
 	storageSlot := crypto.Keccak256Hash(packed)
 
 	// Pad amount to 32 bytes.

--- a/internal/testutil/eip712_signer.go
+++ b/internal/testutil/eip712_signer.go
@@ -49,6 +49,7 @@ func SignRealPaymentHeader(t *testing.T, signerKeyHex string, payTo string, amou
 	if _, err := rand.Read(nonce); err != nil {
 		t.Fatalf("generate nonce: %v", err)
 	}
+
 	nonceHex := fmt.Sprintf("0x%x", nonce)
 
 	// Build EIP-712 typed data for TransferWithAuthorization (ERC-3009).
@@ -103,13 +104,13 @@ func SignRealPaymentHeader(t *testing.T, signerKeyHex string, payTo string, amou
 
 	// Build the x402 V1 payment envelope.
 	// All numeric values that x402-rs expects as strings must be strings here.
-	envelope := map[string]interface{}{
+	envelope := map[string]any{
 		"x402Version": 1,
 		"scheme":      "exact",
 		"network":     chainName(chainID),
-		"payload": map[string]interface{}{
+		"payload": map[string]any{
 			"signature": sigHex,
-			"authorization": map[string]interface{}{
+			"authorization": map[string]any{
 				"from":        fromAddr.Hex(),
 				"to":          payTo,
 				"value":       amount,       // string — x402-rs decimal_u256
@@ -118,7 +119,7 @@ func SignRealPaymentHeader(t *testing.T, signerKeyHex string, payTo string, amou
 				"nonce":       nonceHex,
 			},
 		},
-		"resource": map[string]interface{}{
+		"resource": map[string]any{
 			"payTo":             payTo,
 			"maxAmountRequired": amount,
 			"asset":             USDCBaseSepolia,
@@ -132,17 +133,21 @@ func SignRealPaymentHeader(t *testing.T, signerKeyHex string, payTo string, amou
 	}
 
 	encoded := base64.StdEncoding.EncodeToString(data)
+
 	t.Logf("signed real payment: from=%s, to=%s, amount=%s, chain=%d", fromAddr.Hex(), payTo, amount, chainID)
+
 	return encoded
 }
 
 // ParseAnvilKey converts a hex-encoded private key string to an ecdsa.PrivateKey.
 func ParseAnvilKey(t *testing.T, hexKey string) *ecdsa.PrivateKey {
 	t.Helper()
+
 	key, err := crypto.HexToECDSA(stripHexPrefix(hexKey))
 	if err != nil {
 		t.Fatalf("parse anvil key: %v", err)
 	}
+
 	return key
 }
 
@@ -150,6 +155,7 @@ func ParseAnvilKey(t *testing.T, hexKey string) *ecdsa.PrivateKey {
 func AnvilKeyAddress(t *testing.T, hexKey string) common.Address {
 	t.Helper()
 	key := ParseAnvilKey(t, hexKey)
+
 	return crypto.PubkeyToAddress(key.PublicKey)
 }
 
@@ -158,6 +164,7 @@ func USDCMicroUnits(usdc float64) *big.Int {
 	// USDC has 6 decimals.
 	micro := new(big.Float).Mul(big.NewFloat(usdc), big.NewFloat(1e6))
 	result, _ := micro.Int(nil)
+
 	return result
 }
 
@@ -165,6 +172,7 @@ func stripHexPrefix(s string) string {
 	if len(s) > 2 && (s[:2] == "0x" || s[:2] == "0X") {
 		return s[2:]
 	}
+
 	return s
 }
 
@@ -182,6 +190,7 @@ func SignPaymentHeaderDirect(signerKeyHex, payTo, amount string, chainID int64) 
 	if _, err := rand.Read(nonce); err != nil {
 		panic(fmt.Sprintf("generate nonce: %v", err))
 	}
+
 	nonceHex := fmt.Sprintf("0x%x", nonce)
 
 	typedData := apitypes.TypedData{
@@ -227,15 +236,16 @@ func SignPaymentHeaderDirect(signerKeyHex, payTo, amount string, chainID int64) 
 	if err != nil {
 		panic(fmt.Sprintf("sign: %v", err))
 	}
+
 	sig[64] += 27
 
-	envelope := map[string]interface{}{
+	envelope := map[string]any{
 		"x402Version": 1,
 		"scheme":      "exact",
 		"network":     chainName(chainID),
-		"payload": map[string]interface{}{
+		"payload": map[string]any{
 			"signature": fmt.Sprintf("0x%x", sig),
-			"authorization": map[string]interface{}{
+			"authorization": map[string]any{
 				"from":        fromAddr.Hex(),
 				"to":          payTo,
 				"value":       amount,
@@ -244,7 +254,7 @@ func SignPaymentHeaderDirect(signerKeyHex, payTo, amount string, chainID int64) 
 				"nonce":       nonceHex,
 			},
 		},
-		"resource": map[string]interface{}{
+		"resource": map[string]any{
 			"payTo":             payTo,
 			"maxAmountRequired": amount,
 			"asset":             USDCBaseSepolia,
@@ -256,9 +266,9 @@ func SignPaymentHeaderDirect(signerKeyHex, payTo, amount string, chainID int64) 
 	if err != nil {
 		panic(fmt.Sprintf("marshal: %v", err))
 	}
+
 	return base64.StdEncoding.EncodeToString(data)
 }
-
 
 func chainName(chainID int64) string {
 	switch chainID {

--- a/internal/testutil/facilitator.go
+++ b/internal/testutil/facilitator.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strconv"
 	"sync/atomic"
 	"testing"
 )
@@ -129,7 +130,7 @@ func StartMockFacilitator(t *testing.T) *MockFacilitator {
 	mf.Server.Start()
 
 	mf.Port = port
-	mf.ClusterURL = fmt.Sprintf("http://%s:%d", clusterHostURL(), port)
+	mf.ClusterURL = "http://" + net.JoinHostPort(clusterHostURL(), strconv.Itoa(port))
 
 	t.Cleanup(mf.Server.Close)
 

--- a/internal/testutil/facilitator.go
+++ b/internal/testutil/facilitator.go
@@ -35,6 +35,7 @@ func clusterHostURL() string {
 	if runtime.GOOS == "darwin" {
 		return "host.docker.internal"
 	}
+
 	return "host.k3d.internal"
 }
 
@@ -59,6 +60,7 @@ func ClusterHostIP(t *testing.T) string {
 	if runtime.GOOS == "darwin" {
 		const dockerDesktopGW = "192.168.65.254"
 		t.Logf("%s not resolvable on host, using Docker Desktop gateway %s", hostname, dockerDesktopGW)
+
 		return dockerDesktopGW
 	}
 
@@ -67,17 +69,21 @@ func ClusterHostIP(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("cannot resolve cluster host IP: DNS failed for %s and docker0 not found: %v", hostname, err)
 	}
+
 	ifAddrs, err := iface.Addrs()
 	if err != nil {
 		t.Fatalf("cannot get docker0 addresses: %v", err)
 	}
+
 	for _, addr := range ifAddrs {
 		if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
 			t.Logf("using docker0 bridge IP %s", ipNet.IP)
 			return ipNet.IP.String()
 		}
 	}
+
 	t.Fatalf("no IPv4 address on docker0 interface")
+
 	return ""
 }
 
@@ -114,6 +120,7 @@ func StartMockFacilitator(t *testing.T) *MockFacilitator {
 	if err != nil {
 		t.Fatalf("find free port for mock facilitator: %v", err)
 	}
+
 	port := l.Addr().(*net.TCPAddr).Port
 
 	mf.Server = httptest.NewUnstartedServer(mux)
@@ -125,6 +132,7 @@ func StartMockFacilitator(t *testing.T) *MockFacilitator {
 	mf.ClusterURL = fmt.Sprintf("http://%s:%d", clusterHostURL(), port)
 
 	t.Cleanup(mf.Server.Close)
+
 	return mf
 }
 
@@ -133,13 +141,13 @@ func StartMockFacilitator(t *testing.T) *MockFacilitator {
 func TestPaymentHeader(t *testing.T, payTo string) string {
 	t.Helper()
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"x402Version": 1,
 		"scheme":      "exact",
 		"network":     "base-sepolia",
-		"payload": map[string]interface{}{
+		"payload": map[string]any{
 			"signature": "0xmocksig",
-			"authorization": map[string]interface{}{
+			"authorization": map[string]any{
 				"from":        "0xmockpayer",
 				"to":          payTo,
 				"value":       "1000000",
@@ -148,7 +156,7 @@ func TestPaymentHeader(t *testing.T, payTo string) string {
 				"nonce":       "0x0",
 			},
 		},
-		"resource": map[string]interface{}{
+		"resource": map[string]any{
 			"payTo":             payTo,
 			"maxAmountRequired": "1000000",
 			"asset":             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
@@ -160,5 +168,6 @@ func TestPaymentHeader(t *testing.T, payTo string) string {
 	if err != nil {
 		t.Fatalf("marshal payment header: %v", err)
 	}
+
 	return base64.StdEncoding.EncodeToString(data)
 }

--- a/internal/testutil/facilitator_real.go
+++ b/internal/testutil/facilitator_real.go
@@ -48,6 +48,7 @@ func StartRealFacilitator(t *testing.T, anvil *AnvilFork) *RealFacilitator {
 	if err != nil {
 		t.Fatalf("find free port for facilitator: %v", err)
 	}
+
 	port := l.Addr().(*net.TCPAddr).Port
 	l.Close()
 
@@ -61,7 +62,9 @@ func StartRealFacilitator(t *testing.T, anvil *AnvilFork) *RealFacilitator {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	cmd := exec.CommandContext(ctx, bin, "--config", configPath)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stderr
 
@@ -79,7 +82,9 @@ func StartRealFacilitator(t *testing.T, anvil *AnvilFork) *RealFacilitator {
 
 	t.Cleanup(func() {
 		cancel()
+
 		_ = cmd.Wait()
+
 		os.Remove(configPath)
 	})
 
@@ -89,6 +94,7 @@ func StartRealFacilitator(t *testing.T, anvil *AnvilFork) *RealFacilitator {
 	}
 
 	t.Logf("x402-rs facilitator running on port %d (cluster URL: %s)", port, rf.ClusterURL)
+
 	return rf
 }
 
@@ -102,6 +108,7 @@ func discoverFacilitatorBinary(t *testing.T) string {
 			t.Logf("using X402_FACILITATOR_BIN=%s", bin)
 			return bin
 		}
+
 		t.Fatalf("X402_FACILITATOR_BIN=%s does not exist", bin)
 	}
 
@@ -131,16 +138,21 @@ func discoverFacilitatorBinary(t *testing.T) string {
 		if _, err := exec.LookPath("cargo"); err != nil {
 			t.Skip("x402-rs source found but cargo not installed")
 		}
+
 		t.Logf("building x402-rs facilitator from %s (this may take a while)...", rsDir)
+
 		buildCommands := [][]string{
 			{"build", "--release", "-p", "x402-facilitator"},
 			{"build", "--release", "-p", "facilitator"},
 		}
+
 		var buildErr error
+
 		for _, args := range buildCommands {
 			build := exec.Command("cargo", args...)
 			build.Dir = rsDir
 			build.Stdout = os.Stderr
+
 			build.Stderr = os.Stderr
 			if err := build.Run(); err == nil {
 				buildErr = nil
@@ -149,19 +161,23 @@ func discoverFacilitatorBinary(t *testing.T) string {
 				buildErr = err
 			}
 		}
+
 		if buildErr != nil {
 			t.Fatalf("cargo build --release failed: %v", buildErr)
 		}
+
 		for _, prebuilt := range prebuiltCandidates {
 			if _, err := os.Stat(prebuilt); err == nil {
 				return prebuilt
 			}
 		}
+
 		t.Fatalf("cargo build succeeded but binary not found at any expected path: %v", prebuiltCandidates)
 	}
 
 	t.Skip("x402-rs facilitator not available — set X402_FACILITATOR_BIN or X402_RS_DIR, " +
 		"or clone https://github.com/x402-rs/x402-rs to ~/Development/R&D/x402-rs")
+
 	return ""
 }
 
@@ -174,15 +190,15 @@ func writeRealFacilitatorConfig(t *testing.T, port int, anvilRPCURL, signerKey s
 		signerKey = signerKey[2:]
 	}
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"port": port,
 		"host": "0.0.0.0",
-		"chains": map[string]interface{}{
-			"eip155:84532": map[string]interface{}{
+		"chains": map[string]any{
+			"eip155:84532": map[string]any{
 				"eip1559":     true,
 				"flashblocks": false,
 				"signers":     []string{signerKey},
-				"rpc": []map[string]interface{}{
+				"rpc": []map[string]any{
 					{
 						"http":       anvilRPCURL,
 						"rate_limit": 50,
@@ -190,7 +206,7 @@ func writeRealFacilitatorConfig(t *testing.T, port int, anvilRPCURL, signerKey s
 				},
 			},
 		},
-		"schemes": []map[string]interface{}{
+		"schemes": []map[string]any{
 			{
 				"id":     "v1-eip155-exact",
 				"chains": "eip155:*",
@@ -207,17 +223,20 @@ func writeRealFacilitatorConfig(t *testing.T, port int, anvilRPCURL, signerKey s
 		t.Fatalf("marshal facilitator config: %v", err)
 	}
 
-	f, err := os.CreateTemp("", "x402-facilitator-*.json")
+	f, err := os.CreateTemp(t.TempDir(), "x402-facilitator-*.json")
 	if err != nil {
 		t.Fatalf("create temp config file: %v", err)
 	}
+
 	if _, err := f.Write(data); err != nil {
 		f.Close()
 		t.Fatalf("write facilitator config: %v", err)
 	}
+
 	f.Close()
 
 	t.Logf("wrote facilitator config to %s", f.Name())
+
 	return f.Name()
 }
 
@@ -236,11 +255,14 @@ func (rf *RealFacilitator) waitReady(timeout time.Duration) error {
 		resp, err := http.Get(url)
 		if err == nil {
 			resp.Body.Close()
+
 			if resp.StatusCode == http.StatusOK {
 				return nil
 			}
 		}
+
 		time.Sleep(500 * time.Millisecond)
 	}
+
 	return fmt.Errorf("facilitator not ready after %v on port %d", timeout, rf.Port)
 }

--- a/internal/testutil/facilitator_real.go
+++ b/internal/testutil/facilitator_real.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -75,7 +75,7 @@ func StartRealFacilitator(t *testing.T, anvil *AnvilFork) *RealFacilitator {
 
 	rf := &RealFacilitator{
 		Port:       port,
-		ClusterURL: fmt.Sprintf("http://%s:%d", clusterHostURL(), port),
+		ClusterURL: "http://" + net.JoinHostPort(clusterHostURL(), strconv.Itoa(port)),
 		cmd:        cmd,
 		cancel:     cancel,
 	}
@@ -243,12 +243,7 @@ func writeRealFacilitatorConfig(t *testing.T, port int, anvilRPCURL, signerKey s
 // waitReady polls the facilitator's /supported endpoint until it returns 200.
 func (rf *RealFacilitator) waitReady(timeout time.Duration) error {
 	// Use localhost URL for readiness check (not cluster URL).
-	var url string
-	if runtime.GOOS == "darwin" {
-		url = fmt.Sprintf("http://127.0.0.1:%d/supported", rf.Port)
-	} else {
-		url = fmt.Sprintf("http://127.0.0.1:%d/supported", rf.Port)
-	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/supported", rf.Port)
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/internal/testutil/verifier.go
+++ b/internal/testutil/verifier.go
@@ -37,7 +37,7 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 
 	// Replace the facilitatorURL in the pricing YAML.
 	updated := currentYAML
-	for _, line := range strings.Split(currentYAML, "\n") {
+	for line := range strings.SplitSeq(currentYAML, "\n") {
 		if strings.Contains(line, "facilitatorURL:") {
 			updated = strings.Replace(updated, line, fmt.Sprintf(`facilitatorURL: "%s"`, newURL), 1)
 			break
@@ -51,9 +51,10 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 		},
 	})
 	if err := kubectl.RunSilent(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
-		"--type=merge", fmt.Sprintf("-p=%s", string(patchJSON))); err != nil {
+		"--type=merge", "-p="+string(patchJSON)); err != nil {
 		t.Fatalf("patch x402-pricing ConfigMap: %v", err)
 	}
+
 	t.Logf("Patched x402-pricing facilitatorURL → %s", newURL)
 
 	// Register cleanup to restore original ConfigMap.
@@ -67,6 +68,8 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 
 // restoreVerifierConfigMap restores the x402-pricing ConfigMap from a JSON snapshot.
 func restoreVerifierConfigMap(t *testing.T, kubectlBin, kubeconfig, originalJSON string) {
+	t.Helper()
+
 	var cm struct {
 		Data map[string]string `json:"data"`
 	}
@@ -80,7 +83,7 @@ func restoreVerifierConfigMap(t *testing.T, kubectlBin, kubeconfig, originalJSON
 	})
 
 	if err := kubectl.RunSilent(kubectlBin, kubeconfig, "patch", "cm", "x402-pricing", "-n", "x402",
-		"--type=merge", fmt.Sprintf("-p=%s", string(patchJSON))); err != nil {
+		"--type=merge", "-p="+string(patchJSON)); err != nil {
 		t.Logf("Warning: could not restore x402-pricing ConfigMap: %v", err)
 	} else {
 		t.Log("Restored original x402-pricing ConfigMap")
@@ -106,8 +109,9 @@ func waitForVerifierRestart(t *testing.T, kubectlBin, kubeconfig, expectedURL st
 			t.Log("x402-verifier restarted with updated facilitator URL")
 			return
 		}
+
 		time.Sleep(3 * time.Second)
 	}
+
 	t.Log("Warning: did not confirm verifier restart with new URL (continuing anyway)")
 }
-

--- a/internal/testutil/verifier.go
+++ b/internal/testutil/verifier.go
@@ -45,7 +45,7 @@ func PatchVerifierFacilitator(t *testing.T, kubectlBin, kubeconfig, newURL strin
 	}
 
 	// Patch the ConfigMap with the new facilitator URL.
-	patchJSON, _ := json.Marshal(map[string]any{
+	patchJSON, _ := json.Marshal(map[string]any{ //nolint:errchkjson // map[string]any is safe, keys/values are controlled
 		"data": map[string]string{
 			"pricing.yaml": updated,
 		},
@@ -78,7 +78,7 @@ func restoreVerifierConfigMap(t *testing.T, kubectlBin, kubeconfig, originalJSON
 		return
 	}
 
-	patchJSON, _ := json.Marshal(map[string]any{
+	patchJSON, _ := json.Marshal(map[string]any{ //nolint:errchkjson // map[string]any is safe, keys/values are controlled
 		"data": cm.Data,
 	})
 

--- a/internal/tunnel/agent.go
+++ b/internal/tunnel/agent.go
@@ -27,6 +27,7 @@ func SyncAgentBaseURL(cfg *config.Config, tunnelURL string) error {
 
 	// Run helmfile sync to apply the change to the cluster.
 	deploymentDir := filepath.Dir(overlayPath)
+
 	helmfilePath := filepath.Join(deploymentDir, "helmfile.yaml")
 	if _, err := os.Stat(helmfilePath); os.IsNotExist(err) {
 		// Overlay exists but helmfile.yaml is missing — unusual, skip sync.
@@ -47,8 +48,10 @@ func SyncAgentBaseURL(cfg *config.Config, tunnelURL string) error {
 	}
 
 	fmt.Printf("Syncing AGENT_BASE_URL=%s to obol-agent...\n", tunnelURL)
+
 	cmd := exec.Command(helmfileBin, "-f", helmfilePath, "sync")
 	cmd.Dir = deploymentDir
+
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -59,6 +62,7 @@ func SyncAgentBaseURL(cfg *config.Config, tunnelURL string) error {
 	}
 
 	fmt.Println("✓ AGENT_BASE_URL synced to obol-agent")
+
 	return nil
 }
 
@@ -80,6 +84,7 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 
 	// Pre-scan: check if AGENT_BASE_URL already exists.
 	alreadyPresent := false
+
 	for _, l := range lines {
 		if strings.Contains(l, "name: AGENT_BASE_URL") {
 			alreadyPresent = true
@@ -88,6 +93,7 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 	}
 
 	inserted := false
+
 	var out []string
 
 	for i := 0; i < len(lines); i++ {
@@ -96,12 +102,15 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 		// Case 1: AGENT_BASE_URL already present — update its value line.
 		if strings.Contains(line, "name: AGENT_BASE_URL") {
 			inserted = true
+
 			out = append(out, line)
 			// The next line should be the value line — replace it.
 			if i+1 < len(lines) && strings.Contains(lines[i+1], "value:") {
 				i++
-				out = append(out, fmt.Sprintf("    value: %s", tunnelURL))
+
+				out = append(out, "    value: "+tunnelURL)
 			}
+
 			continue
 		}
 
@@ -111,7 +120,7 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 		if !alreadyPresent && !inserted && strings.Contains(line, "value: http://remote-signer:9000") {
 			out = append(out,
 				"  - name: AGENT_BASE_URL",
-				fmt.Sprintf("    value: %s", tunnelURL),
+				"    value: "+tunnelURL,
 			)
 			inserted = true
 		}
@@ -119,8 +128,8 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 
 	// Case 3: Neither AGENT_BASE_URL nor REMOTE_SIGNER_URL found (unusual).
 	if !inserted {
-		out = append(out, "extraEnv:", fmt.Sprintf("  - name: AGENT_BASE_URL\n    value: %s", tunnelURL))
+		out = append(out, "extraEnv:", "  - name: AGENT_BASE_URL\n    value: "+tunnelURL)
 	}
 
-	return os.WriteFile(path, []byte(strings.Join(out, "\n")), 0644)
+	return os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o644)
 }

--- a/internal/tunnel/agent.go
+++ b/internal/tunnel/agent.go
@@ -131,5 +131,5 @@ func patchAgentBaseURL(path, tunnelURL string) error {
 		out = append(out, "extraEnv:", "  - name: AGENT_BASE_URL\n    value: "+tunnelURL)
 	}
 
-	return os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o644)
+	return os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o600) //nolint:gosec // G703: path from user's local config dir
 }

--- a/internal/tunnel/cloudflare.go
+++ b/internal/tunnel/cloudflare.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,9 +46,11 @@ func (c *cloudflareClient) CreateTunnel(accountID, tunnelName string) (*cloudfla
 	if err := c.doJSON("POST", fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/cfd_tunnel", accountID), reqBody, &resp); err != nil {
 		return nil, err
 	}
+
 	if !resp.Success {
 		return nil, fmt.Errorf("cloudflare tunnel create failed: %v", resp.Errors)
 	}
+
 	return &cloudflareTunnel{ID: resp.Result.ID, Token: resp.Result.Token}, nil
 }
 
@@ -61,9 +64,11 @@ func (c *cloudflareClient) GetTunnelToken(accountID, tunnelID string) (string, e
 	if err := c.doJSON("GET", fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/cfd_tunnel/%s/token", accountID, tunnelID), nil, &resp); err != nil {
 		return "", err
 	}
+
 	if !resp.Success || resp.Result == "" {
-		return "", fmt.Errorf("cloudflare tunnel token fetch failed")
+		return "", errors.New("cloudflare tunnel token fetch failed")
 	}
+
 	return resp.Result, nil
 }
 
@@ -95,9 +100,11 @@ func (c *cloudflareClient) UpdateTunnelConfiguration(accountID, tunnelID, hostna
 	if err := c.doJSON("PUT", url, reqBody, &resp); err != nil {
 		return err
 	}
+
 	if !resp.Success {
 		return fmt.Errorf("cloudflare tunnel configuration update failed: %v", resp.Errors)
 	}
+
 	return nil
 }
 
@@ -112,6 +119,7 @@ type dnsRecord struct {
 func (c *cloudflareClient) UpsertTunnelDNSRecord(zoneID, hostname, content string) error {
 	// Find existing records for this exact name/type.
 	listURL := fmt.Sprintf("https://api.cloudflare.com/client/v4/zones/%s/dns_records?type=CNAME&name=%s", zoneID, url.QueryEscape(hostname))
+
 	var listResp struct {
 		Success bool `json:"success"`
 		Errors  []struct {
@@ -123,6 +131,7 @@ func (c *cloudflareClient) UpsertTunnelDNSRecord(zoneID, hostname, content strin
 	if err := c.doJSON("GET", listURL, nil, &listResp); err != nil {
 		return err
 	}
+
 	if !listResp.Success {
 		return fmt.Errorf("cloudflare dns record list failed: %v", listResp.Errors)
 	}
@@ -148,9 +157,11 @@ func (c *cloudflareClient) UpsertTunnelDNSRecord(zoneID, hostname, content strin
 		if err := c.doJSON("PUT", updateURL, reqBody, &updResp); err != nil {
 			return err
 		}
+
 		if !updResp.Success {
 			return fmt.Errorf("cloudflare dns record update failed: %v", updResp.Errors)
 		}
+
 		return nil
 	}
 
@@ -174,15 +185,20 @@ func (c *cloudflareClient) UpsertTunnelDNSRecord(zoneID, hostname, content strin
 	if err := c.doJSON("POST", createURL, reqBody, &createResp); err != nil {
 		return err
 	}
+
 	if !createResp.Success {
 		return fmt.Errorf("cloudflare dns record create failed: %v", createResp.Errors)
 	}
+
 	return nil
 }
 
 func (c *cloudflareClient) doJSON(method, url string, reqBody any, out any) error {
-	var body []byte
-	var err error
+	var (
+		body []byte
+		err  error
+	)
+
 	if reqBody != nil {
 		body, err = json.Marshal(reqBody)
 		if err != nil {
@@ -194,10 +210,12 @@ func (c *cloudflareClient) doJSON(method, url string, reqBody any, out any) erro
 	if err != nil {
 		return err
 	}
+
 	req.Header.Set("Authorization", "Bearer "+c.apiToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 30 * time.Second}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -217,8 +235,10 @@ func (c *cloudflareClient) doJSON(method, url string, reqBody any, out any) erro
 	if out == nil {
 		return nil
 	}
+
 	if err := json.Unmarshal(respBody, out); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/internal/tunnel/login.go
+++ b/internal/tunnel/login.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -29,36 +30,40 @@ type LoginOptions struct {
 func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 	hostname := normalizeHostname(opts.Hostname)
 	if hostname == "" {
-		return fmt.Errorf("--hostname is required (e.g. stack.example.com)")
+		return errors.New("--hostname is required (e.g. stack.example.com)")
 	}
 
 	// Stack must be running so we can write secrets/config to the cluster.
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+		return errors.New("stack not running, use 'obol stack up' first")
 	}
 
 	stackID := getStackID(cfg)
 	if stackID == "" {
-		return fmt.Errorf("stack not initialized, run 'obol stack init' first")
+		return errors.New("stack not initialized, run 'obol stack init' first")
 	}
-	tunnelName := fmt.Sprintf("obol-stack-%s", stackID)
+
+	tunnelName := "obol-stack-" + stackID
 
 	cloudflaredPath, err := exec.LookPath("cloudflared")
 	if err != nil {
-		return fmt.Errorf("cloudflared not found in PATH. Install it first (e.g. 'brew install cloudflared' on macOS)")
+		return errors.New("cloudflared not found in PATH. Install it first (e.g. 'brew install cloudflared' on macOS)")
 	}
 
 	u.Info("Authenticating cloudflared (browser)...")
+
 	loginCmd := exec.Command(cloudflaredPath, "tunnel", "login")
 	loginCmd.Stdin = os.Stdin
 	loginCmd.Stdout = os.Stdout
+
 	loginCmd.Stderr = os.Stderr
 	if err := loginCmd.Run(); err != nil {
 		return fmt.Errorf("cloudflared tunnel login failed: %w", err)
 	}
 
 	u.Infof("Creating tunnel: %s", tunnelName)
+
 	if out, err := exec.Command(cloudflaredPath, "tunnel", "create", tunnelName).CombinedOutput(); err != nil {
 		// "Already exists" is common if user re-runs. We'll recover by querying tunnel info.
 		u.Warnf("cloudflared tunnel create returned an error (continuing): %s", strings.TrimSpace(string(out)))
@@ -68,6 +73,7 @@ func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 	if err != nil {
 		return fmt.Errorf("cloudflared tunnel info failed: %w\n%s", err, strings.TrimSpace(string(infoOut)))
 	}
+
 	tunnelID, err := parseFirstUUID(string(infoOut))
 	if err != nil {
 		return fmt.Errorf("could not parse tunnel UUID from cloudflared tunnel info:\n%s", strings.TrimSpace(string(infoOut)))
@@ -81,12 +87,14 @@ func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", certPath, err)
 	}
+
 	cred, err := os.ReadFile(credPath)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", credPath, err)
 	}
 
 	u.Infof("Creating DNS route for %s...", hostname)
+
 	routeOut, err := exec.Command(cloudflaredPath, "tunnel", "route", "dns", tunnelName, hostname).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cloudflared tunnel route dns failed: %w\n%s", err, strings.TrimSpace(string(routeOut)))
@@ -105,15 +113,17 @@ func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 	if st == nil {
 		st = &tunnelState{}
 	}
+
 	st.Mode = "dns"
 	st.Hostname = hostname
 	st.TunnelID = tunnelID
+
 	st.TunnelName = tunnelName
 	if err := saveTunnelState(cfg, st); err != nil {
 		return fmt.Errorf("tunnel created, but failed to save local state: %w", err)
 	}
 
-	tunnelURL := fmt.Sprintf("https://%s", hostname)
+	tunnelURL := "https://" + hostname
 
 	// Inject AGENT_BASE_URL into obol-agent overlay if deployed.
 	if err := SyncAgentBaseURL(cfg, tunnelURL); err != nil {
@@ -129,6 +139,7 @@ func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 	u.Success("Tunnel login complete")
 	u.Printf("Persistent URL: https://%s", hostname)
 	u.Print("Tip: run 'obol tunnel status' to verify the connector is active.")
+
 	return nil
 }
 
@@ -137,6 +148,7 @@ func defaultCloudflaredDir() string {
 	if err != nil {
 		return ".cloudflared"
 	}
+
 	return filepath.Join(home, ".cloudflared")
 }
 
@@ -145,7 +157,8 @@ func parseFirstUUID(s string) (string, error) {
 	if m := re.FindString(strings.ToLower(s)); m != "" {
 		return m, nil
 	}
-	return "", fmt.Errorf("uuid not found")
+
+	return "", errors.New("uuid not found")
 }
 
 func applyLocalManagedK8sResources(cfg *config.Config, u *ui.UI, kubeconfigPath, hostname, tunnelID string, certPEM, credJSON []byte) error {
@@ -154,6 +167,7 @@ func applyLocalManagedK8sResources(cfg *config.Config, u *ui.UI, kubeconfigPath,
 	if err != nil {
 		return err
 	}
+
 	if err := kubectlApply(cfg, u, kubeconfigPath, secretYAML); err != nil {
 		return err
 	}
@@ -187,6 +201,7 @@ data:
   credentials.json: %s
 `, localManagedSecretName, tunnelNamespace, certB64, credB64)
 	_ = hostname // reserved for future labels/annotations
+
 	return []byte(secret), nil
 }
 
@@ -207,6 +222,7 @@ data:
         service: http://traefik.traefik.svc.cluster.local:80
       - service: http_status:404
 `, localManagedConfigMapName, tunnelNamespace, tunnelID, tunnelID, hostname)
+
 	return []byte(cfg)
 }
 
@@ -217,6 +233,7 @@ func kubectlApply(cfg *config.Config, u *ui.UI, kubeconfigPath string, manifest 
 		"--kubeconfig", kubeconfigPath,
 		"apply", "-f", "-",
 	)
+
 	cmd.Stdin = bytes.NewReader(manifest)
 	if err := u.Exec(ui.ExecConfig{
 		Name: "Applying Kubernetes manifest",
@@ -224,5 +241,6 @@ func kubectlApply(cfg *config.Config, u *ui.UI, kubeconfigPath string, manifest 
 	}); err != nil {
 		return fmt.Errorf("kubectl apply failed: %w", err)
 	}
+
 	return nil
 }

--- a/internal/tunnel/login.go
+++ b/internal/tunnel/login.go
@@ -163,10 +163,7 @@ func parseFirstUUID(s string) (string, error) {
 
 func applyLocalManagedK8sResources(cfg *config.Config, u *ui.UI, kubeconfigPath, hostname, tunnelID string, certPEM, credJSON []byte) error {
 	// Secret: account certificate + tunnel credentials (locally-managed tunnel requires origincert).
-	secretYAML, err := buildLocalManagedSecretYAML(hostname, certPEM, credJSON)
-	if err != nil {
-		return err
-	}
+	secretYAML := buildLocalManagedSecretYAML(certPEM, credJSON)
 
 	if err := kubectlApply(cfg, u, kubeconfigPath, secretYAML); err != nil {
 		return err
@@ -186,7 +183,7 @@ const (
 	localManagedConfigMapName = "cloudflared-local-config"
 )
 
-func buildLocalManagedSecretYAML(hostname string, certPEM, credJSON []byte) ([]byte, error) {
+func buildLocalManagedSecretYAML(certPEM, credJSON []byte) []byte {
 	certB64 := base64.StdEncoding.EncodeToString(certPEM)
 	credB64 := base64.StdEncoding.EncodeToString(credJSON)
 
@@ -200,9 +197,8 @@ data:
   cert.pem: %s
   credentials.json: %s
 `, localManagedSecretName, tunnelNamespace, certB64, credB64)
-	_ = hostname // reserved for future labels/annotations
 
-	return []byte(secret), nil
+	return []byte(secret)
 }
 
 func buildLocalManagedConfigYAML(hostname, tunnelID string) []byte {

--- a/internal/tunnel/provision.go
+++ b/internal/tunnel/provision.go
@@ -2,6 +2,7 @@ package tunnel
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -29,29 +30,33 @@ type ProvisionOptions struct {
 func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 	hostname := normalizeHostname(opts.Hostname)
 	if hostname == "" {
-		return fmt.Errorf("--hostname is required (e.g. stack.example.com)")
+		return errors.New("--hostname is required (e.g. stack.example.com)")
 	}
+
 	if opts.AccountID == "" {
-		return fmt.Errorf("--account-id is required (or set CLOUDFLARE_ACCOUNT_ID)")
+		return errors.New("--account-id is required (or set CLOUDFLARE_ACCOUNT_ID)")
 	}
+
 	if opts.ZoneID == "" {
-		return fmt.Errorf("--zone-id is required (or set CLOUDFLARE_ZONE_ID)")
+		return errors.New("--zone-id is required (or set CLOUDFLARE_ZONE_ID)")
 	}
+
 	if opts.APIToken == "" {
-		return fmt.Errorf("--api-token is required (or set CLOUDFLARE_API_TOKEN)")
+		return errors.New("--api-token is required (or set CLOUDFLARE_API_TOKEN)")
 	}
 
 	// Stack must be running so we can store the tunnel token in-cluster.
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+		return errors.New("stack not running, use 'obol stack up' first")
 	}
 
 	stackID := getStackID(cfg)
 	if stackID == "" {
-		return fmt.Errorf("stack not initialized, run 'obol stack init' first")
+		return errors.New("stack not initialized, run 'obol stack init' first")
 	}
-	tunnelName := fmt.Sprintf("obol-stack-%s", stackID)
+
+	tunnelName := "obol-stack-" + stackID
 
 	client := newCloudflareClient(opts.APIToken)
 
@@ -70,10 +75,12 @@ func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 
 	if st != nil && st.AccountID == opts.AccountID && st.TunnelID != "" {
 		tunnelID = st.TunnelID
+
 		tok, err := client.GetTunnelToken(opts.AccountID, tunnelID)
 		if err != nil {
 			// If the tunnel no longer exists, create a new one.
 			u.Warnf("Existing tunnel token fetch failed (%v); creating a new tunnel...", err)
+
 			tunnelID = ""
 		} else {
 			tunnelToken = tok
@@ -85,6 +92,7 @@ func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 		if err != nil {
 			return err
 		}
+
 		tunnelID = t.ID
 		tunnelToken = t.Token
 	}
@@ -109,6 +117,7 @@ func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 	if st == nil {
 		st = &tunnelState{}
 	}
+
 	st.Mode = "dns"
 	st.Hostname = hostname
 	st.AccountID = opts.AccountID
@@ -120,7 +129,7 @@ func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 		return fmt.Errorf("tunnel provisioned, but failed to save local state: %w", err)
 	}
 
-	tunnelURL := fmt.Sprintf("https://%s", hostname)
+	tunnelURL := "https://" + hostname
 
 	// Inject AGENT_BASE_URL into obol-agent overlay if deployed.
 	if err := SyncAgentBaseURL(cfg, tunnelURL); err != nil {
@@ -136,6 +145,7 @@ func Provision(cfg *config.Config, u *ui.UI, opts ProvisionOptions) error {
 	u.Success("Tunnel provisioned")
 	u.Printf("Persistent URL: https://%s", hostname)
 	u.Print("Tip: run 'obol tunnel status' to verify the connector is active.")
+
 	return nil
 }
 
@@ -149,9 +159,11 @@ func normalizeHostname(s string) string {
 	if idx := strings.IndexByte(s, '/'); idx >= 0 {
 		s = s[:idx]
 	}
+
 	if idx := strings.IndexByte(s, '?'); idx >= 0 {
 		s = s[:idx]
 	}
+
 	if idx := strings.IndexByte(s, '#'); idx >= 0 {
 		s = s[:idx]
 	}
@@ -170,6 +182,7 @@ func applyTunnelTokenSecret(cfg *config.Config, u *ui.UI, kubeconfigPath, token 
 		"--dry-run=client",
 		"-o", "yaml",
 	)
+
 	out, err := createCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to create secret manifest: %w", err)
@@ -179,6 +192,7 @@ func applyTunnelTokenSecret(cfg *config.Config, u *ui.UI, kubeconfigPath, token 
 		"--kubeconfig", kubeconfigPath,
 		"apply", "-f", "-",
 	)
+
 	applyCmd.Stdin = bytes.NewReader(out)
 	if err := u.Exec(ui.ExecConfig{
 		Name: "Applying tunnel token secret",
@@ -186,6 +200,7 @@ func applyTunnelTokenSecret(cfg *config.Config, u *ui.UI, kubeconfigPath, token 
 	}); err != nil {
 		return fmt.Errorf("failed to apply tunnel token secret: %w", err)
 	}
+
 	return nil
 }
 
@@ -196,6 +211,7 @@ func helmUpgradeCloudflared(cfg *config.Config, u *ui.UI, kubeconfigPath string)
 	if _, err := os.Stat(helmPath); os.IsNotExist(err) {
 		return fmt.Errorf("helm not found at %s", helmPath)
 	}
+
 	if _, err := os.Stat(filepath.Join(defaultsDir, "cloudflared", "Chart.yaml")); os.IsNotExist(err) {
 		return fmt.Errorf("cloudflared chart not found in %s (re-run 'obol stack init --force' to refresh defaults)", defaultsDir)
 	}
@@ -211,6 +227,7 @@ func helmUpgradeCloudflared(cfg *config.Config, u *ui.UI, kubeconfigPath string)
 		"--wait",
 		"--timeout", "2m",
 	)
+
 	cmd.Dir = defaultsDir
 	if err := u.Exec(ui.ExecConfig{
 		Name: "Upgrading cloudflared Helm release",
@@ -218,5 +235,6 @@ func helmUpgradeCloudflared(cfg *config.Config, u *ui.UI, kubeconfigPath string)
 	}); err != nil {
 		return fmt.Errorf("failed to upgrade cloudflared release: %w", err)
 	}
+
 	return nil
 }

--- a/internal/tunnel/stackid.go
+++ b/internal/tunnel/stackid.go
@@ -15,5 +15,6 @@ func getStackID(cfg *config.Config) string {
 	if err != nil {
 		return ""
 	}
+
 	return strings.TrimSpace(string(data))
 }

--- a/internal/tunnel/state.go
+++ b/internal/tunnel/state.go
@@ -27,7 +27,7 @@ func loadTunnelState(cfg *config.Config) (*tunnelState, error) {
 	data, err := os.ReadFile(tunnelStatePath(cfg))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil //nolint:nilnil // no state file means tunnel was never provisioned; not an error
 		}
 
 		return nil, err

--- a/internal/tunnel/state.go
+++ b/internal/tunnel/state.go
@@ -29,6 +29,7 @@ func loadTunnelState(cfg *config.Config) (*tunnelState, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+
 		return nil, err
 	}
 
@@ -36,13 +37,15 @@ func loadTunnelState(cfg *config.Config) (*tunnelState, error) {
 	if err := json.Unmarshal(data, &st); err != nil {
 		return nil, err
 	}
+
 	return &st, nil
 }
 
 func saveTunnelState(cfg *config.Config, st *tunnelState) error {
-	if err := os.MkdirAll(filepath.Dir(tunnelStatePath(cfg)), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tunnelStatePath(cfg)), 0o755); err != nil {
 		return err
 	}
+
 	st.UpdatedAt = time.Now().UTC()
 
 	data, err := json.MarshalIndent(st, "", "  ")
@@ -51,7 +54,7 @@ func saveTunnelState(cfg *config.Config, st *tunnelState) error {
 	}
 
 	// Contains non-secret metadata only, but keep it user-private by default.
-	return os.WriteFile(tunnelStatePath(cfg), data, 0600)
+	return os.WriteFile(tunnelStatePath(cfg), data, 0o600)
 }
 
 // TunnelState is an exported alias so other packages (agent, openclaw)
@@ -68,5 +71,6 @@ func tunnelModeAndURL(st *tunnelState) (mode, url string) {
 	if st != nil && st.Hostname != "" {
 		return "dns", "https://" + st.Hostname
 	}
+
 	return "quick", ""
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -2,6 +2,7 @@ package tunnel
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -31,7 +32,7 @@ func Status(cfg *config.Config, u *ui.UI) error {
 
 	// Check if kubeconfig exists.
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+		return errors.New("stack not running, use 'obol stack up' first")
 	}
 
 	st, _ := loadTunnelState(cfg)
@@ -47,12 +48,15 @@ func Status(cfg *config.Config, u *ui.UI) error {
 			u.Print("The tunnel will start automatically when you sell a service.")
 			u.Print("  Start manually: obol tunnel restart")
 			u.Print("  Persistent URL: obol tunnel login --hostname stack.example.com")
+
 			return nil
 		}
+
 		printStatusBox(u, mode, "not running", url, time.Now())
 		u.Blank()
 		u.Print("Troubleshooting:")
 		u.Print("  - Start the stack: obol stack up")
+
 		return nil
 	}
 
@@ -71,8 +75,10 @@ func Status(cfg *config.Config, u *ui.UI) error {
 			u.Print("Troubleshooting:")
 			u.Print("  - Check logs: obol tunnel logs")
 			u.Print("  - Restart tunnel: obol tunnel restart")
+
 			return nil
 		}
+
 		url = tunnelURL
 	}
 
@@ -103,8 +109,9 @@ func InjectBaseURL(cfg *config.Config, tunnelURL string) error {
 		"--kubeconfig", kubeconfigPath,
 		"set", "env", "deployment/openclaw",
 		"-n", "openclaw-obol-agent",
-		fmt.Sprintf("AGENT_BASE_URL=%s", strings.TrimRight(tunnelURL, "/")),
+		"AGENT_BASE_URL="+strings.TrimRight(tunnelURL, "/"),
 	)
+
 	return cmd.Run()
 }
 
@@ -135,7 +142,7 @@ func GetTunnelURL(cfg *config.Config) (string, error) {
 		return url, nil
 	}
 
-	return "", fmt.Errorf("tunnel URL not found in logs")
+	return "", errors.New("tunnel URL not found in logs")
 }
 
 // EnsureRunning scales the cloudflared deployment to 1 replica if it's at 0,
@@ -146,7 +153,7 @@ func EnsureRunning(cfg *config.Config, u *ui.UI) (string, error) {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("stack not running")
+		return "", errors.New("stack not running")
 	}
 
 	// Check if already running.
@@ -183,8 +190,10 @@ func EnsureRunning(cfg *config.Config, u *ui.UI) (string, error) {
 
 	// Poll for tunnel URL (quick tunnels take a few seconds to register).
 	var tunnelURL string
-	for i := 0; i < 20; i++ {
+
+	for range 20 {
 		time.Sleep(time.Second)
+
 		if url, err := GetTunnelURL(cfg); err == nil {
 			tunnelURL = url
 			break
@@ -192,13 +201,14 @@ func EnsureRunning(cfg *config.Config, u *ui.UI) (string, error) {
 	}
 
 	if tunnelURL == "" {
-		return "", fmt.Errorf("tunnel started but URL not available yet — run 'obol tunnel status' in a few seconds")
+		return "", errors.New("tunnel started but URL not available yet — run 'obol tunnel status' in a few seconds")
 	}
 
 	// Inject into obol-agent.
 	if err := InjectBaseURL(cfg, tunnelURL); err == nil {
 		u.Dim("Agent base URL updated to " + tunnelURL)
 	}
+
 	if err := SyncTunnelConfigMap(cfg, tunnelURL); err != nil {
 		u.Dim("Could not sync tunnel URL to frontend ConfigMap: " + err.Error())
 	}
@@ -213,7 +223,7 @@ func Restart(cfg *config.Config, u *ui.UI) error {
 
 	// Check if kubeconfig exists.
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+		return errors.New("stack not running, use 'obol stack up' first")
 	}
 
 	cmd := exec.Command(kubectlPath,
@@ -242,7 +252,7 @@ func Logs(cfg *config.Config, follow bool) error {
 
 	// Check if kubeconfig exists.
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("stack not running, use 'obol stack up' first")
+		return errors.New("stack not running, use 'obol stack up' first")
 	}
 
 	args := []string{
@@ -279,7 +289,7 @@ func getPodStatus(kubectlPath, kubeconfigPath string) (string, error) {
 
 	status := strings.TrimSpace(string(output))
 	if status == "" {
-		return "", fmt.Errorf("no pods found")
+		return "", errors.New("no pods found")
 	}
 
 	return strings.ToLower(status), nil
@@ -324,10 +334,12 @@ data:
 		"--kubeconfig", kubeconfigPath,
 		"apply", "-f", "-",
 	)
+
 	cmd.Stdin = strings.NewReader(manifest)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl apply failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+
 	return nil
 }
 
@@ -348,16 +360,19 @@ func EnsureTunnelForSell(cfg *config.Config, u *ui.UI) (string, error) {
 	if err := CreateStorefront(cfg, tunnelURL); err != nil {
 		u.Warnf("could not create storefront: %v", err)
 	}
+
 	return tunnelURL, nil
 }
 
 // Stop scales the cloudflared deployment to 0 replicas.
 func Stop(cfg *config.Config, u *ui.UI) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 		return nil // stack not running, nothing to stop
 	}
+
 	cmd := exec.Command(kubectlPath,
 		"--kubeconfig", kubeconfigPath,
 		"scale", "deployment/cloudflared",
@@ -367,7 +382,9 @@ func Stop(cfg *config.Config, u *ui.UI) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to scale cloudflared to 0: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+
 	u.Success("Tunnel stopped")
+
 	return nil
 }
 
@@ -382,6 +399,7 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 	if err != nil {
 		return fmt.Errorf("invalid tunnel URL: %w", err)
 	}
+
 	hostname := parsed.Hostname()
 
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
@@ -412,60 +430,60 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 </html>`, tunnelURL, tunnelURL)
 
 	// Build the resources as a multi-document YAML manifest.
-	resources := []map[string]interface{}{
+	resources := []map[string]any{
 		// ConfigMap with HTML content + httpd mime config.
 		{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "tunnel-storefront",
 				"namespace": storefrontNamespace,
 			},
 			"data": map[string]string{
-				"index.html":  html,
-				"httpd.conf":  "",
-				"mime.types":  "text/html\thtml htm\n",
+				"index.html": html,
+				"httpd.conf": "",
+				"mime.types": "text/html\thtml htm\n",
 			},
 		},
 		// Deployment: busybox httpd serving the ConfigMap.
 		{
 			"apiVersion": "apps/v1",
 			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "tunnel-storefront",
 				"namespace": storefrontNamespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"replicas": 1,
-				"selector": map[string]interface{}{
+				"selector": map[string]any{
 					"matchLabels": map[string]string{"app": "tunnel-storefront"},
 				},
-				"template": map[string]interface{}{
-					"metadata": map[string]interface{}{
+				"template": map[string]any{
+					"metadata": map[string]any{
 						"labels": map[string]string{"app": "tunnel-storefront"},
 					},
-					"spec": map[string]interface{}{
-						"containers": []map[string]interface{}{
+					"spec": map[string]any{
+						"containers": []map[string]any{
 							{
 								"name":    "httpd",
 								"image":   "busybox:1.37",
 								"command": []string{"httpd", "-f", "-p", "8080", "-h", "/www"},
-								"ports": []map[string]interface{}{
+								"ports": []map[string]any{
 									{"containerPort": 8080},
 								},
-								"volumeMounts": []map[string]interface{}{
+								"volumeMounts": []map[string]any{
 									{"name": "html", "mountPath": "/www"},
 								},
-								"resources": map[string]interface{}{
+								"resources": map[string]any{
 									"requests": map[string]string{"cpu": "5m", "memory": "8Mi"},
 									"limits":   map[string]string{"cpu": "20m", "memory": "16Mi"},
 								},
 							},
 						},
-						"volumes": []map[string]interface{}{
+						"volumes": []map[string]any{
 							{
 								"name": "html",
-								"configMap": map[string]interface{}{
+								"configMap": map[string]any{
 									"name": "tunnel-storefront",
 								},
 							},
@@ -478,13 +496,13 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 		{
 			"apiVersion": "v1",
 			"kind":       "Service",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "tunnel-storefront",
 				"namespace": storefrontNamespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"selector": map[string]string{"app": "tunnel-storefront"},
-				"ports": []map[string]interface{}{
+				"ports": []map[string]any{
 					{"port": 8080, "targetPort": 8080},
 				},
 			},
@@ -493,25 +511,25 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 		{
 			"apiVersion": "gateway.networking.k8s.io/v1",
 			"kind":       "HTTPRoute",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "tunnel-storefront",
 				"namespace": storefrontNamespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"hostnames": []string{hostname},
-				"parentRefs": []map[string]interface{}{
+				"parentRefs": []map[string]any{
 					{
 						"name":        "traefik-gateway",
 						"namespace":   "traefik",
 						"sectionName": "web",
 					},
 				},
-				"rules": []map[string]interface{}{
+				"rules": []map[string]any{
 					{
-						"matches": []map[string]interface{}{
+						"matches": []map[string]any{
 							{"path": map[string]string{"type": "PathPrefix", "value": "/"}},
 						},
-						"backendRefs": []map[string]interface{}{
+						"backendRefs": []map[string]any{
 							{
 								"name": "tunnel-storefront",
 								"port": 8080,
@@ -529,21 +547,25 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal resource: %w", err)
 		}
+
 		cmd := exec.Command(kubectlPath,
 			"--kubeconfig", kubeconfigPath,
 			"apply", "-f", "-",
 		)
+
 		cmd.Stdin = strings.NewReader(string(data))
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("failed to apply storefront resource: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 	}
+
 	return nil
 }
 
 // DeleteStorefront removes the storefront landing page resources.
 func DeleteStorefront(cfg *config.Config) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 		return nil
@@ -563,6 +585,7 @@ func DeleteStorefront(cfg *config.Config) error {
 		)
 		_ = cmd.Run() // best-effort cleanup
 	}
+
 	return nil
 }
 
@@ -572,5 +595,6 @@ func parseQuickTunnelURL(logs string) (string, bool) {
 	if url := re.FindString(logs); url != "" {
 		return url, true
 	}
+
 	return "", false
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -76,7 +76,7 @@ func Status(cfg *config.Config, u *ui.UI) error {
 			u.Print("  - Check logs: obol tunnel logs")
 			u.Print("  - Restart tunnel: obol tunnel restart")
 
-			return nil
+			return nil //nolint:nilerr // URL unavailable is a display-only issue; show troubleshooting hints instead
 		}
 
 		url = tunnelURL

--- a/internal/tunnel/tunnel_lifecycle_test.go
+++ b/internal/tunnel/tunnel_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 func testConfig(t *testing.T) *config.Config {
 	t.Helper()
 	dir := t.TempDir()
+
 	return &config.Config{
 		ConfigDir: filepath.Join(dir, "config"),
 		DataDir:   filepath.Join(dir, "data"),
@@ -39,12 +40,15 @@ func TestTunnelState_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+
 	if got.Mode != "quick" {
 		t.Errorf("mode = %q, want quick", got.Mode)
 	}
+
 	if got.Hostname != "abc-def.trycloudflare.com" {
 		t.Errorf("hostname = %q, want abc-def.trycloudflare.com", got.Hostname)
 	}
+
 	if got.UpdatedAt.IsZero() {
 		t.Error("UpdatedAt should be set by save")
 	}
@@ -70,9 +74,11 @@ func TestTunnelState_DNSMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+
 	if got.Mode != "dns" {
 		t.Errorf("mode = %q, want dns", got.Mode)
 	}
+
 	if got.TunnelID != "tun-789" {
 		t.Errorf("tunnel_id = %q, want tun-789", got.TunnelID)
 	}
@@ -85,6 +91,7 @@ func TestTunnelState_NotExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load should not error on missing file: %v", err)
 	}
+
 	if got != nil {
 		t.Fatalf("expected nil state for missing file, got %+v", got)
 	}
@@ -107,6 +114,7 @@ func TestTunnelState_Overwrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+
 	if got.Mode != "dns" || got.Hostname != "new.example.com" {
 		t.Errorf("expected overwritten state, got %+v", got)
 	}
@@ -124,8 +132,9 @@ func TestTunnelState_FilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
+
 	perm := info.Mode().Perm()
-	if perm != 0600 {
+	if perm != 0o600 {
 		t.Errorf("file permissions = %o, want 0600", perm)
 	}
 }
@@ -167,6 +176,7 @@ func TestTunnelModeAndURL(t *testing.T) {
 			if mode != tt.wantMode {
 				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
 			}
+
 			if url != tt.wantURL {
 				t.Errorf("url = %q, want %q", url, tt.wantURL)
 			}
@@ -268,6 +278,7 @@ func TestLoadTunnelState_Exported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTunnelState: %v", err)
 	}
+
 	if st.Hostname != "exported-test.trycloudflare.com" {
 		t.Errorf("hostname = %q, want exported-test.trycloudflare.com", st.Hostname)
 	}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -36,6 +36,7 @@ func TestParseQuickTunnelURL(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected ok=true")
 	}
+
 	if url != "https://seasonal-deck-organisms-sf.trycloudflare.com" {
 		t.Fatalf("unexpected url: %q", url)
 	}
@@ -52,7 +53,7 @@ func TestPatchAgentBaseURL_Insert(t *testing.T) {
 skills:
   enabled: false
 `
-	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,9 +67,11 @@ skills:
 	if !strings.Contains(content, "name: AGENT_BASE_URL") {
 		t.Errorf("patched file missing AGENT_BASE_URL:\n%s", content)
 	}
+
 	if !strings.Contains(content, "value: https://mystack.example.com") {
 		t.Errorf("patched file missing tunnel URL value:\n%s", content)
 	}
+
 	if !strings.Contains(content, "REMOTE_SIGNER_URL") {
 		t.Errorf("patched file lost REMOTE_SIGNER_URL:\n%s", content)
 	}
@@ -87,7 +90,7 @@ func TestPatchAgentBaseURL_Update(t *testing.T) {
 skills:
   enabled: false
 `
-	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,6 +104,7 @@ skills:
 	if !strings.Contains(content, "value: https://new.example.com") {
 		t.Errorf("patched file missing updated URL:\n%s", content)
 	}
+
 	if strings.Contains(content, "old.example.com") {
 		t.Errorf("patched file still has old URL:\n%s", content)
 	}

--- a/internal/ui/errors.go
+++ b/internal/ui/errors.go
@@ -8,6 +8,7 @@ import "fmt"
 //	  Hint: check your configuration
 func (u *UI) FormatError(err error, hint string) {
 	u.Error(err.Error())
+
 	if hint != "" {
 		fmt.Fprintf(u.stderr, "  %s\n", dimStyle.Render(hint))
 	}
@@ -19,6 +20,7 @@ func (u *UI) FormatError(err error, hint string) {
 //	  Run: obol stack up
 func (u *UI) FormatActionableError(err error, action string) {
 	u.Error(err.Error())
+
 	if action != "" {
 		fmt.Fprintf(u.stderr, "  Run: %s\n", boldStyle.Render(action))
 	}

--- a/internal/ui/exec.go
+++ b/internal/ui/exec.go
@@ -43,9 +43,11 @@ func (u *UI) Exec(cfg ExecConfig) error {
 	if cfg.Interactive {
 		return u.execInteractive(cfg)
 	}
+
 	if u.verbose {
 		return u.execVerbose(cfg)
 	}
+
 	return u.execCaptured(cfg)
 }
 
@@ -53,6 +55,7 @@ func (u *UI) Exec(cfg ExecConfig) error {
 // Stderr is captured and shown on error.
 func (u *UI) ExecOutput(cfg ExecConfig) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
+
 	cfg.Cmd.Stdout = &stdout
 	cfg.Cmd.Stderr = &stderr
 
@@ -64,34 +67,41 @@ func (u *UI) ExecOutput(cfg ExecConfig) ([]byte, error) {
 		if combined != "" {
 			u.dumpCapturedOutput(combined)
 		}
+
 		return nil, err
 	}
+
 	return stdout.Bytes(), nil
 }
 
 func (u *UI) execInteractive(cfg ExecConfig) error {
 	u.Infof("%s ...", cfg.Name)
+
 	if cfg.Cmd.Stdin == nil {
 		cfg.Cmd.Stdin = os.Stdin
 	}
+
 	if cfg.Cmd.Stdout == nil {
 		cfg.Cmd.Stdout = os.Stdout
 	}
+
 	if cfg.Cmd.Stderr == nil {
 		cfg.Cmd.Stderr = os.Stderr
 	}
+
 	err := cfg.Cmd.Run()
 	if err == nil {
 		u.Successf("%s", cfg.Name)
 	} else {
 		u.Errorf("%s", cfg.Name)
 	}
+
 	return err
 }
 
-
 func (u *UI) execCaptured(cfg ExecConfig) error {
 	var buf bytes.Buffer
+
 	cfg.Cmd.Stdout = &buf
 	cfg.Cmd.Stderr = &buf
 
@@ -101,6 +111,7 @@ func (u *UI) execCaptured(cfg ExecConfig) error {
 	if err != nil && buf.Len() > 0 {
 		u.dumpCapturedOutput(buf.String())
 	}
+
 	return err
 }
 
@@ -120,8 +131,10 @@ func (u *UI) execVerbose(cfg ExecConfig) error {
 
 	streamLines := func(r io.Reader) {
 		defer wg.Done()
+
 		scanner := bufio.NewScanner(r)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
 		for scanner.Scan() {
 			fmt.Fprintf(u.stdout, "%s%s\n", prefix, scanner.Text())
 		}
@@ -131,6 +144,7 @@ func (u *UI) execVerbose(cfg ExecConfig) error {
 	go streamLines(stderrPipe)
 
 	err := cfg.Cmd.Run()
+
 	stdoutW.Close()
 	stderrW.Close()
 	wg.Wait()
@@ -140,11 +154,13 @@ func (u *UI) execVerbose(cfg ExecConfig) error {
 	} else {
 		u.Errorf("%s", cfg.Name)
 	}
+
 	return err
 }
 
 func (u *UI) dumpCapturedOutput(output string) {
 	separator := dimStyle.Render("  ───────────────────────")
+
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, dimStyle.Render("  Output:"))
 	fmt.Fprintln(os.Stderr, separator)

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -22,6 +22,7 @@ func (u *UI) Info(msg string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintf(u.stdout, "%s %s\n", infoStyle.Render("==>"), msg)
 }
 
@@ -35,6 +36,7 @@ func (u *UI) Success(msg string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintf(u.stdout, "  %s %s\n", successStyle.Render("✓"), msg)
 }
 
@@ -70,6 +72,7 @@ func (u *UI) Print(msg string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintln(u.stdout, msg)
 }
 
@@ -78,6 +81,7 @@ func (u *UI) Printf(format string, args ...any) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintf(u.stdout, format+"\n", args...)
 }
 
@@ -86,6 +90,7 @@ func (u *UI) Detail(key, value string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintf(u.stdout, "  %s: %s\n", dimStyle.Render(key), value)
 }
 
@@ -94,6 +99,7 @@ func (u *UI) Dim(msg string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintln(u.stdout, dimStyle.Render(msg))
 }
 
@@ -102,6 +108,7 @@ func (u *UI) Bold(msg string) {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintln(u.stdout, boldStyle.Render(msg))
 }
 
@@ -110,5 +117,6 @@ func (u *UI) Blank() {
 	if u.quiet {
 		return
 	}
+
 	fmt.Fprintln(u.stdout)
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -17,6 +17,7 @@ func (u *UI) Confirm(msg string, defaultYes bool) bool {
 	if defaultYes {
 		suffix = "[Y/n]"
 	}
+
 	fmt.Fprintf(u.stdout, "%s %s ", msg, dimStyle.Render(suffix))
 
 	reader := bufio.NewReader(os.Stdin)
@@ -26,6 +27,7 @@ func (u *UI) Confirm(msg string, defaultYes bool) bool {
 	if line == "" {
 		return defaultYes
 	}
+
 	return line == "y" || line == "yes"
 }
 
@@ -33,11 +35,13 @@ func (u *UI) Confirm(msg string, defaultYes bool) bool {
 // defaultIdx is 0-based; shown as [default] next to that option.
 func (u *UI) Select(msg string, options []string, defaultIdx int) (int, error) {
 	fmt.Fprintln(u.stdout, msg)
+
 	for i, opt := range options {
 		marker := "  "
 		if i == defaultIdx {
 			marker = accentStyle.Render("→ ")
 		}
+
 		fmt.Fprintf(u.stdout, "  %s%s%s %s\n",
 			marker,
 			accentStyle.Render("["),
@@ -60,6 +64,7 @@ func (u *UI) Select(msg string, options []string, defaultIdx int) (int, error) {
 	if err != nil || choice < 1 || choice > len(options) {
 		return 0, fmt.Errorf("invalid selection: %s", line)
 	}
+
 	return choice - 1, nil
 }
 
@@ -72,24 +77,31 @@ func (u *UI) Input(msg string, defaultVal string) (string, error) {
 	}
 
 	reader := bufio.NewReader(os.Stdin)
+
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return "", err
 	}
+
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return defaultVal, nil
 	}
+
 	return line, nil
 }
 
 // SecretInput reads input without echoing (for API keys, passwords).
 func (u *UI) SecretInput(msg string) (string, error) {
 	fmt.Fprintf(u.stdout, "%s: ", msg)
+
 	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+
 	fmt.Fprintln(u.stdout) // newline after hidden input
+
 	if err != nil {
 		return "", err
 	}
+
 	return strings.TrimSpace(string(b)), nil
 }

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -18,11 +18,14 @@ func (u *UI) RunWithSpinner(msg string, fn func() error) error {
 
 	if !u.isTTY || u.verbose {
 		u.Info(msg)
+
 		err := fn()
+
 		elapsed := time.Since(start).Round(time.Second)
 		if err == nil {
 			u.Successf("%s (%s)", msg, elapsed)
 		}
+
 		return err
 	}
 
@@ -30,9 +33,11 @@ func (u *UI) RunWithSpinner(msg string, fn func() error) error {
 	u.mu.Lock()
 	done := make(chan struct{})
 	frame := 0
+
 	go func() {
 		ticker := time.NewTicker(80 * time.Millisecond)
 		defer ticker.Stop()
+
 		for {
 			select {
 			case <-done:
@@ -51,6 +56,7 @@ func (u *UI) RunWithSpinner(msg string, fn func() error) error {
 	u.mu.Unlock()
 
 	err := fn()
+
 	close(done)
 
 	elapsed := time.Since(start).Round(time.Second)
@@ -65,5 +71,6 @@ func (u *UI) RunWithSpinner(msg string, fn func() error) error {
 	} else {
 		u.Errorf("%s", msg)
 	}
+
 	return err
 }

--- a/internal/ui/suggest.go
+++ b/internal/ui/suggest.go
@@ -15,10 +15,12 @@ func (u *UI) SuggestCommand(app *cli.App, command string) {
 	if len(suggestions) > 0 {
 		fmt.Fprintln(u.stderr)
 		fmt.Fprintln(u.stderr, "Did you mean?")
+
 		for _, s := range suggestions {
 			fmt.Fprintf(u.stderr, "  obol %s\n", boldStyle.Render(s))
 		}
 	}
+
 	fmt.Fprintln(u.stderr)
 	u.Dim("Run 'obol --help' for a list of commands")
 }
@@ -27,10 +29,12 @@ func (u *UI) SuggestCommand(app *cli.App, command string) {
 // distance of the input, searching recursively through subcommands.
 func findSimilarCommands(commands []*cli.Command, input string, maxDist int) []string {
 	var results []string
+
 	for _, cmd := range commands {
 		if cmd.Hidden {
 			continue
 		}
+
 		dist := levenshtein(input, cmd.Name)
 		if dist > 0 && dist <= maxDist {
 			results = append(results, cmd.Name)
@@ -44,6 +48,7 @@ func findSimilarCommands(commands []*cli.Command, input string, maxDist int) []s
 			}
 		}
 	}
+
 	return results
 }
 
@@ -53,6 +58,7 @@ func levenshtein(a, b string) int {
 	if la == 0 {
 		return lb
 	}
+
 	if lb == 0 {
 		return la
 	}
@@ -66,18 +72,22 @@ func levenshtein(a, b string) int {
 	for i := 1; i <= la; i++ {
 		curr := make([]int, lb+1)
 		curr[0] = i
+
 		for j := 1; j <= lb; j++ {
 			cost := 1
 			if a[i-1] == b[j-1] {
 				cost = 0
 			}
+
 			curr[j] = min(
 				prev[j]+1,      // deletion
 				curr[j-1]+1,    // insertion
 				prev[j-1]+cost, // substitution
 			)
 		}
+
 		prev = curr
 	}
+
 	return prev[lb]
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -39,6 +39,7 @@ func New(verbose bool) *UI {
 func NewWithOptions(verbose, quiet bool) *UI {
 	u := New(verbose)
 	u.quiet = quiet
+
 	return u
 }
 

--- a/internal/update/charts.go
+++ b/internal/update/charts.go
@@ -136,9 +136,9 @@ func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 
 		if CompareVersions(rel.Version, latest) < 0 {
 			if MajorVersion(latest) != MajorVersion(rel.Version) {
-				status = "Major update available"
+				status = statusMajorUpdateAvailable
 			} else {
-				status = "Update available"
+				status = statusUpdateAvailable
 			}
 		}
 

--- a/internal/update/charts.go
+++ b/internal/update/charts.go
@@ -14,10 +14,10 @@ import (
 
 // ChartStatus represents the update status of a single helm chart
 type ChartStatus struct {
-	Chart   string // e.g., "traefik/traefik"
-	Pinned  string // Currently pinned version, e.g., "38.0.2"
-	Latest  string // Latest available in repo
-	Status  string // "Up to date", "Update available", "Local chart", "Unpinned"
+	Chart  string // e.g., "traefik/traefik"
+	Pinned string // Currently pinned version, e.g., "38.0.2"
+	Latest string // Latest available in repo
+	Status string // "Up to date", "Update available", "Local chart", "Unpinned"
 }
 
 // helmfileRelease is a subset of a helmfile release entry
@@ -46,15 +46,18 @@ func UpdateHelmRepos(cfg *config.Config, quiet bool) error {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	cmd := exec.Command(helmBinary, "repo", "update")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 	if !quiet {
 		cmd.Stdout = os.Stdout
 	}
+
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("helm repo update failed: %w", err)
 	}
+
 	return nil
 }
 
@@ -62,11 +65,13 @@ func UpdateHelmRepos(cfg *config.Config, quiet bool) error {
 // for pinned chart versions and compares each against the latest available via `helm search repo`.
 func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 	var releases []helmfileRelease
+
 	for _, hf := range collectHelmfiles(cfg) {
 		rels, err := parseHelmfileReleases(hf)
 		if err != nil {
 			continue // best-effort: skip unreadable instance helmfiles
 		}
+
 		releases = append(releases, rels...)
 	}
 
@@ -75,16 +80,20 @@ func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 
 	// Deduplicate releases by chart name (e.g., bedag/raw appears multiple times)
 	seen := make(map[string]bool)
+
 	var uniqueReleases []helmfileRelease
+
 	for _, rel := range releases {
 		if seen[rel.Chart] {
 			continue
 		}
+
 		seen[rel.Chart] = true
 		uniqueReleases = append(uniqueReleases, rel)
 	}
 
 	var statuses []ChartStatus
+
 	for _, rel := range uniqueReleases {
 		// Skip local charts
 		if strings.HasPrefix(rel.Chart, "./") || strings.HasPrefix(rel.Chart, "/") {
@@ -94,6 +103,7 @@ func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 				Latest: "-",
 				Status: "Local chart",
 			})
+
 			continue
 		}
 
@@ -105,6 +115,7 @@ func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 				Latest: "-",
 				Status: "Unpinned",
 			})
+
 			continue
 		}
 
@@ -117,10 +128,12 @@ func CheckChartVersions(cfg *config.Config) ([]ChartStatus, error) {
 				Latest: "?",
 				Status: "Check failed",
 			})
+
 			continue
 		}
 
 		status := "Up to date"
+
 		if CompareVersions(rel.Version, latest) < 0 {
 			if MajorVersion(latest) != MajorVersion(rel.Version) {
 				status = "Major update available"
@@ -159,6 +172,7 @@ func UpgradeHelmfileVersions(cfg *config.Config, major bool, chartFilter string)
 
 	// Track which charts we've already reported (dedup across helmfiles).
 	reported := make(map[string]bool)
+
 	var allBumps []VersionBump
 
 	for _, helmfilePath := range collectHelmfiles(cfg) {
@@ -166,12 +180,14 @@ func UpgradeHelmfileVersions(cfg *config.Config, major bool, chartFilter string)
 		if err != nil {
 			continue // best-effort: skip unreadable instance helmfiles
 		}
+
 		allBumps = append(allBumps, bumps...)
 	}
 
 	if len(allBumps) == 0 {
 		return nil, nil
 	}
+
 	return allBumps, nil
 }
 
@@ -188,23 +204,28 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, err
 	}
+
 	if len(doc.Content) == 0 {
 		return nil, nil
 	}
+
 	root := doc.Content[0]
 
 	var releasesNode *yaml.Node
+
 	for i := 0; i < len(root.Content)-1; i += 2 {
 		if root.Content[i].Value == "releases" {
 			releasesNode = root.Content[i+1]
 			break
 		}
 	}
+
 	if releasesNode == nil {
 		return nil, nil
 	}
 
 	var bumps []VersionBump
+
 	changed := false
 
 	for _, releaseNode := range releasesNode.Content {
@@ -212,8 +233,11 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 			continue
 		}
 
-		var releaseName, chartValue string
-		var versionNode *yaml.Node
+		var (
+			releaseName, chartValue string
+			versionNode             *yaml.Node
+		)
+
 		for i := 0; i < len(releaseNode.Content)-1; i += 2 {
 			switch releaseNode.Content[i].Value {
 			case "name":
@@ -228,9 +252,11 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 		if chartValue == "" || strings.HasPrefix(chartValue, "./") || strings.HasPrefix(chartValue, "/") {
 			continue
 		}
+
 		if chartFilter != "" && !matchesFilter(chartFilter, releaseName, chartValue) {
 			continue
 		}
+
 		if versionNode == nil || reported[chartValue] {
 			continue
 		}
@@ -244,6 +270,7 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 		if CompareVersions(currentVersion, latest) >= 0 {
 			continue
 		}
+
 		if !major && MajorVersion(latest) != MajorVersion(currentVersion) {
 			continue
 		}
@@ -253,8 +280,12 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 			if rn.Kind != yaml.MappingNode {
 				continue
 			}
-			var rnChart string
-			var rnVersion *yaml.Node
+
+			var (
+				rnChart   string
+				rnVersion *yaml.Node
+			)
+
 			for i := 0; i < len(rn.Content)-1; i += 2 {
 				switch rn.Content[i].Value {
 				case "chart":
@@ -263,6 +294,7 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 					rnVersion = rn.Content[i+1]
 				}
 			}
+
 			if rnChart == chartValue && rnVersion != nil {
 				rnVersion.Value = latest
 			}
@@ -270,6 +302,7 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 
 		reported[chartValue] = true
 		changed = true
+
 		bumps = append(bumps, VersionBump{
 			Chart: chartValue,
 			From:  currentVersion,
@@ -285,7 +318,8 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(helmfilePath, out, 0644); err != nil {
+
+	if err := os.WriteFile(helmfilePath, out, 0o644); err != nil {
 		return nil, err
 	}
 
@@ -299,28 +333,34 @@ func collectHelmfiles(cfg *config.Config) []string {
 	paths := []string{filepath.Join(cfg.ConfigDir, "defaults", "helmfile.yaml")}
 
 	appsDir := filepath.Join(cfg.ConfigDir, "applications")
+
 	appDirs, err := os.ReadDir(appsDir)
 	if err != nil {
 		return paths
 	}
+
 	for _, appDir := range appDirs {
 		if !appDir.IsDir() {
 			continue
 		}
+
 		instances, err := os.ReadDir(filepath.Join(appsDir, appDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, inst := range instances {
 			if !inst.IsDir() {
 				continue
 			}
+
 			hf := filepath.Join(appsDir, appDir.Name(), inst.Name(), "helmfile.yaml")
 			if _, err := os.Stat(hf); err == nil {
 				paths = append(paths, hf)
 			}
 		}
 	}
+
 	return paths
 }
 
@@ -346,6 +386,7 @@ func ParseHelmfileReleasesFromBytes(data []byte) ([]helmfileRelease, error) {
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("failed to parse helmfile YAML: %w", err)
 	}
+
 	return doc.Releases, nil
 }
 
@@ -362,24 +403,28 @@ func matchesFilter(filter, releaseName, chartName string) bool {
 // Returns nil if no matches are found.
 func ResolveReleaseNames(cfg *config.Config, filter string) []string {
 	helmfilePath := filepath.Join(cfg.ConfigDir, "defaults", "helmfile.yaml")
+
 	releases, err := parseHelmfileReleases(helmfilePath)
 	if err != nil {
 		return nil
 	}
 
 	var names []string
+
 	for _, rel := range releases {
 		if matchesFilter(filter, rel.Name, rel.Chart) {
 			names = append(names, rel.Name)
 		}
 	}
+
 	return names
 }
 
 // helmSearchLatest queries helm for the latest version of a chart.
 func helmSearchLatest(helmBinary, kubeconfigPath, chart string) (string, error) {
 	cmd := exec.Command(helmBinary, "search", "repo", chart, "--output", "json")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/update/charts.go
+++ b/internal/update/charts.go
@@ -319,7 +319,7 @@ func upgradeOneHelmfile(helmfilePath, helmBinary, kubeconfigPath string, major b
 		return nil, err
 	}
 
-	if err := os.WriteFile(helmfilePath, out, 0o644); err != nil {
+	if err := os.WriteFile(helmfilePath, out, 0o600); err != nil {
 		return nil, err
 	}
 

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -37,7 +38,7 @@ func CheckLatestRelease() (*LatestRelease, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, fmt.Errorf("GitHub API rate limit reached, try again later")
+		return nil, errors.New("GitHub API rate limit reached, try again later")
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -64,14 +65,16 @@ func CompareVersions(current, latest string) int {
 	currentParts := parseSemver(current)
 	latestParts := parseSemver(latest)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if currentParts[i] < latestParts[i] {
 			return -1
 		}
+
 		if currentParts[i] > latestParts[i] {
 			return 1
 		}
 	}
+
 	return 0
 }
 
@@ -91,10 +94,13 @@ func parseSemver(v string) [3]int {
 	}
 
 	parts := strings.Split(v, ".")
+
 	var result [3]int
+
 	for i := 0; i < 3 && i < len(parts); i++ {
 		n, _ := strconv.Atoi(parts[i])
 		result[i] = n
 	}
+
 	return result
 }

--- a/internal/update/hint.go
+++ b/internal/update/hint.go
@@ -22,6 +22,7 @@ func HintIfStale(cfg *config.Config) {
 
 	// Read on-disk helmfile
 	onDiskPath := filepath.Join(cfg.ConfigDir, "defaults", "helmfile.yaml")
+
 	onDiskData, err := os.ReadFile(onDiskPath)
 	if err != nil {
 		return
@@ -32,6 +33,7 @@ func HintIfStale(cfg *config.Config) {
 	if err != nil {
 		return
 	}
+
 	onDiskReleases, err := ParseHelmfileReleasesFromBytes(onDiskData)
 	if err != nil {
 		return
@@ -39,6 +41,7 @@ func HintIfStale(cfg *config.Config) {
 
 	// Build map of on-disk chart versions
 	onDiskVersions := make(map[string]string)
+
 	for _, rel := range onDiskReleases {
 		if rel.Version != "" && !strings.HasPrefix(rel.Chart, "./") {
 			onDiskVersions[rel.Chart] = rel.Version
@@ -50,12 +53,14 @@ func HintIfStale(cfg *config.Config) {
 		if rel.Version == "" || strings.HasPrefix(rel.Chart, "./") {
 			continue
 		}
+
 		onDiskVer, ok := onDiskVersions[rel.Chart]
 		if !ok {
 			// New chart in embedded that doesn't exist on disk
 			fmt.Println("\nHint: Some stack components have updates available. Run 'obol upgrade' to apply.")
 			return
 		}
+
 		if CompareVersions(onDiskVer, rel.Version) < 0 {
 			fmt.Println("\nHint: Some stack components have updates available. Run 'obol upgrade' to apply.")
 			return

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -16,6 +16,11 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/version"
 )
 
+const (
+	statusUpdateAvailable      = "Update available"
+	statusMajorUpdateAvailable = "Major update available"
+)
+
 // UpdateResult holds the complete results of an update check
 type UpdateResult struct {
 	HelmRepoUpdated        bool
@@ -57,9 +62,9 @@ func CheckForUpdates(cfg *config.Config, clusterRunning bool, quiet bool) (*Upda
 			result.ChartStatuses = statuses
 			for _, s := range statuses {
 				switch s.Status {
-				case "Update available":
+				case statusUpdateAvailable:
 					result.ChartUpdatesAvail = true
-				case "Major update available":
+				case statusMajorUpdateAvailable:
 					result.ChartMajorUpdatesAvail = true
 				}
 			}
@@ -251,7 +256,7 @@ func checkSkippedMajorUpdates(cfg *config.Config) []VersionBump {
 	var skipped []VersionBump
 
 	for _, s := range statuses {
-		if s.Status == "Major update available" {
+		if s.Status == statusMajorUpdateAvailable {
 			skipped = append(skipped, VersionBump{
 				Chart: s.Chart,
 				From:  s.Pinned,
@@ -409,7 +414,7 @@ func PrintCLIStatus(u *ui.UI, current string, release *LatestRelease, isDev bool
 
 	status := "Up to date"
 	if CompareVersions(current, release.Version) < 0 {
-		status = "Update available"
+		status = statusUpdateAvailable
 	}
 
 	u.Printf("  Obol CLI  %-10s  %-10s  %s", currentDisplay, release.TagName, status)
@@ -431,7 +436,7 @@ func PrintUpdateSummary(u *ui.UI, result *UpdateResult) {
 		count := 0
 
 		for _, s := range result.ChartStatuses {
-			if s.Status == "Update available" {
+			if s.Status == statusUpdateAvailable {
 				count++
 			}
 		}
@@ -443,7 +448,7 @@ func PrintUpdateSummary(u *ui.UI, result *UpdateResult) {
 		count := 0
 
 		for _, s := range result.ChartStatuses {
-			if s.Status == "Major update available" {
+			if s.Status == statusMajorUpdateAvailable {
 				count++
 			}
 		}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -56,9 +56,10 @@ func CheckForUpdates(cfg *config.Config, clusterRunning bool, quiet bool) (*Upda
 		} else {
 			result.ChartStatuses = statuses
 			for _, s := range statuses {
-				if s.Status == "Update available" {
+				switch s.Status {
+				case "Update available":
 					result.ChartUpdatesAvail = true
-				} else if s.Status == "Major update available" {
+				case "Major update available":
 					result.ChartMajorUpdatesAvail = true
 				}
 			}
@@ -98,34 +99,41 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 
 	// 1. Helm repo update
 	u.Info("Updating helm repositories...")
+
 	if err := UpdateHelmRepos(cfg, false); err != nil {
 		return fmt.Errorf("failed to update helm repos: %w", err)
 	}
+
 	u.Success("Helm repositories updated")
 
 	// 2. Re-copy embedded defaults to pick up new chart versions from binary
 	u.Blank()
 	u.Info("Refreshing default infrastructure templates...")
+
 	ollamaHost := "host.k3d.internal"
 	if runtime.GOOS == "darwin" {
 		ollamaHost = "host.docker.internal"
 	}
+
 	defaultsDir := filepath.Join(cfg.ConfigDir, "defaults")
 	if err := embed.CopyDefaults(defaultsDir, map[string]string{
 		"{{OLLAMA_HOST}}": ollamaHost,
 	}); err != nil {
 		return fmt.Errorf("failed to refresh defaults: %w", err)
 	}
+
 	u.Success("Defaults updated from embedded assets")
 
 	// 3. Bump chart version pins to latest (unless --pinned)
 	if !pinned {
 		u.Blank()
+
 		if major {
 			u.Info("Bumping chart versions to latest (including major versions)...")
 		} else {
 			u.Info("Bumping chart versions to latest (minor/patch only)...")
 		}
+
 		bumps, err := UpgradeHelmfileVersions(cfg, major, opts.ChartFilter)
 		if err != nil {
 			u.Warnf("Failed to bump versions: %v", err)
@@ -143,9 +151,11 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 			if len(skipped) > 0 {
 				u.Blank()
 				u.Warn("Major version updates available (skipped):")
+
 				for _, s := range skipped {
 					u.Printf("    %s: %s → %s", s.Chart, s.From, s.To)
 				}
+
 				u.Dim("  Use 'obol upgrade --major' to apply major version updates.")
 			}
 		}
@@ -156,6 +166,7 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 
 	// 4. Helmfile sync on defaults
 	u.Blank()
+
 	helmfilePath := filepath.Join(defaultsDir, "helmfile.yaml")
 	helmfileArgs := []string{
 		"--file", helmfilePath,
@@ -169,6 +180,7 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 		if len(releaseNames) == 0 {
 			return fmt.Errorf("no release found matching %q in defaults helmfile", opts.ChartFilter)
 		}
+
 		for _, name := range releaseNames {
 			helmfileArgs = append(helmfileArgs, "--selector", "name="+name)
 		}
@@ -179,12 +191,14 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 		filepath.Join(cfg.BinDir, "helmfile"),
 		helmfileArgs...,
 	)
+
 	helmfileCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 
 	label := "Upgrading default infrastructure"
 	if opts.ChartFilter != "" {
-		label = fmt.Sprintf("Upgrading %s", opts.ChartFilter)
+		label = "Upgrading " + opts.ChartFilter
 	}
+
 	if err := u.Exec(ui.ExecConfig{Name: label, Cmd: helmfileCmd}); err != nil {
 		return fmt.Errorf("failed to upgrade default infrastructure: %w", err)
 	}
@@ -194,6 +208,7 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 		// 5. Re-sync installed networks
 		u.Blank()
 		u.Info("Upgrading installed networks...")
+
 		if err := upgradeNetworks(cfg, u); err != nil {
 			u.Warnf("%v", err)
 		}
@@ -201,6 +216,7 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 		// 6. Re-sync installed apps
 		u.Blank()
 		u.Info("Upgrading installed apps...")
+
 		if err := upgradeApps(cfg, u); err != nil {
 			u.Warnf("%v", err)
 		}
@@ -231,7 +247,9 @@ func checkSkippedMajorUpdates(cfg *config.Config) []VersionBump {
 	if err != nil {
 		return nil
 	}
+
 	var skipped []VersionBump
+
 	for _, s := range statuses {
 		if s.Status == "Major update available" {
 			skipped = append(skipped, VersionBump{
@@ -241,6 +259,7 @@ func checkSkippedMajorUpdates(cfg *config.Config) []VersionBump {
 			})
 		}
 	}
+
 	return skipped
 }
 
@@ -258,25 +277,31 @@ func upgradeNetworks(cfg *config.Config, u *ui.UI) error {
 	}
 
 	found := false
+
 	for _, netDir := range networkDirs {
 		if !netDir.IsDir() {
 			continue
 		}
+
 		deployments, err := os.ReadDir(filepath.Join(networksDir, netDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, dep := range deployments {
 			if !dep.IsDir() {
 				continue
 			}
+
 			identifier := fmt.Sprintf("%s/%s", netDir.Name(), dep.Name())
 			u.Printf("  Syncing %s...", identifier)
+
 			if err := network.Sync(cfg, u, identifier); err != nil {
 				u.Warnf("Failed to sync %s: %v", identifier, err)
 			} else {
 				u.Successf("%s upgraded", identifier)
 			}
+
 			found = true
 		}
 	}
@@ -284,6 +309,7 @@ func upgradeNetworks(cfg *config.Config, u *ui.UI) error {
 	if !found {
 		u.Dim("  No networks installed.")
 	}
+
 	return nil
 }
 
@@ -301,25 +327,31 @@ func upgradeApps(cfg *config.Config, u *ui.UI) error {
 	}
 
 	found := false
+
 	for _, appDir := range appDirs {
 		if !appDir.IsDir() {
 			continue
 		}
+
 		deployments, err := os.ReadDir(filepath.Join(appsDir, appDir.Name()))
 		if err != nil {
 			continue
 		}
+
 		for _, dep := range deployments {
 			if !dep.IsDir() {
 				continue
 			}
+
 			identifier := fmt.Sprintf("%s/%s", appDir.Name(), dep.Name())
 			u.Printf("  Syncing %s...", identifier)
+
 			if err := app.Sync(cfg, u, identifier); err != nil {
 				u.Warnf("Failed to sync %s: %v", identifier, err)
 			} else {
 				u.Successf("%s upgraded", identifier)
 			}
+
 			found = true
 		}
 	}
@@ -327,6 +359,7 @@ func upgradeApps(cfg *config.Config, u *ui.UI) error {
 	if !found {
 		u.Dim("  No apps installed.")
 	}
+
 	return nil
 }
 
@@ -342,9 +375,11 @@ func PrintUpdateTable(u *ui.UI, statuses []ChartStatus) {
 		if len(s.Chart) > chartW {
 			chartW = len(s.Chart)
 		}
+
 		if len(s.Pinned) > pinnedW {
 			pinnedW = len(s.Pinned)
 		}
+
 		if len(s.Latest) > latestW {
 			latestW = len(s.Latest)
 		}
@@ -364,15 +399,19 @@ func PrintCLIStatus(u *ui.UI, current string, release *LatestRelease, isDev bool
 	if release == nil {
 		return
 	}
+
 	if isDev {
 		u.Printf("  Obol CLI  %-10s  %-10s  Development build (skipped)", "dev", release.TagName)
 		return
 	}
+
 	currentDisplay := "v" + strings.TrimPrefix(current, "v")
+
 	status := "Up to date"
 	if CompareVersions(current, release.Version) < 0 {
 		status = "Update available"
 	}
+
 	u.Printf("  Obol CLI  %-10s  %-10s  %s", currentDisplay, release.TagName, status)
 }
 
@@ -381,29 +420,37 @@ func PrintUpdateSummary(u *ui.UI, result *UpdateResult) {
 	if !result.ChartUpdatesAvail && !result.ChartMajorUpdatesAvail && !result.CLIUpdateAvail {
 		u.Blank()
 		u.Success("Everything is up to date.")
+
 		return
 	}
 
 	u.Blank()
 	u.Info("Summary:")
+
 	if result.ChartUpdatesAvail {
 		count := 0
+
 		for _, s := range result.ChartStatuses {
 			if s.Status == "Update available" {
 				count++
 			}
 		}
+
 		u.Printf("  %d chart update(s) available. Run 'obol upgrade' to apply.", count)
 	}
+
 	if result.ChartMajorUpdatesAvail {
 		count := 0
+
 		for _, s := range result.ChartStatuses {
 			if s.Status == "Major update available" {
 				count++
 			}
 		}
+
 		u.Printf("  %d major chart update(s) available. Run 'obol upgrade --major' to apply.", count)
 	}
+
 	if result.CLIUpdateAvail && result.CLIRelease != nil {
 		u.Printf("  CLI update available (v%s → %s). Run:", version.Short(), result.CLIRelease.TagName)
 		u.Print("    bash <(curl -s https://stack.obol.org)")

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -95,11 +95,13 @@ func TestMatchesFilter(t *testing.T) {
 func TestResolveReleaseNames(t *testing.T) {
 	// Set up a temp config dir with a helmfile
 	tmpDir := t.TempDir()
+
 	defaultsDir := filepath.Join(tmpDir, "defaults")
-	if err := os.MkdirAll(defaultsDir, 0755); err != nil {
+	if err := os.MkdirAll(defaultsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte(sampleHelmfile), 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte(sampleHelmfile), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,6 +150,7 @@ func TestResolveReleaseNames(t *testing.T) {
 			if len(got) != len(tc.want) {
 				t.Fatalf("ResolveReleaseNames(%q) = %v, want %v", tc.filter, got, tc.want)
 			}
+
 			for i := range got {
 				if got[i] != tc.want[i] {
 					t.Errorf("ResolveReleaseNames(%q)[%d] = %q, want %q", tc.filter, i, got[i], tc.want[i])
@@ -163,7 +166,6 @@ func TestUpgradeOneHelmfile_ChartFilter(t *testing.T) {
 	// We can't call helm search, so we test the filter/skip logic by using
 	// a mock-friendly approach: write a helmfile and verify only the filtered
 	// chart is considered.
-
 	tmpDir := t.TempDir()
 	helmfilePath := filepath.Join(tmpDir, "helmfile.yaml")
 
@@ -178,7 +180,7 @@ func TestUpgradeOneHelmfile_ChartFilter(t *testing.T) {
     chart: prometheus-community/kube-prometheus-stack
     version: 82.2.1
 `
-	if err := os.WriteFile(helmfilePath, []byte(helmfileContent), 0644); err != nil {
+	if err := os.WriteFile(helmfilePath, []byte(helmfileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -197,6 +199,7 @@ func TestUpgradeOneHelmfile_ChartFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if string(data) != helmfileContent {
 		t.Error("helmfile was unexpectedly modified when helm binary is unavailable")
 	}
@@ -209,6 +212,7 @@ func TestUpgradeOneHelmfile_ChartFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if string(data) != helmfileContent {
 		t.Error("helmfile was unexpectedly modified when helm binary is unavailable")
 	}
@@ -264,8 +268,9 @@ func TestMajorVersion(t *testing.T) {
 
 func TestParseHelmfileReleases(t *testing.T) {
 	tmpDir := t.TempDir()
+
 	helmfilePath := filepath.Join(tmpDir, "helmfile.yaml")
-	if err := os.WriteFile(helmfilePath, []byte(sampleHelmfile), 0644); err != nil {
+	if err := os.WriteFile(helmfilePath, []byte(sampleHelmfile), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -294,9 +299,11 @@ func TestParseHelmfileReleases(t *testing.T) {
 		if releases[i].Name != exp.name {
 			t.Errorf("release[%d].Name = %q, want %q", i, releases[i].Name, exp.name)
 		}
+
 		if releases[i].Chart != exp.chart {
 			t.Errorf("release[%d].Chart = %q, want %q", i, releases[i].Chart, exp.chart)
 		}
+
 		if releases[i].Version != exp.version {
 			t.Errorf("release[%d].Version = %q, want %q", i, releases[i].Version, exp.version)
 		}
@@ -308,19 +315,21 @@ func TestCollectHelmfiles(t *testing.T) {
 
 	// Create defaults helmfile
 	defaultsDir := filepath.Join(tmpDir, "defaults")
-	if err := os.MkdirAll(defaultsDir, 0755); err != nil {
+	if err := os.MkdirAll(defaultsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte("releases: []"), 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte("releases: []"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create an app instance helmfile
 	appDir := filepath.Join(tmpDir, "applications", "openclaw", "my-instance")
-	if err := os.MkdirAll(appDir, 0755); err != nil {
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(appDir, "helmfile.yaml"), []byte("releases: []"), 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(appDir, "helmfile.yaml"), []byte("releases: []"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -334,6 +343,7 @@ func TestCollectHelmfiles(t *testing.T) {
 	if paths[0] != filepath.Join(defaultsDir, "helmfile.yaml") {
 		t.Errorf("paths[0] = %q, want defaults helmfile", paths[0])
 	}
+
 	if paths[1] != filepath.Join(appDir, "helmfile.yaml") {
 		t.Errorf("paths[1] = %q, want app instance helmfile", paths[1])
 	}
@@ -342,8 +352,9 @@ func TestCollectHelmfiles(t *testing.T) {
 func TestCheckChartVersions_LocalChart(t *testing.T) {
 	// Test that local charts (./base) are reported as "Local chart"
 	tmpDir := t.TempDir()
+
 	defaultsDir := filepath.Join(tmpDir, "defaults")
-	if err := os.MkdirAll(defaultsDir, 0755); err != nil {
+	if err := os.MkdirAll(defaultsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -351,7 +362,7 @@ func TestCheckChartVersions_LocalChart(t *testing.T) {
   - name: base
     chart: ./base
 `
-	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte(helmfile), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(defaultsDir, "helmfile.yaml"), []byte(helmfile), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -368,6 +379,7 @@ func TestCheckChartVersions_LocalChart(t *testing.T) {
 	if len(statuses) != 1 {
 		t.Fatalf("expected 1 status, got %d", len(statuses))
 	}
+
 	if statuses[0].Status != "Local chart" {
 		t.Errorf("status = %q, want %q", statuses[0].Status, "Local chart")
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,14 +7,15 @@ import (
 
 var (
 	// These variables are set via ldflags during build
-	Version   = "dev"        // Semantic version (e.g., "0.1.0")
-	GitCommit = "unknown"    // Git commit hash (e.g., "a751d4c")
-	BuildTime = "unknown"    // Build timestamp (e.g., "20251015123705")
-	GitDirty  = "false"      // Whether repo had uncommitted changes
+	Version   = "dev"     // Semantic version (e.g., "0.1.0")
+	GitCommit = "unknown" // Git commit hash (e.g., "a751d4c")
+	BuildTime = "unknown" // Build timestamp (e.g., "20251015123705")
+	GitDirty  = "false"   // Whether repo had uncommitted changes
 )
 
 // Full returns the full version string including all metadata
 // Format: version+commit.timestamp[-dirty]
+
 func Full() string {
 	version := Version
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,12 +5,14 @@ import (
 	"runtime/debug"
 )
 
+const unknownValue = "unknown" // default for unset ldflags fields
+
 var (
 	// These variables are set via ldflags during build
-	Version   = "dev"     // Semantic version (e.g., "0.1.0")
-	GitCommit = "unknown" // Git commit hash (e.g., "a751d4c")
-	BuildTime = "unknown" // Build timestamp (e.g., "20251015123705")
-	GitDirty  = "false"   // Whether repo had uncommitted changes
+	Version   = "dev"        // Semantic version (e.g., "0.1.0")
+	GitCommit = unknownValue // Git commit hash (e.g., "a751d4c")
+	BuildTime = unknownValue // Build timestamp (e.g., "20251015123705")
+	GitDirty  = "false"      // Whether repo had uncommitted changes
 )
 
 // Full returns the full version string including all metadata
@@ -20,9 +22,9 @@ func Full() string {
 	version := Version
 
 	// Add build metadata if available
-	if GitCommit != "unknown" && BuildTime != "unknown" {
+	if GitCommit != unknownValue && BuildTime != unknownValue {
 		version = fmt.Sprintf("%s+%s.%s", version, GitCommit, BuildTime)
-	} else if GitCommit != "unknown" {
+	} else if GitCommit != unknownValue {
 		version = fmt.Sprintf("%s+%s", version, GitCommit)
 	}
 

--- a/internal/x402/buy_side_test.go
+++ b/internal/x402/buy_side_test.go
@@ -55,6 +55,7 @@ func TestBuySidecar_EndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -85,6 +86,7 @@ func TestBuySidecar_EndToEnd(t *testing.T) {
 	if err := json.Unmarshal(body, &result); err != nil {
 		t.Fatalf("decode: %v\n%s", err, string(body))
 	}
+
 	if len(result.Choices) == 0 || result.Choices[0].Message.Content != "paid response" {
 		t.Errorf("unexpected response: %s", string(body))
 	}
@@ -93,9 +95,11 @@ func TestBuySidecar_EndToEnd(t *testing.T) {
 	if seller.unpaidRequests.Load() == 0 {
 		t.Error("seller received 0 unpaid requests (should have gotten initial 402)")
 	}
+
 	if seller.paidRequests.Load() == 0 {
 		t.Error("seller received 0 paid requests")
 	}
+
 	t.Logf("Seller requests: unpaid=%d, paid=%d",
 		seller.unpaidRequests.Load(), seller.paidRequests.Load())
 
@@ -108,7 +112,7 @@ func TestBuySidecar_EndToEnd(t *testing.T) {
 		t.Fatal("seller did not record a payment")
 	}
 
-	var envelope map[string]interface{}
+	var envelope map[string]any
 	if err := json.Unmarshal([]byte(lastPayment), &envelope); err != nil {
 		t.Fatalf("parse payment envelope: %v", err)
 	}
@@ -117,25 +121,30 @@ func TestBuySidecar_EndToEnd(t *testing.T) {
 	if v, ok := envelope["x402Version"]; !ok || v != float64(1) {
 		t.Errorf("x402Version = %v, want 1", v)
 	}
+
 	if v, ok := envelope["scheme"]; !ok || v != "exact" {
 		t.Errorf("scheme = %v, want exact", v)
 	}
+
 	if v, ok := envelope["network"]; !ok || v != "base-sepolia" {
 		t.Errorf("network = %v, want base-sepolia", v)
 	}
 
 	// Check payload has authorization with correct fields.
-	payload, ok := envelope["payload"].(map[string]interface{})
+	payload, ok := envelope["payload"].(map[string]any)
 	if !ok {
 		t.Fatal("payload missing or wrong type")
 	}
+
 	if _, ok := payload["signature"]; !ok {
 		t.Error("payload.signature missing")
 	}
-	authz, ok := payload["authorization"].(map[string]interface{})
+
+	authz, ok := payload["authorization"].(map[string]any)
 	if !ok {
 		t.Fatal("payload.authorization missing or wrong type")
 	}
+
 	if authz["to"] != payTo {
 		t.Errorf("authorization.to = %v, want %s", authz["to"], payTo)
 	}
@@ -153,7 +162,7 @@ func TestBuySidecar_MultiplePayments(t *testing.T) {
 
 	// Create 3 unique pre-signed auths.
 	var authPool []*buyer.PreSignedAuth
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		authPool = append(authPool, signPreSignedAuth(t, buyerKey, payTo, "1000", 84532))
 	}
 
@@ -174,11 +183,12 @@ func TestBuySidecar_MultiplePayments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
 	// Send 3 requests, each should succeed.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		resp, err := http.Post(
 			srv.URL+"/upstream/multi/v1/chat/completions",
 			"application/json",
@@ -187,8 +197,10 @@ func TestBuySidecar_MultiplePayments(t *testing.T) {
 		if err != nil {
 			t.Fatalf("request %d: %v", i+1, err)
 		}
+
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
+
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("request %d: expected 200, got %d: %s", i+1, resp.StatusCode, string(body))
 		}
@@ -229,6 +241,7 @@ func TestBuySidecar_PoolExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -238,7 +251,9 @@ func TestBuySidecar_PoolExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request 1: %v", err)
 	}
+
 	resp1.Body.Close()
+
 	if resp1.StatusCode != http.StatusOK {
 		t.Fatalf("request 1: expected 200, got %d", resp1.StatusCode)
 	}
@@ -278,6 +293,7 @@ func TestBuySidecar_Probe(t *testing.T) {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
+
 	var pricing struct {
 		X402Version int `json:"x402Version"`
 		Accepts     []struct {
@@ -295,13 +311,16 @@ func TestBuySidecar_Probe(t *testing.T) {
 	if pricing.X402Version != 1 {
 		t.Errorf("x402Version = %d, want 1", pricing.X402Version)
 	}
+
 	if len(pricing.Accepts) == 0 {
 		t.Fatal("no accepts[] in 402 response")
 	}
+
 	a := pricing.Accepts[0]
 	if a.PayTo != "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" {
 		t.Errorf("payTo = %q", a.PayTo)
 	}
+
 	if a.Amount != "1000" {
 		t.Errorf("amount = %q", a.Amount)
 	}
@@ -330,7 +349,7 @@ func startMockX402Seller(t *testing.T) *mockX402Seller {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
-		paymentHeader := r.Header.Get("X-PAYMENT")
+		paymentHeader := r.Header.Get("X-Payment")
 
 		if paymentHeader == "" {
 			// No payment → 402.
@@ -347,6 +366,7 @@ func startMockX402Seller(t *testing.T) *mockX402Seller {
 					"asset": %q
 				}]
 			}`, testutil.USDCBaseSepolia)
+
 			return
 		}
 
@@ -355,13 +375,15 @@ func startMockX402Seller(t *testing.T) *mockX402Seller {
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, `{"error":"invalid base64 in X-PAYMENT: %v"}`, err)
+
 			return
 		}
 
-		var envelope map[string]interface{}
+		var envelope map[string]any
 		if err := json.Unmarshal(decoded, &envelope); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, `{"error":"invalid JSON in X-PAYMENT: %v"}`, err)
+
 			return
 		}
 
@@ -369,11 +391,14 @@ func startMockX402Seller(t *testing.T) *mockX402Seller {
 		if _, ok := envelope["x402Version"]; !ok {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(w, `{"error":"missing x402Version in payment"}`)
+
 			return
 		}
+
 		if _, ok := envelope["payload"]; !ok {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(w, `{"error":"missing payload in payment"}`)
+
 			return
 		}
 
@@ -402,10 +427,13 @@ func startMockX402Seller(t *testing.T) *mockX402Seller {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
+
 	ms.port = l.Addr().(*net.TCPAddr).Port
 
 	srv := &http.Server{Handler: mux, ReadTimeout: 30 * time.Second}
+
 	go func() { _ = srv.Serve(l) }()
+
 	t.Cleanup(func() { srv.Close() })
 
 	return ms
@@ -422,6 +450,7 @@ func signPreSignedAuth(t *testing.T, signerKeyHex, payTo, amount string, chainID
 	if err != nil {
 		t.Fatalf("parse key: %v", err)
 	}
+
 	fromAddr := crypto.PubkeyToAddress(key.PublicKey)
 
 	// Generate random 32-byte nonce.
@@ -429,6 +458,7 @@ func signPreSignedAuth(t *testing.T, signerKeyHex, payTo, amount string, chainID
 	if _, err := rand.Read(nonce); err != nil {
 		t.Fatalf("generate nonce: %v", err)
 	}
+
 	nonceHex := fmt.Sprintf("0x%x", nonce)
 
 	// Build EIP-712 typed data for TransferWithAuthorization (ERC-3009).
@@ -475,6 +505,7 @@ func signPreSignedAuth(t *testing.T, signerKeyHex, payTo, amount string, chainID
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
+
 	sig[64] += 27 // Ethereum v convention
 	sigHex := fmt.Sprintf("0x%x", sig)
 

--- a/internal/x402/buyer/config.go
+++ b/internal/x402/buyer/config.go
@@ -66,13 +66,16 @@ func LoadConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
+
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
+
 	if cfg.Upstreams == nil {
 		cfg.Upstreams = make(map[string]UpstreamConfig)
 	}
+
 	return &cfg, nil
 }
 
@@ -82,12 +85,15 @@ func LoadAuths(path string) (AuthsFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read auths %s: %w", path, err)
 	}
+
 	var auths AuthsFile
 	if err := json.Unmarshal(data, &auths); err != nil {
 		return nil, fmt.Errorf("parse auths %s: %w", path, err)
 	}
+
 	if auths == nil {
 		auths = make(AuthsFile)
 	}
+
 	return auths, nil
 }

--- a/internal/x402/buyer/proxy.go
+++ b/internal/x402/buyer/proxy.go
@@ -370,7 +370,7 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result) //nolint:errchkjson // controlled status map
 }
 
 // singleJoiningSlash joins a base and suffix path with exactly one slash.

--- a/internal/x402/buyer/proxy.go
+++ b/internal/x402/buyer/proxy.go
@@ -54,6 +54,7 @@ func NewProxy(cfg *Config, auths AuthsFile, state *StateStore) (*Proxy, error) {
 	if state == nil {
 		state = &StateStore{}
 	}
+
 	if state.consumed == nil {
 		state.consumed = make(map[string]map[string]struct{})
 	}
@@ -90,13 +91,16 @@ func (p *Proxy) Reload(cfg *Config, auths AuthsFile) error {
 
 	for name, upstream := range cfg.Upstreams {
 		authPool := auths[name]
+
 		filtered := make([]*PreSignedAuth, 0, len(authPool))
 		for _, auth := range authPool {
 			if auth == nil || p.state.IsConsumed(name, auth.Nonce) {
 				continue
 			}
+
 			filtered = append(filtered, auth)
 		}
+
 		if len(filtered) == 0 {
 			log.Printf("WARNING: upstream %q has 0 remaining pre-signed auths", name)
 		}
@@ -117,6 +121,7 @@ func (p *Proxy) Reload(cfg *Config, auths AuthsFile) error {
 				return p.state.MarkConsumed(name, auth.Nonce)
 			},
 		)
+
 		handler, err := p.buildUpstreamHandler(name, remoteModel, upstream, signer)
 		if err != nil {
 			return fmt.Errorf("build handler for %q: %w", name, err)
@@ -203,13 +208,14 @@ func (p *Proxy) buildUpstreamHandler(name, remoteModel string, cfg UpstreamConfi
 			pr.Out.Host = target.Host
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			if resp != nil && resp.Request != nil && resp.Request.Header.Get("X-PAYMENT") != "" {
+			if resp != nil && resp.Request != nil && resp.Request.Header.Get("X-Payment") != "" {
 				switch {
 				case resp.StatusCode < http.StatusBadRequest:
 					p.metrics.paymentSuccessTotal.With(labels).Inc()
 				default:
 					p.metrics.paymentFailureTotal.With(labels).Inc()
 				}
+
 				p.metrics.authRemaining.With(labels).Set(float64(signer.Remaining()))
 				p.metrics.authSpent.With(labels).Set(float64(signer.Spent()))
 			}
@@ -241,6 +247,7 @@ func (p *Proxy) handleModelRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read request body", http.StatusBadRequest)
 		return
 	}
+
 	r.Body.Close()
 
 	remoteModel, rewrittenBody, entry := p.resolveModelRequest(body)
@@ -278,6 +285,7 @@ func (p *Proxy) resolveModelRequest(body []byte) (string, []byte, *upstreamEntry
 	}
 
 	modelValue, _ := payload["model"].(string)
+
 	remoteModel := normalizeRemoteModel(modelValue)
 	if remoteModel == "" {
 		return "", nil, nil
@@ -287,11 +295,13 @@ func (p *Proxy) resolveModelRequest(body []byte) (string, []byte, *upstreamEntry
 	upstreamName, ok := p.modelRoutes[remoteModel]
 	entry := p.upstreams[upstreamName]
 	p.mu.RUnlock()
+
 	if !ok || entry == nil {
 		return "", nil, nil
 	}
 
 	payload["model"] = remoteModel
+
 	rewrittenBody, err := json.Marshal(payload)
 	if err != nil {
 		return "", nil, nil
@@ -302,6 +312,7 @@ func (p *Proxy) resolveModelRequest(body []byte) (string, []byte, *upstreamEntry
 
 func normalizeRemoteModel(model string) string {
 	normalized := strings.TrimSpace(model)
+
 	for {
 		switch {
 		case strings.HasPrefix(normalized, "paid/"):
@@ -322,16 +333,19 @@ func bodyBufferMiddleware(next http.Handler) http.Handler {
 		if r.Body != nil && r.Body != http.NoBody {
 			body, err := io.ReadAll(r.Body)
 			r.Body.Close()
+
 			if err != nil {
 				http.Error(w, "failed to read request body", http.StatusBadRequest)
 				return
 			}
+
 			r.Body = io.NopCloser(bytes.NewReader(body))
 			r.ContentLength = int64(len(body))
 			r.GetBody = func() (io.ReadCloser, error) {
 				return io.NopCloser(bytes.NewReader(body)), nil
 			}
 		}
+
 		next.ServeHTTP(w, r)
 	})
 }
@@ -342,6 +356,7 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 	defer p.mu.RUnlock()
 
 	result := make(map[string]upstreamStatus)
+
 	for name, signer := range p.signers {
 		us := p.upstreams[name]
 		result[name] = upstreamStatus{
@@ -361,6 +376,7 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 // singleJoiningSlash joins a base and suffix path with exactly one slash.
 func singleJoiningSlash(a, b string) string {
 	aslash := strings.HasSuffix(a, "/")
+
 	bslash := strings.HasPrefix(b, "/")
 	switch {
 	case aslash && bslash:
@@ -368,5 +384,6 @@ func singleJoiningSlash(a, b string) string {
 	case !aslash && !bslash:
 		return a + "/" + b
 	}
+
 	return a + b
 }

--- a/internal/x402/buyer/proxy_test.go
+++ b/internal/x402/buyer/proxy_test.go
@@ -38,14 +38,16 @@ func TestProxy_HealthAndStatus(t *testing.T) {
 
 	// Health check.
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/healthz", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
 	if rec.Code != http.StatusOK {
 		t.Errorf("healthz: got %d, want 200", rec.Code)
 	}
 
 	// Status endpoint.
 	rec = httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 	if rec.Code != http.StatusOK {
 		t.Errorf("status: got %d, want 200", rec.Code)
 	}
@@ -64,12 +66,15 @@ func TestProxy_HealthAndStatus(t *testing.T) {
 	if !ok {
 		t.Fatal("status missing 'test' upstream")
 	}
+
 	if s.Remaining != 2 {
 		t.Errorf("remaining = %d, want 2", s.Remaining)
 	}
+
 	if s.Spent != 0 {
 		t.Errorf("spent = %d, want 0", s.Spent)
 	}
+
 	if s.Network != "base-sepolia" {
 		t.Errorf("network = %q, want base-sepolia", s.Network)
 	}
@@ -126,6 +131,7 @@ func TestProxy_ForwardsToUpstream(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+
 	if result.Path != "/v1/chat/completions" {
 		t.Errorf("upstream saw path %q, want /v1/chat/completions", result.Path)
 	}
@@ -134,7 +140,7 @@ func TestProxy_ForwardsToUpstream(t *testing.T) {
 func TestProxy_Handles402WithPayment(t *testing.T) {
 	// Mock upstream: first request → 402, second request (with X-PAYMENT) → 200.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payment := r.Header.Get("X-PAYMENT")
+		payment := r.Header.Get("X-Payment")
 		if payment == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
@@ -148,6 +154,7 @@ func TestProxy_Handles402WithPayment(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
 
@@ -156,12 +163,15 @@ func TestProxy_Handles402WithPayment(t *testing.T) {
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, `{"error":"bad base64: %v"}`, err)
+
 			return
 		}
-		var envelope map[string]interface{}
+
+		var envelope map[string]any
 		if err := json.Unmarshal(decoded, &envelope); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, `{"error":"bad json: %v"}`, err)
+
 			return
 		}
 
@@ -221,6 +231,7 @@ func TestProxy_Handles402WithPayment(t *testing.T) {
 	if err := json.Unmarshal(body, &result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+
 	if len(result.Choices) == 0 || result.Choices[0].Message.Content != "paid" {
 		t.Errorf("unexpected response: %s", string(body))
 	}
@@ -236,7 +247,8 @@ func TestProxy_UnknownUpstream(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/upstream/nonexistent/v1/chat/completions", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/upstream/nonexistent/v1/chat/completions", nil))
+
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("got %d, want 404 for unknown upstream", rec.Code)
 	}
@@ -244,6 +256,7 @@ func TestProxy_UnknownUpstream(t *testing.T) {
 
 func TestLoadConfig(t *testing.T) {
 	f := t.TempDir() + "/config.json"
+
 	data := `{
 		"upstreams": {
 			"test": {
@@ -263,9 +276,11 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
+
 	if len(cfg.Upstreams) != 1 {
 		t.Fatalf("upstreams = %d, want 1", len(cfg.Upstreams))
 	}
+
 	u := cfg.Upstreams["test"]
 	if u.URL != "http://seller.example.com" || u.Price != "1000" {
 		t.Errorf("unexpected upstream: %+v", u)
@@ -274,6 +289,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestLoadAuths(t *testing.T) {
 	f := t.TempDir() + "/auths.json"
+
 	data := `{
 		"test": [
 			{
@@ -295,9 +311,11 @@ func TestLoadAuths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAuths: %v", err)
 	}
+
 	if len(auths["test"]) != 1 {
 		t.Fatalf("auths[test] = %d, want 1", len(auths["test"]))
 	}
+
 	a := auths["test"][0]
 	if a.Signature != "0xabc" || a.Nonce != "0xdeadbeef" {
 		t.Errorf("unexpected auth: %+v", a)
@@ -307,7 +325,7 @@ func TestLoadAuths(t *testing.T) {
 func TestProxy_AuthPoolExhaustion(t *testing.T) {
 	// Mock upstream: always 402 first, 200 with payment.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-PAYMENT") == "" {
+		if r.Header.Get("X-Payment") == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
 			fmt.Fprint(w, `{
@@ -320,8 +338,10 @@ func TestProxy_AuthPoolExhaustion(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"choices":[{"message":{"content":"ok"}}]}`)
 	}))
@@ -345,11 +365,12 @@ func TestProxy_AuthPoolExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
 	// First 2 requests should succeed (each consumes one auth).
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp, err := http.Post(
 			srv.URL+"/upstream/limited/v1/chat/completions",
 			"application/json",
@@ -358,7 +379,9 @@ func TestProxy_AuthPoolExhaustion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("request %d: %v", i+1, err)
 		}
+
 		resp.Body.Close()
+
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("request %d: expected 200, got %d", i+1, resp.StatusCode)
 		}
@@ -383,7 +406,8 @@ func TestProxy_AuthPoolExhaustion(t *testing.T) {
 
 	// Status should reflect 2 spent, 0 remaining.
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 	var status map[string]struct {
 		Remaining int `json:"remaining"`
 		Spent     int `json:"spent"`
@@ -391,6 +415,7 @@ func TestProxy_AuthPoolExhaustion(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
 		t.Fatalf("decode status: %v", err)
 	}
+
 	if s := status["limited"]; s.Remaining != 0 || s.Spent != 2 {
 		t.Errorf("status: remaining=%d spent=%d, want 0/2", s.Remaining, s.Spent)
 	}
@@ -425,6 +450,7 @@ func TestProxy_MultipleUpstreams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -433,8 +459,10 @@ func TestProxy_MultipleUpstreams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream alpha: %v", err)
 	}
+
 	body1, _ := io.ReadAll(resp1.Body)
 	resp1.Body.Close()
+
 	if !strings.Contains(string(body1), "upstream1") {
 		t.Errorf("upstream alpha: got %s, want upstream1", string(body1))
 	}
@@ -444,15 +472,18 @@ func TestProxy_MultipleUpstreams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream beta: %v", err)
 	}
+
 	body2, _ := io.ReadAll(resp2.Body)
 	resp2.Body.Close()
+
 	if !strings.Contains(string(body2), "upstream2") {
 		t.Errorf("upstream beta: got %s, want upstream2", string(body2))
 	}
 
 	// Status should show both upstreams.
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 	var status map[string]struct {
 		URL     string `json:"url"`
 		Network string `json:"network"`
@@ -460,12 +491,15 @@ func TestProxy_MultipleUpstreams(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
 		t.Fatalf("decode status: %v", err)
 	}
+
 	if len(status) != 2 {
 		t.Errorf("status upstreams = %d, want 2", len(status))
 	}
+
 	if status["alpha"].Network != "base-sepolia" {
 		t.Errorf("alpha network = %q", status["alpha"].Network)
 	}
+
 	if status["beta"].Network != "base" {
 		t.Errorf("beta network = %q", status["beta"].Network)
 	}
@@ -474,7 +508,7 @@ func TestProxy_MultipleUpstreams(t *testing.T) {
 func TestProxy_StatusAfterPayments(t *testing.T) {
 	// Mock upstream: 402 then 200 on payment.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-PAYMENT") == "" {
+		if r.Header.Get("X-Payment") == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
 			fmt.Fprint(w, `{
@@ -487,8 +521,10 @@ func TestProxy_StatusAfterPayments(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"ok":true}`)
 	}))
@@ -511,19 +547,23 @@ func TestProxy_StatusAfterPayments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
 	// Check initial status.
 	checkStatus := func(wantRemaining, wantSpent int) {
 		t.Helper()
+
 		rec := httptest.NewRecorder()
-		proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+		proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 		var status map[string]struct {
 			Remaining int `json:"remaining"`
 			Spent     int `json:"spent"`
 		}
 		json.NewDecoder(rec.Body).Decode(&status)
+
 		s := status["tracked"]
 		if s.Remaining != wantRemaining || s.Spent != wantSpent {
 			t.Errorf("status: remaining=%d spent=%d, want %d/%d",
@@ -552,7 +592,7 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 	var seenModel string
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-PAYMENT") == "" {
+		if r.Header.Get("X-Payment") == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
 			fmt.Fprint(w, `{
@@ -565,6 +605,7 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
 
@@ -575,6 +616,7 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+
 		seenModel = payload.Model
 
 		w.Header().Set("Content-Type", "application/json")
@@ -605,6 +647,7 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -616,7 +659,9 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+
 	resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -626,7 +671,8 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 	var status map[string]struct {
 		RemoteModel string `json:"remote_model"`
 		PublicModel string `json:"public_model"`
@@ -636,13 +682,16 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
 		t.Fatalf("decode status: %v", err)
 	}
+
 	gotStatus := status["seller-qwen"]
 	if gotStatus.RemoteModel != "qwen3:32b" {
 		t.Fatalf("remote_model = %q, want qwen3:32b", gotStatus.RemoteModel)
 	}
+
 	if gotStatus.PublicModel != "paid/qwen3:32b" {
 		t.Fatalf("public_model = %q, want paid/qwen3:32b", gotStatus.PublicModel)
 	}
+
 	if gotStatus.Remaining != 0 || gotStatus.Spent != 1 {
 		t.Fatalf("status remaining/spent = %d/%d, want 0/1", gotStatus.Remaining, gotStatus.Spent)
 	}
@@ -658,11 +707,13 @@ func TestProxy_ModelRoutingAndMetrics(t *testing.T) {
 }
 
 func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
-	var seenPath string
-	var seenModel string
+	var (
+		seenPath  string
+		seenModel string
+	)
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-PAYMENT") == "" {
+		if r.Header.Get("X-Payment") == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
 			fmt.Fprint(w, `{
@@ -675,10 +726,12 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
 
 		seenPath = r.URL.Path
+
 		var payload struct {
 			Model string `json:"model"`
 		}
@@ -686,6 +739,7 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+
 		seenModel = payload.Model
 
 		w.Header().Set("Content-Type", "application/json")
@@ -716,6 +770,7 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -727,7 +782,9 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
+
 	resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -735,6 +792,7 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 	if seenPath != "/chat/completions" {
 		t.Fatalf("upstream path = %q, want /chat/completions", seenPath)
 	}
+
 	if seenModel != "qwen3.5:9b" {
 		t.Fatalf("upstream model = %q, want qwen3.5:9b", seenModel)
 	}
@@ -742,7 +800,7 @@ func TestProxy_ModelRoutingSupportsChatCompletionsAlias(t *testing.T) {
 
 func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	oldUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-PAYMENT") == "" {
+		if r.Header.Get("X-Payment") == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
 			fmt.Fprint(w, `{
@@ -755,6 +813,7 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 					"payTo": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 				}]
 			}`)
+
 			return
 		}
 
@@ -792,6 +851,7 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxy: %v", err)
 	}
+
 	srv := httptest.NewServer(proxy)
 	defer srv.Close()
 
@@ -803,7 +863,9 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("old-model request: %v", err)
 	}
+
 	resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("old-model expected 200, got %d", resp.StatusCode)
 	}
@@ -813,7 +875,8 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
 	var status map[string]struct {
 		Remaining int `json:"remaining"`
 		Spent     int `json:"spent"`
@@ -821,6 +884,7 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
 		t.Fatalf("decode status: %v", err)
 	}
+
 	if status["seller-old"].Remaining != 1 || status["seller-old"].Spent != 1 {
 		t.Fatalf("reload should preserve consumed state, got remaining/spent %d/%d",
 			status["seller-old"].Remaining, status["seller-old"].Spent)
@@ -838,6 +902,7 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 			},
 		},
 	}
+
 	newAuths := AuthsFile{"seller-new": {makeAuth("0xnew1")}}
 	if err := proxy.Reload(newCfg, newAuths); err != nil {
 		t.Fatalf("Reload new config: %v", err)
@@ -851,7 +916,9 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("old model after reload: %v", err)
 	}
+
 	oldResp.Body.Close()
+
 	if oldResp.StatusCode != http.StatusNotFound {
 		t.Fatalf("old model after reload expected 404, got %d", oldResp.StatusCode)
 	}
@@ -864,16 +931,20 @@ func TestProxy_ReloadSkipsConsumedAuthsAndReplacesModelMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new model after reload: %v", err)
 	}
+
 	newResp.Body.Close()
+
 	if newResp.StatusCode != http.StatusOK {
 		t.Fatalf("new model after reload expected 200, got %d", newResp.StatusCode)
 	}
 
 	metrics := scrapeMetricFamilies(t, proxy)
+
 	activeMappings := metrics["obol_x402_buyer_active_model_mappings"]
 	if metricFamilyLen(activeMappings) != 1 {
 		t.Fatalf("active model mapping series = %d, want 1", metricFamilyLen(activeMappings))
 	}
+
 	assertMetricValue(t, activeMappings, map[string]string{"upstream": "seller-new", "remote_model": "new-model"}, 1)
 	assertMetricMissing(t, activeMappings, map[string]string{"upstream": "seller-old", "remote_model": "old-model"})
 	assertMetricValue(t, metrics["obol_x402_buyer_auth_remaining"], map[string]string{"upstream": "seller-new", "remote_model": "new-model"}, 1)
@@ -884,12 +955,14 @@ func scrapeMetricFamilies(t *testing.T, proxy *Proxy) map[string]*dto.MetricFami
 	t.Helper()
 
 	rec := httptest.NewRecorder()
-	proxy.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	proxy.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
 	if rec.Code != http.StatusOK {
 		t.Fatalf("metrics status = %d, want 200", rec.Code)
 	}
 
 	var parser expfmt.TextParser
+
 	families, err := parser.TextToMetricFamilies(strings.NewReader(rec.Body.String()))
 	if err != nil {
 		t.Fatalf("parse metrics: %v", err)
@@ -911,6 +984,7 @@ func assertMetricValue(t *testing.T, family *dto.MetricFamily, wantLabels map[st
 			if got != wantValue {
 				t.Fatalf("%s labels %v = %v, want %v", family.GetName(), wantLabels, got, wantValue)
 			}
+
 			return
 		}
 	}
@@ -936,19 +1010,21 @@ func labelsMatch(metric *dto.Metric, want map[string]string) bool {
 	if len(metric.GetLabel()) != len(want) {
 		return false
 	}
+
 	for _, label := range metric.GetLabel() {
 		if want[label.GetName()] != label.GetValue() {
 			return false
 		}
 	}
+
 	return true
 }
 
 func metricValue(metric *dto.Metric) float64 {
 	switch {
-	case metric.Counter != nil:
+	case metric.GetCounter() != nil:
 		return metric.GetCounter().GetValue()
-	case metric.Gauge != nil:
+	case metric.GetGauge() != nil:
 		return metric.GetGauge().GetValue()
 	default:
 		return 0
@@ -959,10 +1035,11 @@ func metricFamilyLen(family *dto.MetricFamily) int {
 	if family == nil {
 		return 0
 	}
+
 	return len(family.GetMetric())
 }
 
 func writeFile(t *testing.T, path, content string) error {
 	t.Helper()
-	return os.WriteFile(path, []byte(content), 0644)
+	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/internal/x402/buyer/signer.go
+++ b/internal/x402/buyer/signer.go
@@ -31,6 +31,7 @@ type PreSignedSigner struct {
 func NewPreSignedSigner(network, payTo, asset, price string, auths []*PreSignedAuth, spent int, onConsume func(*PreSignedAuth) error) *PreSignedSigner {
 	pool := make([]*PreSignedAuth, len(auths))
 	copy(pool, auths)
+
 	return &PreSignedSigner{
 		network:   network,
 		payTo:     payTo,
@@ -55,21 +56,27 @@ func (s *PreSignedSigner) CanSign(req *x402.PaymentRequirement) bool {
 	if req == nil {
 		return false
 	}
+
 	if !strings.EqualFold(req.Network, s.network) {
 		return false
 	}
+
 	if !strings.EqualFold(req.PayTo, s.payTo) {
 		return false
 	}
+
 	if !strings.EqualFold(req.Asset, s.asset) {
 		return false
 	}
+
 	if req.MaxAmountRequired != "" && req.MaxAmountRequired != s.price {
 		return false
 	}
+
 	s.mu.Lock()
 	remaining := len(s.auths)
 	s.mu.Unlock()
+
 	return remaining > 0
 }
 
@@ -87,11 +94,13 @@ func (s *PreSignedSigner) Sign(req *x402.PaymentRequirement) (*x402.PaymentPaylo
 	// Pop from the front.
 	auth := s.auths[0]
 	s.auths = s.auths[1:]
+
 	s.spent++
 	if s.onConsume != nil {
 		if err := s.onConsume(auth); err != nil {
 			s.auths = append([]*PreSignedAuth{auth}, s.auths...)
 			s.spent--
+
 			return nil, err
 		}
 	}
@@ -131,6 +140,7 @@ func (s *PreSignedSigner) GetMaxAmount() *big.Int { return nil }
 func (s *PreSignedSigner) Remaining() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	return len(s.auths)
 }
 
@@ -138,5 +148,6 @@ func (s *PreSignedSigner) Remaining() int {
 func (s *PreSignedSigner) Spent() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	return s.spent
 }

--- a/internal/x402/buyer/signer_test.go
+++ b/internal/x402/buyer/signer_test.go
@@ -124,10 +124,12 @@ func TestPreSignedSigner_Sign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first Sign: %v", err)
 	}
+
 	payload1 := p1.Payload.(x402.EVMPayload)
 	if payload1.Signature != "0xaaa" {
 		t.Errorf("first signature = %q, want %q", payload1.Signature, "0xaaa")
 	}
+
 	if p1.X402Version != 1 || p1.Scheme != "exact" || p1.Network != "base-sepolia" {
 		t.Errorf("unexpected payload fields: version=%d scheme=%s network=%s",
 			p1.X402Version, p1.Scheme, p1.Network)
@@ -136,6 +138,7 @@ func TestPreSignedSigner_Sign(t *testing.T) {
 	if signer.Remaining() != 1 {
 		t.Errorf("remaining = %d, want 1", signer.Remaining())
 	}
+
 	if signer.Spent() != 1 {
 		t.Errorf("spent = %d, want 1", signer.Spent())
 	}
@@ -145,6 +148,7 @@ func TestPreSignedSigner_Sign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second Sign: %v", err)
 	}
+
 	payload2 := p2.Payload.(x402.EVMPayload)
 	if payload2.Signature != "0xbbb" {
 		t.Errorf("second signature = %q, want %q", payload2.Signature, "0xbbb")
@@ -164,6 +168,7 @@ func TestPreSignedSigner_Sign(t *testing.T) {
 
 func TestPreSignedSigner_ConcurrentSign(t *testing.T) {
 	const N = 100
+
 	auths := make([]*PreSignedAuth, N)
 	for i := range auths {
 		auths[i] = makeAuth("0xsig")
@@ -187,20 +192,19 @@ func TestPreSignedSigner_ConcurrentSign(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+
 	successes := make(chan struct{}, N)
 	failures := make(chan struct{}, N)
 
 	for range N {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, err := signer.Sign(req)
 			if err != nil {
 				failures <- struct{}{}
 			} else {
 				successes <- struct{}{}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -208,13 +212,16 @@ func TestPreSignedSigner_ConcurrentSign(t *testing.T) {
 	close(failures)
 
 	s := len(successes)
+
 	f := len(failures)
 	if s != N {
 		t.Errorf("successes = %d, want %d (failures=%d)", s, N, f)
 	}
+
 	if signer.Remaining() != 0 {
 		t.Errorf("remaining = %d, want 0", signer.Remaining())
 	}
+
 	if signer.Spent() != N {
 		t.Errorf("spent = %d, want %d", signer.Spent(), N)
 	}
@@ -229,15 +236,19 @@ func TestPreSignedSigner_Interface(t *testing.T) {
 	if signer.Network() != "base-sepolia" {
 		t.Errorf("Network() = %q", signer.Network())
 	}
+
 	if signer.Scheme() != "exact" {
 		t.Errorf("Scheme() = %q", signer.Scheme())
 	}
+
 	if signer.GetPriority() != 0 {
 		t.Errorf("GetPriority() = %d", signer.GetPriority())
 	}
+
 	if signer.GetMaxAmount() != nil {
 		t.Errorf("GetMaxAmount() = %v, want nil", signer.GetMaxAmount())
 	}
+
 	tokens := signer.GetTokens()
 	if len(tokens) != 1 || tokens[0].Address != "0xasset" {
 		t.Errorf("GetTokens() = %+v", tokens)

--- a/internal/x402/buyer/state.go
+++ b/internal/x402/buyer/state.go
@@ -36,6 +36,7 @@ func LoadStateStore(path string) (*StateStore, error) {
 		if os.IsNotExist(err) {
 			return store, nil
 		}
+
 		return nil, fmt.Errorf("read state %s: %w", path, err)
 	}
 
@@ -43,11 +44,13 @@ func LoadStateStore(path string) (*StateStore, error) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("parse state %s: %w", path, err)
 	}
+
 	for upstream, nonces := range decoded.Consumed {
 		nonceSet := make(map[string]struct{}, len(nonces))
 		for _, nonce := range nonces {
 			nonceSet[nonce] = struct{}{}
 		}
+
 		store.consumed[upstream] = nonceSet
 	}
 
@@ -58,7 +61,9 @@ func LoadStateStore(path string) (*StateStore, error) {
 func (s *StateStore) IsConsumed(upstream, nonce string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
 	_, ok := s.consumed[upstream][nonce]
+
 	return ok
 }
 
@@ -66,6 +71,7 @@ func (s *StateStore) IsConsumed(upstream, nonce string) bool {
 func (s *StateStore) ConsumedCount(upstream string) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
 	return len(s.consumed[upstream])
 }
 
@@ -78,9 +84,11 @@ func (s *StateStore) MarkConsumed(upstream, nonce string) error {
 	if s.consumed[upstream] == nil {
 		s.consumed[upstream] = make(map[string]struct{})
 	}
+
 	if _, ok := s.consumed[upstream][nonce]; ok {
 		return nil
 	}
+
 	s.consumed[upstream][nonce] = struct{}{}
 
 	return s.writeLocked()
@@ -90,6 +98,7 @@ func (s *StateStore) writeLocked() error {
 	if s.path == "" {
 		return nil
 	}
+
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
 		return fmt.Errorf("mkdir state dir: %w", err)
 	}
@@ -100,6 +109,7 @@ func (s *StateStore) writeLocked() error {
 		for nonce := range nonceSet {
 			nonces = append(nonces, nonce)
 		}
+
 		out.Consumed[upstream] = nonces
 	}
 
@@ -112,6 +122,7 @@ func (s *StateStore) writeLocked() error {
 	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
 		return fmt.Errorf("write temp state: %w", err)
 	}
+
 	if err := os.Rename(tmpPath, s.path); err != nil {
 		return fmt.Errorf("rename state: %w", err)
 	}

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -93,6 +93,7 @@ func LoadConfig(path string) (*PricingConfig, error) {
 	if cfg.FacilitatorURL == "" {
 		cfg.FacilitatorURL = "https://facilitator.x402.rs"
 	}
+
 	if cfg.Chain == "" {
 		cfg.Chain = "base-sepolia"
 	}
@@ -117,6 +118,7 @@ func ValidateFacilitatorURL(u string) error {
 	if parsed.Scheme == "https" {
 		return nil
 	}
+
 	if parsed.Scheme != "http" {
 		return fmt.Errorf("facilitator URL must use HTTPS (except localhost): %q", u)
 	}

--- a/internal/x402/config_test.go
+++ b/internal/x402/config_test.go
@@ -24,7 +24,7 @@ routes:
     price: "0.001"
     description: "Inference gateway"
 `
-	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -36,24 +36,31 @@ routes:
 	if cfg.Wallet != "0xABCDEF1234567890ABCDEF1234567890ABCDEF12" {
 		t.Errorf("wallet = %q, want 0xABCDEF...", cfg.Wallet)
 	}
+
 	if cfg.Chain != "base-sepolia" {
 		t.Errorf("chain = %q, want base-sepolia", cfg.Chain)
 	}
+
 	if cfg.FacilitatorURL != "https://custom-facilitator.example.com" {
 		t.Errorf("facilitatorURL = %q, want custom URL", cfg.FacilitatorURL)
 	}
+
 	if !cfg.VerifyOnly {
 		t.Error("verifyOnly should be true")
 	}
+
 	if len(cfg.Routes) != 2 {
 		t.Fatalf("routes count = %d, want 2", len(cfg.Routes))
 	}
+
 	if cfg.Routes[0].Pattern != "/rpc/*" {
 		t.Errorf("route[0].pattern = %q, want /rpc/*", cfg.Routes[0].Pattern)
 	}
+
 	if cfg.Routes[0].Price != "0.0001" {
 		t.Errorf("route[0].price = %q, want 0.0001", cfg.Routes[0].Price)
 	}
+
 	if cfg.Routes[1].Description != "Inference gateway" {
 		t.Errorf("route[1].description = %q, want 'Inference gateway'", cfg.Routes[1].Description)
 	}
@@ -69,7 +76,7 @@ routes:
   - pattern: "/api/*"
     price: "0.01"
 `
-	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,6 +88,7 @@ routes:
 	if cfg.Chain != "base-sepolia" {
 		t.Errorf("default chain = %q, want base-sepolia", cfg.Chain)
 	}
+
 	if cfg.FacilitatorURL != "https://facilitator.x402.rs" {
 		t.Errorf("default facilitatorURL = %q, want https://facilitator.x402.rs", cfg.FacilitatorURL)
 	}
@@ -90,7 +98,7 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.yaml")
 
-	if err := os.WriteFile(path, []byte("{{not: valid: yaml:"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("{{not: valid: yaml:"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -126,6 +134,7 @@ func TestResolveChain_AllSupported(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ResolveChain(%q): %v", tt.name, err)
 			}
+
 			if got.NetworkID != tt.expected.NetworkID {
 				t.Errorf("ResolveChain(%q).NetworkID = %q, want %q", tt.name, got.NetworkID, tt.expected.NetworkID)
 			}
@@ -135,7 +144,7 @@ func TestResolveChain_AllSupported(t *testing.T) {
 
 func TestResolveChain_Aliases(t *testing.T) {
 	tests := []struct {
-		alias    string
+		alias     string
 		canonical string
 	}{
 		{"base-mainnet", "base"},
@@ -149,10 +158,12 @@ func TestResolveChain_Aliases(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ResolveChain(%q): %v", tt.alias, err)
 			}
+
 			canonResult, err := ResolveChain(tt.canonical)
 			if err != nil {
 				t.Fatalf("ResolveChain(%q): %v", tt.canonical, err)
 			}
+
 			if aliasResult.NetworkID != canonResult.NetworkID {
 				t.Errorf("alias %q NetworkID = %q, canonical %q NetworkID = %q",
 					tt.alias, aliasResult.NetworkID, tt.canonical, canonResult.NetworkID)
@@ -225,7 +236,7 @@ routes:
   - pattern: "/api/*"
     price: "0.01"
 `
-	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -245,7 +256,7 @@ routes:
   - pattern: "/api/*"
     price: "0.01"
 `
-	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -253,6 +264,7 @@ routes:
 	if err != nil {
 		t.Fatalf("LoadConfig should allow localhost HTTP: %v", err)
 	}
+
 	if cfg.FacilitatorURL != "http://localhost:4040" {
 		t.Errorf("facilitatorURL = %q, want http://localhost:4040", cfg.FacilitatorURL)
 	}

--- a/internal/x402/helpers_test.go
+++ b/internal/x402/helpers_test.go
@@ -12,26 +12,31 @@ import (
 // Shared by both unit and integration tests.
 func httpPost(t *testing.T, url, body string, headers map[string]string) *http.Response {
 	t.Helper()
+
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
 	if err != nil {
 		t.Fatalf("create request: %v", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
+
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
 
 	client := &http.Client{Timeout: 120 * time.Second}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("HTTP POST %s: %v", url, err)
 	}
+
 	return resp
 }
 
 // mustQuoteJSON wraps a JSON string as a quoted JSON string value,
 // suitable for embedding in a kubectl patch -p '{"data":{"key":<here>}}'.
-func mustQuoteJSON(s string) string {
+func mustQuoteJSON(s string) string { //nolint:unused // used by integration tests (build tag)
 	b, _ := json.Marshal(s)
 	return string(b)
 }

--- a/internal/x402/matcher.go
+++ b/internal/x402/matcher.go
@@ -22,6 +22,7 @@ func matchRoute(routes []RouteRule, uri string) *RouteRule {
 			return &routes[i]
 		}
 	}
+
 	return nil
 }
 
@@ -34,8 +35,8 @@ func matchPattern(pattern, uri string) bool {
 
 	// Simple prefix match: pattern ends with "/*" and has no other wildcards.
 	// "/rpc/*" matches "/rpc", "/rpc/", "/rpc/anything", and "/rpc/a/b/c".
-	if strings.HasSuffix(pattern, "/*") {
-		prefix := strings.TrimSuffix(pattern, "/*")
+	if before, ok := strings.CutSuffix(pattern, "/*"); ok {
+		prefix := before
 		if !strings.Contains(prefix, "*") {
 			return uri == prefix || strings.HasPrefix(uri, prefix+"/")
 		}

--- a/internal/x402/matcher_test.go
+++ b/internal/x402/matcher_test.go
@@ -10,9 +10,11 @@ func TestMatchRoute_ExactMatch(t *testing.T) {
 	if r := matchRoute(routes, "/health"); r == nil {
 		t.Fatal("expected match for /health")
 	}
+
 	if r := matchRoute(routes, "/healthz"); r != nil {
 		t.Fatal("expected no match for /healthz")
 	}
+
 	if r := matchRoute(routes, "/health/deep"); r != nil {
 		t.Fatal("expected no match for /health/deep")
 	}
@@ -29,11 +31,11 @@ func TestMatchRoute_PrefixMatch(t *testing.T) {
 	}{
 		{"/rpc/mainnet", true},
 		{"/rpc/sepolia", true},
-		{"/rpc/a/b/c", true},   // deep sub-path
-		{"/rpc/", true},        // trailing slash
-		{"/rpc", true},         // exact base path (no trailing slash)
-		{"/rpcx/foo", false},   // different prefix
-		{"/other", false},      // unrelated
+		{"/rpc/a/b/c", true}, // deep sub-path
+		{"/rpc/", true},      // trailing slash
+		{"/rpc", true},       // exact base path (no trailing slash)
+		{"/rpcx/foo", false}, // different prefix
+		{"/other", false},    // unrelated
 	}
 
 	for _, tt := range tests {
@@ -41,6 +43,7 @@ func TestMatchRoute_PrefixMatch(t *testing.T) {
 		if tt.match && r == nil {
 			t.Errorf("expected match for %q", tt.uri)
 		}
+
 		if !tt.match && r != nil {
 			t.Errorf("expected no match for %q", tt.uri)
 		}
@@ -59,10 +62,10 @@ func TestMatchRoute_GlobMatch(t *testing.T) {
 		{"/inference-abc/v1/chat/completions", true},
 		{"/inference-prod/v1/models", true},
 		{"/inference-test-123/v1/embeddings", true},
-		{"/inference-abc/v1/a/b/c", true},     // trailing * is greedy
-		{"/inference-abc/v2/models", false},    // v2 not v1
-		{"/inference/v1/models", false},        // missing segment after inference-
-		{"/other-abc/v1/models", false},        // wrong prefix
+		{"/inference-abc/v1/a/b/c", true},   // trailing * is greedy
+		{"/inference-abc/v2/models", false}, // v2 not v1
+		{"/inference/v1/models", false},     // missing segment after inference-
+		{"/other-abc/v1/models", false},     // wrong prefix
 	}
 
 	for _, tt := range tests {
@@ -70,6 +73,7 @@ func TestMatchRoute_GlobMatch(t *testing.T) {
 		if tt.match && r == nil {
 			t.Errorf("expected match for %q", tt.uri)
 		}
+
 		if !tt.match && r != nil {
 			t.Errorf("expected no match for %q", tt.uri)
 		}
@@ -86,6 +90,7 @@ func TestMatchRoute_FirstMatchWins(t *testing.T) {
 	if r == nil {
 		t.Fatal("expected match")
 	}
+
 	if r.Description != "rpc" {
 		t.Errorf("expected first rule (rpc) to win, got %q", r.Description)
 	}
@@ -100,9 +105,11 @@ func TestMatchRoute_NoMatch(t *testing.T) {
 	if r := matchRoute(routes, "/health"); r != nil {
 		t.Error("expected no match for /health")
 	}
+
 	if r := matchRoute(routes, "/"); r != nil {
 		t.Error("expected no match for /")
 	}
+
 	if r := matchRoute(routes, ""); r != nil {
 		t.Error("expected no match for empty string")
 	}
@@ -112,6 +119,7 @@ func TestMatchRoute_EmptyRoutes(t *testing.T) {
 	if r := matchRoute(nil, "/rpc/mainnet"); r != nil {
 		t.Error("expected no match with nil routes")
 	}
+
 	if r := matchRoute([]RouteRule{}, "/rpc/mainnet"); r != nil {
 		t.Error("expected no match with empty routes")
 	}
@@ -138,6 +146,7 @@ func TestMatchRoute_EthereumNetworkPattern(t *testing.T) {
 		if tt.match && r == nil {
 			t.Errorf("expected match for %q", tt.uri)
 		}
+
 		if !tt.match && r != nil {
 			t.Errorf("expected no match for %q", tt.uri)
 		}
@@ -149,6 +158,7 @@ func TestMatchPattern_GlobSegmentBoundary(t *testing.T) {
 	if matchPattern("/a-*/b", "/a-x/b") != true {
 		t.Error("expected /a-x/b to match /a-*/b")
 	}
+
 	if matchPattern("/a-*/b", "/a-x/c") != false {
 		t.Error("expected /a-x/c NOT to match /a-*/b")
 	}

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -178,6 +178,7 @@ func EnsureVerifier(cfg *config.Config) error {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return err
 	}
+
 	bin, kc := kubectl.Paths(cfg)
 
 	// Quick check: if the namespace already exists, skip the apply.
@@ -186,6 +187,7 @@ func EnsureVerifier(cfg *config.Config) error {
 	}
 
 	fmt.Println("Deploying x402 payment verifier...")
+
 	return kubectl.Apply(bin, kc, x402Manifest)
 }
 
@@ -196,18 +198,23 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	if err := ValidateWallet(wallet); err != nil {
 		return err
 	}
+
 	if err := EnsureVerifier(cfg); err != nil {
 		return fmt.Errorf("deploy x402 verifier: %w", err)
 	}
+
 	bin, kc := kubectl.Paths(cfg)
 
 	// 1. Patch the Secret with the wallet address.
 	fmt.Printf("Configuring x402: setting wallet address...\n")
+
 	secretPatch := map[string]any{"stringData": map[string]string{"WALLET_ADDRESS": wallet}}
+
 	patchJSON, err := json.Marshal(secretPatch)
 	if err != nil {
 		return fmt.Errorf("marshal secret patch: %w", err)
 	}
+
 	if err := kubectl.Run(bin, kc,
 		"patch", "secret", x402SecretName, "-n", x402Namespace,
 		"-p", string(patchJSON), "--type=merge"); err != nil {
@@ -217,14 +224,18 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	// 2. Update the pricing ConfigMap with wallet and chain.
 	// Read existing config to preserve routes added by the ServiceOffer reconciler.
 	fmt.Printf("Updating x402 pricing config...\n")
+
 	if facilitatorURL == "" {
 		facilitatorURL = "https://facilitator.x402.rs"
 	}
+
 	existingCfg, _ := GetPricingConfig(cfg)
+
 	var existingRoutes []RouteRule
 	if existingCfg != nil {
 		existingRoutes = existingCfg.Routes
 	}
+
 	pricingCfg := &PricingConfig{
 		Wallet:         wallet,
 		Chain:          chain,
@@ -237,6 +248,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	}
 
 	fmt.Printf("x402 configured: wallet=%s chain=%s\n", wallet, chain)
+
 	return nil
 }
 
@@ -267,6 +279,7 @@ func AddRoute(cfg *config.Config, pattern, price, description string, opts ...Ro
 
 	// Re-serialize and patch.
 	bin, kc := kubectl.Paths(cfg)
+
 	return patchPricingConfig(bin, kc, pricingCfg)
 }
 
@@ -310,6 +323,7 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 	if err := kubectl.EnsureCluster(cfg); err != nil {
 		return nil, err
 	}
+
 	bin, kc := kubectl.Paths(cfg)
 
 	raw, err := kubectl.Output(bin, kc,
@@ -335,6 +349,7 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 		tmpFile.Close()
 		return nil, err
 	}
+
 	tmpFile.Close()
 
 	return LoadConfig(tmpFile.Name())
@@ -357,6 +372,7 @@ func patchPricingConfig(bin, kc string, pcfg *PricingConfig) error {
 			"pricing.yaml": string(pricingBytes),
 		},
 	}
+
 	cmPatchJSON, err := json.Marshal(cmPatch)
 	if err != nil {
 		return fmt.Errorf("marshal pricing patch: %w", err)

--- a/internal/x402/setup_test.go
+++ b/internal/x402/setup_test.go
@@ -19,6 +19,7 @@ func TestRouteOption_WithPayTo(t *testing.T) {
 	if r.Pattern != "/rpc/*" {
 		t.Errorf("Pattern mutated: %q", r.Pattern)
 	}
+
 	if r.Network != "" {
 		t.Errorf("Network should remain empty, got %q", r.Network)
 	}
@@ -32,6 +33,7 @@ func TestRouteOption_WithNetwork(t *testing.T) {
 	if r.Network != "base" {
 		t.Errorf("Network = %q, want base", r.Network)
 	}
+
 	if r.PayTo != "" {
 		t.Errorf("PayTo should remain empty, got %q", r.PayTo)
 	}
@@ -39,6 +41,7 @@ func TestRouteOption_WithNetwork(t *testing.T) {
 
 func TestRouteOption_Multiple(t *testing.T) {
 	r := RouteRule{Pattern: "/api/*", Price: "0.005", Description: "API"}
+
 	opts := []RouteOption{
 		WithPayTo("0x1111111111111111111111111111111111111111"),
 		WithNetwork("base-sepolia"),
@@ -53,36 +56,44 @@ func TestRouteOption_Multiple(t *testing.T) {
 	if r.PayTo != "0x1111111111111111111111111111111111111111" {
 		t.Errorf("PayTo = %q, want 0x1111...", r.PayTo)
 	}
+
 	if r.Network != "base-sepolia" {
 		t.Errorf("Network = %q, want base-sepolia", r.Network)
 	}
+
 	if r.UpstreamAuth != "Bearer test" {
 		t.Errorf("UpstreamAuth = %q, want %q", r.UpstreamAuth, "Bearer test")
 	}
+
 	if r.PriceModel != "perMTok" {
 		t.Errorf("PriceModel = %q, want %q", r.PriceModel, "perMTok")
 	}
+
 	if r.PerMTok != "0.50" {
 		t.Errorf("PerMTok = %q, want %q", r.PerMTok, "0.50")
 	}
+
 	if r.ApproxTokensPerRequest != 1000 {
 		t.Errorf("ApproxTokensPerRequest = %d, want %d", r.ApproxTokensPerRequest, 1000)
 	}
+
 	if r.OfferNamespace != "default" {
 		t.Errorf("OfferNamespace = %q, want %q", r.OfferNamespace, "default")
 	}
+
 	if r.OfferName != "api-offer" {
 		t.Errorf("OfferName = %q, want %q", r.OfferName, "api-offer")
 	}
 }
 
 func TestRouteOption_NoOptions(t *testing.T) {
-	r := RouteRule{Pattern: "/health", Price: "0", Description: "Health check"}
+	var r RouteRule
 
 	// No options applied — PayTo and Network should remain zero-value.
 	if r.PayTo != "" {
 		t.Errorf("PayTo should be empty, got %q", r.PayTo)
 	}
+
 	if r.Network != "" {
 		t.Errorf("Network should be empty, got %q", r.Network)
 	}
@@ -116,33 +127,43 @@ func TestRouteRule_YAMLRoundTrip(t *testing.T) {
 	if decoded.Pattern != original.Pattern {
 		t.Errorf("Pattern = %q, want %q", decoded.Pattern, original.Pattern)
 	}
+
 	if decoded.Price != original.Price {
 		t.Errorf("Price = %q, want %q", decoded.Price, original.Price)
 	}
+
 	if decoded.Description != original.Description {
 		t.Errorf("Description = %q, want %q", decoded.Description, original.Description)
 	}
+
 	if decoded.PayTo != original.PayTo {
 		t.Errorf("PayTo = %q, want %q", decoded.PayTo, original.PayTo)
 	}
+
 	if decoded.Network != original.Network {
 		t.Errorf("Network = %q, want %q", decoded.Network, original.Network)
 	}
+
 	if decoded.UpstreamAuth != original.UpstreamAuth {
 		t.Errorf("UpstreamAuth = %q, want %q", decoded.UpstreamAuth, original.UpstreamAuth)
 	}
+
 	if decoded.PriceModel != original.PriceModel {
 		t.Errorf("PriceModel = %q, want %q", decoded.PriceModel, original.PriceModel)
 	}
+
 	if decoded.PerMTok != original.PerMTok {
 		t.Errorf("PerMTok = %q, want %q", decoded.PerMTok, original.PerMTok)
 	}
+
 	if decoded.ApproxTokensPerRequest != original.ApproxTokensPerRequest {
 		t.Errorf("ApproxTokensPerRequest = %d, want %d", decoded.ApproxTokensPerRequest, original.ApproxTokensPerRequest)
 	}
+
 	if decoded.OfferNamespace != original.OfferNamespace {
 		t.Errorf("OfferNamespace = %q, want %q", decoded.OfferNamespace, original.OfferNamespace)
 	}
+
 	if decoded.OfferName != original.OfferName {
 		t.Errorf("OfferName = %q, want %q", decoded.OfferName, original.OfferName)
 	}
@@ -165,9 +186,11 @@ func TestRouteRule_OmitEmpty(t *testing.T) {
 	if strings.Contains(out, "payTo") {
 		t.Errorf("YAML output should omit payTo when empty, got:\n%s", out)
 	}
+
 	if strings.Contains(out, "network") {
 		t.Errorf("YAML output should omit network when empty, got:\n%s", out)
 	}
+
 	if strings.Contains(out, "priceModel") {
 		t.Errorf("YAML output should omit priceModel when empty, got:\n%s", out)
 	}
@@ -175,6 +198,7 @@ func TestRouteRule_OmitEmpty(t *testing.T) {
 	if !strings.Contains(out, "pattern:") {
 		t.Errorf("YAML output should contain pattern, got:\n%s", out)
 	}
+
 	if !strings.Contains(out, "price:") {
 		t.Errorf("YAML output should contain price, got:\n%s", out)
 	}
@@ -220,15 +244,19 @@ func TestPricingConfig_YAMLRoundTrip(t *testing.T) {
 	if decoded.Wallet != original.Wallet {
 		t.Errorf("Wallet = %q, want %q", decoded.Wallet, original.Wallet)
 	}
+
 	if decoded.Chain != original.Chain {
 		t.Errorf("Chain = %q, want %q", decoded.Chain, original.Chain)
 	}
+
 	if decoded.FacilitatorURL != original.FacilitatorURL {
 		t.Errorf("FacilitatorURL = %q, want %q", decoded.FacilitatorURL, original.FacilitatorURL)
 	}
+
 	if decoded.VerifyOnly != original.VerifyOnly {
 		t.Errorf("VerifyOnly = %v, want %v", decoded.VerifyOnly, original.VerifyOnly)
 	}
+
 	if len(decoded.Routes) != len(original.Routes) {
 		t.Fatalf("Routes count = %d, want %d", len(decoded.Routes), len(original.Routes))
 	}
@@ -237,6 +265,7 @@ func TestPricingConfig_YAMLRoundTrip(t *testing.T) {
 	if decoded.Routes[0].PayTo != "" {
 		t.Errorf("Routes[0].PayTo = %q, want empty", decoded.Routes[0].PayTo)
 	}
+
 	if decoded.Routes[0].Network != "" {
 		t.Errorf("Routes[0].Network = %q, want empty", decoded.Routes[0].Network)
 	}
@@ -245,21 +274,27 @@ func TestPricingConfig_YAMLRoundTrip(t *testing.T) {
 	if decoded.Routes[1].PayTo != original.Routes[1].PayTo {
 		t.Errorf("Routes[1].PayTo = %q, want %q", decoded.Routes[1].PayTo, original.Routes[1].PayTo)
 	}
+
 	if decoded.Routes[1].Network != original.Routes[1].Network {
 		t.Errorf("Routes[1].Network = %q, want %q", decoded.Routes[1].Network, original.Routes[1].Network)
 	}
+
 	if decoded.Routes[1].PriceModel != original.Routes[1].PriceModel {
 		t.Errorf("Routes[1].PriceModel = %q, want %q", decoded.Routes[1].PriceModel, original.Routes[1].PriceModel)
 	}
+
 	if decoded.Routes[1].PerMTok != original.Routes[1].PerMTok {
 		t.Errorf("Routes[1].PerMTok = %q, want %q", decoded.Routes[1].PerMTok, original.Routes[1].PerMTok)
 	}
+
 	if decoded.Routes[1].ApproxTokensPerRequest != original.Routes[1].ApproxTokensPerRequest {
 		t.Errorf("Routes[1].ApproxTokensPerRequest = %d, want %d", decoded.Routes[1].ApproxTokensPerRequest, original.Routes[1].ApproxTokensPerRequest)
 	}
+
 	if decoded.Routes[1].OfferNamespace != original.Routes[1].OfferNamespace {
 		t.Errorf("Routes[1].OfferNamespace = %q, want %q", decoded.Routes[1].OfferNamespace, original.Routes[1].OfferNamespace)
 	}
+
 	if decoded.Routes[1].OfferName != original.Routes[1].OfferName {
 		t.Errorf("Routes[1].OfferName = %q, want %q", decoded.Routes[1].OfferName, original.Routes[1].OfferName)
 	}
@@ -320,6 +355,7 @@ func TestPricingConfig_YAMLWithPerRouteOverrides(t *testing.T) {
 	if strings.Contains(rpcSection, "payTo") {
 		t.Errorf("RPC route section should not contain payTo:\n%s", rpcSection)
 	}
+
 	if strings.Contains(rpcSection, "network") {
 		t.Errorf("RPC route section should not contain network:\n%s", rpcSection)
 	}
@@ -330,12 +366,15 @@ func TestX402Manifest_IncludesVerifierServiceMonitor(t *testing.T) {
 	if !strings.Contains(manifest, "kind: ServiceMonitor") {
 		t.Fatalf("x402 manifest missing ServiceMonitor:\n%s", manifest)
 	}
+
 	if !strings.Contains(manifest, "name: x402-verifier") {
 		t.Fatalf("x402 manifest missing x402-verifier monitor name:\n%s", manifest)
 	}
+
 	if !strings.Contains(manifest, "release: monitoring") {
 		t.Fatalf("x402 manifest missing monitoring release label:\n%s", manifest)
 	}
+
 	if !strings.Contains(manifest, "path: /metrics") {
 		t.Fatalf("x402 manifest missing metrics scrape path:\n%s", manifest)
 	}

--- a/internal/x402/validate.go
+++ b/internal/x402/validate.go
@@ -12,8 +12,10 @@ func ValidateWallet(addr string) error {
 	if !strings.HasPrefix(addr, "0x") && !strings.HasPrefix(addr, "0X") {
 		return fmt.Errorf("invalid wallet address %q: must be 0x-prefixed 40-char hex", addr)
 	}
+
 	if !common.IsHexAddress(addr) {
 		return fmt.Errorf("invalid wallet address %q: must be 0x-prefixed 40-char hex", addr)
 	}
+
 	return nil
 }

--- a/internal/x402/validate_test.go
+++ b/internal/x402/validate_test.go
@@ -20,9 +20,9 @@ func TestValidateWallet(t *testing.T) {
 		"0xGGGG",
 		"not-an-address",
 		"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", // missing 0x prefix
-		"0xdeadbeef",                                // too short
+		"0xdeadbeef", // too short
 		"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefAA", // too long
-		`0x"; malicious: true; "`,                   // injection attempt
+		`0x"; malicious: true; "`,                      // injection attempt
 	}
 	for _, addr := range invalid {
 		if err := ValidateWallet(addr); err == nil {

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -30,6 +30,7 @@ func NewVerifier(cfg *PricingConfig) (*Verifier, error) {
 	if err := v.load(cfg); err != nil {
 		return nil, err
 	}
+
 	return v, nil
 }
 
@@ -54,6 +55,7 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 				if err != nil {
 					return fmt.Errorf("resolve chain for route %q: %w", r.Pattern, err)
 				}
+
 				chains[r.Network] = rc
 			}
 		}
@@ -62,6 +64,7 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 	v.chain.Store(&chain)
 	v.chains.Store(&chains)
 	v.config.Store(cfg)
+
 	return nil
 }
 
@@ -80,10 +83,12 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		// Fail-closed: deny rather than silently allowing through.
 		log.Printf("x402-verifier: missing X-Forwarded-Uri header (misconfiguration or direct access)")
 		http.Error(w, "forbidden: missing forwarded URI", http.StatusForbidden)
+
 		return
 	}
 
 	cfg := v.config.Load()
+
 	rule := matchRoute(cfg.Routes, uri)
 	if rule == nil {
 		// No pricing rule matches — route is free.
@@ -104,10 +109,12 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 
 	// Look up pre-resolved chain (populated during config load).
 	chains := v.chains.Load()
+
 	chain, ok := (*chains)[chainName]
 	if !ok {
 		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
 		http.Error(w, "internal error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -119,6 +126,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("x402-verifier: failed to create payment requirement: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -127,7 +135,9 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if host := r.Header.Get("X-Forwarded-Host"); host != "" {
 		r.Host = host
 	}
+
 	r.URL.Path = uri
+
 	r.RequestURI = uri
 	if method := r.Header.Get("X-Forwarded-Method"); method != "" {
 		r.Method = method
@@ -139,6 +149,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	// copies this to the forwarded request, authenticating it with the upstream.
 	labels := prometheusLabels(rule)
 	v.metrics.requestsTotal.With(labels).Inc()
+
 	middleware := x402http.NewX402Middleware(&x402http.Config{
 		FacilitatorURL:      cfg.FacilitatorURL,
 		PaymentRequirements: []x402lib.PaymentRequirement{requirement},
@@ -150,16 +161,18 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		if upstreamAuth != "" {
 			w.Header().Set("Authorization", upstreamAuth)
 		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 
 	tracker := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 	middleware(inner).ServeHTTP(tracker, r)
+
 	switch {
-	case tracker.status == http.StatusOK && r.Header.Get("X-PAYMENT") != "":
+	case tracker.status == http.StatusOK && r.Header.Get("X-Payment") != "":
 		v.metrics.paymentVerified.With(labels).Inc()
 		v.metrics.chargedRequests.With(labels).Inc()
-	case tracker.status == http.StatusPaymentRequired && r.Header.Get("X-PAYMENT") != "":
+	case tracker.status == http.StatusPaymentRequired && r.Header.Get("X-Payment") != "":
 		v.metrics.paymentFailed.With(labels).Inc()
 	case tracker.status == http.StatusPaymentRequired:
 		v.metrics.paymentRequired.With(labels).Inc()
@@ -178,6 +191,7 @@ func (v *Verifier) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not ready", http.StatusServiceUnavailable)
 		return
 	}
+
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, `{"status":"ready"}`)
 }
@@ -195,6 +209,7 @@ func (v *Verifier) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no registration configured", http.StatusNotFound)
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(reg)
 }
@@ -206,6 +221,7 @@ func (v *Verifier) MetricsHandler() http.Handler {
 
 type statusRecorder struct {
 	http.ResponseWriter
+
 	status int
 }
 

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -211,7 +211,7 @@ func (v *Verifier) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(reg)
+	_ = json.NewEncoder(w).Encode(reg) //nolint:errchkjson // controlled registration struct
 }
 
 // MetricsHandler exposes Prometheus metrics for the verifier.

--- a/internal/x402/verifier_test.go
+++ b/internal/x402/verifier_test.go
@@ -25,12 +25,14 @@ type mockFacilitatorOpts struct {
 
 type mockFacilitator struct {
 	*httptest.Server
+
 	verifyCalls atomic.Int32
 	settleCalls atomic.Int32
 }
 
 func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator {
 	t.Helper()
+
 	mf := &mockFacilitator{}
 
 	mux := http.NewServeMux()
@@ -43,10 +45,12 @@ func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator
 	mux.HandleFunc("/verify", func(w http.ResponseWriter, r *http.Request) {
 		mf.verifyCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
+
 		if opts.rejectPayment {
 			fmt.Fprintf(w, `{"isValid":false,"invalidReason":"mock rejection"}`)
 			return
 		}
+
 		fmt.Fprintf(w, `{"isValid":true,"payer":"0xmockpayer"}`)
 	})
 
@@ -57,13 +61,15 @@ func newMockFacilitator(t *testing.T, opts mockFacilitatorOpts) *mockFacilitator
 	})
 
 	mf.Server = httptest.NewServer(mux)
-	t.Cleanup(mf.Server.Close)
+	t.Cleanup(mf.Close)
+
 	return mf
 }
 
 // testPaymentHeader returns a base64-encoded x402 PaymentPayload for BaseSepolia.
 func testPaymentHeader(t *testing.T) string {
 	t.Helper()
+
 	p := x402lib.PaymentPayload{
 		X402Version: 1,
 		Scheme:      "exact",
@@ -80,16 +86,19 @@ func testPaymentHeader(t *testing.T) string {
 			},
 		},
 	}
+
 	data, err := json.Marshal(p)
 	if err != nil {
 		t.Fatalf("marshal payment: %v", err)
 	}
+
 	return base64.StdEncoding.EncodeToString(data)
 }
 
 // newTestVerifier creates a Verifier backed by the given facilitator URL.
 func newTestVerifier(t *testing.T, facilitatorURL string, routes []RouteRule) *Verifier {
 	t.Helper()
+
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
@@ -100,6 +109,7 @@ func newTestVerifier(t *testing.T, facilitatorURL string, routes []RouteRule) *V
 	if err != nil {
 		t.Fatalf("NewVerifier: %v", err)
 	}
+
 	return v
 }
 
@@ -129,12 +139,14 @@ func TestVerifier_FreeRoute_Returns200(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/health")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for free route, got %d", w.Code)
 	}
+
 	if fac.verifyCalls.Load() != 0 {
 		t.Error("facilitator should not be called for free routes")
 	}
@@ -173,16 +185,19 @@ func TestVerifier_PaidRoute_ValidPayment_Returns200(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 with valid payment, got %d", w.Code)
 	}
+
 	if fac.verifyCalls.Load() != 1 {
 		t.Errorf("expected 1 verify call, got %d", fac.verifyCalls.Load())
 	}
+
 	if fac.settleCalls.Load() != 1 {
 		t.Errorf("expected 1 settle call, got %d", fac.settleCalls.Load())
 	}
@@ -197,13 +212,15 @@ func TestVerifier_PaidRoute_RejectedPayment_Returns402(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
 	if w.Code != http.StatusPaymentRequired {
 		t.Errorf("expected 402 for rejected payment, got %d", w.Code)
 	}
+
 	if fac.settleCalls.Load() != 0 {
 		t.Error("settle should not be called when verify fails")
 	}
@@ -211,6 +228,7 @@ func TestVerifier_PaidRoute_RejectedPayment_Returns402(t *testing.T) {
 
 func TestVerifier_VerifyOnly_SkipsSettle(t *testing.T) {
 	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
@@ -225,16 +243,19 @@ func TestVerifier_VerifyOnly_SkipsSettle(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
+
 	if fac.verifyCalls.Load() != 1 {
 		t.Errorf("expected 1 verify call, got %d", fac.verifyCalls.Load())
 	}
+
 	if fac.settleCalls.Load() != 0 {
 		t.Errorf("expected 0 settle calls (verifyOnly), got %d", fac.settleCalls.Load())
 	}
@@ -251,8 +272,10 @@ func TestVerifier_MultipleRoutes_CorrectMatching(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
+
 	if w.Code != http.StatusPaymentRequired {
 		t.Errorf("rpc route: expected 402, got %d", w.Code)
 	}
@@ -261,8 +284,10 @@ func TestVerifier_MultipleRoutes_CorrectMatching(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req2.Header.Set("X-Forwarded-Uri", "/inference-prod/v1/chat/completions")
 	req2.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w2 := httptest.NewRecorder()
 	v.HandleVerify(w2, req2)
+
 	if w2.Code != http.StatusPaymentRequired {
 		t.Errorf("inference route: expected 402, got %d", w2.Code)
 	}
@@ -270,8 +295,10 @@ func TestVerifier_MultipleRoutes_CorrectMatching(t *testing.T) {
 	// Frontend route — should be free.
 	req3 := httptest.NewRequest(http.MethodGet, "/verify", nil)
 	req3.Header.Set("X-Forwarded-Uri", "/dashboard")
+
 	w3 := httptest.NewRecorder()
 	v.HandleVerify(w3, req3)
+
 	if w3.Code != http.StatusOK {
 		t.Errorf("frontend route: expected 200 (free), got %d", w3.Code)
 	}
@@ -286,8 +313,10 @@ func TestVerifier_ConfigReload(t *testing.T) {
 	// Initially /api/* is free.
 	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/api/data")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
+
 	if w.Code != http.StatusOK {
 		t.Errorf("before reload: expected 200 for /api/data, got %d", w.Code)
 	}
@@ -310,8 +339,10 @@ func TestVerifier_ConfigReload(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodGet, "/verify", nil)
 	req2.Header.Set("X-Forwarded-Uri", "/api/data")
 	req2.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w2 := httptest.NewRecorder()
 	v.HandleVerify(w2, req2)
+
 	if w2.Code != http.StatusPaymentRequired {
 		t.Errorf("after reload: expected 402 for /api/data, got %d", w2.Code)
 	}
@@ -385,9 +416,11 @@ func TestVerifier_SetRegistration(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
+
 	if got.Name != "test-agent" {
 		t.Errorf("name = %q, want test-agent", got.Name)
 	}
+
 	if !got.X402Support {
 		t.Error("x402Support should be true")
 	}
@@ -444,6 +477,7 @@ func TestVerifier_HandleWellKnown_JSON(t *testing.T) {
 
 	// Verify the response is valid JSON with expected fields.
 	body, _ := io.ReadAll(w.Body)
+
 	var raw map[string]any
 	if err := json.Unmarshal(body, &raw); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
@@ -452,12 +486,15 @@ func TestVerifier_HandleWellKnown_JSON(t *testing.T) {
 	if raw["type"] != erc8004.RegistrationType {
 		t.Errorf("type = %v, want %s", raw["type"], erc8004.RegistrationType)
 	}
+
 	if raw["name"] != "json-test" {
 		t.Errorf("name = %v, want json-test", raw["name"])
 	}
+
 	if raw["x402Support"] != true {
 		t.Errorf("x402Support = %v, want true", raw["x402Support"])
 	}
+
 	if raw["active"] != true {
 		t.Errorf("active = %v, want true", raw["active"])
 	}
@@ -487,15 +524,18 @@ func TestVerifier_ReadyzNotReady(t *testing.T) {
 // the first PaymentRequirement from the "accepts" array.
 func parse402Accepts(t *testing.T, body []byte) x402lib.PaymentRequirement {
 	t.Helper()
+
 	var resp struct {
 		Accepts []x402lib.PaymentRequirement `json:"accepts"`
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
 		t.Fatalf("failed to decode 402 body: %v\nbody: %s", err, string(body))
 	}
+
 	if len(resp.Accepts) == 0 {
 		t.Fatal("402 response has empty accepts array")
 	}
+
 	return resp.Accepts[0]
 }
 
@@ -522,6 +562,7 @@ func TestVerifier_PerRoutePayTo_UsesRouteWallet(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/services/test/foo")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
@@ -535,6 +576,7 @@ func TestVerifier_PerRoutePayTo_UsesRouteWallet(t *testing.T) {
 	if pr.PayTo != routeWallet {
 		t.Errorf("payTo = %q, want route wallet %q", pr.PayTo, routeWallet)
 	}
+
 	if pr.PayTo == globalWallet {
 		t.Error("payTo should NOT be the global wallet — per-route override was ignored")
 	}
@@ -560,6 +602,7 @@ func TestVerifier_PerRouteNetwork_ResolvesCorrectChain(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/services/mainnet/rpc")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
@@ -574,6 +617,7 @@ func TestVerifier_PerRouteNetwork_ResolvesCorrectChain(t *testing.T) {
 	if pr.Network != x402lib.BaseMainnet.NetworkID {
 		t.Errorf("network = %q, want %q (base mainnet)", pr.Network, x402lib.BaseMainnet.NetworkID)
 	}
+
 	if pr.Network == x402lib.BaseSepolia.NetworkID {
 		t.Error("network should NOT be base-sepolia — per-route override was ignored")
 	}
@@ -601,13 +645,15 @@ func TestVerifier_PerRoutePayTo_WithValidPayment(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/services/test/foo")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
-	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	req.Header.Set("X-Payment", testPaymentHeader(t))
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 with valid payment on per-route PayTo, got %d", w.Code)
 	}
+
 	if fac.verifyCalls.Load() != 1 {
 		t.Errorf("expected 1 verify call, got %d", fac.verifyCalls.Load())
 	}
@@ -629,6 +675,7 @@ func TestVerifier_PerRouteNetwork_InvalidChain_RejectsAtLoad(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected NewVerifier to reject invalid per-route chain at load time")
 	}
+
 	if !strings.Contains(err.Error(), "unsupported chain") {
 		t.Errorf("expected 'unsupported chain' error, got: %v", err)
 	}
@@ -656,6 +703,7 @@ func TestVerifier_NoPerRouteOverride_UsesGlobalWallet(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
@@ -694,13 +742,16 @@ func TestVerifier_MixedRoutes_CorrectOverrides(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req1.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req1.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w1 := httptest.NewRecorder()
 	v.HandleVerify(w1, req1)
 
 	if w1.Code != http.StatusPaymentRequired {
 		t.Fatalf("rpc route: expected 402, got %d", w1.Code)
 	}
+
 	body1, _ := io.ReadAll(w1.Body)
+
 	pr1 := parse402Accepts(t, body1)
 	if pr1.PayTo != globalWallet {
 		t.Errorf("rpc route: payTo = %q, want global wallet %q", pr1.PayTo, globalWallet)
@@ -710,13 +761,16 @@ func TestVerifier_MixedRoutes_CorrectOverrides(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req2.Header.Set("X-Forwarded-Uri", "/services/custom/endpoint")
 	req2.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w2 := httptest.NewRecorder()
 	v.HandleVerify(w2, req2)
 
 	if w2.Code != http.StatusPaymentRequired {
 		t.Fatalf("custom route: expected 402, got %d", w2.Code)
 	}
+
 	body2, _ := io.ReadAll(w2.Body)
+
 	pr2 := parse402Accepts(t, body2)
 	if pr2.PayTo != customWallet {
 		t.Errorf("custom route: payTo = %q, want custom wallet %q", pr2.PayTo, customWallet)
@@ -735,6 +789,7 @@ func TestVerifier_MetricsPaymentRequired(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	req.Header.Set("X-Forwarded-Host", "obol.stack")
+
 	w := httptest.NewRecorder()
 	v.HandleVerify(w, req)
 
@@ -773,9 +828,11 @@ func TestVerifier_MetricsVerifiedAndRejectedPayments(t *testing.T) {
 	okReq := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	okReq.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	okReq.Header.Set("X-Forwarded-Host", "obol.stack")
-	okReq.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	okReq.Header.Set("X-Payment", testPaymentHeader(t))
+
 	okResp := httptest.NewRecorder()
 	okVerifier.HandleVerify(okResp, okReq)
+
 	if okResp.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", okResp.Code)
 	}
@@ -798,9 +855,11 @@ func TestVerifier_MetricsVerifiedAndRejectedPayments(t *testing.T) {
 	rejectReq := httptest.NewRequest(http.MethodPost, "/verify", nil)
 	rejectReq.Header.Set("X-Forwarded-Uri", "/rpc/mainnet")
 	rejectReq.Header.Set("X-Forwarded-Host", "obol.stack")
-	rejectReq.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	rejectReq.Header.Set("X-Payment", testPaymentHeader(t))
+
 	rejectResp := httptest.NewRecorder()
 	rejectVerifier.HandleVerify(rejectResp, rejectReq)
+
 	if rejectResp.Code != http.StatusPaymentRequired {
 		t.Fatalf("expected 402, got %d", rejectResp.Code)
 	}
@@ -818,11 +877,13 @@ func scrapeVerifierMetrics(t *testing.T, v *Verifier) map[string]*dto.MetricFami
 
 	rec := httptest.NewRecorder()
 	v.MetricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
 	if rec.Code != http.StatusOK {
 		t.Fatalf("metrics status = %d, want 200", rec.Code)
 	}
 
 	var parser expfmt.TextParser
+
 	families, err := parser.TextToMetricFamilies(strings.NewReader(rec.Body.String()))
 	if err != nil {
 		t.Fatalf("parse metrics: %v", err)
@@ -844,6 +905,7 @@ func assertVerifierMetricValue(t *testing.T, family *dto.MetricFamily, wantLabel
 			if got != wantValue {
 				t.Fatalf("%s labels %v = %v, want %v", family.GetName(), wantLabels, got, wantValue)
 			}
+
 			return
 		}
 	}
@@ -869,19 +931,21 @@ func verifierLabelsMatch(metric *dto.Metric, want map[string]string) bool {
 	if len(metric.GetLabel()) != len(want) {
 		return false
 	}
+
 	for _, label := range metric.GetLabel() {
 		if want[label.GetName()] != label.GetValue() {
 			return false
 		}
 	}
+
 	return true
 }
 
 func verifierMetricValue(metric *dto.Metric) float64 {
 	switch {
-	case metric.Counter != nil:
+	case metric.GetCounter() != nil:
 		return metric.GetCounter().GetValue()
-	case metric.Gauge != nil:
+	case metric.GetGauge() != nil:
 		return metric.GetGauge().GetValue()
 	default:
 		return 0

--- a/internal/x402/watcher.go
+++ b/internal/x402/watcher.go
@@ -38,6 +38,7 @@ func WatchConfig(ctx context.Context, path string, v *Verifier, interval time.Du
 			if mod.Equal(lastMod) {
 				continue
 			}
+
 			lastMod = mod
 
 			cfg, err := LoadConfig(path)

--- a/internal/x402/watcher_test.go
+++ b/internal/x402/watcher_test.go
@@ -18,7 +18,8 @@ routes:
 
 func writeConfig(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -38,8 +39,7 @@ func TestWatchConfig_DetectsChange(t *testing.T) {
 		t.Fatalf("NewVerifier: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go WatchConfig(ctx, path, v, 10*time.Millisecond)
 
@@ -65,6 +65,7 @@ routes:
 	if cfg == nil {
 		t.Fatal("config is nil after reload")
 	}
+
 	if len(cfg.Routes) != 2 {
 		t.Errorf("expected 2 routes after reload, got %d", len(cfg.Routes))
 	}
@@ -85,8 +86,7 @@ func TestWatchConfig_IgnoresUnchanged(t *testing.T) {
 		t.Fatalf("NewVerifier: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go WatchConfig(ctx, path, v, 10*time.Millisecond)
 
@@ -98,6 +98,7 @@ func TestWatchConfig_IgnoresUnchanged(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("config should not be nil")
 	}
+
 	if len(cfg.Routes) != 1 {
 		t.Errorf("expected 1 route (unchanged), got %d", len(cfg.Routes))
 	}
@@ -118,8 +119,7 @@ func TestWatchConfig_InvalidConfig(t *testing.T) {
 		t.Fatalf("NewVerifier: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go WatchConfig(ctx, path, v, 10*time.Millisecond)
 
@@ -159,6 +159,7 @@ func TestWatchConfig_CancelContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan struct{})
+
 	go func() {
 		WatchConfig(ctx, path, v, 10*time.Millisecond)
 		close(done)
@@ -187,8 +188,7 @@ func TestWatchConfig_MissingFile(t *testing.T) {
 		t.Fatalf("NewVerifier: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Point at a non-existent path — watcher should log but not crash.
 	go WatchConfig(ctx, "/nonexistent/config.yaml", v, 10*time.Millisecond)
@@ -201,6 +201,7 @@ func TestWatchConfig_MissingFile(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("config should not be nil — original should be preserved")
 	}
+
 	if len(cfg.Routes) != 1 {
 		t.Errorf("expected original config (1 route), got %d", len(cfg.Routes))
 	}

--- a/justfile
+++ b/justfile
@@ -27,13 +27,13 @@ clean:
 
 # Initialize and start the cluster
 up:
-    obol cluster init
-    obol cluster up
+    obol stack init
+    obol stack up
 
 # Stop and purge the cluster
 down:
-    obol cluster down
-    obol cluster purge
+    obol stack down
+    obol stack purge
 
 # Path to the frontend repo (override with FRONTEND_DIR=../path just dev-frontend)
 frontend_dir := env("FRONTEND_DIR", justfile_directory() / "../obol-stack-front-end")


### PR DESCRIPTION
## Summary

- **golangci-lint v2 config** aligned with `ObolNetwork/charon`'s lint stance, adapted for obol-stack
- **All linters active with zero issues** — every linter from the config passes cleanly
- **gofumpt + goimports** formatting applied across the entire codebase (130 Go files)
- **PostToolUse hook** — `golangci-lint fmt` on edited Go files (single-file scope, via PATH)
- **CLAUDE.md** trimmed (219→190 lines): removed discoverable sections, added conventions
- **justfile** fixed stale `obol cluster` → `obol stack` commands

### Security (gosec)
- Tighten WriteFile permissions 0644→0600 across 13 files
- Exclude G204 (subprocess), G101 (credential naming) — CLI false positives
- Nolint SSRF/XSS/TOCTOU false positives with explanations

### Correctness
- Fix appendAssign slice mutation bugs (gocritic) — copy before append
- Fix unchecked errors (errcheck) — `_ =` for best-effort calls
- Annotate intentional fallback patterns (nilerr) — missing config, optional features
- Lowercase error strings (staticcheck ST1005), De Morgan's law (QF1001)
- Remove unused code: `sellInfoCommand`, `pubKeyBytes`
- Simplify `buildLocalManagedSecretYAML` — remove always-nil error return

### Code quality
- Extract provider constants (`ProviderOllama`, `ProviderAnthropic`, `ProviderOpenAI`)
- Extract env var constants, OS name constants, update status messages
- Remove unnecessary `int()` conversions, use `net.JoinHostPort`

### Config
- `fix: false` — lint runs are non-mutating, suitable for CI
- Disabled linters not applicable to CLI apps: wrapcheck, forbidigo, noctx, testpackage, depguard
- Noisy revive rules disabled (enforce-switch-style, unnecessary-format, etc.)
- goconst/unparam/errcheck excluded from test files

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing x402/buyer proxy failures unchanged)
- [x] `golangci-lint run ./...` reports 0 issues with all linters active
- [x] PostToolUse hook verified: formats single file on edit