### PR TITLE
feat(sell): register by default with explicit opt-out

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -721,9 +721,28 @@ Example:
 				u.Successf("Tunnel active: %s", tunnelURL)
 			}
 
+			if reg, ok := spec["registration"].(map[string]any); ok {
+				if enabled, _ := reg["enabled"].(bool); enabled {
+					u.Blank()
+					u.Warn("`obol sell http --register` publishes the off-chain registration document only.")
+					u.Dim("  To mint an on-chain ERC-8004 identity, run:")
+					u.Dim(fmt.Sprintf("    obol sell register --chain %s --name %q", cmd.String("chain"), registrationNameForPrompt(name, reg)))
+				}
+			}
+
 			return nil
 		},
 	}
+}
+
+func registrationNameForPrompt(fallback string, reg map[string]any) string {
+	if reg == nil {
+		return fallback
+	}
+	if name, ok := reg["name"].(string); ok && strings.TrimSpace(name) != "" {
+		return name
+	}
+	return fallback
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/erc8004"
 	"github.com/ObolNetwork/obol-stack/internal/inference"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	"github.com/ObolNetwork/obol-stack/internal/openclaw"
 	"github.com/ObolNetwork/obol-stack/internal/schemas"
 	"github.com/ObolNetwork/obol-stack/internal/stack"
@@ -969,12 +970,37 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 				if ns == "" {
 					return errors.New("namespace required: obol sell status <name> -n <ns>")
 				}
-				outputFmt := "-o"
-				outputVal := "yaml"
 				if u.IsJSON() {
-					outputVal = "json"
+					return kubectlRun(cfg, "get", "serviceoffers.obol.org", name, "-n", ns, "-o", "json")
 				}
-				return kubectlRun(cfg, "get", "serviceoffers.obol.org", name, "-n", ns, outputFmt, outputVal)
+
+				raw, err := kubectlOutput(cfg, "get", "serviceoffers.obol.org", name, "-n", ns, "-o", "json")
+				if err != nil {
+					return err
+				}
+
+				var offer monetizeapi.ServiceOffer
+				if err := json.Unmarshal([]byte(raw), &offer); err != nil {
+					return fmt.Errorf("parse ServiceOffer: %w", err)
+				}
+
+				u.Printf("ServiceOffer:    %s/%s", ns, name)
+				u.Printf("Endpoint:        %s", valueOrNone(offer.Status.Endpoint))
+				u.Printf("Agent ID:        %s", valueOrNone(offer.Status.AgentID))
+				u.Printf("Registration Tx: %s", valueOrNone(offer.Status.RegistrationTxHash))
+				u.Blank()
+				u.Print("Conditions:")
+				for _, cond := range offer.Status.Conditions {
+					u.Printf("  - type: %s", cond.Type)
+					u.Printf("    status: %q", cond.Status)
+					if cond.Reason != "" {
+						u.Printf("    reason: %s", cond.Reason)
+					}
+					if cond.Message != "" {
+						u.Printf("    message: %s", cond.Message)
+					}
+				}
+				return nil
 			}
 
 			// No name: show global pricing config + registrations.

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -660,47 +660,21 @@ Examples:
 					prov.Framework, prov.MetricName, prov.MetricValue, prov.ParamCount)
 			}
 
