### PR TITLE
test(erc8004): cover metadata revert propagation

### DIFF
--- a/internal/erc8004/client_test.go
+++ b/internal/erc8004/client_test.go
@@ -486,6 +486,37 @@ func TestSetMetadata(t *testing.T) {
 	}
 }
 
+func TestSetMetadata_TransactRevert(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlers := txMockHandlers(common.HexToHash("0x2222"))
+	handlers["eth_estimateGas"] = func(_ []json.RawMessage) (json.RawMessage, error) {
+		return nil, errors.New("execution reverted")
+	}
+
+	srv := mockRPC(t, handlers)
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	err = client.SetMetadata(ctx, key, big.NewInt(42), "x402", []byte(`{"payment":"info"}`))
+	if err == nil {
+		t.Fatal("expected setMetadata revert error, got nil")
+	}
+	if !strings.Contains(err.Error(), "erc8004: setMetadata tx: execution reverted") {
+		t.Fatalf("error = %q, want setMetadata tx execution reverted", err)
+	}
+}
+
 func TestNewClient_DialError(t *testing.T) {
 	ctx := context.Background()
 	// Use an unreachable address to trigger a dial/chain-id error.


### PR DESCRIPTION
## Summary
- Add focused coverage for the ERC-8004 setMetadata transaction revert path observed during Flow 11.
- Assert SetMetadata surfaces the exact wrapped error: erc8004: setMetadata tx: execution reverted.

## Validation
- go test ./internal/erc8004 ./internal/x402 ./internal/serviceoffercontroller

## Notes
- This is intentionally separated from PR #335. Base is feat/x402-buy-side-integration; head is test/erc8004-metadata-revert-coverage.