### PR TITLE
fix: x402 verifier TLS and facilitator compatibility

### DIFF
--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -52,6 +52,10 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	}
 	bin, kc := kubectl.Paths(cfg)
 
+	// Populate the CA certificates bundle from the host so the distroless
+	// verifier image can TLS-verify the facilitator (e.g. facilitator.x402.rs).
+	populateCABundle(bin, kc)
+
 	// 1. Patch the Secret with the wallet address.
 	fmt.Printf("Configuring x402: setting wallet address...\n")
 	secretPatch := map[string]any{"stringData": map[string]string{"WALLET_ADDRESS": wallet}}
@@ -129,6 +133,39 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 		return nil, err
 	}
 	return pcfg, nil
+}
+
+// populateCABundle reads the host's CA certificate bundle and patches
+// it into the ca-certificates ConfigMap in the x402 namespace. The
+// x402-verifier image is distroless and ships without a CA store, so
+// TLS verification of external facilitators fails without this.
+func populateCABundle(bin, kc string) {
+	// Common CA bundle paths across Linux distros and macOS.
+	candidates := []string{
+		"/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu
+		"/etc/pki/tls/certs/ca-bundle.crt",   // RHEL/Fedora
+		"/etc/ssl/cert.pem",                   // macOS / Alpine
+	}
+	var caData []byte
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			caData = data
+			break
+		}
+	}
+	if len(caData) == 0 {
+		return // no CA bundle found — skip silently
+	}
+
+	patch := map[string]any{"data": map[string]string{"ca-certificates.crt": string(caData)}}
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return
+	}
+	_ = kubectl.RunSilent(bin, kc,
+		"patch", "configmap", "ca-certificates", "-n", x402Namespace,
+		"-p", string(patchJSON), "--type=merge")
 }
 
 func patchPricingConfig(bin, kc string, pcfg *PricingConfig) error {

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -119,6 +119,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		Chain:            chain,
 		Amount:           rule.Price,
 		RecipientAddress: wallet,
+		Description:      fmt.Sprintf("Payment required for %s", rule.Pattern),
 	})
 	if err != nil {
 		log.Printf("x402-verifier: failed to create payment requirement: %v", err)


### PR DESCRIPTION
## Summary

- **CA certificate bundle**: `obol sell pricing` now populates the `ca-certificates` ConfigMap from the host's cert bundle so the distroless verifier can TLS-verify external facilitators
- **Missing Description field**: facilitator rejects verify requests without `description` in PaymentRequirement

## Validated: two-stack Base Sepolia testnet flow

Two independent DGX Spark nodes (ARM64), each running their own obol stack with Nemotron 120B (120B params, tensor-parallel across 2 GPUs):

### Alice (spark-1, seller)

```bash
obolup.sh
obol stack init && obol stack up
obol model setup custom --name nemotron-120b \
  --endpoint http://host.k3d.internal:8000/v1 \
  --model "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
obol sell pricing --wallet 0xC0De...97E --chain base-sepolia
obol sell http nemotron --wallet 0xC0De...97E --chain base-sepolia \
  --per-request 0.001 --namespace llm --upstream litellm --port 4000 \
  --health-path /health/readiness --register \
  --register-name "Nemotron 120B on DGX Spark"
obol tunnel restart
```

### Bob (spark-2, buyer)

**Path 1 — Direct x402 payment:**
```bash
# Discover → probe 402 → sign EIP-712 → pay → HTTP 200
curl $TUNNEL/.well-known/agent-registration.json  # x402Support: true
curl -X POST $TUNNEL/services/nemotron/...        # 402 with pricing
python3 bob_buy.py                                 # sign + pay → 200
```

**Path 2 — `paid/*` through buyer sidecar (full LiteLLM supply chain):**
```bash
obolup.sh
obol stack init && obol stack up
# Configure x402-buyer sidecar with pre-signed ERC-3009 auths
# Agent calls: model="paid/nemotron-120b"
#   → LiteLLM paid/* → x402-buyer sidecar → Alice's tunnel
#   → x402-verifier → facilitator → on-chain settlement
#   → LiteLLM → vLLM Nemotron 120B → response
```

### On-chain receipts (Base Sepolia)

| Tx | Description |
|----|-------------|
| [`0xd769953b...`](https://sepolia.basescan.org/tx/0xd769953bab675ab97a5140dbf7b5583367c788ecb445251c19fea7194c231ec0) | Direct: Bob → Alice 0.001 USDC |
| [`0xd004b8cd...`](https://sepolia.basescan.org/tx/0xd004b8cd6e330bb14f4c5dbd238ea995a10da381f551fd041dc32f939d9c0306) | Sidecar: Bob → Alice 0.001 USDC via `paid/*` |

### Balance changes

| Wallet | Role | Before | After |
|--------|------|--------|-------|
| `0xC0De...97E` | Alice (seller) | 15.021 USDC | 15.023 USDC |
| `0x57b0...490E` | Bob (buyer) | 5.000 USDC | 4.998 USDC |

## Test plan
- [x] `go test ./internal/x402/...` passes
- [x] Real on-chain x402 payment (direct path)
- [x] Real on-chain x402 payment (sidecar `paid/*` path)
- [x] Two independent stacks, two separate clusters