### PR TITLE
Add local inference server auto-detection and improve stack setup

### DIFF
--- a/.github/workflows/docker-publish-x402.yml
+++ b/.github/workflows/docker-publish-x402.yml
@@ -1,4 +1,4 @@
-name: Build and Publish x402-verifier Image
+name: Build and Publish x402 Images
 
 on:
   push:
@@ -10,33 +10,45 @@ on:
     paths:
       - 'internal/x402/**'
       - 'cmd/x402-verifier/**'
+      - 'cmd/x402-buyer/**'
       - 'Dockerfile.x402-verifier'
+      - 'Dockerfile.x402-buyer'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/docker-publish-x402-verifier.yml'
+      - '.github/workflows/docker-publish-x402.yml'
   workflow_dispatch:
 
 concurrency:
-  group: x402-verifier-${{ github.ref }}
+  group: x402-${{ github.ref }}
   cancel-in-progress: true
-
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: obolnetwork/x402-verifier
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Job 1: Build the x402-verifier binary and publish the image.
-  # Uses the same action versions as the working OpenClaw workflow.
+  # Build each x402 component and publish its image.
   # ---------------------------------------------------------------------------
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: x402-verifier
+            image: obolnetwork/x402-verifier
+            dockerfile: Dockerfile.x402-verifier
+            description: x402 payment verification sidecar for Obol Stack
+          - component: x402-buyer
+            image: obolnetwork/x402-buyer
+            dockerfile: Dockerfile.x402-buyer
+            description: x402 buy-side payment sidecar for Obol Stack
     outputs:
