### PR TITLE
fix(stack): preload openclaw image in dev k3d

### DIFF
--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -75,6 +75,15 @@ func openclawImageTag() string {
 	return ""
 }
 
+// ImageRef returns the pinned OpenClaw image reference used by the local
+// binary when it writes overlay values. Empty string means no explicit ref.
+func ImageRef() string {
+	if tag := openclawImageTag(); tag != "" {
+		return "ghcr.io/obolnetwork/openclaw:" + tag
+	}
+	return ""
+}
+
 // OnboardOptions contains options for the onboard command
 type OnboardOptions struct {
 	ID           string   // Deployment ID (empty = generate petname)

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -691,6 +691,14 @@ var localImages = []localImage{
 	{tag: "ghcr.io/obolnetwork/x402-buyer:latest", dockerfile: "Dockerfile.x402-buyer"},
 }
 
+func devPreloadImages() []string {
+	var images []string
+	if ref := openclaw.ImageRef(); ref != "" {
+		images = append(images, ref)
+	}
+	return images
+}
+
 // buildAndImportLocalImages builds Docker images from source and imports them
 // into the k3d cluster. This ensures images are available even when the GHCR
 // publish workflow hasn't run. Non-fatal: logs warnings on failure.
@@ -734,6 +742,20 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 		if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
 			fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
+		}
+	}
+
+	for _, ref := range devPreloadImages() {
+		fmt.Printf("Preloading %s into cluster %s...\n", ref, clusterName)
+		pullCmd := exec.Command("docker", "pull", ref)
+		pullCmd.Stdout = os.Stdout
+		pullCmd.Stderr = os.Stderr
+		if err := pullCmd.Run(); err != nil {
+			fmt.Printf("Warning: failed to pull %s: %v\n", ref, err)
+			continue
+		}
+		if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
+			fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Mitigates first-pull OpenClaw image failures in dev-mode k3d clusters by pre-pulling and importing the pinned OpenClaw image before the default agent bootstrap relies on it.

## Why

Production-readiness testing reported a case where the first in-cluster OpenClaw pull through the k3d mirror path failed and only recovered after a manual `docker pull` + `k3d image import`. This PR automates that recovery path in development mode.

## What changed

- export `openclaw.ImageRef()` from the pinned local OpenClaw version
- in dev mode, `buildAndImportLocalImages()` now also:
  - `docker pull` the pinned OpenClaw image
  - `k3d image import` it into the cluster

## Scope

This is a mitigation for local development / test clusters. It does not claim to root-cause or repair registry cache corruption in general.

## Validation

- `go test ./internal/stack -run TestDoesNotExist`
