### PR TITLE
feat(x402-buyer): expose confirm-spend persistence failures

### DIFF
--- a/internal/x402/buyer/metrics.go
+++ b/internal/x402/buyer/metrics.go
@@ -14,6 +14,7 @@ type metrics struct {
 	paymentAttempts               *prometheus.CounterVec
 	paymentSuccessTotal           *prometheus.CounterVec
 	paymentFailureTotal           *prometheus.CounterVec
+	confirmSpendFailureTotal      *prometheus.CounterVec
 	paymentUnsettledConfirmations *prometheus.CounterVec
 	authRemaining                 *prometheus.GaugeVec
 	authSpent                     *prometheus.GaugeVec
@@ -48,6 +49,13 @@ func newMetrics() *metrics {
 			prometheus.CounterOpts{
 				Name: "obol_x402_buyer_payment_failure_total",
 				Help: "Total failed x402 payments attempted by the buyer sidecar.",
+			},
+			[]string{"upstream", "remote_model"},
+		),
+		confirmSpendFailureTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "obol_x402_buyer_confirm_spend_failure_total",
+				Help: "Successful upstream responses whose consumed-auth state could not be persisted.",
 			},
 			[]string{"upstream", "remote_model"},
 		),
@@ -91,6 +99,7 @@ func newMetrics() *metrics {
 		m.paymentAttempts,
 		m.paymentSuccessTotal,
 		m.paymentFailureTotal,
+		m.confirmSpendFailureTotal,
 		m.paymentUnsettledConfirmations,
 		m.authRemaining,
 		m.authSpent,

--- a/internal/x402/buyer/proxy.go
+++ b/internal/x402/buyer/proxy.go
@@ -239,6 +239,12 @@ func (p *Proxy) buildUpstreamHandler(name, remoteModel string, cfg UpstreamConfi
 				p.metrics.authSpent.With(labels).Set(float64(signer.Spent()))
 				log.Printf("[%s] payment failed: %v", name, event.Error)
 			},
+			OnConfirmSpendFailure: func(event PaymentEvent) {
+				p.metrics.confirmSpendFailureTotal.With(labels).Inc()
+				p.metrics.authRemaining.With(labels).Set(float64(signer.Remaining()))
+				p.metrics.authSpent.With(labels).Set(float64(signer.Spent()))
+				log.Printf("[%s] confirm spend persistence failed: %v", name, event.Error)
+			},
 			OnPaymentUnsettled: func(event PaymentEvent) {
 				p.metrics.paymentUnsettledConfirmations.With(labels).Inc()
 			},
@@ -390,6 +396,7 @@ type replayableX402Transport struct {
 	OnPaymentAttempt PaymentCallback
 	OnPaymentSuccess PaymentCallback
 	OnPaymentFailure PaymentCallback
+	OnConfirmSpendFailure PaymentCallback
 	// OnPaymentUnsettled fires when the upstream returned 2xx without a
 	// successful X-PAYMENT-RESPONSE. The auth has been consumed locally via
 	// ConfirmSpend, but there is no observed on-chain settlement. Sellers
@@ -524,6 +531,24 @@ func (t *replayableX402Transport) RoundTrip(req *http.Request) (*http.Response, 
 		if ps, ok := t.Signers[0].(*PreSignedSigner); ok && heldAuth != nil {
 			if confirmErr := ps.ConfirmSpend(heldAuth); confirmErr != nil {
 				log.Printf("x402-buyer: confirm spend: %v", confirmErr)
+				if t.OnConfirmSpendFailure != nil {
+					event := PaymentEvent{
+						Type:      PaymentEventFailure,
+						Timestamp: time.Now(),
+						Method:    "HTTP",
+						URL:       req.URL.String(),
+						Error:     confirmErr,
+						Duration:  duration,
+					}
+					if selectedRequirement != nil {
+						event.Network = selectedRequirement.Network
+						event.Scheme = selectedRequirement.Scheme
+						event.Amount = selectedRequirement.Amount
+						event.Asset = selectedRequirement.Asset
+						event.Recipient = selectedRequirement.PayTo
+					}
+					t.OnConfirmSpendFailure(event)
+				}
 			}
 		}
 	}

--- a/internal/x402/buyer/proxy_test.go
+++ b/internal/x402/buyer/proxy_test.go
@@ -1622,6 +1622,77 @@ func TestProxy_UpstreamSuccessWithSettlementHeader_DoesNotIncrementUnsettledMetr
 	})
 }
 
+func TestProxy_ConfirmSpendFailure_IncrementsMetric(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o500); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	statePath := filepath.Join(stateDir, "consumed.json")
+
+	st, err := LoadStateStore(statePath)
+	if err != nil {
+		t.Fatalf("LoadStateStore: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Payment") == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			fmt.Fprint(w, `{"x402Version":1,"accepts":[{"scheme":"exact","network":"base-sepolia","maxAmountRequired":"1000","asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","payTo":"0x70997970C51812dc3A010C7d01b50e0d17dc79C8"}]}`)
+			return
+		}
+
+		settleJSON := `{"success":true,"transaction":"0xabc","network":"base-sepolia","payer":"0xdef"}`
+		w.Header().Set("X-Payment-Response", base64.StdEncoding.EncodeToString([]byte(settleJSON)))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"paid"}}]}`)
+	}))
+	defer upstream.Close()
+
+	auth := makeAuth("0xconfirmfail")
+	cfg := &Config{
+		Upstreams: map[string]UpstreamConfig{
+			"paid": {
+				URL:     upstream.URL,
+				Network: "base-sepolia",
+				PayTo:   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+				Asset:   "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+				Price:   "1000",
+			},
+		},
+	}
+	auths := AuthsFile{"paid": {auth}}
+
+	proxy, err := NewProxy(cfg, auths, st)
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	srv := httptest.NewServer(proxy)
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/upstream/paid/v1/chat/completions",
+		"application/json",
+		strings.NewReader(`{"model":"test"}`),
+	)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	metrics := scrapeMetricFamilies(t, proxy)
+	assertMetricValue(t, metrics["obol_x402_buyer_confirm_spend_failure_total"], map[string]string{
+		"upstream":     "paid",
+		"remote_model": "paid",
+	}, 1)
+}
+
 // TestProxy_OpenAIMuxSymmetry_BothV1AndBarePathsRouteIdentically pins down the
 // invariant that the buyer sidecar serves /chat/completions AND
 // /v1/chat/completions. The LiteLLM templates hardcode api_base with /v1


### PR DESCRIPTION
## Summary

Adds an explicit buyer-side metric for successful requests whose consumed-auth state could not be persisted.

## Why

Production-readiness testing found a live mismatch between:

- `payment_attempts_total`
- `payment_success_total`
- `auth_spent`

A likely explanation is that `ConfirmSpend()` can fail after a successful upstream response, causing the live gauges to drift after reload. This PR makes that path directly observable.

## What changed

- added `obol_x402_buyer_confirm_spend_failure_total`
- increment the metric when `ConfirmSpend()` fails after an upstream success
- keep the request successful; this PR is observability-first, not a behavioral change
- added a regression test using an unwritable state path to force the persistence failure path

## Validation

- `go test ./internal/x402/buyer`
