### PR TITLE
feat(openclaw): surface generated agent wallet

### DIFF
--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -276,6 +276,36 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 				},
 			},
 			{
+				Name:      "address",
+				Usage:     "Show the wallet address for an OpenClaw instance",
+				ArgsUsage: "[instance-name]",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					args := cmd.Args().Slice()
+
+					if len(args) == 0 {
+						addr, err := openclaw.ResolveWalletAddress(cfg)
+						if err != nil {
+							return err
+						}
+						getUI(cmd).Print(addr)
+						return nil
+					}
+
+					id, _, err := openclaw.ResolveInstance(cfg, args)
+					if err != nil {
+						return err
+					}
+
+					walletsUI := getUI(cmd)
+					walletInfo, err := openclaw.ReadWalletMetadata(openclaw.DeploymentPath(cfg, id))
+					if err != nil {
+						return err
+					}
+					walletsUI.Print(walletInfo.Address)
+					return nil
+				},
+			},
+			{
 				Name:      "list",
 				Usage:     "List wallets for OpenClaw instances",
 				ArgsUsage: "[instance-name]",

--- a/cmd/obol/openclaw_test.go
+++ b/cmd/obol/openclaw_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestOpenClawWalletCommand_Structure(t *testing.T) {
+	cfg := newTestConfig(t)
+	cmd := openclawCommand(cfg)
+	wallet := findSubcommand(t, cmd, "wallet")
+
+	expected := map[string]bool{
+		"backup":  false,
+		"restore": false,
+		"address": false,
+		"list":    false,
+	}
+
+	for _, sub := range wallet.Commands {
+		if _, ok := expected[sub.Name]; ok {
+			expected[sub.Name] = true
+		}
+	}
+
+	for name, found := range expected {
+		if !found {
+			t.Errorf("missing wallet subcommand %q", name)
+		}
+	}
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -524,6 +524,11 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	if err := openclaw.SetupDefault(cfg, u); err != nil {
 		u.Warnf("Failed to set up default OpenClaw: %v", err)
 		u.Dim("  You can manually set up OpenClaw later with: obol openclaw onboard")
+	} else if walletAddr, walletErr := openclaw.ResolveWalletAddress(cfg); walletErr == nil {
+		u.Blank()
+		u.Successf("Default agent wallet: %s", walletAddr)
+		u.Dim("  Fund this wallet for x402 buying or direct on-chain registration.")
+		u.Dim("  Retrieve later with: obol openclaw wallet address obol-agent")
 	}
 
 	// Apply agent capabilities (RBAC + heartbeat) to the default instance.


### PR DESCRIPTION
## Summary

Surfaces the actual generated OpenClaw remote-signer wallet more aggressively in the CLI.

## Why

Production-readiness testing showed it is too easy to fund the wrong wallet during the buy-side flow. The real buyer wallet is the generated remote-signer wallet for the OpenClaw instance, not an arbitrary `.env` key the operator might already have on hand.

## What changed

- `stack up` now prints the default agent wallet address after `SetupDefault()` succeeds
- added `obol openclaw wallet address [instance]`
- added command-structure coverage for the wallet command group

## Validation

- `go test ./cmd/obol`
- `go test ./internal/stack -run TestDoesNotExist`
