### PR TITLE
feat(model): add master token accessor

### DIFF
--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -23,10 +23,33 @@ func modelCommand(cfg *config.Config) *cli.Command {
 		Commands: []*cli.Command{
 			modelSetupCommand(cfg),
 			modelStatusCommand(cfg),
+			modelTokenCommand(cfg),
 			modelSyncCommand(cfg),
 			modelPullCommand(),
 			modelListCommand(cfg),
 			modelRemoveCommand(cfg),
+		},
+	}
+}
+
+func modelTokenCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "token",
+		Usage: "Print the LiteLLM master token for API access",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u := getUI(cmd)
+
+			token, err := model.GetMasterKey(cfg)
+			if err != nil {
+				return err
+			}
+
+			if u.IsJSON() {
+				return u.JSON(map[string]string{"token": token})
+			}
+
+			u.Print(token)
+			return nil
 		},
 	}
 }

--- a/cmd/obol/model_test.go
+++ b/cmd/obol/model_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+func TestModelCommand_Structure(t *testing.T) {
+	cfg := &config.Config{}
+	cmd := modelCommand(cfg)
+
+	if cmd.Name != "model" {
+		t.Fatalf("command name = %q, want model", cmd.Name)
+	}
+
+	expected := map[string]bool{
+		"setup":  false,
+		"status": false,
+		"token":  false,
+		"sync":   false,
+		"pull":   false,
+		"list":   false,
+		"remove": false,
+	}
+
+	for _, sub := range cmd.Commands {
+		if _, ok := expected[sub.Name]; ok {
+			expected[sub.Name] = true
+		}
+	}
+
+	for name, found := range expected {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `obol model token` as a direct accessor for the LiteLLM master token stored in-cluster.

## Why

Production-readiness testing found that API consumers currently have to discover the LiteLLM master token by reading the `litellm-secrets` Secret manually via `obol kubectl get secret ...`. This PR turns the existing internal accessor into a supported CLI path.

## What changed

- added `model token` subcommand
- prints the LiteLLM master token in human mode
- returns `{"token": ...}` in JSON mode
- added command-structure coverage in `cmd/obol/model_test.go`

## Validation

- `go test ./cmd/obol`
