### PR TITLE
Refactor monetization to controller-based reconciliation + autoresearch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ Skills = SKILL.md + optional scripts/references, embedded in `obol` binary (`int
 1. **Absolute paths required** — Docker volume mounts need absolute paths (resolved at `obol stack init`)
 2. **Two-stage templating** — Stage 1 (CLI flags) → Stage 2 (Helmfile) separation is critical
 3. **Unique namespaces** — each deployment must have unique namespace
-4. **`OBOL_DEVELOPMENT=true`** — required for `obol stack up` to auto-build local images (x402-verifier, x402-buyer)
+4. **`OBOL_DEVELOPMENT=true`** — required for `obol stack up` to auto-build local images (x402-verifier, serviceoffer-controller, x402-buyer)
 5. **Root-owned PVCs** — `-f` flag required to remove in `obol stack purge`
 
 ### OpenClaw Version Management

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -6,6 +6,7 @@ package kubectl
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,8 +21,9 @@ import (
 func EnsureCluster(cfg *config.Config) error {
 	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("cluster not running. Run 'obol stack up' first")
+		return errors.New("cluster not running. Run 'obol stack up' first")
 	}
+
 	return nil
 }
 
@@ -35,17 +37,23 @@ func Paths(cfg *config.Config) (binary, kubeconfig string) {
 // capturing stderr. The error message includes stderr output on failure.
 func Run(binary, kubeconfig string, args ...string) error {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
+
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -53,16 +61,21 @@ func Run(binary, kubeconfig string, args ...string) error {
 // and included in the returned error on failure.
 func RunSilent(binary, kubeconfig string, args ...string) error {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stderr bytes.Buffer
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -70,17 +83,23 @@ func RunSilent(binary, kubeconfig string, args ...string) error {
 // captured and included in the returned error on failure.
 func Output(binary, kubeconfig string, args ...string) (string, error) {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+
 	var stdout, stderr bytes.Buffer
+
 	cmd.Stdout = &stdout
+
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
 			return "", fmt.Errorf("%w: %s", err, errMsg)
 		}
+
 		return "", err
 	}
+
 	return stdout.String(), nil
 }
 
@@ -90,13 +109,15 @@ func Apply(binary, kubeconfig string, data []byte) error {
 	return err
 }
 
-// ApplyOutput runs kubectl apply and returns the stdout (for example
-// "serviceoffer.obol.org/foo configured").
+// ApplyOutput pipes the given data into kubectl apply -f - and returns stdout.
 func ApplyOutput(binary, kubeconfig string, data []byte) (string, error) {
 	cmd := exec.Command(binary, "apply", "-f", "-")
-	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
 	cmd.Stdin = bytes.NewReader(data)
+
 	var stdout, stderr bytes.Buffer
+
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -104,11 +125,14 @@ func ApplyOutput(binary, kubeconfig string, data []byte) (string, error) {
 		if errMsg != "" {
 			return "", fmt.Errorf("kubectl apply: %w: %s", err, errMsg)
 		}
+
 		return "", fmt.Errorf("kubectl apply: %w", err)
 	}
+
 	out := strings.TrimSpace(stdout.String())
 	if out != "" {
 		fmt.Println(out)
 	}
+
 	return out, nil
 }

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -1016,51 +1016,51 @@ func (c *Controller) applyObject(ctx context.Context, resource dynamic.ResourceI
 }
 
 func (c *Controller) updateOfferStatus(ctx context.Context, raw *unstructured.Unstructured, status monetizeapi.ServiceOfferStatus) error {
-	copy := raw.DeepCopy()
+	patched := raw.DeepCopy()
 	statusObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&status)
 	if err != nil {
 		return err
 	}
-	if existing, found := copy.Object["status"]; found && equality.Semantic.DeepEqual(existing, statusObject) {
+	if existing, found := patched.Object["status"]; found && equality.Semantic.DeepEqual(existing, statusObject) {
 		return nil
 	}
-	copy.Object["status"] = statusObject
-	_, err = c.offers.Namespace(copy.GetNamespace()).UpdateStatus(ctx, copy, metav1.UpdateOptions{})
+	patched.Object["status"] = statusObject
+	_, err = c.offers.Namespace(patched.GetNamespace()).UpdateStatus(ctx, patched, metav1.UpdateOptions{})
 	return err
 }
 
 func (c *Controller) updateRegistrationStatus(ctx context.Context, raw *unstructured.Unstructured, status monetizeapi.RegistrationRequestStatus) error {
-	copy := raw.DeepCopy()
+	patched := raw.DeepCopy()
 	statusObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&status)
 	if err != nil {
 		return err
 	}
-	if existing, found := copy.Object["status"]; found && equality.Semantic.DeepEqual(existing, statusObject) {
+	if existing, found := patched.Object["status"]; found && equality.Semantic.DeepEqual(existing, statusObject) {
 		return nil
 	}
-	copy.Object["status"] = statusObject
-	_, err = c.registrationRequests.Namespace(copy.GetNamespace()).UpdateStatus(ctx, copy, metav1.UpdateOptions{})
+	patched.Object["status"] = statusObject
+	_, err = c.registrationRequests.Namespace(patched.GetNamespace()).UpdateStatus(ctx, patched, metav1.UpdateOptions{})
 	return err
 }
 
 func (c *Controller) addFinalizer(ctx context.Context, raw *unstructured.Unstructured, finalizer string) error {
-	copy := raw.DeepCopy()
-	copy.SetFinalizers(append(copy.GetFinalizers(), finalizer))
-	_, err := c.offers.Namespace(copy.GetNamespace()).Update(ctx, copy, metav1.UpdateOptions{})
+	patched := raw.DeepCopy()
+	patched.SetFinalizers(append(patched.GetFinalizers(), finalizer))
+	_, err := c.offers.Namespace(patched.GetNamespace()).Update(ctx, patched, metav1.UpdateOptions{})
 	return err
 }
 
 func (c *Controller) removeFinalizer(ctx context.Context, raw *unstructured.Unstructured, finalizer string) error {
-	copy := raw.DeepCopy()
-	finalizers := copy.GetFinalizers()
+	patched := raw.DeepCopy()
+	finalizers := patched.GetFinalizers()
 	filtered := finalizers[:0]
 	for _, item := range finalizers {
 		if item != finalizer {
 			filtered = append(filtered, item)
 		}
 	}
-	copy.SetFinalizers(filtered)
-	_, err := c.offers.Namespace(copy.GetNamespace()).Update(ctx, copy, metav1.UpdateOptions{})
+	patched.SetFinalizers(filtered)
+	_, err := c.offers.Namespace(patched.GetNamespace()).Update(ctx, patched, metav1.UpdateOptions{})
 	return err
 }
 

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -27,6 +27,7 @@ func NewVerifier(cfg *PricingConfig) (*Verifier, error) {
 	if err := v.load(cfg); err != nil {
 		return nil, err
 	}
+
 	return v, nil
 }
 
@@ -51,6 +52,7 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 				if err != nil {
 					return fmt.Errorf("resolve chain for route %q: %w", r.Pattern, err)
 				}
+
 				chains[r.Network] = rc
 			}
 		}
@@ -59,6 +61,7 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 	v.chain.Store(&chain)
 	v.chains.Store(&chains)
 	v.config.Store(cfg)
+
 	return nil
 }
 
@@ -77,10 +80,12 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		// Fail-closed: deny rather than silently allowing through.
 		log.Printf("x402-verifier: missing X-Forwarded-Uri header (misconfiguration or direct access)")
 		http.Error(w, "forbidden: missing forwarded URI", http.StatusForbidden)
+
 		return
 	}
 
 	cfg := v.config.Load()
+
 	rule := matchRoute(cfg.Routes, uri)
 	if rule == nil {
 		// No pricing rule matches — route is free.
@@ -101,10 +106,12 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 
 	// Look up pre-resolved chain (populated during config load).
 	chains := v.chains.Load()
+
 	chain, ok := (*chains)[chainName]
 	if !ok {
 		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
 		http.Error(w, "internal error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -116,6 +123,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("x402-verifier: failed to create payment requirement: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -124,7 +132,9 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if host := r.Header.Get("X-Forwarded-Host"); host != "" {
 		r.Host = host
 	}
+
 	r.URL.Path = uri
+
 	r.RequestURI = uri
 	if method := r.Header.Get("X-Forwarded-Method"); method != "" {
 		r.Method = method
@@ -136,6 +146,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	// copies this to the forwarded request, authenticating it with the upstream.
 	labels := prometheusLabels(rule)
 	v.metrics.requestsTotal.With(labels).Inc()
+
 	middleware := x402http.NewX402Middleware(&x402http.Config{
 		FacilitatorURL:      cfg.FacilitatorURL,
 		PaymentRequirements: []x402lib.PaymentRequirement{requirement},
@@ -147,16 +158,18 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		if upstreamAuth != "" {
 			w.Header().Set("Authorization", upstreamAuth)
 		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 
 	tracker := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 	middleware(inner).ServeHTTP(tracker, r)
+
 	switch {
-	case tracker.status == http.StatusOK && r.Header.Get("X-PAYMENT") != "":
+	case tracker.status == http.StatusOK && r.Header.Get("X-Payment") != "":
 		v.metrics.paymentVerified.With(labels).Inc()
 		v.metrics.chargedRequests.With(labels).Inc()
-	case tracker.status == http.StatusPaymentRequired && r.Header.Get("X-PAYMENT") != "":
+	case tracker.status == http.StatusPaymentRequired && r.Header.Get("X-Payment") != "":
 		v.metrics.paymentFailed.With(labels).Inc()
 	case tracker.status == http.StatusPaymentRequired:
 		v.metrics.paymentRequired.With(labels).Inc()
@@ -175,6 +188,7 @@ func (v *Verifier) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not ready", http.StatusServiceUnavailable)
 		return
 	}
+
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, `{"status":"ready"}`)
 }
@@ -186,6 +200,7 @@ func (v *Verifier) MetricsHandler() http.Handler {
 
 type statusRecorder struct {
 	http.ResponseWriter
+
 	status int
 }
 


### PR DESCRIPTION
## Summary

This PR significantly refactors the monetization system to move ServiceOffer reconciliation from a Python CLI script into a dedicated Kubernetes controller, while adding comprehensive autoresearch capabilities (coordinator, worker, publisher). The changes establish a cleaner separation of concerns: the controller handles all CRD state management and ERC-8004 registration side effects, while the Python CLI becomes a thin helper for CRUD operations and catalog publishing.

## Key Changes

### Monetization Architecture Refactor
- **ServiceOffer Controller** (`cmd/serviceoffer-controller/main.go`, `internal/serviceoffercontroller/`): New Kubernetes controller that owns ServiceOffer reconciliation, child resource management, and ERC-8004 registration side effects
- **Simplified monetize.py**: Reduced from 400+ lines of reconciliation logic to ~200 lines of CRUD helpers; controller now handles staged pipeline (ModelReady → UpstreamHealthy → PaymentGateReady → RoutePublished → Registered → Ready)
- **New RegistrationRequest CRD** (`internal/embed/infrastructure/base/templates/registrationrequest-crd.yaml`): Isolates ERC-8004 publication from ServiceOffer, enabling cleaner async side-effect handling
- **x402 source abstraction** (`internal/x402/source.go`, `internal/x402/serviceoffer_source.go`): Decouples pricing configuration from ServiceOffer CRD, supporting both static and dynamic pricing models

### Autoresearch System (New)
- **Coordinator** (`internal/embed/skills/autoresearch-coordinator/scripts/coordinate.py`): Discovers GPU workers via ERC-8004/8004scan API, probes x402 pricing, submits experiments with micropayments, replaces Ensue-based shared-memory model
- **Worker API** (`internal/embed/skills/autoresearch-worker/scripts/worker_api.py`): Minimal HTTP service for running submitted train.py experiments, storing results, exposing x402-gatable endpoints
- **Publisher** (`internal/embed/skills/autoresearch/scripts/publish.py`): Publishes best autoresearch results to Ollama and optionally sells via x402
- **Skills & Documentation**: New SKILL.md files for autoresearch, autoresearch-coordinator, autoresearch-worker, and monetize-guide with end-to-end guides

### CLI Enhancements
- **`obol sell probe`** (`cmd/obol/sell.go`): New subcommand to check x402 pricing for a worker endpoint
- **`obol sell http`** improvements: Better integration with ServiceOffer controller lifecycle
- **Flow scripts** (`flows/flow-*.sh`): Comprehensive test flows covering stack init, inference, agent setup, selling, buying, and lifecycle management

### Infrastructure & Testing
- **Dockerfiles**: New containers for serviceoffer-controller, autoresearch-worker, and reth-erc8004-indexer
- **Anvil + Facilitator flow** (`flows/flow-10-anvil-facilitator.sh`): Local test infrastructure for paid flows
- **golangci.yml**: Linter configuration with sensible defaults for the project
- **Test utilities**: Enhanced facilitator and anvil test helpers for payment flow testing
- **Import validation** (`internal/openclaw/import.go`): Better model API key environment handling

### Code Quality
- Consistent error handling: Added explicit `errors` imports across packages
- Type modernization: Changed `map[string]interface{}` to `map[string]any` for Go 1.18+ compatibility
- Import organization: Alphabetical sorting and grouping improvements
- Validation layer: New `internal/network/validate.go` for install option validation

## Notable Implementation Details

1. **Controller-driven reconciliation**: ServiceOffer conditions now managed by controller watching CRD state, eliminating polling from Python script
2. **ERC-8004 integration**: RegistrationRequest CRD enables async on-chain registration without blocking ServiceOffer readiness
3. **Decentralized discovery**: Autoresearch coordinator uses 8004scan API instead of shared memory, enabling true peer-to-peer worker discovery
4. **x402 microp

https://claude.ai/code/session_016ktZi3zLxbnWrjF8cLyTjm