-			registerEnabled := !cmd.Bool("no-register")
-			if !registerEnabled && (cmd.Bool("register") || cmd.String("register-name") != "" || cmd.String("register-description") != "" ||
-				cmd.String("register-image") != "" || len(cmd.StringSlice("register-skills")) > 0 || len(cmd.StringSlice("register-domains")) > 0 ||
-				len(cmd.StringSlice("register-metadata")) > 0 || cmd.String("private-key-file") != "") {
-				return errors.New("--no-register cannot be combined with registration-specific flags")
+			reg, registerEnabled, err := buildSellHTTPRegistrationConfig(name, sellHTTPRegistrationInput{
+				NoRegister:     cmd.Bool("no-register"),
+				Register:       cmd.Bool("register"),
+				Name:           cmd.String("register-name"),
+				Description:    cmd.String("register-description"),
+				Image:          cmd.String("register-image"),
+				PrivateKeyFile: cmd.String("private-key-file"),
+				Skills:         cmd.StringSlice("register-skills"),
+				Domains:        cmd.StringSlice("register-domains"),
+				MetadataPairs:  cmd.StringSlice("register-metadata"),
+			})
+			if err != nil {
+				return err
 			}
 			if registerEnabled {
-				reg := map[string]any{
-					"enabled":     true,
-					"name":        registrationNameForPrompt(name, nil),
-					"description": registrationDescriptionForPrompt(name, nil),
-				}
-				if n := cmd.String("register-name"); n != "" {
-					reg["name"] = n
-				}
-
-				if d := cmd.String("register-description"); d != "" {
-					reg["description"] = d
-				}
-
-				if img := cmd.String("register-image"); img != "" {
-					reg["image"] = img
-				}
-
-				if skills := cmd.StringSlice("register-skills"); len(skills) > 0 {
-					reg["skills"] = skills
-				}
-
-				if domains := cmd.StringSlice("register-domains"); len(domains) > 0 {
-					reg["domains"] = domains
-				}
-
-				if metaPairs := cmd.StringSlice("register-metadata"); len(metaPairs) > 0 {
-					meta, err := parseMetadataPairs(metaPairs)
-					if err != nil {
-						return err
-					}
-
-					reg["metadata"] = meta
-				}
-
 				spec["registration"] = reg
 			}
 
@@ -791,6 +765,18 @@ type autoRegisterOptions struct {
 	ExpectedOwner   string
 }
 
+type sellHTTPRegistrationInput struct {
+	NoRegister     bool
+	Register       bool
+	Name           string
+	Description    string
+	Image          string
+	PrivateKeyFile string
+	Skills         []string
+	Domains        []string
+	MetadataPairs  []string
+}
+
 func autoRegisterServiceOffer(ctx context.Context, cfg *config.Config, u *ui.UI, opts autoRegisterOptions) error {
 	if opts.Endpoint == "" {
 		return errors.New("endpoint is required for automatic registration")
@@ -878,6 +864,46 @@ func autoRegisterServiceOffer(ctx context.Context, cfg *config.Config, u *ui.UI,
 	return nil
 }
 
+func buildSellHTTPRegistrationConfig(serviceName string, in sellHTTPRegistrationInput) (map[string]any, bool, error) {
+	registerEnabled := !in.NoRegister
+	if !registerEnabled && (in.Register || in.Name != "" || in.Description != "" || in.Image != "" ||
+		len(in.Skills) > 0 || len(in.Domains) > 0 || len(in.MetadataPairs) > 0 || in.PrivateKeyFile != "") {
+		return nil, false, errors.New("--no-register cannot be combined with registration-specific flags")
+	}
+	if !registerEnabled {
+		return nil, false, nil
+	}
+
+	reg := map[string]any{
+		"enabled":     true,
+		"name":        registrationNameForPrompt(serviceName, nil),
+		"description": registrationDescriptionForPrompt(serviceName, nil),
+	}
+	if in.Name != "" {
+		reg["name"] = in.Name
+	}
+	if in.Description != "" {
+		reg["description"] = in.Description
+	}
+	if in.Image != "" {
+		reg["image"] = in.Image
+	}
+	if len(in.Skills) > 0 {
+		reg["skills"] = in.Skills
+	}
+	if len(in.Domains) > 0 {
+		reg["domains"] = in.Domains
+	}
+	if len(in.MetadataPairs) > 0 {
+		meta, err := parseMetadataPairs(in.MetadataPairs)
+		if err != nil {
+			return nil, false, err
+		}
+		reg["metadata"] = meta
+	}
+	return reg, true, nil
+}
+
 func readPrivateKeyMaterial(input string) (keyHex string, address string, err error) {
 	raw := strings.TrimSpace(input)
 	if raw == "" {
@@ -902,6 +928,28 @@ func readPrivateKeyMaterial(input string) (keyHex string, address string, err er
 
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	return "0x" + keyHex, addr.Hex(), nil
+}
+
+func serviceOfferStatusLines(namespace, name string, offer monetizeapi.ServiceOffer) []string {
+	lines := []string{
+		fmt.Sprintf("ServiceOffer:    %s/%s", namespace, name),
+		fmt.Sprintf("Endpoint:        %s", valueOrNone(offer.Status.Endpoint)),
+		fmt.Sprintf("Agent ID:        %s", valueOrNone(offer.Status.AgentID)),
+		fmt.Sprintf("Registration Tx: %s", valueOrNone(offer.Status.RegistrationTxHash)),
+		"",
+		"Conditions:",
+	}
+	for _, cond := range offer.Status.Conditions {
+		lines = append(lines, fmt.Sprintf("  - type: %s", cond.Type))
+		lines = append(lines, fmt.Sprintf("    status: %q", cond.Status))
+		if cond.Reason != "" {
+			lines = append(lines, fmt.Sprintf("    reason: %s", cond.Reason))
+		}
+		if cond.Message != "" {
+			lines = append(lines, fmt.Sprintf("    message: %s", cond.Message))
+		}
+	}
+	return lines
 }
 
 // ---------------------------------------------------------------------------
@@ -984,21 +1032,12 @@ func sellStatusCommand(cfg *config.Config) *cli.Command {
 					return fmt.Errorf("parse ServiceOffer: %w", err)
 				}
 
-				u.Printf("ServiceOffer:    %s/%s", ns, name)
-				u.Printf("Endpoint:        %s", valueOrNone(offer.Status.Endpoint))
-				u.Printf("Agent ID:        %s", valueOrNone(offer.Status.AgentID))
-				u.Printf("Registration Tx: %s", valueOrNone(offer.Status.RegistrationTxHash))
-				u.Blank()
-				u.Print("Conditions:")
-				for _, cond := range offer.Status.Conditions {
-					u.Printf("  - type: %s", cond.Type)
-					u.Printf("    status: %q", cond.Status)
-					if cond.Reason != "" {
-						u.Printf("    reason: %s", cond.Reason)
+				for _, line := range serviceOfferStatusLines(ns, name, offer) {
+					if line == "" {
+						u.Blank()
+						continue
 					}
-					if cond.Message != "" {
-						u.Printf("    message: %s", cond.Message)
-					}
+					u.Print(line)
 				}
 				return nil
 			}

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -395,11 +395,13 @@ func sellHTTPCommand(cfg *config.Config) *cli.Command {
 		Name:      "http",
 		Usage:     "Sell any local HTTP service with x402 payments",
 		ArgsUsage: "<name>",
-		Description: `Publishes a payment gated HTTP API to any service within the stack, along with a SKILL.md detailing how to use it.
-Include --register to have the service listed on EIP8004 onchain agent registry.
+		Description: `Publishes a payment gated HTTP API to any service within the stack.
+By default it also registers the seller agent on ERC-8004 after the route is live.
+Use --no-register to skip the on-chain registration step.
 
-Example:
-  obol sell http my-cool-api --upstream my-svc.my-namespace.svc.cluster.local --port 8080 --wallet 0x... --price 0.01 --chain base --register`,
+Examples:
+  obol sell http my-cool-api --upstream my-svc.my-namespace.svc.cluster.local --port 8080 --wallet 0x... --price 0.01 --chain base
+  obol sell http my-cool-api --upstream my-svc --port 8080 --wallet 0x... --price 0.01 --chain base --no-register`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "wallet",
@@ -460,7 +462,11 @@ Example:
 			// Registration flags
 			&cli.BoolFlag{
 				Name:  "register",
-				Usage: "Register on ERC-8004 after routing is live",
+				Usage: "Deprecated: registration is enabled by default",
+			},
+			&cli.BoolFlag{
+				Name:  "no-register",
+				Usage: "Skip the automatic ERC-8004 registration step",
 			},
 			&cli.StringFlag{
 				Name:  "register-name",
@@ -473,6 +479,10 @@ Example:
 			&cli.StringFlag{
 				Name:  "register-image",
 				Usage: "Agent image URL for ERC-8004 registration",
+			},
+			&cli.StringFlag{
+				Name:  "private-key-file",
+				Usage: "Path to the ERC-8004 signing key file (defaults to the OpenClaw remote-signer wallet)",
 			},
 			&cli.StringSliceFlag{
 				Name:  "register-skills",
@@ -649,9 +659,17 @@ Example:
 					prov.Framework, prov.MetricName, prov.MetricValue, prov.ParamCount)
 			}
 
-			if cmd.Bool("register") || cmd.String("register-name") != "" {
+			registerEnabled := !cmd.Bool("no-register")
+			if !registerEnabled && (cmd.Bool("register") || cmd.String("register-name") != "" || cmd.String("register-description") != "" ||
+				cmd.String("register-image") != "" || len(cmd.StringSlice("register-skills")) > 0 || len(cmd.StringSlice("register-domains")) > 0 ||
+				len(cmd.StringSlice("register-metadata")) > 0 || cmd.String("private-key-file") != "") {
+				return errors.New("--no-register cannot be combined with registration-specific flags")
+			}
+			if registerEnabled {
 				reg := map[string]any{
-					"enabled": cmd.Bool("register"),
+					"enabled":     true,
+					"name":        registrationNameForPrompt(name, nil),
+					"description": registrationDescriptionForPrompt(name, nil),
 				}
 				if n := cmd.String("register-name"); n != "" {
 					reg["name"] = n
@@ -719,14 +737,22 @@ Example:
 				u.Dim("  Start manually with: obol tunnel restart")
 			} else {
 				u.Successf("Tunnel active: %s", tunnelURL)
-			}
 
-			if reg, ok := spec["registration"].(map[string]any); ok {
-				if enabled, _ := reg["enabled"].(bool); enabled {
-					u.Blank()
-					u.Warn("`obol sell http --register` publishes the off-chain registration document only.")
-					u.Dim("  To mint an on-chain ERC-8004 identity, run:")
-					u.Dim(fmt.Sprintf("    obol sell register --chain %s --name %q", cmd.String("chain"), registrationNameForPrompt(name, reg)))
+				if reg, ok := spec["registration"].(map[string]any); ok {
+					if enabled, _ := reg["enabled"].(bool); enabled {
+						u.Blank()
+						u.Info("Registering seller agent on ERC-8004...")
+						if err := autoRegisterServiceOffer(ctx, cfg, u, autoRegisterOptions{
+							ChainCSV:        cmd.String("chain"),
+							Endpoint:        tunnelURL,
+							AgentName:       registrationNameForPrompt(name, reg),
+							AgentDesc:       registrationDescriptionForPrompt(name, reg),
+							PrivateKeyInput: cmd.String("private-key-file"),
+							ExpectedOwner:   wallet,
+						}); err != nil {
+							return fmt.Errorf("automatic sell registration failed: %w", err)
+						}
+					}
 				}
 			}
 
@@ -743,6 +769,138 @@ func registrationNameForPrompt(fallback string, reg map[string]any) string {
 		return name
 	}
 	return fallback
+}
+
+func registrationDescriptionForPrompt(fallback string, reg map[string]any) string {
+	if reg == nil {
+		return fmt.Sprintf("Obol Stack service %s", fallback)
+	}
+	if desc, ok := reg["description"].(string); ok && strings.TrimSpace(desc) != "" {
+		return desc
+	}
+	return fmt.Sprintf("Obol Stack service %s", fallback)
+}
+
+type autoRegisterOptions struct {
+	ChainCSV        string
+	Endpoint        string
+	AgentName       string
+	AgentDesc       string
+	PrivateKeyInput string
+	ExpectedOwner   string
+}
+
+func autoRegisterServiceOffer(ctx context.Context, cfg *config.Config, u *ui.UI, opts autoRegisterOptions) error {
+	if opts.Endpoint == "" {
+		return errors.New("endpoint is required for automatic registration")
+	}
+
+	networks, err := erc8004.ResolveNetworks(opts.ChainCSV)
+	if err != nil {
+		return err
+	}
+
+	useRemoteSigner := false
+	var (
+		signerNS    string
+		fallbackKey string
+		signerAddr  string
+	)
+
+	if strings.TrimSpace(opts.PrivateKeyInput) == "" {
+		if _, err := openclaw.ResolveWalletAddress(cfg); err == nil {
+			ns, nsErr := openclaw.ResolveInstanceNamespace(cfg)
+			if nsErr == nil {
+				pf, pfErr := startSignerPortForward(cfg, ns)
+				if pfErr != nil {
+					return fmt.Errorf("port-forward to remote-signer: %w", pfErr)
+				}
+				defer pf.Stop()
+
+				signer := erc8004.NewRemoteSigner(fmt.Sprintf("http://localhost:%d", pf.localPort))
+				addr, addrErr := signer.GetAddress(ctx)
+				if addrErr != nil {
+					return addrErr
+				}
+
+				signerAddr = addr.Hex()
+				useRemoteSigner = true
+				signerNS = ns
+			}
+		}
+	}
+
+	if !useRemoteSigner {
+		fallbackKey, signerAddr, err = readPrivateKeyMaterial(opts.PrivateKeyInput)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.ExpectedOwner != "" && !strings.EqualFold(strings.TrimSpace(opts.ExpectedOwner), strings.TrimSpace(signerAddr)) {
+		return fmt.Errorf("registration signer %s does not match the payment wallet %s.\nUse a matching signer, omit --wallet so the remote-signer wallet is used, or pass --no-register", signerAddr, opts.ExpectedOwner)
+	}
+
+	agentURI := strings.TrimRight(opts.Endpoint, "/") + "/.well-known/agent-registration.json"
+	u.Printf("  Agent URI: %s", agentURI)
+
+	var successes int
+	for _, net := range networks {
+		u.Blank()
+		u.Printf("  [%s] (chain ID %d)", net.Name, net.ChainID)
+		u.Printf("    Registry: %s", net.RegistryAddress)
+
+		if useRemoteSigner {
+			if err := registerDirectViaSigner(ctx, cfg, u, net, agentURI, signerNS); err != nil {
+				u.Warnf("direct registration failed: %v", err)
+				continue
+			}
+		} else {
+			if err := registerDirectWithKey(ctx, cfg, u, net, agentURI, fallbackKey); err != nil {
+				u.Warnf("registration failed: %v", err)
+				continue
+			}
+		}
+
+		u.Printf("    Name:     %s", opts.AgentName)
+		u.Printf("    Summary:  %s", opts.AgentDesc)
+		u.Printf("    CAIP-10:  %s", net.CAIP10Registry())
+		successes++
+	}
+
+	if successes == 0 {
+		return fmt.Errorf("registration failed on all networks")
+	}
+
+	u.Blank()
+	u.Successf("Seller agent registered on %d/%d networks.", successes, len(networks))
+	return nil
+}
+
+func readPrivateKeyMaterial(input string) (keyHex string, address string, err error) {
+	raw := strings.TrimSpace(input)
+	if raw == "" {
+		return "", "", nil
+	}
+
+	if strings.HasPrefix(raw, "0x") && len(raw) >= 64 {
+		keyHex = raw
+	} else {
+		data, readErr := os.ReadFile(raw)
+		if readErr != nil {
+			return "", "", fmt.Errorf("read private key file: %w", readErr)
+		}
+		keyHex = strings.TrimSpace(string(data))
+	}
+
+	keyHex = strings.TrimPrefix(keyHex, "0x")
+	key, parseErr := crypto.HexToECDSA(keyHex)
+	if parseErr != nil {
+		return "", "", fmt.Errorf("invalid private key: %w", parseErr)
+	}
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return "0x" + keyHex, addr.Hex(), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1416,17 +1574,12 @@ Examples:
 			// Fallback to private key file if no remote-signer.
 			var fallbackKey string
 			if !useRemoteSigner {
-				keyFile := cmd.String("private-key-file")
-				if keyFile != "" {
-					data, err := os.ReadFile(keyFile)
-					if err != nil {
-						return fmt.Errorf("read private key file: %w", err)
-					}
-					fallbackKey = strings.TrimSpace(string(data))
-				}
+				var signerAddr string
+				fallbackKey, signerAddr, err = readPrivateKeyMaterial(cmd.String("private-key-file"))
 				if fallbackKey == "" {
 					return fmt.Errorf("no remote-signer wallet found and no --private-key-file provided.\nRun 'obol agent init' first, or use --private-key-file")
 				}
+				u.Printf("  Wallet:    %s", signerAddr)
 			}
 
 			// Register on each network (best-effort).

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -204,7 +204,7 @@ func TestSellHTTP_Flags(t *testing.T) {
 		"wallet", "chain", "price", "per-request", "per-mtok", "per-hour",
 		"namespace", "upstream", "port", "health-path", "path",
 		"max-timeout",
-		"register", "register-name", "register-description", "register-image",
+		"register", "no-register", "register-name", "register-description", "register-image", "private-key-file",
 	)
 
 	assertStringDefault(t, flags, "chain", "base")

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v3"
 )
 
@@ -212,6 +217,103 @@ func TestSellHTTP_Flags(t *testing.T) {
 	assertStringDefault(t, flags, "health-path", "/health")
 	assertIntDefault(t, flags, "port", 8080)
 	assertIntDefault(t, flags, "max-timeout", 300)
+}
+
+func TestBuildSellHTTPRegistrationConfig_DefaultEnabled(t *testing.T) {
+	reg, enabled, err := buildSellHTTPRegistrationConfig("demo", sellHTTPRegistrationInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("registration should be enabled by default")
+	}
+	if reg["enabled"] != true {
+		t.Fatalf("registration.enabled = %v, want true", reg["enabled"])
+	}
+	if reg["name"] != "demo" {
+		t.Fatalf("registration.name = %v, want demo", reg["name"])
+	}
+}
+
+func TestBuildSellHTTPRegistrationConfig_NoRegisterConflicts(t *testing.T) {
+	_, _, err := buildSellHTTPRegistrationConfig("demo", sellHTTPRegistrationInput{
+		NoRegister: true,
+		Name:       "custom",
+	})
+	if err == nil {
+		t.Fatal("expected error for --no-register with registration-specific flags")
+	}
+}
+
+func TestReadPrivateKeyMaterial_RawKey(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	raw := "0x" + fmt.Sprintf("%x", crypto.FromECDSA(key))
+	gotKey, gotAddr, err := readPrivateKeyMaterial(raw)
+	if err != nil {
+		t.Fatalf("readPrivateKeyMaterial: %v", err)
+	}
+	if gotKey != raw {
+		t.Fatalf("got key = %q, want %q", gotKey, raw)
+	}
+	if gotAddr != crypto.PubkeyToAddress(key.PublicKey).Hex() {
+		t.Fatalf("got addr = %q, want %q", gotAddr, crypto.PubkeyToAddress(key.PublicKey).Hex())
+	}
+}
+
+func TestReadPrivateKeyMaterial_File(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	raw := "0x" + fmt.Sprintf("%x", crypto.FromECDSA(key))
+	path := filepath.Join(t.TempDir(), "key.txt")
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	gotKey, gotAddr, err := readPrivateKeyMaterial(path)
+	if err != nil {
+		t.Fatalf("readPrivateKeyMaterial: %v", err)
+	}
+	if gotKey != raw {
+		t.Fatalf("got key = %q, want %q", gotKey, raw)
+	}
+	if gotAddr != crypto.PubkeyToAddress(key.PublicKey).Hex() {
+		t.Fatalf("got addr = %q, want %q", gotAddr, crypto.PubkeyToAddress(key.PublicKey).Hex())
+	}
+}
+
+func TestReadPrivateKeyMaterial_Invalid(t *testing.T) {
+	if _, _, err := readPrivateKeyMaterial("0xdeadbeef"); err == nil {
+		t.Fatal("expected error for invalid private key")
+	}
+}
+
+func TestServiceOfferStatusLines(t *testing.T) {
+	offer := monetizeapi.ServiceOffer{
+		Status: monetizeapi.ServiceOfferStatus{
+			Endpoint:           "/services/demo",
+			AgentID:            "5008",
+			RegistrationTxHash: "0xabc",
+			Conditions: []monetizeapi.Condition{
+				{Type: "Registered", Status: "True", Reason: "Registered", Message: "Published registration document and recorded agent 5008"},
+			},
+		},
+	}
+	lines := serviceOfferStatusLines("llm", "demo", offer)
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"ServiceOffer:    llm/demo",
+		"Agent ID:        5008",
+		"Registration Tx: 0xabc",
+		"type: Registered",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("status lines missing %q\n%s", want, joined)
+		}
+	}
 }
 
 func TestSellStop_Structure(t *testing.T) {

--- a/docs/guides/monetize-inference.md
+++ b/docs/guides/monetize-inference.md
@@ -157,6 +157,10 @@ obol sell http my-qwen \
     --port 11434
 ```
 
+By default this also registers the seller agent on ERC-8004. Use
+`--no-register` only for local or private-only testing where on-chain
+discovery is intentionally skipped.
+
 If you want to price by million tokens instead of explicitly setting a flat
 request price, use `--per-mtok`. In phase 1, the verifier still enforces a
 derived per-request price:
@@ -177,14 +181,14 @@ That stores both values in the pricing config:
 - enforced phase-1 charge: `price = 0.00125 USDC / request`
 - approximation input: `approxTokensPerRequest = 1000`
 
-The agent automatically reconciles the offer through six stages:
+The stack now treats on-chain registration as part of the default selling flow:
 
 ```
 ModelReady       [check]  Agent checks /api/tags, model already cached
 UpstreamHealthy  [check]  Agent health-checks ollama:11434
-PaymentGateReady [check]  Creates Middleware x402-my-qwen + adds pricing route
-RoutePublished   [check]  Creates HTTPRoute so-my-qwen -> ollama backend
-Registered         --     Skipped (--register not set)
+PaymentGateReady [check]  Shared x402 seller gateway available
+RoutePublished   [check]  Creates HTTPRoute so-my-qwen -> x402-verifier backend
+Registered      [check]  ERC-8004 registration completes on-chain
 Ready            [check]  All required conditions True
 ```
 
@@ -196,7 +200,6 @@ obol sell status my-qwen --namespace llm
 
 # Verify Kubernetes resources
 obol kubectl get serviceoffer my-qwen -n llm
-obol kubectl get middleware -n llm           # x402-my-qwen
 obol kubectl get httproute -n llm            # so-my-qwen
 ```
 
@@ -616,7 +619,7 @@ Traefik Gateway
                 +---------+----------+
                           |
                 +---------v----------+
-                | Registered         |  (ERC-8004, optional)
+                | Registered         |  (ERC-8004, default unless --no-register)
                 +---------+----------+
                           |
                     +-----v-----+
@@ -781,13 +784,13 @@ Replace `openclaw-obol-agent` with your actual OpenClaw namespace if different.
 | Command | Description |
 |---------|-------------|
 | `obol sell pricing --wallet ... --chain ...` | Configure x402 payment settings |
-| `obol sell http <name> --wallet ... --chain ... --per-request ... --upstream ... --port ...` | Create a ServiceOffer |
+| `obol sell http <name> --wallet ... --chain ... --per-request ... --upstream ... --port ...` | Create a ServiceOffer and register by default |
 | `obol sell list` | List all ServiceOffers |
 | `obol sell status <name> -n <ns>` | Show conditions for an offer |
 | `obol sell stop <name> -n <ns>` | Pause an offer (remove pricing route) |
 | `obol sell delete <name> -n <ns>` | Delete an offer and cleanup |
 | `obol sell status` | Show cluster pricing and registration |
-| `obol sell register --private-key-file ...` | Register on ERC-8004 |
+| `obol sell register --private-key-file ...` | Advanced/manual registration or repair path |
 
 ### Key Kubernetes Resources
 

--- a/flows/flow-06-sell-setup.sh
+++ b/flows/flow-06-sell-setup.sh
@@ -155,6 +155,7 @@ run_step_grep "sell http flow-qwen" \
     "$OBOL" sell http flow-qwen \
     --wallet "$SELLER_WALLET" \
     --chain "$CHAIN" \
+    --no-register \
     --per-request 0.001 \
     --namespace llm \
     --upstream ollama \
@@ -164,6 +165,7 @@ run_step_grep "sell http flow-qwen" \
 step "sell http idempotent: re-run shows 'updated' not 'created'"
 rerun_out=$("$OBOL" sell http flow-qwen \
     --wallet "$SELLER_WALLET" --chain "$CHAIN" \
+    --no-register \
     --per-request 0.001 --namespace llm \
     --upstream ollama --port 11434 2>&1) || true
 if echo "$rerun_out" | grep -q "ServiceOffer.*updated"; then

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -344,7 +344,16 @@ else
     fail "CA bundle empty or too small: $ca_size bytes"
 fi
 
+step "Alice: add Base Sepolia RPC to eRPC (for registration + metadata sync)"
+alice network add base-sepolia --endpoint https://sepolia.base.org --allow-writes 2>&1 | tail -2
+# eRPC needs a restart to pick up the new chain config
+alice kubectl rollout restart deployment/erpc -n erpc 2>/dev/null || true
+alice kubectl rollout status deployment/erpc -n erpc --timeout=60s 2>/dev/null || true
+pass "Base Sepolia RPC added to eRPC (with write access)"
+
 step "Alice: create ServiceOffer"
+KEY_FILE=$(mktemp)
+echo "$SIGNER_KEY" > "$KEY_FILE"
 alice sell http alice-inference \
     --wallet "$ALICE_WALLET" \
     --chain base-sepolia \
@@ -353,11 +362,12 @@ alice sell http alice-inference \
     --upstream litellm \
     --port 4000 \
     --health-path /health/readiness \
-    --register \
     --register-name "Dual-Stack Test Inference" \
     --register-description "Integration test: local model inference via x402" \
     --register-skills natural_language_processing/text_generation \
-    --register-domains technology/artificial_intelligence 2>&1 | tail -3
+    --register-domains technology/artificial_intelligence \
+    --private-key-file "$KEY_FILE" 2>&1 | tail -8
+rm -f "$KEY_FILE"
 pass "ServiceOffer created"
 
 poll_step_grep "Alice: ServiceOffer Ready" "True" 24 5 \
@@ -377,33 +387,14 @@ poll_step_grep "Alice: 402 gate works" "402" 12 5 \
         "$TUNNEL_URL/services/alice-inference/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d '{"model":"qwen3.5:9b","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
-
-step "Alice: add Base Sepolia RPC to eRPC (for on-chain registration)"
-alice network add base-sepolia --endpoint https://sepolia.base.org --allow-writes 2>&1 | tail -2
-# eRPC needs a restart to pick up the new chain config
-alice kubectl rollout restart deployment/erpc -n erpc 2>/dev/null || true
-alice kubectl rollout status deployment/erpc -n erpc --timeout=60s 2>/dev/null || true
-pass "Base Sepolia RPC added to eRPC (with write access)"
-
-step "Alice: register on ERC-8004 (Base Sepolia)"
-# Use the .env private key for on-chain registration (has ETH for gas)
-KEY_FILE=$(mktemp)
-echo "$SIGNER_KEY" > "$KEY_FILE"
-set +e
-register_out=$(alice sell register \
-    --chain base-sepolia \
-    --name "Dual-Stack Test Inference" \
-    --description "Integration test: local model inference via x402" \
-    --private-key-file "$KEY_FILE" 2>&1)
-register_rc=$?
-set -e
-rm -f "$KEY_FILE"
-echo "$register_out" | tail -5
-if [ "$register_rc" -eq 0 ] && echo "$register_out" | grep -q "Agent ID:\|registered"; then
-    AGENT_ID=$(echo "$register_out" | grep -o 'Agent ID: [0-9]*' | grep -o '[0-9]*' | head -1)
+step "Alice: ERC-8004 registration reflected in ServiceOffer"
+reg_out=$(alice sell status alice-inference -n llm 2>&1) || true
+echo "$reg_out" | tail -12
+if echo "$reg_out" | grep -q "Agent ID:"; then
+    AGENT_ID=$(echo "$reg_out" | grep 'Agent ID:' | awk '{print $3}' | head -1)
     pass "ERC-8004 registered: Agent ID $AGENT_ID"
 else
-    fail "Registration failed: ${register_out:0:200}"
+    fail "Registration not reflected in sell status: ${reg_out:0:200}"
 fi
 
 # ═════════════════════════════════════════════════════════════════

--- a/internal/embed/skills/autoresearch-worker/SKILL.md
+++ b/internal/embed/skills/autoresearch-worker/SKILL.md
@@ -73,7 +73,6 @@ obol sell http autoresearch-worker \
   --chain base-sepolia \
   --per-hour 0.50 \
   --path /services/autoresearch-worker \
-  --register \
   --register-name "GPU Worker Alpha" \
   --register-description "A GPU worker for paid autoresearch experiments" \
   --register-skills devops_mlops/model_versioning \
@@ -83,7 +82,7 @@ obol sell http autoresearch-worker \
 This creates a `ServiceOffer` that:
 - health-checks the worker
 - creates a payment-gated public route
-- optionally registers the worker on ERC-8004 for discovery
+- registers the worker on ERC-8004 for discovery by default
 
 ## Request Format
 

--- a/internal/embed/skills/autoresearch-worker/references/k3s-gpu-worker.md
+++ b/internal/embed/skills/autoresearch-worker/references/k3s-gpu-worker.md
@@ -68,7 +68,6 @@ obol sell http autoresearch-worker \
   --chain base-sepolia \
   --per-hour 0.50 \
   --path /services/autoresearch-worker \
-  --register \
   --register-name "GPU Worker Alpha" \
   --register-description "A GPU worker for paid autoresearch experiments" \
   --register-skills devops_mlops/model_versioning \

--- a/internal/embed/skills/autoresearch-worker/references/worker-api.md
+++ b/internal/embed/skills/autoresearch-worker/references/worker-api.md
@@ -131,7 +131,6 @@ obol sell http autoresearch-worker \
   --chain base-sepolia \
   --per-hour 0.50 \
   --path /services/autoresearch-worker \
-  --register \
   --register-name "GPU Worker Alpha" \
   --register-description "A GPU worker for paid autoresearch experiments" \
   --register-skills devops_mlops/model_versioning \

--- a/internal/embed/skills/monetize-guide/SKILL.md
+++ b/internal/embed/skills/monetize-guide/SKILL.md
@@ -128,7 +128,6 @@ Only proceed after the user has confirmed the price.
 obol sell inference <name> \
   --model <model_name> \
   --price <confirmed_price> \
-  --register \
   --register-name "<descriptive name>" \
   --register-description "<what the model does>" \
   --register-skills natural_language_processing/natural_language_generation/text_completion \
@@ -156,7 +155,6 @@ obol sell http <name> \
   --wallet <wallet_address> \
   --chain base-sepolia \
   --health-path /health/liveliness \
-  --register \
   --register-name "<descriptive name>" \
   --register-description "<what the service does>" \
   --register-skills natural_language_processing/natural_language_generation/text_completion \
@@ -177,7 +175,6 @@ obol sell http <name> \
   --per-request <confirmed_price> \
   --chain base-sepolia \
   --health-path <health_endpoint> \
-  --register \
   --register-name "<descriptive name>" \
   --register-description "<what the service does>" \
   --register-skills <oasf_skill_path> \
@@ -185,6 +182,9 @@ obol sell http <name> \
 ```
 
 ### Phase 5: Wait for Reconciliation
+
+`obol sell http` now registers by default. Use `--no-register` only for local
+or private-only flows where on-chain discovery is intentionally skipped.
 
 The agent reconciler automatically processes the ServiceOffer through 6 stages.
 

--- a/internal/embed/skills/sell/scripts/monetize.py
+++ b/internal/embed/skills/sell/scripts/monetize.py
@@ -576,7 +576,7 @@ def main():
     create_parser.add_argument("--pay-to", required=True, help="USDC recipient wallet")
     create_parser.add_argument("--path", help="Public route path")
     create_parser.add_argument("--max-timeout", type=int, default=300, help="Payment timeout seconds")
-    create_parser.add_argument("--register", action="store_true", help="Publish registration document")
+    create_parser.add_argument("--register", action="store_true", help="Legacy flag: publish registration metadata")
     create_parser.add_argument("--register-name", help="Registration name")
     create_parser.add_argument("--register-description", help="Registration description")
     create_parser.add_argument("--register-image", help="Registration image URL")

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -41,11 +41,12 @@ const (
 	registrationDesiredActive     = "Active"
 	registrationDesiredTombstoned = "Tombstoned"
 
-	registrationPhasePublishing   = "Publishing"
-	registrationPhaseRegistering  = "Registering"
-	registrationPhaseRegistered   = "Registered"
-	registrationPhaseOffChainOnly = "OffChainOnly"
-	registrationPhaseTombstoned   = "Tombstoned"
+	registrationPhasePublishing       = "Publishing"
+	registrationPhaseRegistering      = "Registering"
+	registrationPhaseAwaitingExternal = "AwaitingExternalRegistration"
+	registrationPhaseRegistered       = "Registered"
+	registrationPhaseOffChainOnly     = "OffChainOnly"
+	registrationPhaseTombstoned       = "Tombstoned"
 )
 
 type Controller struct {
@@ -696,10 +697,14 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 	}
 
 	var client *erc8004.Client
-	if c.registrationKey != nil {
+	if agentID == "" || c.registrationKey != nil {
 		client, err = erc8004.NewClient(ctx, c.registrationRPCURL)
 		if err != nil {
-			status.Phase = registrationPhaseRegistering
+			waitPhase := registrationPhaseRegistering
+			if c.registrationKey == nil {
+				waitPhase = registrationPhaseAwaitingExternal
+			}
+			status.Phase = waitPhase
 			status.Message = truncateMessage(fmt.Sprintf("Waiting for ERC-8004 RPC connectivity: %v", err))
 			return c.updateRegistrationStatus(ctx, raw, status)
 		}
@@ -764,6 +769,47 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 			status.Message = fmt.Sprintf("Waiting for on-chain registration transaction %s", status.RegistrationTxHash)
 			return c.updateRegistrationStatus(ctx, raw, status)
 		}
+	} else if agentID == "" {
+		if status.RegistrationURI != status.PublishedURL ||
+			!strings.EqualFold(status.RegistrationOwner, offer.Spec.Payment.PayTo) ||
+			status.RegistrationSearchFromBlock == 0 {
+			height, err := client.CurrentBlockNumber(ctx)
+			if err != nil {
+				status.Phase = registrationPhaseAwaitingExternal
+				status.Message = truncateMessage(fmt.Sprintf("Preparing external registration recovery: %v", err))
+				return c.updateRegistrationStatus(ctx, raw, status)
+			}
+
+			status.Phase = registrationPhaseAwaitingExternal
+			status.Message = "Waiting for external ERC-8004 registration"
+			status.RegistrationOwner = offer.Spec.Payment.PayTo
+			status.RegistrationURI = status.PublishedURL
+			fromBlock := int64(height) - 1024
+			if fromBlock < 0 {
+				fromBlock = 0
+			}
+			status.RegistrationSearchFromBlock = fromBlock
+			status.RegistrationTxHash = ""
+			return c.updateRegistrationStatus(ctx, raw, status)
+		}
+
+		recoveredAgentID, recoveredTxHash, found, err := c.recoverRegistration(ctx, client, status)
+		if err != nil {
+			status.Phase = registrationPhaseAwaitingExternal
+			status.Message = truncateMessage(fmt.Sprintf("Recovering external registration state: %v", err))
+			if updateErr := c.updateRegistrationStatus(ctx, raw, status); updateErr != nil {
+				return updateErr
+			}
+			return err
+		}
+		if !found {
+			status.Phase = registrationPhaseAwaitingExternal
+			status.Message = fmt.Sprintf("Waiting for external ERC-8004 registration for owner %s", status.RegistrationOwner)
+			return c.updateRegistrationStatus(ctx, raw, status)
+		}
+
+		agentID = recoveredAgentID
+		txHash = recoveredTxHash
 	}
 
 	status.AgentID = agentID
@@ -789,9 +835,6 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 		} else {
 			status.Message = fmt.Sprintf("Published registration document and recorded agent %s; metadata sync will retry on the next reconcile", agentID)
 		}
-	} else {
-		status.Phase = registrationPhaseOffChainOnly
-		status.Message = "Published registration document; controller has no ERC-8004 signing key"
 	}
 
 	return c.updateRegistrationStatus(ctx, raw, status)
@@ -1226,7 +1269,7 @@ func statusFor(status *monetizeapi.ServiceOfferStatus) *monetizeapi.ServiceOffer
 }
 
 func requestPhaseReady(phase string) bool {
-	return phase == registrationPhaseRegistered || phase == registrationPhaseOffChainOnly
+	return phase == registrationPhaseRegistered
 }
 
 func requestCleanupComplete(phase string) bool {

--- a/internal/serviceoffercontroller/controller_test.go
+++ b/internal/serviceoffercontroller/controller_test.go
@@ -64,6 +64,18 @@ func TestSelectRegistrationOwnerEmpty(t *testing.T) {
 	}
 }
 
+func TestRequestPhaseReady(t *testing.T) {
+	if !requestPhaseReady(registrationPhaseRegistered) {
+		t.Fatal("Registered should be ready")
+	}
+	if requestPhaseReady(registrationPhaseAwaitingExternal) {
+		t.Fatal("AwaitingExternalRegistration should not be ready")
+	}
+	if requestPhaseReady(registrationPhaseOffChainOnly) {
+		t.Fatal("OffChainOnly should not be ready")
+	}
+}
+
 func TestShouldRefreshSkillCatalogWhenGenerationObservedLags(t *testing.T) {
 	controller := &Controller{}
 	offer := &monetizeapi.ServiceOffer{

--- a/internal/x402/bdd_integration_test.go
+++ b/internal/x402/bdd_integration_test.go
@@ -35,8 +35,9 @@ var (
 const (
 	serviceOfferName      = "bdd-test"
 	serviceOfferNamespace = "llm"
-	serviceOfferPayTo     = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 )
+
+var serviceOfferPayTo string
 
 // TestMain bootstraps the full obol stack following the real user journey:
 //
@@ -58,7 +59,6 @@ func TestMain(m *testing.M) {
 			integrationKubeconfig = filepath.Join(configDir, "kubeconfig.yaml")
 			integrationObolBin = filepath.Join(binDir, "obol")
 			integrationRoutePath = "/services/" + serviceOfferName + "/v1/chat/completions"
-			integrationPayTo = serviceOfferPayTo
 			integrationModel = os.Getenv("OBOL_TEST_MODEL")
 			if integrationModel == "" {
 				integrationModel = "qwen3.5:9b"
@@ -103,6 +103,13 @@ func TestMain(m *testing.M) {
 	if err := runObol(obolBin, "stack", "up"); err != nil {
 		log.Fatalf("obol stack up: %v", err)
 	}
+
+	payTo, err := runObolOutput(obolBin, "openclaw", "wallet", "address", "obol-agent")
+	if err != nil {
+		teardown(obolBin)
+		log.Fatalf("resolve seller wallet: %v", err)
+	}
+	serviceOfferPayTo = strings.TrimSpace(payTo)
 
 	integrationKubectlBin = kubectlBin
 	integrationKubeconfig = kubeconfigPath
@@ -302,6 +309,15 @@ func ensureExistingClusterBootstrap(obolBin, kubectlBin, kubeconfig string) erro
 	if err := waitForServiceOfferReady(kubectlBin, kubeconfig, serviceOfferName, serviceOfferNamespace, 300*time.Second); err != nil {
 		return fmt.Errorf("existing-cluster ServiceOffer not Ready: %w", err)
 	}
+
+	payTo, err := kubectl.Output(kubectlBin, kubeconfig,
+		"get", "serviceoffers.obol.org", serviceOfferName, "-n", serviceOfferNamespace,
+		"-o", "jsonpath={.spec.payment.payTo}")
+	if err != nil {
+		return fmt.Errorf("read ServiceOffer payTo: %w", err)
+	}
+	serviceOfferPayTo = strings.TrimSpace(payTo)
+	integrationPayTo = serviceOfferPayTo
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Replaces the warning-only UX with the actual stronger design:

- `obol sell http` now **registers by default**
- `--no-register` is the explicit opt-out
- registration is treated as part of the sell flow, not an optional afterthought
- the controller no longer treats `OffChainOnly` as "registered and ready"

## Why

The previous UX was not coherent:

- `obol sell http --register` could still mean "only publish an off-chain document"
- `Registered=True / OffChainOnly` looked like success even when nothing was on-chain
- users had to mentally stitch together `sell http` and `sell register` as two unrelated commands

That is the wrong model.

The product model should be:

- selling a public service registers it by default
- if a signer is not available, that is a blocking requirement unless the user explicitly opts out

## Flow

### Old behavior

```mermaid
flowchart TD
    A[obol sell http --register] --> B[Create ServiceOffer]
    B --> C[Controller publishes off-chain registration doc]
    C --> D{Controller signing key configured?}
    D -- yes --> E[Register on ERC-8004]
    D -- no --> F[Registered=True / OffChainOnly]
```

### New behavior

```mermaid
flowchart TD
    A[obol sell http] --> B[Create ServiceOffer]
    B --> C[Ensure public route is live]
    C --> D{--no-register?}
    D -- yes --> E[Skip on-chain registration intentionally]
    D -- no --> F[Resolve signer]
    F --> G[Register on ERC-8004]
    G --> H[Controller observes on-chain registration]
    H --> I[Registered=True]
```

### Seller UX

```mermaid
sequenceDiagram
    participant User
    participant CLI as obol sell http
    participant Ctrl as serviceoffer-controller
    participant Chain as ERC-8004

    User->>CLI: sell http ...
    CLI->>Ctrl: create ServiceOffer
    CLI->>CLI: ensure tunnel / route
    CLI->>CLI: resolve signer
    CLI->>Chain: register agent + metadata
    Ctrl->>Chain: recover registration by owner + URI
    Ctrl-->>User: Ready with Registered=True
```

## What changed

### CLI

- `sell http` now enables registration by default
- added `--no-register` to skip the automatic on-chain registration step
- retained `--register` only as a compatibility no-op / deprecated path
- added `--private-key-file` to `sell http` for explicit registration signer input
- automatic registration uses the same registration machinery as `sell register`
- registration signer must match the payment wallet for the automatic path
- `sell status <name>` now prints a human summary including `Agent ID` and `Registration Tx`

### Controller semantics

- `OffChainOnly` is no longer considered ready
- when the controller has no signing key, it waits for external registration instead of reporting success
- the controller now recovers externally-created registrations by owner + published URI and then marks the offer registered

### Tests / flows

- updated CLI flag coverage
- added direct tests for:
  - registration defaults / `--no-register` conflicts
  - private key material parsing
  - human `sell status` summary output
- updated controller phase expectations
- updated the BDD harness to use the actual default agent wallet as the seller wallet
- updated `flow-06` to use `--no-register` where registration is intentionally out of scope
- updated `flow-11` to use the unified flow instead of a separate `sell register` step

### Docs

- updated the public monetize guide
- updated embedded skill docs and examples that still taught the old `--register` flow
- updated the embedded `monetize.py` help text to mark `--register` as legacy metadata publishing

## Validation

- `go test ./cmd/obol ./internal/serviceoffercontroller ./internal/x402`
- `bash -n flows/flow-06-sell-setup.sh flows/flow-11-dual-stack.sh`
- full `flow-11` rerun from clean Obol/k3d state: **41/41 passed**

### Flow-11 artifacts from the passing run

- seller wallet: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- seller agent ID: `5008`
- tunnel URL: `https://eliminate-counting-bonus-skating.trycloudflare.com`
- buyer signer wallet: `0x9aE40E84fb587fB3B526f5542934c3B2d18D67bF`
- settlement tx: `0xca98062273d612c700dd036aa2bd68c252f1c71e5da6d2bc469e589a98cc5031`

## User-visible contract

From this PR onward, the intended contract is:

- `obol sell http ...` means **sell and register**
- `obol sell http ... --no-register` means **sell without on-chain registration on purpose**
- `obol sell register` remains the advanced/manual repair path, not the normal primary flow
