### PR TITLE
fix: x402 verifier TLS and facilitator compatibility

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -105,7 +105,7 @@ Examples:
 			&cli.StringFlag{
 				Name:  "facilitator",
 				Usage: "x402 facilitator URL",
-				Value: "https://facilitator.x402.rs",
+				Value: x402verifier.DefaultFacilitatorURL,
 			},
 			&cli.StringFlag{
 				Name:    "listen",

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -186,7 +186,7 @@ func TestSellInference_Flags(t *testing.T) {
 	assertStringDefault(t, flags, "chain", "base-sepolia")
 	assertStringDefault(t, flags, "listen", ":8402")
 	assertStringDefault(t, flags, "upstream", "http://localhost:11434")
-	assertStringDefault(t, flags, "facilitator", "https://facilitator.x402.rs")
+	assertStringDefault(t, flags, "facilitator", "https://x402.gcp.obol.tech")
 	assertStringDefault(t, flags, "vm-image", "ollama/ollama:latest")
 	assertIntDefault(t, flags, "vm-cpus", 4)
 	assertIntDefault(t, flags, "vm-memory", 8192)

--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -121,7 +121,12 @@ metadata:
   labels:
     app: litellm
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: litellm
@@ -129,7 +134,10 @@ spec:
     metadata:
       labels:
         app: litellm
+      annotations:
+        secret.reloader.stakater.com/reload: "litellm-secrets"
     spec:
+      terminationGracePeriodSeconds: 60
       containers:
         - name: litellm
           # Pinned to v1.82.3 — main-stable is a floating tag vulnerable to
@@ -178,6 +186,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "10"]
           resources:
             requests:
               cpu: 100m
@@ -238,6 +250,18 @@ spec:
                   name: x402-buyer-auths
         - name: x402-buyer-state
           emptyDir: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: litellm
+  namespace: llm
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: litellm
 
 ---
 apiVersion: v1

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -122,7 +122,7 @@ func NewGateway(cfg GatewayConfig) (*Gateway, error) {
 	}
 
 	if cfg.FacilitatorURL == "" {
-		cfg.FacilitatorURL = "https://facilitator.x402.rs"
+		cfg.FacilitatorURL = x402verifier.DefaultFacilitatorURL
 	}
 
 	if err := x402verifier.ValidateFacilitatorURL(cfg.FacilitatorURL); err != nil {

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 )
 
 // ErrDeploymentNotFound is returned when a named inference deployment does
@@ -181,7 +183,7 @@ func (s *Store) Create(d *Deployment, force bool) error {
 	}
 
 	if d.FacilitatorURL == "" {
-		d.FacilitatorURL = "https://facilitator.x402.rs"
+		d.FacilitatorURL = x402verifier.DefaultFacilitatorURL
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -301,13 +301,15 @@ func hotAddModels(cfg *config.Config, u *ui.UI, entries []ModelEntry) error {
 		}
 
 		// POST /model/new via kubectl exec on a running litellm pod.
-		curlCmd := fmt.Sprintf(
-			`wget -qO- --post-data='%s' --header='Content-Type: application/json' --header='Authorization: Bearer %s' http://localhost:4000/model/new`,
-			string(bodyJSON), masterKey)
-
 		out, err := kubectl.Output(kubectlBinary, kubeconfigPath,
 			"exec", "-n", namespace, "deployment/"+deployName, "-c", "litellm",
-			"--", "sh", "-c", curlCmd)
+			"--",
+			"wget", "-qO-",
+			"--post-data", string(bodyJSON),
+			"--header", "Content-Type: application/json",
+			"--header", fmt.Sprintf("Authorization: Bearer %s", masterKey),
+			"http://localhost:4000/model/new",
+		)
 		if err != nil {
 			u.Warnf("Hot-add %s failed: %v (%s)", entry.ModelName, err, strings.TrimSpace(out))
 			return fmt.Errorf("hot-add %s: %w", entry.ModelName, err)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -174,14 +174,30 @@ func LoadDotEnv(path string) map[string]string {
 // ConfigureLiteLLM adds a provider to the LiteLLM gateway.
 // For cloud providers, it patches the Secret with the API key and adds
 // the model to config.yaml. For Ollama, it discovers local models and adds them.
-// Restarts the deployment after patching. Use PatchLiteLLMProvider +
-// RestartLiteLLM to batch multiple providers with a single restart.
+//
+// When only models change (no API key), models are hot-added via the
+// /model/new API — no restart required. When API keys change, a rolling
+// restart is triggered so the new Secret values are picked up.
 func ConfigureLiteLLM(cfg *config.Config, u *ui.UI, provider, apiKey string, models []string) error {
 	if err := PatchLiteLLMProvider(cfg, u, provider, apiKey, models); err != nil {
 		return err
 	}
 
-	return RestartLiteLLM(cfg, u, provider)
+	// API key changes require a restart (Secret mounted as envFrom).
+	// Model-only changes can be hot-added via the /model/new API.
+	needsRestart := apiKey != ""
+	if needsRestart {
+		return RestartLiteLLM(cfg, u, provider)
+	}
+
+	entries := buildModelEntries(provider, models)
+	if err := hotAddModels(cfg, u, entries); err != nil {
+		u.Warnf("Hot-add failed, falling back to restart: %v", err)
+		return RestartLiteLLM(cfg, u, provider)
+	}
+
+	u.Successf("LiteLLM configured with %s provider", provider)
+	return nil
 }
 
 // PatchLiteLLMProvider patches the LiteLLM Secret (API key) and ConfigMap
@@ -243,6 +259,59 @@ func RestartLiteLLM(cfg *config.Config, u *ui.UI, provider string) error {
 		u.Print("The deployment may still be rolling out.")
 	} else {
 		u.Successf("LiteLLM configured with %s provider", provider)
+	}
+
+	return nil
+}
+
+// hotAddModels uses the LiteLLM /model/new API to add models to the running
+// router without a restart. The ConfigMap is already patched by
+// PatchLiteLLMProvider for persistence across restarts.
+func hotAddModels(cfg *config.Config, u *ui.UI, entries []ModelEntry) error {
+	masterKey, err := GetMasterKey(cfg)
+	if err != nil {
+		return fmt.Errorf("get master key: %w", err)
+	}
+
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	// Get the LiteLLM ClusterIP for direct access.
+	svcIP, err := kubectl.Output(kubectlBinary, kubeconfigPath,
+		"get", "svc", deployName, "-n", namespace,
+		"-o", "jsonpath={.spec.clusterIP}")
+	if err != nil || strings.TrimSpace(svcIP) == "" {
+		return fmt.Errorf("get litellm service IP: %w", err)
+	}
+
+	// Use kubectl exec to call the API from inside the cluster (avoids
+	// port-forward complexity and works on any host OS).
+	for _, entry := range entries {
+		body := map[string]any{
+			"model_name": entry.ModelName,
+			"litellm_params": map[string]any{
+				"model":    entry.LiteLLMParams.Model,
+				"api_base": entry.LiteLLMParams.APIBase,
+				"api_key":  entry.LiteLLMParams.APIKey,
+			},
+		}
+		bodyJSON, err := json.Marshal(body)
+		if err != nil {
+			continue
+		}
+
+		// POST /model/new via kubectl exec on a running litellm pod.
+		curlCmd := fmt.Sprintf(
+			`wget -qO- --post-data='%s' --header='Content-Type: application/json' --header='Authorization: Bearer %s' http://localhost:4000/model/new`,
+			string(bodyJSON), masterKey)
+
+		out, err := kubectl.Output(kubectlBinary, kubeconfigPath,
+			"exec", "-n", namespace, "deployment/"+deployName, "-c", "litellm",
+			"--", "sh", "-c", curlCmd)
+		if err != nil {
+			u.Warnf("Hot-add %s failed: %v (%s)", entry.ModelName, err, strings.TrimSpace(out))
+			return fmt.Errorf("hot-add %s: %w", entry.ModelName, err)
+		}
 	}
 
 	return nil

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -91,7 +91,7 @@ func LoadConfig(path string) (*PricingConfig, error) {
 
 	// Apply defaults.
 	if cfg.FacilitatorURL == "" {
-		cfg.FacilitatorURL = "https://facilitator.x402.rs"
+		cfg.FacilitatorURL = DefaultFacilitatorURL
 	}
 
 	if cfg.Chain == "" {

--- a/internal/x402/config_test.go
+++ b/internal/x402/config_test.go
@@ -89,8 +89,8 @@ routes:
 		t.Errorf("default chain = %q, want base-sepolia", cfg.Chain)
 	}
 
-	if cfg.FacilitatorURL != "https://facilitator.x402.rs" {
-		t.Errorf("default facilitatorURL = %q, want https://facilitator.x402.rs", cfg.FacilitatorURL)
+	if cfg.FacilitatorURL != "https://x402.gcp.obol.tech" {
+		t.Errorf("default facilitatorURL = %q, want https://x402.gcp.obol.tech", cfg.FacilitatorURL)
 	}
 }
 
@@ -194,7 +194,7 @@ func TestValidateFacilitatorURL(t *testing.T) {
 		wantErr bool
 	}{
 		// HTTPS always allowed.
-		{"https standard", "https://facilitator.x402.rs", false},
+		{"https standard", "https://x402.gcp.obol.tech", false},
 		{"https custom", "https://my-facilitator.example.com:8443/verify", false},
 
 		// Loopback/internal addresses allowed over HTTP.

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -52,6 +52,10 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	}
 	bin, kc := kubectl.Paths(cfg)
 
+	// Populate the CA certificates bundle from the host so the distroless
+	// verifier image can TLS-verify the facilitator (e.g. facilitator.x402.rs).
+	populateCABundle(bin, kc)
+
 	// 1. Patch the Secret with the wallet address.
 	fmt.Printf("Configuring x402: setting wallet address...\n")
 	secretPatch := map[string]any{"stringData": map[string]string{"WALLET_ADDRESS": wallet}}
@@ -129,6 +133,39 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 		return nil, err
 	}
 	return pcfg, nil
+}
+
+// populateCABundle reads the host's CA certificate bundle and patches
+// it into the ca-certificates ConfigMap in the x402 namespace. The
+// x402-verifier image is distroless and ships without a CA store, so
+// TLS verification of external facilitators fails without this.
+func populateCABundle(bin, kc string) {
+	// Common CA bundle paths across Linux distros and macOS.
+	candidates := []string{
+		"/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu
+		"/etc/pki/tls/certs/ca-bundle.crt",   // RHEL/Fedora
+		"/etc/ssl/cert.pem",                   // macOS / Alpine
+	}
+	var caData []byte
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			caData = data
+			break
+		}
+	}
+	if len(caData) == 0 {
+		return // no CA bundle found — skip silently
+	}
+
+	patch := map[string]any{"data": map[string]string{"ca-certificates.crt": string(caData)}}
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return
+	}
+	_ = kubectl.RunSilent(bin, kc,
+		"patch", "configmap", "ca-certificates", "-n", x402Namespace,
+		"-p", string(patchJSON), "--type=merge")
 }
 
 func patchPricingConfig(bin, kc string, pcfg *PricingConfig) error {

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -16,6 +16,10 @@ const (
 	x402Namespace    = "x402"
 	pricingConfigMap = "x402-pricing"
 	x402SecretName   = "x402-secrets"
+
+	// DefaultFacilitatorURL is the Obol-operated x402 facilitator for payment
+	// verification and settlement. Supports Base Mainnet and Base Sepolia.
+	DefaultFacilitatorURL = "https://x402.gcp.obol.tech"
 )
 
 var x402Manifest = mustReadX402Manifest()
@@ -42,7 +46,7 @@ func EnsureVerifier(cfg *config.Config) error {
 
 // Setup configures x402 pricing in the cluster by patching the ConfigMap
 // and Secret. Stakater Reloader auto-restarts the verifier pod.
-// If facilitatorURL is empty, the default (https://facilitator.x402.rs) is used.
+// If facilitatorURL is empty, the Obol-operated facilitator is used.
 func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	if err := ValidateWallet(wallet); err != nil {
 		return err
@@ -53,7 +57,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	bin, kc := kubectl.Paths(cfg)
 
 	// Populate the CA certificates bundle from the host so the distroless
-	// verifier image can TLS-verify the facilitator (e.g. facilitator.x402.rs).
+	// verifier image can TLS-verify the facilitator.
 	populateCABundle(bin, kc)
 
 	// 1. Patch the Secret with the wallet address.
@@ -73,7 +77,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	// static/manual routes.
 	fmt.Printf("Updating x402 pricing config...\n")
 	if facilitatorURL == "" {
-		facilitatorURL = "https://facilitator.x402.rs"
+		facilitatorURL = DefaultFacilitatorURL
 	}
 	existingCfg, _ := GetPricingConfig(cfg)
 	var existingRoutes []RouteRule

--- a/internal/x402/setup_test.go
+++ b/internal/x402/setup_test.go
@@ -103,7 +103,7 @@ func TestPricingConfig_YAMLRoundTrip(t *testing.T) {
 	original := PricingConfig{
 		Wallet:         "0xGLOBALGLOBALGLOBALGLOBALGLOBALGLOBALGL",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		VerifyOnly:     true,
 		Routes: []RouteRule{
 			{
@@ -188,7 +188,7 @@ func TestPricingConfig_YAMLWithPerRouteOverrides(t *testing.T) {
 	pcfg := PricingConfig{
 		Wallet:         "0xGLOBALGLOBALGLOBALGLOBALGLOBALGLOBALGL",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes: []RouteRule{
 			{
 				Pattern:     "/inference-llama/v1/*",

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -119,6 +119,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		Chain:            chain,
 		Amount:           rule.Price,
 		RecipientAddress: wallet,
+		Description:      fmt.Sprintf("Payment required for %s", rule.Pattern),
 	})
 	if err != nil {
 		log.Printf("x402-verifier: failed to create payment requirement: %v", err)

--- a/internal/x402/watcher_test.go
+++ b/internal/x402/watcher_test.go
@@ -10,7 +10,7 @@ import (
 
 const validWatcherYAML = `wallet: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 chain: "base-sepolia"
-facilitatorURL: "https://facilitator.x402.rs"
+facilitatorURL: "https://x402.gcp.obol.tech"
 routes:
   - pattern: "/rpc/*"
     price: "0.0001"
@@ -32,7 +32,7 @@ func TestWatchConfig_DetectsChange(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func TestWatchConfig_DetectsChange(t *testing.T) {
 	// Write updated config with a new route.
 	updatedYAML := `wallet: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 chain: "base-sepolia"
-facilitatorURL: "https://facilitator.x402.rs"
+facilitatorURL: "https://x402.gcp.obol.tech"
 routes:
   - pattern: "/rpc/*"
     price: "0.0001"
@@ -79,7 +79,7 @@ func TestWatchConfig_IgnoresUnchanged(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -112,7 +112,7 @@ func TestWatchConfig_InvalidConfig(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func TestWatchConfig_CancelContext(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func TestWatchConfig_MissingFile(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **CA certificate bundle**: The x402-verifier distroless image has no CA store. `obol sell pricing` now populates the `ca-certificates` ConfigMap from the host's cert bundle so TLS verification of `facilitator.x402.rs` works out of the box.
- **Missing Description field**: The facilitator rejects verify requests without `description` in `PaymentRequirement`. Added it from the route pattern.

## Validated on Base Sepolia testnet

Real x402 payment flow between two ARM64 nodes running Nemotron 120B (120B parameter model, tensor-parallel across two GPUs):

**Alice (seller)**: `obolup.sh` → `obol stack up` → `obol sell pricing` → `obol sell http nemotron` → tunnel  
**Bob (buyer)**: discover `.well-known` → probe 402 → sign EIP-712 → pay → HTTP 200 + real inference

### On-chain receipt

| Field | Value |
|-------|-------|
| Settlement tx | [`0xd769953bab675ab97a5140dbf7b5583367c788ecb445251c19fea7194c231ec0`](https://sepolia.basescan.org/tx/0xd769953bab675ab97a5140dbf7b5583367c788ecb445251c19fea7194c231ec0) |
| Network | Base Sepolia (84532) |
| Facilitator | `facilitator.x402.rs` (real public settlement) |
| Amount | 1000 micro-USDC (0.001 USDC) |
| Seller balance delta | +0.001 USDC |
| Buyer balance delta | -0.001 USDC |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/x402/...` passes
- [x] Real Base Sepolia payment: 402 → sign → 200 + on-chain settlement
- [x] Inference from Nemotron 120B served through the paid route