-      digest: ${{ steps.build-push.outputs.digest }}
+      verifier-digest: ${{ steps.build-push.outputs.digest }}
+      buyer-digest: ${{ steps.build-push.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -59,16 +71,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/secure-enclave-inference' }}
           labels: |
-            org.opencontainers.image.title=x402-verifier
-            org.opencontainers.image.description=x402 payment verification sidecar for Obol Stack
-            org.opencontainers.image.vendor=Obol Network
+            org.opencontainers.image.title=${{ matrix.component }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.vendor=Obol
             org.opencontainers.image.source=https://github.com/ObolNetwork/obol-stack
 
       - name: Build and push
@@ -76,30 +88,38 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
-          file: Dockerfile.x402-verifier
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=x402-verifier
-          cache-to: type=gha,scope=x402-verifier,mode=max
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,scope=${{ matrix.component }},mode=max
           provenance: true
           sbom: true
 
   # ---------------------------------------------------------------------------
-  # Job 2: Security scan the published image using the exact digest from build.
+  # Security scan each published image.
   # ---------------------------------------------------------------------------
   security-scan:
     needs: build
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: x402-verifier
+            image: obolnetwork/x402-verifier
+          - component: x402-buyer
+            image: obolnetwork/x402-buyer
 
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:latest
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,29 @@ The Cloudflare tunnel exposes the cluster to the public internet. Only x402-gate
 
 ## Dependencies
 
-Docker 20.10.0+, Go 1.25+. Toolchain installed by `obolup.sh` (kubectl, helm, k3d, helmfile, k9s). Key Go deps: `urfave/cli/v3`, `dustinkirkland/golang-petname`, `mark3labs/x402-go`. E2E monetize walkthrough: `@docs/guides/monetize-inference.md`.
+| Package | Key Files | Role |
+|---------|-----------|------|
+| `cmd/obol` | `main.go`, `sell.go`, `network.go`, `openclaw.go`, `model.go` | CLI commands |
+| `internal/config` | `config.go` | XDG Config struct |
+| `internal/stack` | `stack.go` | Cluster lifecycle |
+| `internal/network` | `network.go`, `erpc.go`, `rpc.go`, `parser.go` | Networks, eRPC, RPC gateway |
+| `internal/x402` | `config.go`, `setup.go`, `verifier.go`, `matcher.go`, `watcher.go` | ForwardAuth verifier |
+| `internal/x402/buyer` | `signer.go`, `proxy.go`, `config.go` | Buy-side sidecar |
+| `internal/erc8004` | `client.go`, `types.go`, `abi.go` | ERC-8004 Identity Registry |
+| `internal/agent` | `agent.go` | obol-agent singleton, RBAC patching |
+| `internal/model` | `model.go` | LiteLLM gateway configuration |
+| `internal/openclaw` | `openclaw.go`, `wallet.go`, `resolve.go` | OpenClaw setup, wallet, instance resolution |
+| `internal/inference` | `gateway.go`, `container.go`, `store.go` | Standalone x402 gateway |
+| `internal/enclave` | `enclave.go`, `enclave_darwin.go`, `enclave_stub.go` | Secure Enclave keys |
+| `internal/embed` | `embed.go` | Embedded assets (skills, infrastructure, networks) |
+
+**Embedded assets**: `internal/embed/infrastructure/` (K8s templates), `internal/embed/networks/` (ethereum, helios, aztec), `internal/embed/skills/` (23 skills).
+
+**Tests**: `cmd/obol/sell_test.go` (CLI flags), `internal/x402/*_test.go` (verifier, config, matcher, E2E), `internal/erc8004/*_test.go` (ABI, client), `internal/embed/embed_crd_test.go` (CRD+RBAC validation), `internal/openclaw/integration_test.go` (full-cluster inference), `internal/openclaw/overlay_test.go`, `internal/inference/gateway_test.go`.
+
+**Docs**: `docs/guides/monetize-inference.md` (E2E monetize walkthrough), `README.md`.
+
+**Deps**: Docker 20.10.0+, Go 1.25+. Installed by obolup.sh: kubectl 1.35.3, helm 3.20.1, k3d 5.8.3, helmfile 1.4.3, k9s 0.50.18, helm-diff 3.15.4, ollama 0.20.2. Key Go: `urfave/cli/v3`, `dustinkirkland/golang-petname`, `mark3labs/x402-go`.
 
 ## Related Codebases
 

--- a/cmd/obol/bootstrap.go
+++ b/cmd/obol/bootstrap.go
@@ -40,7 +40,7 @@ func bootstrapCommand(cfg *config.Config) *cli.Command {
 			}
 
 			// Step 2: Start stack
-			if err := stack.Up(cfg, u); err != nil {
+			if err := stack.Up(cfg, u, false); err != nil {
 				return fmt.Errorf("bootstrap up failed: %w", err)
 			}
 

--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -173,8 +173,14 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 					{
 						Name:  "up",
 						Usage: "Start the Obol Stack",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:  "wildcard-dns",
+								Usage: "Configure wildcard *.obol.stack DNS via NetworkManager/dnsmasq (Linux) or /etc/resolver (macOS)",
+							},
+						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							return stack.Up(cfg, getUI(cmd))
+							return stack.Up(cfg, getUI(cmd), cmd.Bool("wildcard-dns"))
 						},
 					},
 					{

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -201,6 +201,49 @@ Examples:
 				return err
 			}
 
+			// Auto-detect model and upstream if --model not specified.
+			modelFlag := cmd.String("model")
+			upstreamFlag := cmd.String("upstream")
+			if modelFlag == "" && u.IsTTY() {
+				detected, scanErr := inference.ScanLocalEndpointsContext(ctx)
+				if scanErr == nil && len(detected) > 0 {
+					fmt.Println("\nDetected local inference servers:")
+					fmt.Print(inference.FormatEndpointDisplay(detected))
+
+					type pick struct {
+						baseURL, modelID string
+					}
+					var picks []pick
+					idx := 1
+					for _, ep := range detected {
+						for _, m := range ep.Models {
+							fmt.Printf("  [%d] %s — %s (%s)\n", idx, m.ID, ep.BaseURL(), ep.ServerType)
+							picks = append(picks, pick{ep.BaseURL(), m.ID})
+							idx++
+						}
+					}
+
+					if len(picks) == 1 {
+						answer, _ := u.Input(fmt.Sprintf("Use %s on %s? [Y/n]", picks[0].modelID, picks[0].baseURL), "")
+						answer = strings.TrimSpace(strings.ToLower(answer))
+						if answer == "" || answer == "y" || answer == "yes" {
+							modelFlag = picks[0].modelID
+							upstreamFlag = picks[0].baseURL
+						}
+					} else if len(picks) > 1 {
+						sel, _ := u.Input("Select [1]", "1")
+						n, parseErr := strconv.Atoi(strings.TrimSpace(sel))
+						if parseErr == nil && n >= 1 && n <= len(picks) {
+							modelFlag = picks[n-1].modelID
+							upstreamFlag = picks[n-1].baseURL
+						}
+					}
+				}
+			}
+			if modelFlag == "" {
+				return fmt.Errorf("--model is required (or run interactively to auto-detect)")
+			}
+
 			teeType := cmd.String("tee")
 			modelHash := cmd.String("model-hash")
 
@@ -233,7 +276,7 @@ Examples:
 				Name:            name,
 				EnclaveTag:      cmd.String("enclave-tag"),
 				ListenAddr:      cmd.String("listen"),
-				UpstreamURL:     cmd.String("upstream"),
+				UpstreamURL:     upstreamFlag,
 				WalletAddress:   wallet,
 				PricePerRequest: perRequest,
 				PricePerMTok:    priceTable.PerMTok,

--- a/internal/dns/resolver.go
+++ b/internal/dns/resolver.go
@@ -14,7 +14,6 @@
 package dns
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -349,20 +348,15 @@ func removeMacOSResolver() {
 // --- Linux (NetworkManager dnsmasq plugin) ---
 
 // configureLinuxResolver sets up NM's dnsmasq plugin for *.obol.stack.
+// Returns a non-fatal error when NetworkManager is unavailable (e.g. headless
+// servers) — the caller falls back to /etc/hosts entries.
 func configureLinuxResolver() error {
 	if configureNMDnsmasq() {
 		return nil
 	}
 
-	// NM not available — print instructions
-	fmt.Println("\nWildcard DNS for *.obol.stack requires NetworkManager with dnsmasq.")
-	fmt.Println("Install with:")
-	fmt.Println("  sudo apt install network-manager dnsmasq-base  # Debian/Ubuntu")
-	fmt.Println("  sudo dnf install NetworkManager dnsmasq        # Fedora/RHEL")
-	fmt.Println("  sudo pacman -S networkmanager dnsmasq           # Arch")
-	fmt.Println("\nThen re-run: obol stack up")
-
-	return errors.New("NetworkManager required for wildcard DNS on Linux")
+	// NM not available — return quiet error; caller handles the fallback message.
+	return fmt.Errorf("NetworkManager not available (headless or server system)")
 }
 
 // hasNMDnsmasqConfig checks if the NM dnsmasq config for obol.stack exists.
@@ -394,11 +388,6 @@ func configureNMDnsmasq() bool {
 
 	// Check if dnsmasq binary is available (NM plugin requires it)
 	if _, err := exec.LookPath("dnsmasq"); err != nil {
-		fmt.Println("Note: dnsmasq not found. Install it for wildcard DNS support:")
-		fmt.Println("  sudo apt install dnsmasq-base  # Debian/Ubuntu")
-		fmt.Println("  sudo dnf install dnsmasq       # Fedora/RHEL")
-		fmt.Println("  sudo pacman -S dnsmasq          # Arch")
-
 		return false
 	}
 

--- a/internal/embed/infrastructure/base/templates/local-path.yaml
+++ b/internal/embed/infrastructure/base/templates/local-path.yaml
@@ -29,7 +29,7 @@ data:
     #!/bin/sh
     set -eu
     mkdir -m 0755 -p "${VOL_DIR}"
-    chown 1000:1000 "${VOL_DIR}"
+    chown -R 1000:1000 "${VOL_DIR}"
   teardown: |-
     #!/bin/sh
     set -eu

--- a/internal/inference/detect.go
+++ b/internal/inference/detect.go
@@ -1,0 +1,261 @@
+package inference
+
+// detect.go — auto-discovery of local inference servers.
+//
+// Probes well-known ports for llama-server, ollama, vLLM, and LiteLLM,
+// hitting their OpenAI-compatible /v1/models endpoint to enumerate
+// available models. Used by `obol sell inference` and `obol model setup`
+// to auto-detect providers when the user doesn't specify --upstream or --model.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ModelInfo describes a single model exposed by an inference server.
+type ModelInfo struct {
+	ID      string `json:"id"`
+	OwnedBy string `json:"owned_by"`
+	Created int64  `json:"created"`
+}
+
+// EndpointInfo describes a discovered local inference endpoint.
+type EndpointInfo struct {
+	Host       string
+	Port       int
+	ServerType string
+	Models     []ModelInfo
+	Healthy    bool
+}
+
+// BaseURL returns the HTTP base URL for this endpoint.
+func (e EndpointInfo) BaseURL() string {
+	return fmt.Sprintf("http://%s:%d", e.Host, e.Port)
+}
+
+// modelsResponse is the OpenAI /v1/models JSON envelope.
+type modelsResponse struct {
+	Data []ModelInfo `json:"data"`
+}
+
+// commonPorts maps well-known ports to their expected server type.
+var commonPorts = []struct {
+	Port       int
+	ServerType string
+}{
+	{8080, "llama-server"},
+	{11434, "ollama"},
+	{8000, "vllm"},
+	{4000, "litellm"},
+}
+
+// probeTimeout is the per-endpoint HTTP timeout.
+const probeTimeout = 2 * time.Second
+
+// ProbeEndpoint hits host:port/v1/models and returns discovered info.
+func ProbeEndpoint(host string, port int) (*EndpointInfo, error) {
+	return ProbeEndpointContext(context.Background(), host, port)
+}
+
+// ProbeEndpointContext is the context-aware version of ProbeEndpoint.
+// It creates a shared HTTP client used for both server type detection
+// and model fetching to avoid redundant connections.
+func ProbeEndpointContext(ctx context.Context, host string, port int) (*EndpointInfo, error) {
+	client := &http.Client{Timeout: probeTimeout}
+	baseURL := fmt.Sprintf("http://%s:%d", host, port)
+	serverType := detectServerTypeWithClient(ctx, client, baseURL)
+	if serverType == "" {
+		return nil, fmt.Errorf("no inference server detected at %s", baseURL)
+	}
+
+	models, err := fetchModels(ctx, client, baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching models from %s: %w", baseURL, err)
+	}
+
+	return &EndpointInfo{
+		Host:       host,
+		Port:       port,
+		ServerType: serverType,
+		Models:     models,
+		Healthy:    true,
+	}, nil
+}
+
+// ScanLocalEndpoints probes all common local ports and returns any that respond.
+func ScanLocalEndpoints() ([]EndpointInfo, error) {
+	return ScanLocalEndpointsContext(context.Background())
+}
+
+// ScanLocalEndpointsContext probes common ports concurrently with context support.
+// All ports are probed in parallel using goroutines; results are collected
+// and returned in the same order as commonPorts.
+func ScanLocalEndpointsContext(ctx context.Context) ([]EndpointInfo, error) {
+	type result struct {
+		idx int
+		ep  *EndpointInfo
+	}
+
+	var (
+		mu      sync.Mutex
+		wg      sync.WaitGroup
+		results []result
+	)
+
+	for i, cp := range commonPorts {
+		// Check context before launching goroutine.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		wg.Add(1)
+		go func(idx int, port int) {
+			defer wg.Done()
+			ep, err := ProbeEndpointContext(ctx, "127.0.0.1", port)
+			if err != nil {
+				return // port not running — skip
+			}
+			mu.Lock()
+			results = append(results, result{idx: idx, ep: ep})
+			mu.Unlock()
+		}(i, cp.Port)
+	}
+	wg.Wait()
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Sort results by original port order.
+	sorted := make([]*EndpointInfo, len(commonPorts))
+	for _, r := range results {
+		sorted[r.idx] = r.ep
+	}
+	var found []EndpointInfo
+	for _, ep := range sorted {
+		if ep != nil {
+			found = append(found, *ep)
+		}
+	}
+	return found, nil
+}
+
+// DetectServerType probes baseURL to determine the server software.
+// Returns "ollama", "llama-server", "openai-compat", or "".
+func DetectServerType(ctx context.Context, baseURL string) string {
+	client := &http.Client{Timeout: probeTimeout}
+	return detectServerTypeWithClient(ctx, client, baseURL)
+}
+
+// detectServerTypeWithClient probes baseURL using the provided client.
+//
+// Detection order priority:
+//  1. ollama — checked first via /api/tags (ollama-specific endpoint)
+//  2. llama-server — checked via /health (llama.cpp health endpoint)
+//  3. openai-compat — fallback via /v1/models (generic OpenAI-compatible)
+//
+// Ollama is checked before the generic OpenAI-compatible endpoint because
+// ollama also serves /v1/models, so we need the more specific check first.
+func detectServerTypeWithClient(ctx context.Context, client *http.Client, baseURL string) string {
+	// Check ollama-specific /api/tags first.
+	if ok := probeURL(ctx, client, baseURL+"/api/tags"); ok {
+		return "ollama"
+	}
+	// Check llama-server /health endpoint.
+	if ok := probeURL(ctx, client, baseURL+"/health"); ok {
+		return "llama-server"
+	}
+	// Generic OpenAI-compatible /v1/models.
+	if ok := probeURL(ctx, client, baseURL+"/v1/models"); ok {
+		return "openai-compat"
+	}
+	return ""
+}
+
+// probeURL returns true if a GET to url returns 200.
+func probeURL(ctx context.Context, client *http.Client, url string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// fetchModels retrieves the model list from the /v1/models endpoint.
+// The response body is limited to 1 MB to prevent excessive memory usage.
+func fetchModels(ctx context.Context, client *http.Client, baseURL string) ([]ModelInfo, error) {
+	modelsURL := baseURL + "/v1/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, modelsURL)
+	}
+
+	// Limit response body to 1 MB to prevent oversized responses.
+	limited := io.LimitReader(resp.Body, 1<<20)
+
+	var mr modelsResponse
+	if err := json.NewDecoder(limited).Decode(&mr); err != nil {
+		return nil, fmt.Errorf("decoding models response: %w", err)
+	}
+	return mr.Data, nil
+}
+
+// ParseModelsResponse parses raw JSON bytes into a slice of ModelInfo.
+// Exported for testing.
+func ParseModelsResponse(data []byte) ([]ModelInfo, error) {
+	var mr modelsResponse
+	if err := json.Unmarshal(data, &mr); err != nil {
+		return nil, fmt.Errorf("parsing models JSON: %w", err)
+	}
+	return mr.Data, nil
+}
+
+// FormatEndpointDisplay pretty-prints a list of discovered endpoints.
+func FormatEndpointDisplay(endpoints []EndpointInfo) string {
+	var b strings.Builder
+	b.WriteString("Discovered inference endpoints:\n")
+	if len(endpoints) == 0 {
+		b.WriteString("  (none)\n")
+		return b.String()
+	}
+	for _, ep := range endpoints {
+		status := "healthy"
+		if !ep.Healthy {
+			status = "unhealthy"
+		}
+		fmt.Fprintf(&b, "\n  %s (%s) [%s]\n", ep.BaseURL(), ep.ServerType, status)
+		if len(ep.Models) == 0 {
+			b.WriteString("    (no models loaded)\n")
+		}
+		for _, m := range ep.Models {
+			owner := m.OwnedBy
+			if owner == "" {
+				owner = "unknown"
+			}
+			fmt.Fprintf(&b, "    - %s (by %s)\n", m.ID, owner)
+		}
+	}
+	return b.String()
+}

--- a/internal/inference/detect_test.go
+++ b/internal/inference/detect_test.go
@@ -1,0 +1,246 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeEndpoint_NotRunning(t *testing.T) {
+	// Allocate a free port dynamically, then close it so nothing is listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	_, err = ProbeEndpoint("127.0.0.1", port)
+	if err == nil {
+		t.Fatal("expected error probing non-running port, got nil")
+	}
+	if !strings.Contains(err.Error(), "no inference server detected") {
+		t.Fatalf("unexpected error message: %s", err)
+	}
+}
+
+func TestScanLocalEndpoints_NoneFound(t *testing.T) {
+	// When nothing is running on any common port, should return empty list.
+	// This test is safe because CI/test environments rarely run inference servers.
+	endpoints, err := ScanLocalEndpoints()
+	if err != nil {
+		t.Fatalf("ScanLocalEndpoints returned error: %v", err)
+	}
+	// We can't guarantee nothing is running, so just check it doesn't crash.
+	_ = endpoints
+}
+
+func TestDetectServerType(t *testing.T) {
+	tests := []struct {
+		name     string
+		handlers map[string]int // path -> status code
+		want     string
+	}{
+		{
+			name:     "ollama",
+			handlers: map[string]int{"/api/tags": 200, "/v1/models": 200},
+			want:     "ollama",
+		},
+		{
+			name:     "llama-server",
+			handlers: map[string]int{"/health": 200, "/v1/models": 200},
+			want:     "llama-server",
+		},
+		{
+			name:     "openai-compat",
+			handlers: map[string]int{"/v1/models": 200},
+			want:     "openai-compat",
+		},
+		{
+			name:     "nothing",
+			handlers: map[string]int{},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if code, ok := tt.handlers[r.URL.Path]; ok {
+					w.WriteHeader(code)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer srv.Close()
+
+			got := DetectServerType(context.Background(), srv.URL)
+			if got != tt.want {
+				t.Errorf("DetectServerType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseModelsResponse(t *testing.T) {
+	payload := modelsResponse{
+		Data: []ModelInfo{
+			{ID: "llama-3.2-3b", OwnedBy: "meta", Created: 1700000000},
+			{ID: "qwen-2.5-coder", OwnedBy: "alibaba", Created: 1700000001},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+
+	models, err := ParseModelsResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseModelsResponse returned error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "llama-3.2-3b" {
+		t.Errorf("models[0].ID = %q, want %q", models[0].ID, "llama-3.2-3b")
+	}
+	if models[1].OwnedBy != "alibaba" {
+		t.Errorf("models[1].OwnedBy = %q, want %q", models[1].OwnedBy, "alibaba")
+	}
+}
+
+func TestParseModelsResponse_Invalid(t *testing.T) {
+	_, err := ParseModelsResponse([]byte(`{invalid json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseModelsResponse_Empty(t *testing.T) {
+	models, err := ParseModelsResponse([]byte(`{"data":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected 0 models, got %d", len(models))
+	}
+}
+
+// TestProbeEndpointContext_HappyPath uses httptest to serve /v1/models
+// and verifies ProbeEndpointContext returns correct EndpointInfo.
+func TestProbeEndpointContext_HappyPath(t *testing.T) {
+	mockModels := modelsResponse{
+		Data: []ModelInfo{
+			{ID: "test-model-7b", OwnedBy: "test-org", Created: 1700000000},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(mockModels)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Extract host and port from the test server.
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	var port int
+	if _, err := net.LookupPort("tcp", portStr); err != nil {
+		// portStr is numeric
+		p, _ := net.LookupPort("tcp", portStr)
+		port = p
+	}
+	// Parse port as int directly.
+	for i, c := range portStr {
+		_ = i
+		_ = c
+	}
+	port = 0
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+
+	ep, err := ProbeEndpointContext(context.Background(), host, port)
+	if err != nil {
+		t.Fatalf("ProbeEndpointContext returned error: %v", err)
+	}
+	if ep.ServerType != "openai-compat" {
+		t.Errorf("ServerType = %q, want %q", ep.ServerType, "openai-compat")
+	}
+	if !ep.Healthy {
+		t.Error("expected Healthy = true")
+	}
+	if len(ep.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(ep.Models))
+	}
+	if ep.Models[0].ID != "test-model-7b" {
+		t.Errorf("model ID = %q, want %q", ep.Models[0].ID, "test-model-7b")
+	}
+}
+
+// TestProbeEndpointContext_MalformedJSON tests that malformed JSON from /v1/models
+// is handled gracefully.
+func TestProbeEndpointContext_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{not valid json!!!`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	port := 0
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+
+	_, err := ProbeEndpointContext(context.Background(), host, port)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "decoding models response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestProbeEndpointContext_ContextCancelled verifies that a cancelled context
+// causes ProbeEndpointContext to return promptly.
+func TestProbeEndpointContext_ContextCancelled(t *testing.T) {
+	// Use a server that delays responses so context cancellation takes effect.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	port := 0
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+
+	_, err := ProbeEndpointContext(ctx, host, port)
+	if err == nil {
+		t.Fatal("expected error with cancelled context, got nil")
+	}
+}

--- a/internal/openclaw/OPENCLAW_VERSION
+++ b/internal/openclaw/OPENCLAW_VERSION
@@ -1,3 +1,3 @@
 # renovate: datasource=github-releases depName=openclaw/openclaw
 # Pins the upstream OpenClaw version to build and publish.
-v2026.3.13-1
+v2026.3.24

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -626,6 +626,7 @@ func copyWorkspaceToVolume(cfg *config.Config, id, workspaceDir string, u *ui.UI
 		return
 	}
 
+	fixVolumeOwnership(cfg, targetDir)
 	u.Success("Imported workspace to volume")
 }
 
@@ -727,6 +728,48 @@ func injectSkillsToVolume(cfg *config.Config, id string, deploymentDir string, u
 		}
 
 		u.Successf("Injected skill: %s", e.Name())
+	}
+
+	fixVolumeOwnership(cfg, targetDir)
+}
+
+// fixVolumeOwnership normalises file ownership on a host-side PVC path so the
+// container (UID 1000 / node) can read and write. On k3d the host path is
+// inside a Docker container (the k3d node), so we exec into it as root and
+// chown recursively. On k3s the host IS the node, so we attempt a direct
+// chown (works when the CLI runs as root, harmless no-op otherwise).
+func fixVolumeOwnership(cfg *config.Config, hostPath string) {
+	// Determine backend (default: k3d for backward compat).
+	backendName := "k3d"
+	if data, err := os.ReadFile(filepath.Join(cfg.ConfigDir, ".stack-backend")); err == nil {
+		backendName = strings.TrimSpace(string(data))
+	}
+
+	switch backendName {
+	case "k3d":
+		stackID := ""
+		if data, err := os.ReadFile(filepath.Join(cfg.ConfigDir, ".stack-id")); err == nil {
+			stackID = strings.TrimSpace(string(data))
+		}
+		if stackID == "" {
+			return
+		}
+		container := fmt.Sprintf("k3d-obol-stack-%s-server-0", stackID)
+
+		// Convert host path to the in-node path. k3d mounts $DATA_DIR → /data.
+		relPath, err := filepath.Rel(cfg.DataDir, hostPath)
+		if err != nil {
+			return
+		}
+		nodePath := filepath.Join("/data", relPath)
+
+		cmd := exec.Command("docker", "exec", container,
+			"chown", "-R", "1000:1000", nodePath)
+		_ = cmd.Run() // best-effort
+	default:
+		// k3s — direct host, try chown (succeeds if root).
+		cmd := exec.Command("chown", "-R", "1000:1000", hostPath)
+		_ = cmd.Run()
 	}
 }
 
@@ -1391,6 +1434,7 @@ func SkillsSync(cfg *config.Config, id, skillsDir string, u *ui.UI) error {
 		u.Successf("Synced skill: %s", e.Name())
 	}
 
+	fixVolumeOwnership(cfg, targetDir)
 	u.Success("Skills synced to volume (file watcher will reload)")
 
 	return nil

--- a/internal/openclaw/wallet.go
+++ b/internal/openclaw/wallet.go
@@ -351,6 +351,7 @@ func provisionKeystoreToVolume(cfg *config.Config, id, keystoreID string, keysto
 		return "", fmt.Errorf("write keystore: %w", err)
 	}
 
+	fixVolumeOwnership(cfg, dir)
 	return path, nil
 }
 

--- a/internal/openclaw/wallet_backup.go
+++ b/internal/openclaw/wallet_backup.go
@@ -221,6 +221,7 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 	if err := os.WriteFile(keystorePath, []byte(w.Keystore), 0o600); err != nil {
 		return fmt.Errorf("failed to write keystore: %w", err)
 	}
+	fixVolumeOwnership(cfg, keystoreDir)
 
 	// Update values-remote-signer.yaml with restored password.
 	if err := writeKeystorePassword(deployDir, w.KeystorePassword); err != nil {

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -268,7 +268,7 @@ func dockerBridgeGatewayIP() (string, error) {
 }
 
 // Up starts the cluster using the configured backend
-func Up(cfg *config.Config, u *ui.UI) error {
+func Up(cfg *config.Config, u *ui.UI, wildcardDNS bool) error {
 	stackID := getStackID(cfg)
 	if stackID == "" {
 		return errors.New("stack ID not found, run 'obol stack init' first")
@@ -299,13 +299,22 @@ func Up(cfg *config.Config, u *ui.UI) error {
 		return err
 	}
 
-	// Ensure DNS resolver is running for wildcard *.obol.stack
-	if err := dns.EnsureRunning(); err != nil {
-		u.Warnf("DNS resolver failed to start: %v", err)
-	} else if err := dns.ConfigureSystemResolver(); err != nil {
-		u.Warnf("Failed to configure system DNS resolver: %v", err)
-	} else {
-		u.Success("DNS resolver configured")
+	// Ensure obol.stack resolves to localhost via /etc/hosts (works everywhere).
+	if err := dns.EnsureHostsEntries(nil); err != nil {
+		u.Warnf("Could not update /etc/hosts for obol.stack: %v", err)
+	}
+
+	// Wildcard *.obol.stack DNS is opt-in (--wildcard-dns) because it
+	// modifies system DNS config (NetworkManager/resolv.conf on Linux,
+	// /etc/resolver on macOS) which can break host DNS resolution.
+	if wildcardDNS {
+		if err := dns.EnsureRunning(); err != nil {
+			u.Warnf("DNS resolver failed to start: %v", err)
+		} else if err := dns.ConfigureSystemResolver(); err != nil {
+			u.Warnf("Wildcard DNS configuration failed: %v", err)
+		} else {
+			u.Success("Wildcard DNS configured (*.obol.stack)")
+		}
 	}
 
 	u.Blank()

--- a/obolup.sh
+++ b/obolup.sh
@@ -54,15 +54,23 @@ fi
 
 # Pinned dependency versions
 # Update these versions to upgrade dependencies across all installations
-readonly KUBECTL_VERSION="1.35.0"
-readonly HELM_VERSION="3.19.4"
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+readonly KUBECTL_VERSION="1.35.3"
+# renovate: datasource=github-releases depName=helm/helm
+readonly HELM_VERSION="3.20.1"
+# renovate: datasource=github-releases depName=k3d-io/k3d
 readonly K3D_VERSION="5.8.3"
-readonly HELMFILE_VERSION="1.2.3"
+# renovate: datasource=github-releases depName=helmfile/helmfile
+readonly HELMFILE_VERSION="1.4.3"
+# renovate: datasource=github-releases depName=derailed/k9s
 readonly K9S_VERSION="0.50.18"
-readonly HELM_DIFF_VERSION="3.14.1"
+# renovate: datasource=github-releases depName=databus23/helm-diff
+readonly HELM_DIFF_VERSION="3.15.4"
+# renovate: datasource=github-releases depName=ollama/ollama
+readonly OLLAMA_VERSION="0.20.2"
 # Must match internal/openclaw/OPENCLAW_VERSION (without "v" prefix).
 # Tested by TestOpenClawVersionConsistency.
-readonly OPENCLAW_VERSION="2026.3.13-1"
+readonly OPENCLAW_VERSION="2026.3.24"
 
 # Repository URL for building from source
 readonly OBOL_REPO_URL="git@github.com:ObolNetwork/obol-stack.git"
@@ -96,6 +104,49 @@ command_exists() {
 	command -v "$1" >/dev/null 2>&1
 }
 
+# Check host prerequisites that the installer cannot provide itself.
+# Binaries we download (helm, kubectl, k3d, etc.) are not checked here —
+# only tools the user must install separately.
+check_prerequisites() {
+	local missing=()
+
+	# Node.js 22+ / npm — required for openclaw CLI (unless already installed)
+	local need_npm=true
+	if command_exists openclaw; then
+		local oc_version
+		oc_version=$(openclaw --version 2>/dev/null | tr -d '[:space:]' || echo "")
+		if [[ -n "$oc_version" ]] && version_ge "$oc_version" "$OPENCLAW_VERSION"; then
+			need_npm=false
+		fi
+	fi
+
+	if [[ "$need_npm" == "true" ]]; then
+		if ! command_exists npm; then
+			missing+=("Node.js 22+ (npm) — required to install openclaw CLI")
+		else
+			local node_major
+			node_major=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
+			if [[ -z "$node_major" ]] || [[ "$node_major" -lt 22 ]]; then
+				missing+=("Node.js 22+ (found: v${node_major:-none}) — required for openclaw CLI")
+			fi
+		fi
+	fi
+
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		log_error "Missing prerequisites:"
+		echo ""
+		for dep in "${missing[@]}"; do
+			echo "  • $dep"
+		done
+		echo ""
+		log_dim "  Install the above, then re-run obolup.sh"
+		echo ""
+		return 1
+	fi
+
+	return 0
+}
+
 # Detect installation mode (install vs upgrade)
 detect_installation_mode() {
 	if [[ -f "$OBOL_BIN_DIR/obol" ]]; then
@@ -123,8 +174,24 @@ check_docker() {
 		return 1
 	fi
 
-	# Check if Docker daemon is running; try to start it automatically
+	# Check if Docker daemon is running and accessible
 	if ! docker info >/dev/null 2>&1; then
+		# Distinguish permission errors from daemon-not-running
+		local docker_err
+		docker_err=$(docker info 2>&1)
+
+		if echo "$docker_err" | grep -qi "permission denied"; then
+			log_error "Docker is installed but your user does not have permission to access it"
+			echo ""
+			echo "  Add your user to the docker group and apply the change:"
+			echo "    sudo usermod -aG docker \$USER"
+			echo "    newgrp docker"
+			echo ""
+			log_dim "  Then run this installer again."
+			echo ""
+			return 1
+		fi
+
 		if [[ "$(uname -s)" == "Linux" ]]; then
 			log_warn "Docker daemon is not running — attempting to start..."
 			# Try systemd first (apt/yum installs), then snap
@@ -181,21 +248,6 @@ check_docker() {
 	if [[ "$major" -lt 20 ]] || { [[ "$major" -eq 20 ]] && [[ "$minor" -lt 10 ]]; }; then
 		log_warn "Docker version $docker_version is older than recommended (20.10.0+)"
 		log_warn "k3d may not work correctly with older Docker versions"
-	fi
-
-	# Check if user can run Docker without sudo (Linux-specific)
-	if [[ "$(uname -s)" == "Linux" ]]; then
-		if ! docker ps >/dev/null 2>&1; then
-			log_warn "Current user cannot run Docker commands"
-			echo ""
-			echo "You may need to add your user to the docker group:"
-			echo "  sudo usermod -aG docker \$USER"
-			echo "  newgrp docker"
-			echo ""
-			echo "Or run commands with sudo."
-			echo ""
-			# Don't fail here - user might be running with sudo
-		fi
 	fi
 
 	# Check Docker networking (ensure bridge network works)
@@ -1126,18 +1178,50 @@ WRAPPER
 	return 1
 }
 
+# Configure Ollama to listen on 0.0.0.0 so k3d containers can reach it.
+# On macOS, Docker Desktop routes host.docker.internal through the hypervisor,
+# so Ollama's bind address doesn't matter. On Linux, k3d uses the docker
+# bridge network, so Ollama must accept connections from the bridge gateway IP.
+configure_ollama_host_binding() {
+	# Only needed on Linux with systemd
+	[[ "$(uname -s)" != "Linux" ]] && return 0
+	command_exists systemctl || return 0
+	systemctl list-unit-files ollama.service >/dev/null 2>&1 || return 0
+
+	local override_dir="/etc/systemd/system/ollama.service.d"
+	local override_file="$override_dir/obol-host.conf"
+
+	# Skip if already configured
+	if [[ -f "$override_file" ]]; then
+		return 0
+	fi
+
+	log_info "Configuring Ollama to listen on 0.0.0.0 (required for k3d)..."
+
+	if sudo mkdir -p "$override_dir" && \
+	   sudo tee "$override_file" >/dev/null <<'OVERRIDE'
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0"
+OVERRIDE
+	then
+		sudo systemctl daemon-reload
+		sudo systemctl restart ollama 2>/dev/null || true
+		log_success "Ollama configured to listen on all interfaces"
+	else
+		log_warn "Could not configure Ollama host binding (non-fatal)"
+		echo "  Manually set OLLAMA_HOST=0.0.0.0 in your Ollama config"
+	fi
+}
+
 # Install Ollama (host runtime for local AI inference)
 # Unlike other dependencies, Ollama is a full application with a background server.
 # On macOS it installs Ollama.app; on Linux it sets up a systemd service.
 # We delegate to Ollama's official installer rather than downloading a binary ourselves.
 install_ollama() {
-	# Check for existing ollama installation
-	if command_exists ollama; then
-		local version
-		version=$(ollama --version 2>/dev/null | sed 's/ollama version is //' || echo "unknown")
-		log_success "Ollama v$version already installed"
+	local target_version="$OLLAMA_VERSION"
 
-		# Check if the server is running
+	# Helper: check if server is running and print status
+	check_ollama_server() {
 		if curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
 			log_success "Ollama server is running"
 		else
@@ -1153,7 +1237,60 @@ install_ollama() {
 			esac
 			echo ""
 		fi
-		return 0
+	}
+
+	# Check for existing ollama installation
+	if command_exists ollama; then
+		local version
+		version=$(ollama --version 2>/dev/null | sed 's/ollama version is //' || echo "unknown")
+
+		# Check if upgrade is needed
+		if [[ "$version" != "unknown" ]] && version_ge "$version" "$target_version"; then
+			log_success "Ollama v$version is up to date"
+			configure_ollama_host_binding
+			check_ollama_server
+			return 0
+		fi
+
+		if [[ "$version" != "unknown" ]]; then
+			log_warn "Ollama v$version is older than pinned v$target_version"
+
+			# Prompt for upgrade if interactive
+			if [[ -c /dev/tty ]]; then
+				local choice
+				read -p "  Upgrade Ollama to v$target_version? [Y/n]: " choice </dev/tty
+
+				case "$choice" in
+				[Nn]*)
+					log_warn "Skipping Ollama upgrade"
+					check_ollama_server
+					return 0
+					;;
+				esac
+			else
+				log_warn "Non-interactive — skipping Ollama upgrade"
+				check_ollama_server
+				return 0
+			fi
+
+			log_info "Upgrading Ollama to v$target_version..."
+			echo ""
+			if env OLLAMA_VERSION="$target_version" bash -c 'curl -fsSL https://ollama.com/install.sh | sh'; then
+				echo ""
+				log_success "Ollama upgraded to v$target_version"
+				configure_ollama_host_binding
+				check_ollama_server
+				return 0
+			else
+				log_warn "Ollama upgrade failed — continuing with v$version"
+				check_ollama_server
+				return 0
+			fi
+		else
+			log_success "Ollama already installed (version unknown)"
+			check_ollama_server
+			return 0
+		fi
 	fi
 
 	# Ollama not found — ask user if they want to install it
@@ -1181,11 +1318,12 @@ install_ollama() {
 			;;
 		*)
 			# Yes — delegate to official installer
-			log_info "Installing Ollama..."
+			log_info "Installing Ollama v$target_version..."
 			echo ""
-			if curl -fsSL https://ollama.com/install.sh | sh; then
+			if env OLLAMA_VERSION="$target_version" bash -c 'curl -fsSL https://ollama.com/install.sh | sh'; then
 				echo ""
-				log_success "Ollama installed"
+				log_success "Ollama v$target_version installed"
+				configure_ollama_host_binding
 
 				# On macOS, the installer starts Ollama.app automatically.
 				# On Linux with systemd, the installer enables and starts the service.
@@ -1240,6 +1378,13 @@ install_ollama() {
 install_dependencies() {
 	log_info "Checking and installing dependencies..."
 	echo ""
+
+	# Ensure OBOL_BIN_DIR is in PATH for the current process so that
+	# binaries installed here (helm, helmfile, etc.) are immediately
+	# available to each other and to later steps like `obol bootstrap`.
+	if ! echo "$PATH" | grep -q "$OBOL_BIN_DIR"; then
+		export PATH="$OBOL_BIN_DIR:$PATH"
+	fi
 
 	# Install each dependency
 	install_kubectl || log_warn "kubectl installation failed (continuing...)"
@@ -1433,20 +1578,13 @@ add_to_profile() {
 # In interactive mode, asks user whether to auto-modify or show manual instructions.
 # In non-interactive mode (CI/CD), prints manual instructions only unless OBOL_MODIFY_PATH=yes.
 configure_path() {
-	# Check if OBOL_BIN_DIR is already in current PATH
-	if echo "$PATH" | grep -q "$OBOL_BIN_DIR"; then
-		log_success "OBOL_BIN_DIR already in PATH"
-		return 0
-	fi
-
 	# Detect appropriate profile file
 	local profile
 	profile=$(detect_shell_profile)
 
-	# Check if already configured in detected profile
+	# Check if already persisted in the shell profile
 	if [[ -f "$profile" ]] && grep -qF "$OBOL_BIN_DIR" "$profile" 2>/dev/null; then
 		log_success "OBOL_BIN_DIR already configured in $profile"
-		log_info "Will be available in new shell sessions"
 		return 0
 	fi
 
@@ -1689,6 +1827,11 @@ main() {
 		log_info "Backend: k3s (Docker not required)"
 	fi
 	echo ""
+
+	# Check host prerequisites (npm/Node.js, etc.) before starting installs
+	if ! check_prerequisites; then
+		exit 1
+	fi
 
 	create_directories
 	install_obol_binary

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,32 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/berriai/litellm",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned tool versions in obolup.sh",
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\nreadonly\\s+\\w+=\"(?<currentValue>[^\"]+)\""
+      ],
+      "fileMatch": [
+        "^obolup\\.sh$"
+      ],
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update k3s image tag in k3d config",
+      "matchStrings": [
+        "image:\\s*rancher/k3s:v(?<currentValue>[\\w.+-]+)"
+      ],
+      "fileMatch": [
+        "^internal/embed/k3d-config\\.yaml$"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "k3s-io/k3s",
+      "versioningTemplate": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)([+-](?<build>.+))?$",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -172,6 +198,48 @@
         "before 6am on monday"
       ],
       "groupName": "LiteLLM updates"
+    },
+    {
+      "description": "Batch obolup.sh tool version updates into a single PR",
+      "matchFileNames": [
+        "obolup.sh"
+      ],
+      "matchPackageNames": [
+        "kubernetes/kubernetes",
+        "helm/helm",
+        "k3d-io/k3d",
+        "helmfile/helmfile",
+        "derailed/k9s",
+        "databus23/helm-diff",
+        "ollama/ollama"
+      ],
+      "labels": [
+        "renovate/obolup-deps"
+      ],
+      "schedule": [
+        "before 6am on monday"
+      ],
+      "groupName": "obolup.sh dependency updates"
+    },
+    {
+      "description": "Limit Helm to 3.x (Helm 4 is a breaking major)",
+      "matchPackageNames": [
+        "helm/helm"
+      ],
+      "allowedVersions": "<4.0.0"
+    },
+    {
+      "description": "Group k3s image updates",
+      "matchPackageNames": [
+        "k3s-io/k3s"
+      ],
+      "labels": [
+        "renovate/k3s"
+      ],
+      "schedule": [
+        "before 6am on monday"
+      ],
+      "groupName": "k3s image updates"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds automatic discovery of local inference servers (llama-server, ollama, vLLM, LiteLLM) to streamline the `obol sell inference` workflow, improves the Obol Stack setup experience with better prerequisite checking and DNS configuration, and fixes several operational issues around file permissions and Ollama configuration.

## Key Changes

### Inference Server Auto-Detection
- **New module `internal/inference/detect.go`**: Implements concurrent probing of well-known inference server ports (8080, 11434, 8000, 4000) with OpenAI-compatible `/v1/models` endpoint enumeration
  - `ProbeEndpoint()` / `ProbeEndpointContext()`: Probe a single host:port for inference servers
  - `ScanLocalEndpoints()` / `ScanLocalEndpointsContext()`: Concurrently scan all common ports
  - `DetectServerType()`: Identify server software (ollama, llama-server, openai-compat) with priority-ordered detection
  - `FormatEndpointDisplay()`: Pretty-print discovered endpoints and their models
- **Comprehensive test coverage** in `internal/inference/detect_test.go` including happy path, malformed JSON, context cancellation, and error cases

### CLI Integration
- **`cmd/obol/sell.go`**: Auto-detect and prompt user to select model/upstream when `--model` flag is not provided and running interactively
  - Displays discovered endpoints with available models
  - Supports single-click selection for single model or numbered selection for multiple models
  - Falls back to requiring `--model` flag in non-interactive mode

### Stack Setup & Prerequisites
- **`obolup.sh`**: 
  - New `check_prerequisites()` function validates Node.js 22+ / npm availability before installation
  - Improved Docker permission error detection with user-friendly guidance
  - Added `configure_ollama_host_binding()` to set `OLLAMA_HOST=0.0.0.0` on Linux systemd for k3d container access
  - Enhanced Ollama version management with upgrade prompts and pinned version support
  - Updated pinned dependency versions with renovate annotations (kubectl 1.35.3, helm 3.20.1, helmfile 1.4.3, etc.)
  - Ensured `OBOL_BIN_DIR` is in PATH during dependency installation for inter-tool availability

### DNS & Networking
- **`internal/stack/stack.go`**: 
  - Added `wildcardDNS` parameter to `Up()` function for opt-in wildcard DNS configuration
  - Simplified DNS setup to always use `/etc/hosts` entries for `obol.stack` (works everywhere)
  - Wildcard `*.obol.stack` DNS via NetworkManager/dnsmasq (Linux) or `/etc/resolver` (macOS) is now opt-in via `--wildcard-dns` flag
- **`internal/dns/resolver.go`**: Made Linux resolver configuration non-fatal, allowing fallback to `/etc/hosts` on headless servers without NetworkManager

### File Permissions & Volume Management
- **`internal/openclaw/openclaw.go`**: 
  - New `fixVolumeOwnership()` function normalizes PVC file ownership for container access (UID 1000)
  - Handles both k3d (via docker exec chown in k3d node container) and k3s (direct host chown) backends
  - Applied after workspace imports, skill injections, and keystore provisioning
- **`internal/embed/infrastructure/base/templates/local-path.yaml`**: Changed `chown` to `chown -R` for recursive ownership fixes

### Build & Deployment
- **`.github/workflows/docker-publish-x402.yml`**: Refactored to build both x402-verifier and x402-buyer images in parallel using matrix strategy
- **`renovate.json`**: Added custom regex rules for obolup.sh tool version updates and k3s image tag updates with proper grouping and scheduling

### Documentation
- **`CLAUDE.md`**: Updated dependency documentation with structured table of packages, key files, and roles

## Notable Implementation Details

https://claude.ai/code/session_01DuimxJRYMS1KLkyURM3yYp