### PR TITLE
Better error for methods that require the cluster to be running

### DIFF
--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/agent"
 	"github.com/ObolNetwork/obol-stack/internal/app"
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/stack"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
@@ -660,7 +661,12 @@ Find charts at https://artifacthub.io`,
 			u = ui.New(false)
 		}
 
-		u.Error(err.Error())
+		// Contextual cluster-down message based on the command the user ran.
+		if msg := kubectl.FormatClusterDownError(err, os.Args); msg != "" {
+			u.Error(msg)
+		} else {
+			u.Error(err.Error())
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -27,6 +27,90 @@ func EnsureCluster(cfg *config.Config) error {
 	return nil
 }
 
+// ErrClusterDown indicates the Kubernetes API server is unreachable,
+// typically because the k3d cluster is stopped.
+var ErrClusterDown = errors.New("cluster appears to be stopped — run 'obol stack up' to start it")
+
+// wrapClusterDown checks whether an error (or the accompanying stderr text)
+// indicates the Kubernetes API server is unreachable and, if so, returns
+// ErrClusterDown.  This catches the common case where the kubeconfig file
+// still exists from a prior session but the k3d cluster has been stopped.
+func wrapClusterDown(err error, stderr string) error {
+	if err == nil {
+		return nil
+	}
+
+	combined := err.Error() + " " + stderr
+	if strings.Contains(combined, "connection refused") ||
+		strings.Contains(combined, "connect: no route to host") ||
+		strings.Contains(combined, "Unable to connect to the server") {
+		return ErrClusterDown
+	}
+
+	return err
+}
+
+// clusterDownHints maps CLI subcommand paths to human-friendly descriptions
+// of what the command was trying to do.  Used by FormatClusterDownError to
+// produce contextual messages like "run 'obol stack up' before listing
+// services for sale".
+var clusterDownHints = map[string]string{
+	"sell list":          "listing services for sale",
+	"sell status":        "checking service status",
+	"sell stop":          "stopping a service",
+	"sell delete":        "deleting a service",
+	"sell test":          "testing a service endpoint",
+	"sell pricing":       "configuring pricing",
+	"sell register":      "registering on the agent registry",
+	"sell inference":     "starting the inference gateway",
+	"sell http":          "creating an HTTP service offer",
+	"network sync":       "syncing a network deployment",
+	"network delete":     "deleting a network deployment",
+	"network status":     "checking network status",
+	"openclaw onboard":   "onboarding an OpenClaw instance",
+	"openclaw sync":      "syncing an OpenClaw instance",
+	"openclaw setup":     "configuring OpenClaw",
+	"openclaw token":     "retrieving the gateway token",
+	"openclaw delete":    "deleting an OpenClaw instance",
+	"openclaw list":      "listing OpenClaw instances",
+	"openclaw dashboard": "opening the dashboard",
+	"model status":       "checking model status",
+	"model list":         "listing models",
+	"model setup":        "configuring a model",
+	"model remove":       "removing a model",
+	"app sync":           "syncing an app deployment",
+	"app delete":         "deleting an app deployment",
+	"tunnel status":      "checking tunnel status",
+	"tunnel restart":     "restarting the tunnel",
+	"tunnel logs":        "fetching tunnel logs",
+	"tunnel login":       "configuring the tunnel",
+	"tunnel provision":   "provisioning the tunnel",
+	"agent init":         "initializing the agent",
+}
+
+// FormatClusterDownError returns a contextual message for a cluster-down
+// error based on the CLI arguments.  Returns empty string if err is not
+// ErrClusterDown.
+func FormatClusterDownError(err error, args []string) string {
+	if !errors.Is(err, ErrClusterDown) {
+		return ""
+	}
+
+	// Try "subcmd subsubcmd" then "subcmd" to find a matching hint.
+	if len(args) >= 3 {
+		if hint, ok := clusterDownHints[args[1]+" "+args[2]]; ok {
+			return fmt.Sprintf("cluster appears to be stopped — run 'obol stack up' before %s", hint)
+		}
+	}
+	if len(args) >= 2 {
+		if hint, ok := clusterDownHints[args[1]]; ok {
+			return fmt.Sprintf("cluster appears to be stopped — run 'obol stack up' before %s", hint)
+		}
+	}
+
+	return ErrClusterDown.Error()
+}
+
 // Paths returns the absolute paths to the kubectl binary and kubeconfig.
 func Paths(cfg *config.Config) (binary, kubeconfig string) {
 	return filepath.Join(cfg.BinDir, "kubectl"),
@@ -48,10 +132,10 @@ func Run(binary, kubeconfig string, args ...string) error {
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
+			return wrapClusterDown(fmt.Errorf("%w: %s", err, errMsg), errMsg)
 		}
 
-		return err
+		return wrapClusterDown(err, "")
 	}
 
 	return nil
@@ -70,10 +154,10 @@ func RunSilent(binary, kubeconfig string, args ...string) error {
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
-			return fmt.Errorf("%w: %s", err, errMsg)
+			return wrapClusterDown(fmt.Errorf("%w: %s", err, errMsg), errMsg)
 		}
 
-		return err
+		return wrapClusterDown(err, "")
 	}
 
 	return nil
