### PR TITLE
feat(x402): route sell http through seller gateway

### DIFF
--- a/cmd/x402-verifier/main.go
+++ b/cmd/x402-verifier/main.go
@@ -48,6 +48,7 @@ func main() {
 	mux.HandleFunc("/healthz", v.HandleHealthz)
 	mux.HandleFunc("/readyz", v.HandleReadyz)
 	mux.Handle("GET /metrics", v.MetricsHandler())
+	mux.Handle("/", http.HandlerFunc(v.HandleProxy))
 
 	server := &http.Server{
 		Addr:              *listen,
@@ -103,7 +104,7 @@ func main() {
 		log.Fatalf("listen: %v", err)
 	}
 
-	log.Printf("x402 verifier listening on %s", *listen)
+	log.Printf("x402 gateway listening on %s", *listen)
 	log.Printf("  config:      %s", *configPath)
 	log.Printf("  wallet:      %s", cfg.Wallet)
 	log.Printf("  chain:       %s", cfg.Chain)
@@ -112,15 +113,13 @@ func main() {
 	log.Printf("  verifyOnly:  %v", cfg.VerifyOnly)
 	log.Printf("  routeSource: %s", *routeSource)
 
-	// The Traefik ForwardAuth path cannot observe the upstream response, so
-	// settling there debits the payer before the upstream serves the request.
-	// Keep verifyOnly=true for this deployment and settle on a component that
-	// can observe the upstream status (x402-buyer or obol sell inference).
+	// verifyOnly only affects the legacy /verify endpoint. The shared seller
+	// gateway path served on all other routes always settles after upstream
+	// success, which is the correct x402 resource-server semantic.
 	if !cfg.VerifyOnly {
-		log.Printf("x402 verifier: WARNING verifyOnly=false loaded from %s. "+
-			"This is unsafe for Traefik ForwardAuth — the hop runs before the upstream "+
-			"is contacted, so settlement debits the payer before the upstream serves the "+
-			"request. Set verifyOnly=true in x402-pricing.yaml.", *configPath)
+		log.Printf("x402 gateway: WARNING verifyOnly=false loaded from %s. "+
+			"This only impacts the legacy /verify endpoint and is unsafe for Traefik "+
+			"ForwardAuth. Keep verifyOnly=true in x402-pricing.yaml if /verify is used.", *configPath)
 	}
 
 	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,7 @@ All pods should show `Running` or `Completed` within ~2 minutes:
 | **Frontend** | `obol-frontend` | Web interface at http://obol.stack/ |
 | **Monitoring** | `monitoring` | Prometheus + kube-prometheus-stack |
 | **Reloader** | `reloader` | Auto-restarts workloads on config changes |
-| **x402 Verifier** | `x402` | Payment gate (ForwardAuth middleware) |
+| **x402 Gateway** | `x402` | Shared seller-owned payment gateway for priced HTTP routes |
 | **OpenClaw** | `openclaw-default` | AI agent with Ethereum wallet |
 | **Remote Signer** | `openclaw-default` | Ethereum transaction signing service |
 

--- a/docs/guides/monetize-inference.md
+++ b/docs/guides/monetize-inference.md
@@ -342,8 +342,10 @@ The SDK handles the full x402 flow:
 2. Receives 402 with payment requirements
 3. Signs an EIP-712 `TransferWithAuthorization` message (ERC-3009)
 4. Retries with the `X-PAYMENT` header (base64-encoded x402 envelope)
-5. Facilitator verifies the signature and settles USDC on-chain
-6. Returns the inference response
+5. The seller-owned x402 gateway verifies the payment with the facilitator
+6. The seller gateway forwards the request to the protected upstream
+7. After upstream success, the seller gateway settles USDC on-chain
+8. Returns the inference response
 
 **Manual flow with curl** -- for debugging or custom integrations:
 
@@ -395,14 +397,14 @@ curl -s -w "\nHTTP %{http_code}" -X POST \
     -H "Content-Type: application/json" \
     -d '{"model":"qwen3:0.6b","messages":[{"role":"user","content":"Hello"}]}'
 
-# Paid request through tunnel (supported production path: x402-buyer)
+# Paid request through tunnel (supported production path)
 # The buyer talks to LiteLLM, which routes paid models through the in-pod
-# x402-buyer sidecar. The sidecar performs the paid retry and settlement after
-# upstream success. Do not treat raw direct X-PAYMENT through Traefik
-# ForwardAuth as the supported production buyer flow.
+# x402-buyer sidecar. The sidecar performs the paid retry. The seller-owned
+# shared x402 gateway verifies the payment, forwards to the upstream, and
+# settles only after upstream success.
 ```
 
-This proves the supported public paid path: **Buyer → LiteLLM → x402-buyer → Cloudflare/Traefik → x402 ForwardAuth verify gate → upstream → x402-buyer settles after success → 200 + inference**.
+This proves the supported public paid path: **Buyer → LiteLLM → x402-buyer → Cloudflare/Traefik → shared x402 gateway → upstream → seller-side settle → 200 + inference**.
 
 ---
 
@@ -562,7 +564,6 @@ Verify cleanup:
 
 ```bash
 obol kubectl get so my-qwen -n llm              # NotFound
-obol kubectl get middleware x402-my-qwen -n llm  # NotFound
 obol kubectl get httproute so-my-qwen -n llm     # NotFound
 ```
 
@@ -570,9 +571,10 @@ obol kubectl get httproute so-my-qwen -n llm     # NotFound
 
 ## Architecture Deep-Dive
 
-### x402 ForwardAuth Pattern
+### Shared x402 Seller Gateway
 
-The x402 verifier sits in the request path as a Traefik ForwardAuth middleware:
+The x402 gateway now acts as the seller-owned resource server in front of the
+real upstream:
 
 ```
 Client
@@ -582,21 +584,16 @@ Client
   v
 Traefik Gateway
   |
-  --> ForwardAuth to x402-verifier.x402.svc:8080
-  |       |
-  |       +-- Match request path against pricing routes
-  |       +-- No match? Return 200 (allow, free route)
-  |       +-- Match + no payment header? Return 402 + requirements
-  |       +-- Match + payment header? Verify with facilitator
-  |       |       |
-  |       |       +-- POST facilitator/verify
-  |       |       +-- Valid? Return 200 (allow)
-  |       |       +-- Invalid? Return 402
-  |       |
-  |       <-- 200 or 402
-  |
-  +-- 200? Proxy to upstream (Ollama)
-  +-- 402? Return to client with payment requirements
+  --> Route match /services/my-qwen/*
+          |
+          v
+      x402-verifier.x402.svc:8080
+          |
+          +-- No payment header? Return 402 + requirements
+          +-- Payment header? POST facilitator/verify
+          +-- Valid? Proxy to upstream
+          +-- Upstream success? POST facilitator/settle
+          +-- Return 200 + X-PAYMENT-RESPONSE
 ```
 
 ### ServiceOffer Condition State Machine
@@ -798,7 +795,7 @@ Replace `openclaw-obol-agent` with your actual OpenClaw namespace if different.
 |----------|-----------|---------|
 | `x402-pricing` ConfigMap | `x402` | Pricing routes and wallet config |
 | `x402-secrets` Secret | `x402` | Wallet address |
-| `x402-verifier` Deployment | `x402` | ForwardAuth payment verifier |
+| `x402-verifier` Deployment | `x402` | Shared seller-owned x402 gateway and legacy `/verify` endpoint |
 | `serviceoffers.obol.org` CRD | (cluster) | ServiceOffer custom resource definition |
 | `traefik-gateway` Gateway | `traefik` | Main ingress gateway |
 

--- a/docs/reports/x402-seller-gateway-redesign-report.md
+++ b/docs/reports/x402-seller-gateway-redesign-report.md
@@ -1,0 +1,184 @@
+# x402 Seller Gateway Redesign Report
+
+## Branch
+
+- `feature/x402-seller-gateway-redesign`
+
+## Summary
+
+This branch redesigns `sell http` from:
+
+- `Traefik -> ForwardAuth verifier -> upstream`
+
+to:
+
+- `Traefik -> shared seller-owned x402 gateway -> upstream`
+
+The gateway now owns:
+
+1. `402` payment requirement generation
+2. payment verification with the facilitator
+3. upstream proxying
+4. settlement after upstream success
+5. `X-PAYMENT-RESPONSE` emission back to the buyer
+
+This restores correct x402 seller-side semantics for cluster-routed `sell http`.
+
+## Test Results
+
+### Unit Tests
+
+- `go test ./internal/x402` : passed
+- `go test ./internal/serviceoffercontroller` : passed
+
+### Integration Compile / Smoke
+
+- `go test -tags integration ./internal/openclaw -run TestDoesNotExist` : passed compile
+- `go test -tags integration -v -run TestBDDIntegration -timeout 20m ./internal/x402` : blocked by host environment
+
+Blocked environment detail:
+
+- the x402 BDD bootstrap path still assumes host port `8080`
+- this machine already has `8080` allocated by another process
+- I did not kill that unrelated listener
+
+### Flow Tests
+
+- `flows/flow-11-dual-stack.sh` : passed `41/41`
+
+Run used high-port overrides for both stacks:
+
+- Alice: `18080/18081/18443/18444`
+- Bob: `19080/19081/19443/19444`
+
+## Successful Flow-11 Artifacts
+
+### Seller
+
+- Seller wallet: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
+- Published tunnel URL:
+  - `https://ten-municipal-mortgages-offerings.trycloudflare.com`
+- Registered agent ID:
+  - `5003`
+
+### Buyer
+
+- Buyer discovery wallet:
+  - `0x57b0eF875DeB5A37301F1640E469a2129Da9490E`
+- Bob remote-signer wallet:
+  - `0x5D01290Fd77EbD7a82bD316dC2d762C30B07D107`
+- Purchased alias:
+  - `paid/qwen3.5:9b`
+
+## Seller Registration Receipts
+
+### 1. Identity Registration
+
+- Tx hash:
+  - `0x32eef92ede6779a3d05e780bf0920f4744b22ec6e85eb81d4d83371644d751b9`
+- Block:
+  - `40331698`
+- Chain:
+  - Base Sepolia (`84532`)
+- Function:
+  - `register(string)`
+- Registry:
+  - `0x8004A818BFB912233c491871b3d84c89A494BD9e`
+- Sender / owner:
+  - `0xC0De030F6C37f490594F93fB99e2756703c4297E`
+- Agent ID:
+  - `5003`
+- Registered URI:
+  - `https://ten-municipal-mortgages-offerings.trycloudflare.com/.well-known/agent-registration.json`
+
+Observed receipt facts:
+
+- status: `1`
+- gas used: `183900`
+- emitted `Registered(agentId=5003, agentURI=..., owner=seller)`
+- emitted `MetadataSet(agentWallet=0xC0De...)`
+
+### 2. x402 Metadata Write
+
+- Tx hash:
+  - `0xab815b78ab688697ef1e39f479bf83d57b53c7afb26c00c85775105d860b1df8`
+- Block:
+  - `40331700`
+- Function:
+  - `setMetadata(uint256,string,bytes)`
+- Metadata key:
+  - `x402`
+- Metadata value:
+  - `{"x402":true}`
+
+Observed receipt facts:
+
+- status: `1`
+- gas used: `57552`
+- sender: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
+- target: `0x8004A818BFB912233c491871b3d84c89A494BD9e`
+
+## Buyer Settlement Receipt
+
+### 3. x402 Settlement Transfer
+
+- Tx hash:
+  - `0x847de0118110b4f056c025b9804cd82f87274a2b95926419c34ccfc0eb1216a2`
+- Block:
+  - `40331811`
+- Function:
+  - `transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)`
+- Chain:
+  - Base Sepolia (`84532`)
+- Token:
+  - USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
+- Facilitator settlement sender:
+  - `0xd744494E28b01073514EBC89987B305001ed257A`
+- Buyer signer:
+  - `0x5D01290Fd77EbD7a82bD316dC2d762C30B07D107`
+- Seller payTo:
+  - `0xC0De030F6C37f490594F93fB99e2756703c4297E`
+- Settled amount:
+  - `1000` micro-USDC (`0.001 USDC`)
+
+Observed receipt facts:
+
+- status: `1`
+- gas used: `86144`
+- `AuthorizationUsed` emitted by USDC
+- `Transfer` emitted from buyer signer to seller for `1000`
+
+## Buyer-Side Receipt Summary
+
+From the successful `flow-11` run:
+
+- `PurchaseRequest` reached `Ready=True`
+- buyer sidecar live status changed:
+  - before: `remaining=5 spent=0`
+  - after one paid request: `remaining=4 spent=1` in effect, with one settled request consumed
+- paid inference returned `200`
+- settlement transaction was observed on-chain
+
+## Supported x402 Chain Recipes In This Repo
+
+These are the chain recipes currently encoded in `internal/x402/chains.go`.
+
+| Chain | CAIP-2 | USDC |
+|---|---|---|
+| `base` | `eip155:8453` | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| `base-sepolia` | `eip155:84532` | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `ethereum` | `eip155:1` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| `polygon` | `eip155:137` | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+| `polygon-amoy` | `eip155:80002` | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` |
+| `avalanche` | `eip155:43114` | `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E` |
+| `avalanche-fuji` | `eip155:43113` | `0x5425890298aed601595a70AB815c96711a31Bc65` |
+| `arbitrum-one` | `eip155:42161` | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| `arbitrum-sepolia` | `eip155:421614` | `0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d` |
+
+## Architecture Outcome
+
+This branch makes the seller-side responsibility explicit:
+
+- buyers still use `x402-buyer` for bounded auth pools and automatic paid retries
+- sellers now settle from the shared seller-owned gateway after upstream success
+- the legacy `/verify` endpoint remains available, but `verifyOnly=true` is treated as a legacy ForwardAuth-only safety setting, not the hot path for `sell http`

--- a/flows/flow-06-sell-setup.sh
+++ b/flows/flow-06-sell-setup.sh
@@ -205,9 +205,16 @@ else
     fail "Ollama service port unexpected: $ollama_port (expected 11434)"
 fi
 
-run_step_grep "Middleware exists" "x402-flow-qwen" \
-    "$OBOL" kubectl get middleware -n llm
 run_step_grep "HTTPRoute exists" "so-flow-qwen" \
     "$OBOL" kubectl get httproute -n llm
+
+step "HTTPRoute backend is shared x402 gateway"
+route_backend=$("$OBOL" kubectl get httproute so-flow-qwen -n llm \
+    -o jsonpath='{.spec.rules[0].backendRefs[0].namespace}/{.spec.rules[0].backendRefs[0].name}:{.spec.rules[0].backendRefs[0].port}' 2>&1) || true
+if [ "$route_backend" = "x402/x402-verifier:8080" ]; then
+    pass "HTTPRoute backend: $route_backend"
+else
+    fail "HTTPRoute backend unexpected — ${route_backend:0:100}"
+fi
 
 emit_metrics

--- a/flows/flow-09-lifecycle.sh
+++ b/flows/flow-09-lifecycle.sh
@@ -58,14 +58,6 @@ else
     fail "ServiceOffer still exists — $so_out"
 fi
 
-step "Middleware NotFound after delete"
-mw_out=$("$OBOL" kubectl get middleware x402-flow-qwen -n llm 2>&1) || true
-if echo "$mw_out" | grep -qi "NotFound\|not found"; then
-    pass "Middleware deleted"
-else
-    fail "Middleware still exists — $mw_out"
-fi
-
 step "HTTPRoute NotFound after delete"
 hr_out=$("$OBOL" kubectl get httproute so-flow-qwen -n llm 2>&1) || true
 if echo "$hr_out" | grep -qi "NotFound\|not found"; then

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -1,6 +1,6 @@
 ---
 # x402 runtime components:
-# - x402-verifier: live ForwardAuth request path
+# - x402-verifier: shared seller-owned x402 gateway (and legacy /verify endpoint)
 # - serviceoffer-controller: control-plane reconciler for ServiceOffer child resources
 apiVersion: v1
 kind: Namespace
@@ -8,8 +8,8 @@ metadata:
   name: x402
 
 ---
-# Static verifier settings plus optional manual routes. In cluster mode the
-# verifier merges these with dynamic routes derived from ready ServiceOffers.
+# Static gateway settings plus optional manual routes. In cluster mode the
+# gateway merges these with dynamic routes derived from ready ServiceOffers.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,9 +20,8 @@ data:
     wallet: ""
     chain: "base"
     facilitatorURL: "https://x402.gcp.obol.tech"
-    # ForwardAuth is a pre-upstream gate only. Keep it permanently verify-only;
-    # final settlement belongs in a component that can observe the upstream
-    # response, such as x402-buyer or the standalone inference gateway.
+    # verifyOnly applies to the legacy /verify endpoint only. The shared seller
+    # gateway path always settles after upstream success.
     verifyOnly: true
     routes: []
 
@@ -124,6 +123,9 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "create", "update", "patch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/internal/embed/skills/sell/references/x402-pricing.md
+++ b/internal/embed/skills/sell/references/x402-pricing.md
@@ -6,30 +6,30 @@ x402 enables HTTP-native micropayments using the `402 Payment Required` status c
 
 ## How It Works in Obol Stack
 
-1. **ForwardAuth Middleware**: Traefik routes each request through a ForwardAuth middleware pointing at the x402-verifier service
-2. **Payment Check**: The verifier checks for a valid `X-PAYMENT` header
+1. **Shared x402 Gateway**: Traefik routes priced paths to the shared `x402-verifier` service
+2. **Payment Check**: The gateway checks for a valid `X-PAYMENT` header
 3. **402 Response**: If missing/invalid, returns 402 with payment requirements (wallet, amount, chain)
-4. **Payment**: Client sends on-chain payment (USDC) via the facilitator
-5. **Verification**: Client retries with payment proof; verifier validates and forwards to upstream
+4. **Payment**: Client sends on-chain payment intent (USDC) via the facilitator flow
+5. **Verification + Proxy**: Client retries with payment proof; the gateway verifies, forwards to the upstream, then settles only after upstream success
 
 ## Settlement Semantics
 
 Obol Stack supports two correct paid request models:
 
-- **`x402-buyer` path**: the LiteLLM sidecar retries with `X-PAYMENT`, waits for a successful upstream response, and then settles. This is the supported production path for cluster-routed paid traffic.
-- **`obol sell inference` path**: the standalone gateway runs x402 middleware in-process, so it can also settle after upstream success. This is the right path for direct buyers that need to send raw `X-PAYMENT`.
+- **Shared seller gateway path**: `sell http` routes through the shared `x402-verifier` resource server, which verifies, proxies, and settles after upstream success.
+- **`obol sell inference` path**: the standalone gateway runs x402 middleware in-process, so it also settles after upstream success. This is the right path for direct buyers that need to send raw `X-PAYMENT`.
 
-### Traefik ForwardAuth limitation
+### Legacy `/verify` limitation
 
 - Traefik `ForwardAuth` is a pre-upstream authorization hook.
-- With `verifyOnly: true`, the verifier can validate payment but cannot safely make the final settlement decision after the upstream finishes.
-- Because of that, raw direct `X-PAYMENT` through Traefik is not a supported production payment path.
+- With `verifyOnly: true`, the legacy `/verify` endpoint can validate payment but cannot safely make the final settlement decision after the upstream finishes.
+- Because of that, the shared seller gateway path is preferred for `sell http`.
 
 ### Choosing a path
 
-- Use `x402-buyer` for cluster-routed paid traffic.
+- Use `x402-buyer` plus the shared seller gateway for cluster-routed paid traffic.
 - Use `obol sell inference` for direct buyers that need raw `X-PAYMENT`.
-- Keep Traefik `x402-verifier` on `verifyOnly: true`.
+- Keep the legacy `/verify` endpoint on `verifyOnly: true`.
 
 ## Pricing Fields
 
@@ -59,15 +59,15 @@ Client
   |
   | GET /services/my-model/v1/chat/completions
   v
-Traefik Gateway
-  |
-  | ForwardAuth
-  v
-x402-verifier (x402.svc:8080/verify)
-  |
-  | 402 or 200
-  v
-Upstream Service (e.g., Ollama)
+    Traefik Gateway
+      |
+      | Route to shared x402 gateway
+      v
+    x402-verifier (x402.svc:8080)
+      |
+      | 402 or proxy after verify
+      v
+    Upstream Service (e.g., LiteLLM / Ollama)
 ```
 
 ## Payment Flow

--- a/internal/monetizeapi/types.go
+++ b/internal/monetizeapi/types.go
@@ -27,12 +27,13 @@ var (
 	RegistrationRequestGVR = schema.GroupVersionResource{Group: Group, Version: Version, Resource: RegistrationRequestResource}
 	PurchaseRequestGVR     = schema.GroupVersionResource{Group: Group, Version: Version, Resource: PurchaseRequestResource}
 
-	ServiceGVR    = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
-	SecretGVR     = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-	ConfigMapGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	DeploymentGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	MiddlewareGVR = schema.GroupVersionResource{Group: "traefik.io", Version: "v1alpha1", Resource: "middlewares"}
-	HTTPRouteGVR  = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	ServiceGVR        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	SecretGVR         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	ConfigMapGVR      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	DeploymentGVR     = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	MiddlewareGVR     = schema.GroupVersionResource{Group: "traefik.io", Version: "v1alpha1", Resource: "middlewares"}
+	HTTPRouteGVR      = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	ReferenceGrantGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"}
 )
 
 type ServiceOffer struct {
@@ -184,12 +185,12 @@ type PurchaseRequest struct {
 }
 
 type PurchaseRequestSpec struct {
-	Endpoint        string                   `json:"endpoint"`
-	Model           string                   `json:"model"`
-	Count           int                      `json:"count"`
-	PreSignedAuths  []PreSignedAuth          `json:"preSignedAuths,omitempty"`
-	AutoRefill      PurchaseAutoRefill       `json:"autoRefill,omitempty"`
-	Payment         PurchasePayment          `json:"payment"`
+	Endpoint       string             `json:"endpoint"`
+	Model          string             `json:"model"`
+	Count          int                `json:"count"`
+	PreSignedAuths []PreSignedAuth    `json:"preSignedAuths,omitempty"`
+	AutoRefill     PurchaseAutoRefill `json:"autoRefill,omitempty"`
+	Payment        PurchasePayment    `json:"payment"`
 }
 
 type PreSignedAuth struct {

--- a/internal/openclaw/monetize_integration_test.go
+++ b/internal/openclaw/monetize_integration_test.go
@@ -83,9 +83,6 @@ func resourceExists(t *testing.T, cfg *config.Config, kind, name, namespace stri
 
 func assertOfferRouteResourcesPresent(t *testing.T, cfg *config.Config, name, namespace string) {
 	t.Helper()
-	if !resourceExists(t, cfg, "middleware", "x402-"+name, namespace) {
-		t.Fatalf("middleware x402-%s not found in %s", name, namespace)
-	}
 	if !resourceExists(t, cfg, "httproute", "so-"+name, namespace) {
 		t.Fatalf("httproute so-%s not found in %s", name, namespace)
 	}
@@ -93,9 +90,6 @@ func assertOfferRouteResourcesPresent(t *testing.T, cfg *config.Config, name, na
 
 func assertOfferRouteResourcesAbsent(t *testing.T, cfg *config.Config, name, namespace string) {
 	t.Helper()
-	if resourceExists(t, cfg, "middleware", "x402-"+name, namespace) {
-		t.Fatalf("middleware x402-%s still exists in %s", name, namespace)
-	}
 	if resourceExists(t, cfg, "httproute", "so-"+name, namespace) {
 		t.Fatalf("httproute so-%s still exists in %s", name, namespace)
 	}
@@ -1169,7 +1163,7 @@ func TestIntegration_Route_FullReconcile(t *testing.T) {
 	}
 }
 
-func TestIntegration_Route_MiddlewareCreated(t *testing.T) {
+func TestIntegration_Route_SharedGatewayBacked(t *testing.T) {
 	cfg := requireCluster(t)
 	requireCRD(t, cfg)
 	requireAgent(t, cfg)
@@ -1189,13 +1183,13 @@ func TestIntegration_Route_MiddlewareCreated(t *testing.T) {
 		"/data/.openclaw/skills/monetize/scripts/monetize.py",
 		"process", name, "--namespace", ns)
 
-	// Check for ForwardAuth Middleware
-	out, err := obolRunErr(cfg, "kubectl", "get", "middleware", "-n", ns, "-o", "json")
+	// Check the shared x402 gateway Service exists.
+	out, err := obolRunErr(cfg, "kubectl", "get", "svc", "x402-verifier", "-n", "x402", "-o", "json")
 	if err != nil {
-		t.Skipf("no middlewares found: %v", err)
+		t.Skipf("shared gateway service not found: %v", err)
 	}
-	if !strings.Contains(out, "forwardAuth") && !strings.Contains(out, "ForwardAuth") {
-		t.Logf("middleware output: %s", out)
+	if !strings.Contains(out, "\"name\":\"x402-verifier\"") {
+		t.Logf("gateway output: %s", out)
 	}
 }
 
@@ -1319,12 +1313,7 @@ func TestIntegration_Route_DeleteCascades(t *testing.T) {
 	// Wait for garbage collection
 	time.Sleep(3 * time.Second)
 
-	// Middleware and HTTPRoute should be gone (owner reference cascade)
-	mwOut, _ := obolRunErr(cfg, "kubectl", "get", "middleware", "-n", ns, "-o", "name")
-	if strings.Contains(mwOut, name) {
-		t.Errorf("middleware still exists after ServiceOffer deletion:\n%s", mwOut)
-	}
-
+	// HTTPRoute should be gone (owner reference cascade).
 	hrOut, _ := obolRunErr(cfg, "kubectl", "get", "httproute", "-n", ns, "-o", "name")
 	if strings.Contains(hrOut, name) {
 		t.Errorf("httproute still exists after ServiceOffer deletion:\n%s", hrOut)
@@ -2040,11 +2029,7 @@ func TestIntegration_Tunnel_OllamaMonetized(t *testing.T) {
 
 	// Delete happened via kubectl, so only Kubernetes-owned resources are expected
 	// to disappear automatically here.
-	// Let's verify the K8s resources are gone (cascade via OwnerRef).
-	mwOut, _ := obolRunErr(cfg, "kubectl", "get", "middleware", "-n", ns, "-o", "name")
-	if strings.Contains(mwOut, name) {
-		t.Errorf("middleware still exists after deletion")
-	}
+	// Let's verify the K8s route resource is gone (cascade via OwnerRef).
 	hrOut, _ := obolRunErr(cfg, "kubectl", "get", "httproute", "-n", ns, "-o", "name")
 	if strings.Contains(hrOut, name) {
 		t.Errorf("httproute still exists after deletion")
@@ -2688,12 +2673,11 @@ func TestIntegration_Tunnel_RealFacilitatorOllama(t *testing.T) {
 //
 //	Step 1: ModelReady        → model checked in Ollama /api/tags
 //	Step 2: UpstreamHealthy   → upstream service health-checked
-//	Step 3: PaymentGateReady  → Middleware x402-<name> created
+//	Step 3: PaymentGateReady  → shared x402 gateway is available
 //	                          → verifier derives route from published ServiceOffer
 //	Step 4: RoutePublished    → HTTPRoute so-<name> created
 //	                          → parentRef = traefik-gateway
-//	                          → filter = ExtensionRef to Middleware
-//	                          → backend = upstream service
+//	                          → backend = shared x402 gateway service
 //	Step 5: Registered        → skipped (registration.enabled=false)
 //	Step 6: Ready             → all conditions True
 //
@@ -2736,11 +2720,7 @@ func TestIntegration_AgentCoordination_FullReconcileOrder(t *testing.T) {
 	}
 	t.Log("Step 0: CR created — no conditions, no derived resources")
 
-	// Verify no derived resources exist yet.
-	_, mwErr := obolRunErr(cfg, "kubectl", "get", "middleware", fmt.Sprintf("x402-%s", name), "-n", ns)
-	if mwErr == nil {
-		t.Error("Step 0: Middleware should not exist before reconciliation")
-	}
+	// Verify no route resources exist yet.
 	_, hrErr := obolRunErr(cfg, "kubectl", "get", "httproute", fmt.Sprintf("so-%s", name), "-n", ns)
 	if hrErr == nil {
 		t.Error("Step 0: HTTPRoute should not exist before reconciliation")
@@ -2793,32 +2773,20 @@ func TestIntegration_AgentCoordination_FullReconcileOrder(t *testing.T) {
 	}
 
 	// ────────────────────────────────────────────────────────────────────
-	// Step 3: Verify Middleware — ForwardAuth to x402-verifier
+	// Step 3: Verify shared x402 gateway is available
 	// ────────────────────────────────────────────────────────────────────
-	t.Log("Step 3: Verifying Middleware x402-" + name)
-	mwJSON := obolRun(t, cfg, "kubectl", "get", "middleware",
-		fmt.Sprintf("x402-%s", name), "-n", ns, "-o", "json")
+	t.Log("Step 3: Verifying shared gateway x402/x402-verifier")
+	gatewayJSON := obolRun(t, cfg, "kubectl", "get", "svc",
+		"x402-verifier", "-n", "x402", "-o", "json")
 
-	var mw map[string]interface{}
-	if err := json.Unmarshal([]byte(mwJSON), &mw); err != nil {
-		t.Fatalf("parse middleware JSON: %v", err)
+	var gateway map[string]interface{}
+	if err := json.Unmarshal([]byte(gatewayJSON), &gateway); err != nil {
+		t.Fatalf("parse gateway service JSON: %v", err)
 	}
-
-	// Verify ForwardAuth address points at x402-verifier.
-	spec := mw["spec"].(map[string]interface{})
-	forwardAuth, ok := spec["forwardAuth"].(map[string]interface{})
-	if !ok {
-		t.Fatal("Middleware missing spec.forwardAuth")
+	if metadata, ok := gateway["metadata"].(map[string]interface{}); !ok || metadata["name"] != "x402-verifier" {
+		t.Fatalf("shared gateway service metadata = %+v, want name=x402-verifier", gateway["metadata"])
 	}
-	address, _ := forwardAuth["address"].(string)
-	if !strings.Contains(address, "x402-verifier") {
-		t.Errorf("Middleware forwardAuth address = %q, want x402-verifier URL", address)
-	} else {
-		t.Logf("  ✓ Middleware ForwardAuth → %s", address)
-	}
-
-	// Verify ownerReference back to ServiceOffer.
-	verifyOwnerRef(t, mw, name, "ServiceOffer")
+	t.Log("  ✓ Shared x402 gateway service exists")
 
 	// ────────────────────────────────────────────────────────────────────
 	// Step 4: Verify route resources
@@ -2827,7 +2795,7 @@ func TestIntegration_AgentCoordination_FullReconcileOrder(t *testing.T) {
 	assertOfferRouteResourcesPresent(t, cfg, name, ns)
 
 	// ────────────────────────────────────────────────────────────────────
-	// Step 5: Verify HTTPRoute — gateway parent + middleware filter + backend
+	// Step 5: Verify HTTPRoute — gateway parent + shared gateway backend
 	// ────────────────────────────────────────────────────────────────────
 	t.Log("Step 5: Verifying HTTPRoute so-" + name)
 	hrJSON := obolRun(t, cfg, "kubectl", "get", "httproute",
@@ -2872,34 +2840,20 @@ func TestIntegration_AgentCoordination_FullReconcileOrder(t *testing.T) {
 		}
 	}
 
-	// 5c: filters include ExtensionRef to Middleware x402-<name>.
-	filters, _ := rule0["filters"].([]interface{})
-	foundMiddlewareFilter := false
-	for _, f := range filters {
-		fm := f.(map[string]interface{})
-		if fm["type"] == "ExtensionRef" {
-			ref, _ := fm["extensionRef"].(map[string]interface{})
-			refName, _ := ref["name"].(string)
-			if refName == fmt.Sprintf("x402-%s", name) {
-				foundMiddlewareFilter = true
-				t.Logf("  ✓ HTTPRoute filter: ExtensionRef → x402-%s", name)
-			}
-		}
-	}
-	if !foundMiddlewareFilter {
-		t.Errorf("HTTPRoute missing ExtensionRef filter to x402-%s", name)
-	}
-
-	// 5d: backendRefs point at the upstream service.
+	// 5c: backendRefs point at the shared x402 gateway service.
 	backendRefs, _ := rule0["backendRefs"].([]interface{})
 	if len(backendRefs) > 0 {
 		backend := backendRefs[0].(map[string]interface{})
 		backendName, _ := backend["name"].(string)
 		backendNS, _ := backend["namespace"].(string)
-		t.Logf("  ✓ HTTPRoute backend: %s/%s", backendNS, backendName)
+		if backendName != "x402-verifier" || backendNS != "x402" {
+			t.Errorf("HTTPRoute backend = %s/%s, want x402/x402-verifier", backendNS, backendName)
+		} else {
+			t.Logf("  ✓ HTTPRoute backend: %s/%s", backendNS, backendName)
+		}
 	}
 
-	// 5e: ownerReference.
+	// 5d: ownerReference.
 	verifyOwnerRef(t, hr, name, "ServiceOffer")
 
 	// ────────────────────────────────────────────────────────────────────
@@ -2971,15 +2925,7 @@ func TestIntegration_AgentCoordination_FullReconcileOrder(t *testing.T) {
 		t.Logf("  ✓ ServiceOffer CR deleted")
 	}
 
-	// 8c: Middleware gone (ownerRef cascade).
-	_, err = obolRunErr(cfg, "kubectl", "get", "middleware", fmt.Sprintf("x402-%s", name), "-n", ns)
-	if err == nil {
-		t.Error("Middleware still exists after ServiceOffer delete (ownerRef cascade failed)")
-	} else {
-		t.Logf("  ✓ Middleware x402-%s cascaded", name)
-	}
-
-	// 8d: HTTPRoute gone (ownerRef cascade).
+	// 8c: HTTPRoute gone (ownerRef cascade).
 	_, err = obolRunErr(cfg, "kubectl", "get", "httproute", fmt.Sprintf("so-%s", name), "-n", ns)
 	if err == nil {
 		t.Error("HTTPRoute still exists after ServiceOffer delete (ownerRef cascade failed)")
@@ -3139,20 +3085,7 @@ spec:
 	regStatus := getConditionStatus(so, "Registered")
 	t.Logf("  Registered: %s", regStatus)
 
-	// Patch the HTTPRoute with LiteLLM auth header (monetize.py doesn't add it yet).
-	// Without this, paid requests that pass x402 verification get 401 from LiteLLM.
-	masterKey := obolRun(t, cfg, "kubectl", "get", "secret", "litellm-secrets",
-		"-n", "llm", "-o", "jsonpath={.data.LITELLM_MASTER_KEY}")
-	// Decode base64
-	if decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(masterKey)); err == nil {
-		masterKey = string(decoded)
-	}
-	patchJSON := fmt.Sprintf(`[{"op":"add","path":"/spec/rules/0/filters/-","value":{"type":"RequestHeaderModifier","requestHeaderModifier":{"set":[{"name":"Authorization","value":"Bearer %s"}]}}}]`, masterKey)
-	obolRun(t, cfg, "kubectl", "patch", "httproute", fmt.Sprintf("so-%s", name),
-		"-n", ns, "--type=json", "-p", patchJSON)
-	t.Log("  ✓ Patched HTTPRoute with LiteLLM auth header")
-
-	// Wait for Traefik to pick up the HTTPRoute + Reloader to restart x402-verifier
+	// Wait for Traefik to pick up the HTTPRoute and the shared gateway to reload routes.
 	t.Log("  Waiting 15s for route propagation...")
 	time.Sleep(15 * time.Second)
 

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -49,8 +49,8 @@ const (
 )
 
 type Controller struct {
-	kubeClient kubernetes.Interface
-	dynClient  dynamic.Interface
+	kubeClient           kubernetes.Interface
+	dynClient            dynamic.Interface
 	client               dynamic.Interface
 	offers               dynamic.NamespaceableResourceInterface
 	registrationRequests dynamic.NamespaceableResourceInterface
@@ -59,6 +59,7 @@ type Controller struct {
 	deployments          dynamic.NamespaceableResourceInterface
 	middlewares          dynamic.NamespaceableResourceInterface
 	httpRoutes           dynamic.NamespaceableResourceInterface
+	referenceGrants      dynamic.NamespaceableResourceInterface
 
 	offerInformer        cache.SharedIndexInformer
 	registrationInformer cache.SharedIndexInformer
@@ -130,6 +131,7 @@ func New(cfg *rest.Config) (*Controller, error) {
 		deployments:              client.Resource(monetizeapi.DeploymentGVR),
 		middlewares:              client.Resource(monetizeapi.MiddlewareGVR),
 		httpRoutes:               client.Resource(monetizeapi.HTTPRouteGVR),
+		referenceGrants:          client.Resource(monetizeapi.ReferenceGrantGVR),
 		offerInformer:            offerInformer,
 		registrationInformer:     registrationInformer,
 		purchaseInformer:         purchaseInformer,
@@ -493,11 +495,37 @@ func (c *Controller) reconcileUpstream(ctx context.Context, status *monetizeapi.
 }
 
 func (c *Controller) reconcilePaymentGate(ctx context.Context, status *monetizeapi.ServiceOfferStatus, offer *monetizeapi.ServiceOffer) error {
-	if err := c.applyObject(ctx, c.middlewares.Namespace(offer.Namespace), buildMiddleware(offer)); err != nil {
+	if err := c.applyObject(ctx, c.referenceGrants.Namespace("x402"), buildReferenceGrant(offer)); err != nil {
 		setCondition(status, "PaymentGateReady", "False", "ApplyFailed", err.Error())
 		return err
 	}
-	setCondition(status, "PaymentGateReady", "True", "Reconciled", "Middleware is present")
+
+	if _, err := c.services.Namespace("x402").Get(ctx, "x402-verifier", metav1.GetOptions{}); apierrors.IsNotFound(err) {
+		setCondition(status, "PaymentGateReady", "False", "WaitingForGateway", "Shared x402 gateway Service does not exist")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	deployment, err := c.deployments.Namespace("x402").Get(ctx, "x402-verifier", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		setCondition(status, "PaymentGateReady", "False", "WaitingForGateway", "Shared x402 gateway Deployment does not exist")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	availableReplicas, _, err := unstructured.NestedInt64(deployment.Object, "status", "availableReplicas")
+	if err != nil {
+		return err
+	}
+	if availableReplicas < 1 {
+		setCondition(status, "PaymentGateReady", "False", "WaitingForGateway", "Shared x402 gateway Deployment is not yet available")
+		return nil
+	}
+
+	setCondition(status, "PaymentGateReady", "True", "Reconciled", "Shared x402 gateway is available")
 	return nil
 }
 
@@ -979,7 +1007,7 @@ func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi
 		resource dynamic.ResourceInterface
 		name     string
 	}{
-		{resource: c.middlewares.Namespace(offer.Namespace), name: "x402-" + offer.Name},
+		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: childName(offer.Name)},
 	} {
 		err := deletion.resource.Delete(ctx, deletion.name, metav1.DeleteOptions{})

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -408,30 +408,11 @@ func buildHTTPRoute(offer *monetizeapi.ServiceOffer) *unstructured.Unstructured 
 								},
 							},
 						},
-						"filters": []any{
-							map[string]any{
-								"type": "ExtensionRef",
-								"extensionRef": map[string]any{
-									"group": "traefik.io",
-									"kind":  "Middleware",
-									"name":  "x402-" + offer.Name,
-								},
-							},
-							map[string]any{
-								"type": "URLRewrite",
-								"urlRewrite": map[string]any{
-									"path": map[string]any{
-										"type":               "ReplacePrefixMatch",
-										"replacePrefixMatch": "/",
-									},
-								},
-							},
-						},
 						"backendRefs": []any{
 							map[string]any{
-								"name":      offer.Spec.Upstream.Service,
-								"namespace": offer.EffectiveNamespace(),
-								"port":      offer.EffectivePort(),
+								"name":      "x402-verifier",
+								"namespace": "x402",
+								"port":      int64(8080),
 							},
 						},
 					},
@@ -440,6 +421,40 @@ func buildHTTPRoute(offer *monetizeapi.ServiceOffer) *unstructured.Unstructured 
 		},
 	}
 	return obj
+}
+
+func buildReferenceGrant(offer *monetizeapi.ServiceOffer) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1beta1",
+			"kind":       "ReferenceGrant",
+			"metadata": map[string]any{
+				"name":      backendReferenceGrantName(offer.Name),
+				"namespace": "x402",
+				"labels": map[string]any{
+					"obol.org/serviceoffer-namespace": offer.Namespace,
+					"obol.org/serviceoffer-name":      offer.Name,
+					"obol.org/managed-by":             "serviceoffer-controller",
+				},
+			},
+			"spec": map[string]any{
+				"from": []any{
+					map[string]any{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "HTTPRoute",
+						"namespace": offer.Namespace,
+					},
+				},
+				"to": []any{
+					map[string]any{
+						"group": "",
+						"kind":  "Service",
+						"name":  "x402-verifier",
+					},
+				},
+			},
+		},
+	}
 }
 
 // maxK8sNameLen is the maximum length for a Kubernetes resource name (DNS subdomain).
@@ -463,6 +478,10 @@ func safeName(prefix, name, suffix string) string {
 
 func childName(name string) string {
 	return safeName("so-", name, "")
+}
+
+func backendReferenceGrantName(name string) string {
+	return safeName("so-", name, "-backend-grant")
 }
 
 func registrationRequestName(name string) string {

--- a/internal/serviceoffercontroller/render_test.go
+++ b/internal/serviceoffercontroller/render_test.go
@@ -10,27 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestBuildMiddleware(t *testing.T) {
-	offer := &monetizeapi.ServiceOffer{
-		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "llm", UID: types.UID("demo-uid")},
-	}
-
-	middleware := buildMiddleware(offer)
-
-	if middleware.GetName() != "x402-demo" {
-		t.Fatalf("middleware name = %q, want x402-demo", middleware.GetName())
-	}
-	if middleware.GetNamespace() != "llm" {
-		t.Fatalf("middleware namespace = %q, want llm", middleware.GetNamespace())
-	}
-	spec := middleware.Object["spec"].(map[string]any)
-	forwardAuth := spec["forwardAuth"].(map[string]any)
-	address := forwardAuth["address"].(string)
-	if address != "http://x402-verifier.x402.svc.cluster.local:8080/verify" {
-		t.Fatalf("forwardAuth address = %q", address)
-	}
-}
-
 func TestBuildHTTPRoute(t *testing.T) {
 	offer := &monetizeapi.ServiceOffer{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "llm", UID: types.UID("demo-uid")},
@@ -57,13 +36,39 @@ func TestBuildHTTPRoute(t *testing.T) {
 	if path["value"] != "/services/demo" {
 		t.Fatalf("match path = %v, want /services/demo", path["value"])
 	}
+	if _, found := firstRule["filters"]; found {
+		t.Fatalf("sell http route should not use Traefik ForwardAuth middleware anymore: %+v", firstRule["filters"])
+	}
 	backends := firstRule["backendRefs"].([]any)
 	backend := backends[0].(map[string]any)
-	if backend["name"] != "litellm" {
-		t.Fatalf("backend name = %v, want litellm", backend["name"])
+	if backend["name"] != "x402-verifier" {
+		t.Fatalf("backend name = %v, want x402-verifier", backend["name"])
 	}
-	if backend["port"] != int64(4000) {
-		t.Fatalf("backend port = %v, want 4000", backend["port"])
+	if backend["namespace"] != "x402" {
+		t.Fatalf("backend namespace = %v, want x402", backend["namespace"])
+	}
+	if backend["port"] != int64(8080) {
+		t.Fatalf("backend port = %v, want 8080", backend["port"])
+	}
+}
+
+func TestBuildReferenceGrant(t *testing.T) {
+	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "llm"},
+	}
+
+	grant := buildReferenceGrant(offer)
+	if grant.GetNamespace() != "x402" {
+		t.Fatalf("grant namespace = %q, want x402", grant.GetNamespace())
+	}
+	spec := grant.Object["spec"].(map[string]any)
+	from := spec["from"].([]any)[0].(map[string]any)
+	to := spec["to"].([]any)[0].(map[string]any)
+	if from["namespace"] != "llm" {
+		t.Fatalf("grant from.namespace = %v, want llm", from["namespace"])
+	}
+	if to["name"] != "x402-verifier" {
+		t.Fatalf("grant to.name = %v, want x402-verifier", to["name"])
 	}
 }
 

--- a/internal/x402/bdd_integration_steps_test.go
+++ b/internal/x402/bdd_integration_steps_test.go
@@ -427,16 +427,6 @@ func registerIntegrationSteps(ctx *godog.ScenarioContext, w *integrationWorld) {
 		return nil
 	})
 
-	ctx.Then(`^a Middleware "([^"]*)" exists in the offer namespace$`, func(name string) error {
-		_, err := kubectl.Output(w.kubectlBin, w.kubeconfig,
-			"get", "middleware", name, "-n", serviceOfferNamespace)
-		if err != nil {
-			return fmt.Errorf("Middleware %s not found in %s: %v", name, serviceOfferNamespace, err)
-		}
-		w.t.Logf("integration: ✓ Middleware %s exists", name)
-		return nil
-	})
-
 	ctx.Then(`^an HTTPRoute "([^"]*)" exists in the offer namespace$`, func(name string) error {
 		_, err := kubectl.Output(w.kubectlBin, w.kubeconfig,
 			"get", "httproute", name, "-n", serviceOfferNamespace)
@@ -444,6 +434,20 @@ func registerIntegrationSteps(ctx *godog.ScenarioContext, w *integrationWorld) {
 			return fmt.Errorf("HTTPRoute %s not found in %s: %v", name, serviceOfferNamespace, err)
 		}
 		w.t.Logf("integration: ✓ HTTPRoute %s exists", name)
+		return nil
+	})
+
+	ctx.Then(`^the HTTPRoute "([^"]*)" targets the shared x402 gateway$`, func(name string) error {
+		out, err := kubectl.Output(w.kubectlBin, w.kubeconfig,
+			"get", "httproute", name, "-n", serviceOfferNamespace,
+			"-o", "jsonpath={.spec.rules[0].backendRefs[0].namespace}/{.spec.rules[0].backendRefs[0].name}:{.spec.rules[0].backendRefs[0].port}")
+		if err != nil {
+			return fmt.Errorf("read HTTPRoute backend: %w", err)
+		}
+		if strings.TrimSpace(out) != "x402/x402-verifier:8080" {
+			return fmt.Errorf("HTTPRoute backend = %q, want x402/x402-verifier:8080", out)
+		}
+		w.t.Logf("integration: ✓ HTTPRoute %s targets shared x402 gateway", name)
 		return nil
 	})
 
@@ -612,17 +616,6 @@ func registerIntegrationSteps(ctx *godog.ScenarioContext, w *integrationWorld) {
 			return fmt.Errorf("ServiceOffer still exists after delete")
 		}
 		w.t.Log("integration: ✓ ServiceOffer deleted")
-		return nil
-	})
-
-	ctx.Then(`^no Middleware exists for the offer$`, func() error {
-		_, err := kubectl.Output(w.kubectlBin, w.kubeconfig,
-			"get", "middleware", "x402-"+serviceOfferName,
-			"-n", serviceOfferNamespace)
-		if err == nil {
-			return fmt.Errorf("Middleware still exists after delete")
-		}
-		w.t.Log("integration: ✓ Middleware removed")
 		return nil
 	})
 

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -52,10 +52,19 @@ type RouteRule struct {
 	Network string `yaml:"network,omitempty"`
 
 	// UpstreamAuth is injected as the Authorization header on approved requests.
-	// The x402-verifier sets this header in its 200 response; Traefik copies it
-	// to the forwarded request via authResponseHeaders. This lets the upstream
-	// (e.g., LiteLLM) authenticate the request without exposing the key to buyers.
+	// The shared seller gateway injects this header on approved upstream
+	// requests. This lets the upstream (e.g., LiteLLM) authenticate the request
+	// without exposing the key to buyers.
 	UpstreamAuth string `yaml:"upstreamAuth,omitempty"`
+
+	// UpstreamURL is the in-cluster HTTP base URL for the protected upstream.
+	// The shared seller gateway proxies matched paid routes to this target after
+	// successful payment verification.
+	UpstreamURL string `yaml:"upstreamURL,omitempty"`
+
+	// StripPrefix is removed from the incoming request path before proxying to
+	// the upstream. For ServiceOffers this is usually /services/<offer-name>.
+	StripPrefix string `yaml:"stripPrefix,omitempty"`
 
 	// PriceModel records which price field produced the enforced request price.
 	// It is metadata only; the verifier always enforces Price.

--- a/internal/x402/features/integration_payment_flow.feature
+++ b/internal/x402/features/integration_payment_flow.feature
@@ -28,8 +28,8 @@ Feature: x402 Payment Flow — Real User Journey
     When the operator runs "obol sell http" to create a ServiceOffer
     And the controller reconciles the ServiceOffer
     Then the ServiceOffer status is "Ready"
-    And a Middleware "x402-bdd-test" exists in the offer namespace
     And an HTTPRoute "so-bdd-test" exists in the offer namespace
+    And the HTTPRoute "so-bdd-test" targets the shared x402 gateway
 
   # ─── Buy-side: unpaid request gets 402 ──────────────────────────────
 
@@ -95,5 +95,4 @@ Feature: x402 Payment Flow — Real User Journey
   Scenario: Operator deletes ServiceOffer and resources are cleaned up
     When the operator deletes the ServiceOffer via CLI
     Then the ServiceOffer no longer exists
-    And no Middleware exists for the offer
     And no HTTPRoute exists for the offer

--- a/internal/x402/serviceoffer_source.go
+++ b/internal/x402/serviceoffer_source.go
@@ -115,6 +115,13 @@ func routeRuleFromOffer(offer *monetizeapi.ServiceOffer, upstreamAuth string) (R
 		return RouteRule{}, err
 	}
 
+	upstreamURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+		offer.Spec.Upstream.Service,
+		offer.EffectiveNamespace(),
+		offer.EffectivePort(),
+	)
+	stripPrefix := offer.EffectivePath()
+
 	return RouteRule{
 		Pattern:                strings.TrimSuffix(offer.EffectivePath(), "/") + "/*",
 		Price:                  price,
@@ -122,6 +129,8 @@ func routeRuleFromOffer(offer *monetizeapi.ServiceOffer, upstreamAuth string) (R
 		PayTo:                  offer.Spec.Payment.PayTo,
 		Network:                offer.Spec.Payment.Network,
 		UpstreamAuth:           effectiveUpstreamAuth(offer, upstreamAuth),
+		UpstreamURL:            upstreamURL,
+		StripPrefix:            stripPrefix,
 		PriceModel:             priceModel,
 		PerMTok:                perMTok,
 		ApproxTokensPerRequest: approx,

--- a/internal/x402/serviceoffer_source_test.go
+++ b/internal/x402/serviceoffer_source_test.go
@@ -77,8 +77,17 @@ func TestRoutesFromStore(t *testing.T) {
 	if routes[0].UpstreamAuth != "Bearer sk-test" {
 		t.Fatalf("routes[0].UpstreamAuth = %q, want Bearer sk-test", routes[0].UpstreamAuth)
 	}
+	if routes[0].UpstreamURL != "http://litellm.alpha.svc.cluster.local:11434" {
+		t.Fatalf("routes[0].UpstreamURL = %q, want litellm upstream URL", routes[0].UpstreamURL)
+	}
+	if routes[0].StripPrefix != "/services/a" {
+		t.Fatalf("routes[0].StripPrefix = %q, want /services/a", routes[0].StripPrefix)
+	}
 	if routes[1].UpstreamAuth != "" {
 		t.Fatalf("routes[1].UpstreamAuth = %q, want empty", routes[1].UpstreamAuth)
+	}
+	if routes[1].UpstreamURL != "http://httpbin.beta.svc.cluster.local:11434" {
+		t.Fatalf("routes[1].UpstreamURL = %q, want httpbin upstream URL", routes[1].UpstreamURL)
 	}
 }
 

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 	"sync/atomic"
 
 	x402types "github.com/coinbase/x402/go/types"
@@ -85,36 +88,12 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 
 	cfg := v.config.Load()
 
-	rule := matchRoute(cfg.Routes, uri)
-	if rule == nil {
+	rule, requirement, _, ok := v.matchPaidRoute(cfg, uri)
+	if !ok {
 		// No pricing rule matches — route is free.
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-
-	// Per-route payTo and network override global config.
-	wallet := cfg.Wallet
-	if rule.PayTo != "" {
-		wallet = rule.PayTo
-	}
-
-	chainName := cfg.Chain
-	if rule.Network != "" {
-		chainName = rule.Network
-	}
-
-	// Look up pre-resolved chain (populated during config load).
-	chains := v.chains.Load()
-
-	chain, ok := (*chains)[chainName]
-	if !ok {
-		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-
-		return
-	}
-
-	requirement := BuildV2Requirement(chain, rule.Price, wallet)
 
 	// Reconstruct the original request context so the middleware generates
 	// correct payment requirements (resource URL, host, etc.).
@@ -164,6 +143,49 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// HandleProxy serves the seller-owned paid route directly. It matches the
+// incoming path to a ServiceOffer-derived route rule, verifies the payment,
+// proxies to the real upstream, and settles only after the upstream succeeds.
+func (v *Verifier) HandleProxy(w http.ResponseWriter, r *http.Request) {
+	cfg := v.config.Load()
+
+	rule, requirement, labels, ok := v.matchPaidRoute(cfg, r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	v.metrics.requestsTotal.With(labels).Inc()
+
+	proxy, err := buildUpstreamProxy(rule)
+	if err != nil {
+		log.Printf("x402-verifier: build upstream proxy for %s/%s: %v", rule.OfferNamespace, rule.OfferName, err)
+		http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	middleware := NewForwardAuthMiddleware(ForwardAuthConfig{
+		FacilitatorURL: cfg.FacilitatorURL,
+		VerifyOnly:     false,
+	}, []x402types.PaymentRequirements{requirement})
+
+	hadPayment := r.Header.Get("X-PAYMENT") != ""
+	tracker := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+	middleware(proxy).ServeHTTP(tracker, r)
+
+	switch {
+	case tracker.status == http.StatusPaymentRequired && !hadPayment:
+		v.metrics.paymentRequired.With(labels).Inc()
+	case tracker.status == http.StatusPaymentRequired:
+		v.metrics.paymentFailed.With(labels).Inc()
+	case tracker.status < http.StatusBadRequest && hadPayment:
+		v.metrics.paymentVerified.With(labels).Inc()
+		if tracker.Header().Get("X-PAYMENT-RESPONSE") != "" {
+			v.metrics.chargedRequests.With(labels).Inc()
+		}
+	}
+}
+
 // HandleHealthz returns 200 OK for liveness probes.
 func (v *Verifier) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
@@ -184,6 +206,90 @@ func (v *Verifier) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 // MetricsHandler exposes Prometheus metrics for the verifier.
 func (v *Verifier) MetricsHandler() http.Handler {
 	return v.metrics.handler()
+}
+
+func (v *Verifier) matchPaidRoute(cfg *PricingConfig, uri string) (*RouteRule, x402types.PaymentRequirements, prometheus.Labels, bool) {
+	rule := matchRoute(cfg.Routes, uri)
+	if rule == nil {
+		return nil, x402types.PaymentRequirements{}, nil, false
+	}
+
+	wallet := cfg.Wallet
+	if rule.PayTo != "" {
+		wallet = rule.PayTo
+	}
+
+	chainName := cfg.Chain
+	if rule.Network != "" {
+		chainName = rule.Network
+	}
+
+	chains := v.chains.Load()
+	chain, ok := (*chains)[chainName]
+	if !ok {
+		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
+		return nil, x402types.PaymentRequirements{}, nil, false
+	}
+
+	requirement := BuildV2Requirement(chain, rule.Price, wallet)
+	return rule, requirement, prometheusLabels(rule), true
+}
+
+func buildUpstreamProxy(rule *RouteRule) (http.Handler, error) {
+	target, err := url.Parse(rule.UpstreamURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse upstream URL %q: %w", rule.UpstreamURL, err)
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			strippedPath := stripRoutePrefix(rule.StripPrefix, pr.In.URL.Path)
+			pr.Out.URL.Path = singleJoiningSlash(target.Path, strippedPath)
+			pr.Out.URL.RawQuery = pr.In.URL.RawQuery
+			pr.Out.Host = target.Host
+			if rule.UpstreamAuth != "" {
+				pr.Out.Header.Set("Authorization", rule.UpstreamAuth)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("x402-verifier: upstream proxy error for %s/%s: %v", rule.OfferNamespace, rule.OfferName, err)
+			http.Error(w, "upstream unavailable", http.StatusBadGateway)
+		},
+	}
+	return proxy, nil
+}
+
+func stripRoutePrefix(prefix, requestPath string) string {
+	prefix = strings.TrimSuffix(prefix, "/")
+	if prefix == "" || prefix == "/" {
+		if requestPath == "" {
+			return "/"
+		}
+		return requestPath
+	}
+
+	switch {
+	case requestPath == prefix:
+		return "/"
+	case strings.HasPrefix(requestPath, prefix+"/"):
+		return strings.TrimPrefix(requestPath, prefix)
+	default:
+		return requestPath
+	}
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	default:
+		return a + b
+	}
 }
 
 type statusRecorder struct {

--- a/internal/x402/verifier_test.go
+++ b/internal/x402/verifier_test.go
@@ -328,6 +328,116 @@ func TestVerifier_ConfigReload(t *testing.T) {
 	}
 }
 
+func TestVerifier_HandleProxy_NoPayment_Returns402(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be called without payment")
+	}))
+	defer upstream.Close()
+
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:     "/services/demo/*",
+		Price:       "0.001",
+		UpstreamURL: upstream.URL,
+		StripPrefix: "/services/demo",
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/services/demo/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	v.HandleProxy(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", w.Code)
+	}
+	if fac.verifyCalls.Load() != 0 {
+		t.Fatalf("verify should not be called without payment, got %d", fac.verifyCalls.Load())
+	}
+}
+
+func TestVerifier_HandleProxy_ValidPayment_SettlesAndStripsPrefix(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	var seenPath, seenAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:      "/services/demo/*",
+		Price:        "0.0001",
+		UpstreamURL:  upstream.URL,
+		StripPrefix:  "/services/demo",
+		UpstreamAuth: "Bearer sk-upstream",
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/services/demo/v1/chat/completions", strings.NewReader(`{"model":"qwen3.5:9b"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	w := httptest.NewRecorder()
+	v.HandleProxy(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := strings.TrimSpace(w.Body.String()); body != `{"ok":true}` {
+		t.Fatalf("body = %q, want %q", body, `{"ok":true}`)
+	}
+	if seenPath != "/v1/chat/completions" {
+		t.Fatalf("upstream path = %q, want /v1/chat/completions", seenPath)
+	}
+	if seenAuth != "Bearer sk-upstream" {
+		t.Fatalf("upstream auth = %q, want Bearer sk-upstream", seenAuth)
+	}
+	if fac.verifyCalls.Load() != 1 {
+		t.Fatalf("verify calls = %d, want 1", fac.verifyCalls.Load())
+	}
+	if fac.settleCalls.Load() != 1 {
+		t.Fatalf("settle calls = %d, want 1", fac.settleCalls.Load())
+	}
+	if w.Header().Get("X-PAYMENT-RESPONSE") == "" {
+		t.Fatal("expected X-PAYMENT-RESPONSE header on successful settlement")
+	}
+}
+
+func TestVerifier_HandleProxy_UpstreamFailure_DoesNotSettle(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer upstream.Close()
+
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:     "/services/demo/*",
+		Price:       "0.0001",
+		UpstreamURL: upstream.URL,
+		StripPrefix: "/services/demo",
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/services/demo/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+	w := httptest.NewRecorder()
+	v.HandleProxy(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+	if fac.verifyCalls.Load() != 1 {
+		t.Fatalf("verify calls = %d, want 1", fac.verifyCalls.Load())
+	}
+	if fac.settleCalls.Load() != 0 {
+		t.Fatalf("settle calls = %d, want 0", fac.settleCalls.Load())
+	}
+	if w.Header().Get("X-PAYMENT-RESPONSE") != "" {
+		t.Fatal("did not expect X-PAYMENT-RESPONSE header on upstream failure")
+	}
+}
+
 func TestVerifier_Healthz(t *testing.T) {
 	fac := newMockFacilitator(t, mockFacilitatorOpts{})
 	v := newTestVerifier(t, fac.URL, nil)


### PR DESCRIPTION
## Summary

This PR redesigns `sell http` from:

- `Traefik -> ForwardAuth verifier -> upstream`

into:

- `Traefik -> shared seller-owned x402 gateway -> upstream`

The shared gateway now owns:

1. `402` payment requirement generation
2. payment verification with the facilitator
3. upstream proxying
4. settlement after upstream success
5. `X-PAYMENT-RESPONSE` emission back to the buyer

This restores correct seller-side x402 semantics for cluster-routed `sell http`.

## Why

The old `sell http` path relied on a pre-upstream auth hop. That shape could safely verify but could not safely own settlement once `verifyOnly=true` was introduced for ForwardAuth safety. The result was a semantic gap between:

- the standalone `sell inference` path, which can settle after success
- the cluster-routed `sell http` path, which previously could not

This PR closes that gap by making the shared `x402-verifier` service act as the seller-owned resource server for priced HTTP routes.

## What Changed

### Runtime architecture

- Route `HTTPRoute` backends for `ServiceOffer`s to the shared `x402-verifier` service instead of the raw upstream service.
- Extend route config with upstream target metadata (`upstreamURL`, `stripPrefix`) so the shared gateway can proxy correctly.
- Add seller-side proxy handling in `internal/x402/verifier.go`:
  - match route
  - emit `402`
  - verify payment
  - proxy to upstream
  - settle only after upstream success
  - return `X-PAYMENT-RESPONSE`
- Keep the legacy `/verify` endpoint, but treat `verifyOnly=true` as a legacy ForwardAuth safety setting instead of the hot path for `sell http`.
- Add `ReferenceGrant` creation so cross-namespace `HTTPRoute -> x402/x402-verifier` backend refs are permitted.
- Expand RBAC for `serviceoffer-controller` to manage `ReferenceGrant`s.

### Tests and flows

- Updated unit tests for:
  - verifier proxy path
  - route rendering
  - dynamic route derivation
- Updated integration expectations to the shared-gateway model.
- Updated flow scripts to stop asserting per-offer middleware resources.
- `flow-11` now passes end-to-end with the redesigned routing and seller-side settlement.

### Docs

- Updated the monetization architecture docs and getting-started component description.
- Added a detailed report under:
  - `docs/reports/x402-seller-gateway-redesign-report.md`

## Validation

### Unit tests

- `go test ./internal/x402`
- `go test ./internal/serviceoffercontroller`

### Integration compile / smoke

- `go test -tags integration ./internal/openclaw -run TestDoesNotExist`

### Flow tests

- `flows/flow-11-dual-stack.sh`
  - passed `41/41`
  - run with high-port overrides to avoid occupied low ports on the local machine

### Known environment limitation

- `go test -tags integration -v -run TestBDDIntegration -timeout 20m ./internal/x402`
  - blocked locally by an existing listener on host port `8080`
  - I did not kill that unrelated process

## Full Report

### Branch

- `feature/x402-seller-gateway-redesign`

### Successful Flow-11 artifacts

#### Seller

- Seller wallet: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- Published tunnel URL:
  - `https://ten-municipal-mortgages-offerings.trycloudflare.com`
- Registered agent ID:
  - `5003`

#### Buyer

- Buyer discovery wallet:
  - `0x57b0eF875DeB5A37301F1640E469a2129Da9490E`
- Bob remote-signer wallet:
  - `0x5D01290Fd77EbD7a82bD316dC2d762C30B07D107`
- Purchased alias:
  - `paid/qwen3.5:9b`

### Seller registration receipts

#### 1. Identity registration

- Tx hash:
  - `0x32eef92ede6779a3d05e780bf0920f4744b22ec6e85eb81d4d83371644d751b9`
- Block:
  - `40331698`
- Chain:
  - Base Sepolia (`84532`)
- Function:
  - `register(string)`
- Registry:
  - `0x8004A818BFB912233c491871b3d84c89A494BD9e`
- Sender / owner:
  - `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- Agent ID:
  - `5003`
- Registered URI:
  - `https://ten-municipal-mortgages-offerings.trycloudflare.com/.well-known/agent-registration.json`

Observed receipt facts:

- status: `1`
- gas used: `183900`
- emitted `Registered(agentId=5003, agentURI=..., owner=seller)`
- emitted `MetadataSet(agentWallet=0xC0De...)`

#### 2. x402 metadata write

- Tx hash:
  - `0xab815b78ab688697ef1e39f479bf83d57b53c7afb26c00c85775105d860b1df8`
- Block:
  - `40331700`
- Function:
  - `setMetadata(uint256,string,bytes)`
- Metadata key:
  - `x402`
- Metadata value:
  - `{"x402":true}`

Observed receipt facts:

- status: `1`
- gas used: `57552`
- sender: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- target: `0x8004A818BFB912233c491871b3d84c89A494BD9e`

### Buyer settlement receipt

#### 3. x402 settlement transfer

- Tx hash:
  - `0x847de0118110b4f056c025b9804cd82f87274a2b95926419c34ccfc0eb1216a2`
- Block:
  - `40331811`
- Function:
  - `transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)`
- Chain:
  - Base Sepolia (`84532`)
- Token:
  - USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
- Facilitator settlement sender:
  - `0xd744494E28b01073514EBC89987B305001ed257A`
- Buyer signer:
  - `0x5D01290Fd77EbD7a82bD316dC2d762C30B07D107`
- Seller payTo:
  - `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- Settled amount:
  - `1000` micro-USDC (`0.001 USDC`)

Observed receipt facts:

- status: `1`
- gas used: `86144`
- `AuthorizationUsed` emitted by USDC
- `Transfer` emitted from buyer signer to seller for `1000`

### Buyer-side receipt summary

From the successful `flow-11` run:

- `PurchaseRequest` reached `Ready=True`
- buyer sidecar live status changed:
  - before: `remaining=5 spent=0`
  - after one paid request: one request consumed and settled
- paid inference returned `200`
- settlement transaction was observed on-chain

### Supported x402 chain recipes in this repo

| Chain | CAIP-2 | USDC |
|---|---|---|
| `base` | `eip155:8453` | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
| `base-sepolia` | `eip155:84532` | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
| `ethereum` | `eip155:1` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
| `polygon` | `eip155:137` | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
| `polygon-amoy` | `eip155:80002` | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` |
| `avalanche` | `eip155:43114` | `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E` |
| `avalanche-fuji` | `eip155:43113` | `0x5425890298aed601595a70AB815c96711a31Bc65` |
| `arbitrum-one` | `eip155:42161` | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
| `arbitrum-sepolia` | `eip155:421614` | `0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d` |

## Public Repo Note

This PR body intentionally includes only public or operationally non-secret information:

- public chain addresses
- public transaction hashes
- public contract addresses
- ephemeral public tunnel URL from the successful test run

It does not include any private keys, tokens, or `.env` secrets.
