### PR TITLE
feat: switch default facilitator to Obol-operated x402.gcp.obol.tech

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -105,7 +105,7 @@ Examples:
 			&cli.StringFlag{
 				Name:  "facilitator",
 				Usage: "x402 facilitator URL",
-				Value: "https://facilitator.x402.rs",
+				Value: x402verifier.DefaultFacilitatorURL,
 			},
 			&cli.StringFlag{
 				Name:    "listen",

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -186,7 +186,7 @@ func TestSellInference_Flags(t *testing.T) {
 	assertStringDefault(t, flags, "chain", "base-sepolia")
 	assertStringDefault(t, flags, "listen", ":8402")
 	assertStringDefault(t, flags, "upstream", "http://localhost:11434")
-	assertStringDefault(t, flags, "facilitator", "https://facilitator.x402.rs")
+	assertStringDefault(t, flags, "facilitator", "https://x402.gcp.obol.tech")
 	assertStringDefault(t, flags, "vm-image", "ollama/ollama:latest")
 	assertIntDefault(t, flags, "vm-cpus", 4)
 	assertIntDefault(t, flags, "vm-memory", 8192)

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -122,7 +122,7 @@ func NewGateway(cfg GatewayConfig) (*Gateway, error) {
 	}
 
 	if cfg.FacilitatorURL == "" {
-		cfg.FacilitatorURL = "https://facilitator.x402.rs"
+		cfg.FacilitatorURL = x402verifier.DefaultFacilitatorURL
 	}
 
 	if err := x402verifier.ValidateFacilitatorURL(cfg.FacilitatorURL); err != nil {

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 )
 
 // ErrDeploymentNotFound is returned when a named inference deployment does
@@ -181,7 +183,7 @@ func (s *Store) Create(d *Deployment, force bool) error {
 	}
 
 	if d.FacilitatorURL == "" {
-		d.FacilitatorURL = "https://facilitator.x402.rs"
+		d.FacilitatorURL = x402verifier.DefaultFacilitatorURL
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -91,7 +91,7 @@ func LoadConfig(path string) (*PricingConfig, error) {
 
 	// Apply defaults.
 	if cfg.FacilitatorURL == "" {
-		cfg.FacilitatorURL = "https://facilitator.x402.rs"
+		cfg.FacilitatorURL = DefaultFacilitatorURL
 	}
 
 	if cfg.Chain == "" {

--- a/internal/x402/config_test.go
+++ b/internal/x402/config_test.go
@@ -89,8 +89,8 @@ routes:
 		t.Errorf("default chain = %q, want base-sepolia", cfg.Chain)
 	}
 
-	if cfg.FacilitatorURL != "https://facilitator.x402.rs" {
-		t.Errorf("default facilitatorURL = %q, want https://facilitator.x402.rs", cfg.FacilitatorURL)
+	if cfg.FacilitatorURL != "https://x402.gcp.obol.tech" {
+		t.Errorf("default facilitatorURL = %q, want https://x402.gcp.obol.tech", cfg.FacilitatorURL)
 	}
 }
 
@@ -194,7 +194,7 @@ func TestValidateFacilitatorURL(t *testing.T) {
 		wantErr bool
 	}{
 		// HTTPS always allowed.
-		{"https standard", "https://facilitator.x402.rs", false},
+		{"https standard", "https://x402.gcp.obol.tech", false},
 		{"https custom", "https://my-facilitator.example.com:8443/verify", false},
 
 		// Loopback/internal addresses allowed over HTTP.

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -52,6 +52,10 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	}
 	bin, kc := kubectl.Paths(cfg)
 
+	// Populate the CA certificates bundle from the host so the distroless
+	// verifier image can TLS-verify the facilitator (e.g. facilitator.x402.rs).
+	populateCABundle(bin, kc)
+
 	// 1. Patch the Secret with the wallet address.
 	fmt.Printf("Configuring x402: setting wallet address...\n")
 	secretPatch := map[string]any{"stringData": map[string]string{"WALLET_ADDRESS": wallet}}
@@ -129,6 +133,39 @@ func GetPricingConfig(cfg *config.Config) (*PricingConfig, error) {
 		return nil, err
 	}
 	return pcfg, nil
+}
+
+// populateCABundle reads the host's CA certificate bundle and patches
+// it into the ca-certificates ConfigMap in the x402 namespace. The
+// x402-verifier image is distroless and ships without a CA store, so
+// TLS verification of external facilitators fails without this.
+func populateCABundle(bin, kc string) {
+	// Common CA bundle paths across Linux distros and macOS.
+	candidates := []string{
+		"/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu
+		"/etc/pki/tls/certs/ca-bundle.crt",   // RHEL/Fedora
+		"/etc/ssl/cert.pem",                   // macOS / Alpine
+	}
+	var caData []byte
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			caData = data
+			break
+		}
+	}
+	if len(caData) == 0 {
+		return // no CA bundle found — skip silently
+	}
+
+	patch := map[string]any{"data": map[string]string{"ca-certificates.crt": string(caData)}}
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return
+	}
+	_ = kubectl.RunSilent(bin, kc,
+		"patch", "configmap", "ca-certificates", "-n", x402Namespace,
+		"-p", string(patchJSON), "--type=merge")
 }
 
 func patchPricingConfig(bin, kc string, pcfg *PricingConfig) error {

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -16,6 +16,10 @@ const (
 	x402Namespace    = "x402"
 	pricingConfigMap = "x402-pricing"
 	x402SecretName   = "x402-secrets"
+
+	// DefaultFacilitatorURL is the Obol-operated x402 facilitator for payment
+	// verification and settlement. Supports Base Mainnet and Base Sepolia.
+	DefaultFacilitatorURL = "https://x402.gcp.obol.tech"
 )
 
 var x402Manifest = mustReadX402Manifest()
@@ -42,7 +46,7 @@ func EnsureVerifier(cfg *config.Config) error {
 
 // Setup configures x402 pricing in the cluster by patching the ConfigMap
 // and Secret. Stakater Reloader auto-restarts the verifier pod.
-// If facilitatorURL is empty, the default (https://facilitator.x402.rs) is used.
+// If facilitatorURL is empty, the Obol-operated facilitator is used.
 func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	if err := ValidateWallet(wallet); err != nil {
 		return err
@@ -53,7 +57,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	bin, kc := kubectl.Paths(cfg)
 
 	// Populate the CA certificates bundle from the host so the distroless
-	// verifier image can TLS-verify the facilitator (e.g. facilitator.x402.rs).
+	// verifier image can TLS-verify the facilitator.
 	populateCABundle(bin, kc)
 
 	// 1. Patch the Secret with the wallet address.
@@ -73,7 +77,7 @@ func Setup(cfg *config.Config, wallet, chain, facilitatorURL string) error {
 	// static/manual routes.
 	fmt.Printf("Updating x402 pricing config...\n")
 	if facilitatorURL == "" {
-		facilitatorURL = "https://facilitator.x402.rs"
+		facilitatorURL = DefaultFacilitatorURL
 	}
 	existingCfg, _ := GetPricingConfig(cfg)
 	var existingRoutes []RouteRule

--- a/internal/x402/setup_test.go
+++ b/internal/x402/setup_test.go
@@ -103,7 +103,7 @@ func TestPricingConfig_YAMLRoundTrip(t *testing.T) {
 	original := PricingConfig{
 		Wallet:         "0xGLOBALGLOBALGLOBALGLOBALGLOBALGLOBALGL",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		VerifyOnly:     true,
 		Routes: []RouteRule{
 			{
@@ -188,7 +188,7 @@ func TestPricingConfig_YAMLWithPerRouteOverrides(t *testing.T) {
 	pcfg := PricingConfig{
 		Wallet:         "0xGLOBALGLOBALGLOBALGLOBALGLOBALGLOBALGL",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes: []RouteRule{
 			{
 				Pattern:     "/inference-llama/v1/*",

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -119,6 +119,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 		Chain:            chain,
 		Amount:           rule.Price,
 		RecipientAddress: wallet,
+		Description:      fmt.Sprintf("Payment required for %s", rule.Pattern),
 	})
 	if err != nil {
 		log.Printf("x402-verifier: failed to create payment requirement: %v", err)

--- a/internal/x402/watcher_test.go
+++ b/internal/x402/watcher_test.go
@@ -10,7 +10,7 @@ import (
 
 const validWatcherYAML = `wallet: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 chain: "base-sepolia"
-facilitatorURL: "https://facilitator.x402.rs"
+facilitatorURL: "https://x402.gcp.obol.tech"
 routes:
   - pattern: "/rpc/*"
     price: "0.0001"
@@ -32,7 +32,7 @@ func TestWatchConfig_DetectsChange(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func TestWatchConfig_DetectsChange(t *testing.T) {
 	// Write updated config with a new route.
 	updatedYAML := `wallet: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 chain: "base-sepolia"
-facilitatorURL: "https://facilitator.x402.rs"
+facilitatorURL: "https://x402.gcp.obol.tech"
 routes:
   - pattern: "/rpc/*"
     price: "0.0001"
@@ -79,7 +79,7 @@ func TestWatchConfig_IgnoresUnchanged(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -112,7 +112,7 @@ func TestWatchConfig_InvalidConfig(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func TestWatchConfig_CancelContext(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func TestWatchConfig_MissingFile(t *testing.T) {
 	v, err := NewVerifier(&PricingConfig{
 		Wallet:         "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 		Chain:          "base-sepolia",
-		FacilitatorURL: "https://facilitator.x402.rs",
+		FacilitatorURL: "https://x402.gcp.obol.tech",
 		Routes:         []RouteRule{{Pattern: "/rpc/*", Price: "0.0001"}},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Replace third-party `facilitator.x402.rs` with Obol-operated `x402.gcp.obol.tech`. Introduces `DefaultFacilitatorURL` constant and updates all references.

Depends on companion infra PR adding Base Sepolia to the Obol facilitator.

## Test plan
- [x] `go test ./...` passes
- [x] All test files updated to new URL