@@ -94,10 +178,10 @@ func Output(binary, kubeconfig string, args ...string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
-			return "", fmt.Errorf("%w: %s", err, errMsg)
+			return "", wrapClusterDown(fmt.Errorf("%w: %s", err, errMsg), errMsg)
 		}
 
-		return "", err
+		return "", wrapClusterDown(err, "")
 	}
 
 	return stdout.String(), nil
@@ -123,10 +207,10 @@ func ApplyOutput(binary, kubeconfig string, data []byte) (string, error) {
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
 		if errMsg != "" {
-			return "", fmt.Errorf("kubectl apply: %w: %s", err, errMsg)
+			return "", wrapClusterDown(fmt.Errorf("kubectl apply: %w: %s", err, errMsg), errMsg)
 		}
 
-		return "", fmt.Errorf("kubectl apply: %w", err)
+		return "", wrapClusterDown(fmt.Errorf("kubectl apply: %w", err), "")
 	}
 
 	out := strings.TrimSpace(stdout.String())
@@ -172,10 +256,12 @@ func PipeCommands(binary, kubeconfig string, args1, args2 []string) error {
 	err2 := cmd2.Wait()
 
 	if err1 != nil {
-		return fmt.Errorf("cmd1: %w: %s", err1, strings.TrimSpace(stderr1.String()))
+		s := strings.TrimSpace(stderr1.String())
+		return wrapClusterDown(fmt.Errorf("cmd1: %w: %s", err1, s), s)
 	}
 	if err2 != nil {
-		return fmt.Errorf("cmd2: %w: %s", err2, strings.TrimSpace(stderr2.String()))
+		s := strings.TrimSpace(stderr2.String())
+		return wrapClusterDown(fmt.Errorf("cmd2: %w: %s", err2, s), s)
 	}
 
 	return nil

--- a/internal/kubectl/kubectl_test.go
+++ b/internal/kubectl/kubectl_test.go
@@ -1,8 +1,10 @@
 package kubectl
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
@@ -56,5 +58,78 @@ func TestRunSilent_BinaryNotFound(t *testing.T) {
 	err := RunSilent("/nonexistent/kubectl", "/tmp/kc.yaml", "version")
 	if err == nil {
 		t.Fatal("expected error for missing binary")
+	}
+}
+
+func TestWrapClusterDown(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		stderr  string
+		wrapped bool
+	}{
+		{
+			name:    "connection refused",
+			err:     errors.New("exit status 1"),
+			stderr:  `dial tcp 127.0.0.1:50839: connect: connection refused`,
+			wrapped: true,
+		},
+		{
+			name:    "unable to connect",
+			err:     errors.New("exit status 1"),
+			stderr:  `Unable to connect to the server: dial tcp 127.0.0.1:6443`,
+			wrapped: true,
+		},
+		{
+			name:    "normal error",
+			err:     errors.New("resource not found"),
+			stderr:  "Error from server (NotFound)",
+			wrapped: false,
+		},
+		{
+			name:    "nil error",
+			err:     nil,
+			stderr:  "",
+			wrapped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapClusterDown(tt.err, tt.stderr)
+			if tt.wrapped {
+				if got == nil || !strings.Contains(got.Error(), "cluster appears to be stopped") {
+					t.Errorf("expected cluster-down wrapper, got: %v", got)
+				}
+			} else if tt.err == nil {
+				if got != nil {
+					t.Errorf("expected nil, got: %v", got)
+				}
+			} else {
+				if got == nil || strings.Contains(got.Error(), "cluster appears to be stopped") {
+					t.Errorf("should not wrap normal errors, got: %v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatClusterDownError(t *testing.T) {
+	// Contextual message for a known command.
+	msg := FormatClusterDownError(ErrClusterDown, []string{"obol", "sell", "list"})
+	if !strings.Contains(msg, "before listing services for sale") {
+		t.Errorf("expected contextual hint, got: %s", msg)
+	}
+
+	// Fallback for an unknown subcommand.
+	msg = FormatClusterDownError(ErrClusterDown, []string{"obol", "frobnicate"})
+	if msg != ErrClusterDown.Error() {
+		t.Errorf("expected fallback message, got: %s", msg)
+	}
+
+	// Non-cluster-down error returns empty.
+	msg = FormatClusterDownError(errors.New("something else"), []string{"obol", "sell", "list"})
+	if msg != "" {
+		t.Errorf("expected empty for non-cluster-down error, got: %s", msg)
 	}
 }


### PR DESCRIPTION
## Problem to be solved

I ran commands that didn't work because the cluster was down


## Proposed solution

Better commands when kubectl can't reach the cluster