### PR TITLE
fix(erc8004): align with canonical remote-signer string contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Skills = SKILL.md + optional scripts/references, embedded in `obol` binary (`int
 
 **Monetize skill** (`internal/embed/skills/monetize/`): thin compatibility wrapper around ServiceOffer CRUD, controller waiting, and `/skill.md` publication.
 
-**Remote-signer wallet**: `GenerateWallet()` in `internal/openclaw/wallet.go`. secp256k1 → Web3 V3 keystore, remote-signer REST API at port 9000 in same ns.
+**Remote-signer wallet**: `GenerateWallet()` in `internal/openclaw/wallet.go`. secp256k1 → Web3 V3 keystore, remote-signer REST API at port 9000 in same ns. Canonical EIP-1559 sign-tx contract lives in `ObolNetwork/remote-signer` at `schema/sign-transaction-request.canonical.schema.json`; all stack consumers should match that schema exactly.
 
 ## Buyer Sidecar
 

--- a/internal/embed/skills/ethereum-local-wallet/SKILL.md
+++ b/internal/embed/skills/ethereum-local-wallet/SKILL.md
@@ -103,6 +103,7 @@ Supported networks: `mainnet`, `hoodi`, `sepolia`, `base-sepolia` (depends on eR
 - Values are in **wei** (1 ETH = 1000000000000000000 wei)
 - Use `ethereum-networks` skill (`rpc.sh balance <address>`) to check balances before sending
 - The `send-tx` command will broadcast the transaction immediately after signing
+- Transaction signing requests must follow the canonical remote-signer schema in `ObolNetwork/remote-signer/schema/sign-transaction-request.canonical.schema.json`; all numeric tx fields are decimal strings
 
 ## See Also
 

--- a/internal/embed/skills/ethereum-local-wallet/references/remote-signer-api.md
+++ b/internal/embed/skills/ethereum-local-wallet/references/remote-signer-api.md
@@ -27,20 +27,20 @@ POST /api/v1/sign/0x{ADDRESS}/transaction
 Content-Type: application/json
 
 {
-  "chain_id": 1,
+  "chain_id": "1",
   "to": "0x...",
-  "nonce": 42,
-  "gas_limit": 21000,
-  "max_fee_per_gas": 30000000000,
-  "max_priority_fee_per_gas": 1000000000,
-  "value": "0x0",
+  "nonce": "42",
+  "gas_limit": "21000",
+  "max_fee_per_gas": "30000000000",
+  "max_priority_fee_per_gas": "1000000000",
+  "value": "0",
   "data": "0x"
 }
 
 → 200: {"signed_transaction": "0x02f8..."}
 ```
 
-Gas fields accept JSON numbers or hex strings.
+Canonical transaction requests use decimal strings for all numeric fields. For compatibility, the server also accepts JSON numbers and `0x...` hex strings. The machine-readable contract lives in `ObolNetwork/remote-signer` at `schema/sign-transaction-request.canonical.schema.json`.
 
 ### Sign Message (EIP-191)
 

--- a/internal/embed/skills/ethereum-local-wallet/references/remote-signer-api.md
+++ b/internal/embed/skills/ethereum-local-wallet/references/remote-signer-api.md
@@ -40,7 +40,7 @@ Content-Type: application/json
 → 200: {"signed_transaction": "0x02f8..."}
 ```
 
-Canonical transaction requests use decimal strings for all numeric fields. For compatibility, the server also accepts JSON numbers and `0x...` hex strings. The machine-readable contract lives in `ObolNetwork/remote-signer` at `schema/sign-transaction-request.canonical.schema.json`.
+Canonical transaction requests use decimal strings for all numeric fields. The machine-readable contract lives in `ObolNetwork/remote-signer` at `schema/sign-transaction-request.canonical.schema.json`.
 
 ### Sign Message (EIP-191)
 

--- a/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
+++ b/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
@@ -179,21 +179,23 @@ def cmd_sign_tx(args):
     else:
         gas_limit = int(gas_limit)
 
-    # Format value.
+    # The canonical remote-signer contract uses decimal strings for all numeric
+    # transaction fields, even though the server accepts numbers and hex for
+    # backward compatibility.
     if isinstance(value, str) and value.startswith("0x"):
-        value_hex = value
+        value_wei = str(int(value, 16))
     else:
-        value_hex = hex(int(value))
+        value_wei = str(int(value))
 
     # Build and sign transaction.
     tx_req = {
-        "chain_id": chain_id,
+        "chain_id": str(chain_id),
         "to": to_addr,
-        "nonce": nonce,
-        "gas_limit": gas_limit,
-        "max_fee_per_gas": max_fee,
-        "max_priority_fee_per_gas": max_priority,
-        "value": value_hex,
+        "nonce": str(nonce),
+        "gas_limit": str(gas_limit),
+        "max_fee_per_gas": str(max_fee),
+        "max_priority_fee_per_gas": str(max_priority),
+        "value": value_wei,
         "data": call_data,
     }
 
@@ -203,7 +205,7 @@ def cmd_sign_tx(args):
     print(f"Chain:     {network} (chain_id={chain_id})")
     print(f"From:      {from_addr}")
     print(f"To:        {to_addr}")
-    print(f"Value:     {int(value_hex, 16)} wei")
+    print(f"Value:     {value_wei} wei")
     print(f"Gas:       {gas_limit}")
     print(f"Max fee:   {max_fee} wei")
     print(f"Priority:  {max_priority} wei")

--- a/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
+++ b/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
@@ -179,9 +179,8 @@ def cmd_sign_tx(args):
     else:
         gas_limit = int(gas_limit)
 
-    # The canonical remote-signer contract uses decimal strings for all numeric
-    # transaction fields, even though the server accepts numbers and hex for
-    # backward compatibility.
+    # The remote-signer contract uses canonical decimal strings for all numeric
+    # transaction fields.
     if isinstance(value, str) and value.startswith("0x"):
         value_wei = str(int(value, 16))
     else:

--- a/internal/erc8004/signer.go
+++ b/internal/erc8004/signer.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -67,11 +68,11 @@ func (s *RemoteSigner) GetAddress(ctx context.Context) (common.Address, error) {
 	return common.HexToAddress(kr.Keys[0]), nil
 }
 
-// SignTxRequest contains the fields for signing an EIP-1559 transaction.
-// chain_id is sent as a JSON integer (u64) to match the Rust remote-signer's
-// expected type — sending it as a string causes HTTP 422.
+// SignTxRequest contains the canonical request body for remote-signer EIP-1559
+// transaction signing. The canonical wire contract is published in
+// ObolNetwork/remote-signer at schema/sign-transaction-request.canonical.schema.json.
 type SignTxRequest struct {
-	ChainID              int64  `json:"chain_id"`
+	ChainID              string `json:"chain_id"`
 	To                   string `json:"to"`
 	Nonce                string `json:"nonce"`
 	GasLimit             string `json:"gas_limit"`
@@ -186,26 +187,44 @@ func (s *RemoteSigner) RemoteTransactOpts(ctx context.Context, addr common.Addre
 		From:    addr,
 		Context: ctx,
 		Signer: func(fromAddr common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			chainIDText, err := decimalString("chain_id", chainID)
+			if err != nil {
+				return nil, err
+			}
+			valueText, err := decimalString("value", tx.Value())
+			if err != nil {
+				return nil, err
+			}
+
 			// Convert the unsigned transaction to a SignTxRequest.
 			var toAddr string
 			if tx.To() != nil {
 				toAddr = tx.To().Hex()
 			}
 			req := SignTxRequest{
-				ChainID:              chainID.Int64(),
-				To:                   toAddr,
-				Nonce:                fmt.Sprintf("%d", tx.Nonce()),
-				GasLimit:             fmt.Sprintf("%d", tx.Gas()),
-				Value:                tx.Value().String(),
-				Data:                 "0x" + hex.EncodeToString(tx.Data()),
+				ChainID:  chainIDText,
+				To:       toAddr,
+				Nonce:    strconv.FormatUint(tx.Nonce(), 10),
+				GasLimit: strconv.FormatUint(tx.Gas(), 10),
+				Value:    valueText,
+				Data:     "0x" + hex.EncodeToString(tx.Data()),
 			}
 			// Use EIP-1559 fields if available, otherwise legacy gas price.
 			if tx.GasFeeCap() != nil && tx.GasFeeCap().Sign() > 0 {
-				req.MaxFeePerGas = tx.GasFeeCap().String()
-				req.MaxPriorityFeePerGas = tx.GasTipCap().String()
+				req.MaxFeePerGas, err = decimalString("max_fee_per_gas", tx.GasFeeCap())
+				if err != nil {
+					return nil, err
+				}
+				req.MaxPriorityFeePerGas, err = decimalString("max_priority_fee_per_gas", tx.GasTipCap())
+				if err != nil {
+					return nil, err
+				}
 			} else if tx.GasPrice() != nil {
-				req.MaxFeePerGas = tx.GasPrice().String()
-				req.MaxPriorityFeePerGas = tx.GasPrice().String()
+				req.MaxFeePerGas, err = decimalString("gas_price", tx.GasPrice())
+				if err != nil {
+					return nil, err
+				}
+				req.MaxPriorityFeePerGas = req.MaxFeePerGas
 			}
 
 			signedHex, err := s.SignTransaction(ctx, fromAddr, req)
@@ -229,6 +248,17 @@ func (s *RemoteSigner) RemoteTransactOpts(ctx context.Context, addr common.Addre
 			return &signedTx, nil
 		},
 	}
+}
+
+func decimalString(field string, value *big.Int) (string, error) {
+	if value == nil {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if value.Sign() < 0 {
+		return "", fmt.Errorf("%s must be non-negative", field)
+	}
+
+	return value.String(), nil
 }
 
 // hexToBytes decodes a hex string (with optional 0x prefix) to bytes.

--- a/internal/erc8004/signer_test.go
+++ b/internal/erc8004/signer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestRemoteSigner_GetAddress(t *testing.T) {
@@ -213,16 +214,19 @@ func TestRemoteSigner_GetAddress_HTTPError(t *testing.T) {
 
 func TestRemoteTransactOpts(t *testing.T) {
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	to := common.HexToAddress("0x8004A818BFB912233c491871b3d84c89A494BD9e")
 	chainID := big.NewInt(84532)
+	var body map[string]json.RawMessage
+	var path string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// This verifies the signer receives proper requests.
-		if r.URL.Path == "/api/v1/keys" {
-			json.NewEncoder(w).Encode(keysResponse{Keys: []string{addr.Hex()}})
-			return
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		// For transaction signing, return the error since we can't easily
-		// produce a valid signed tx in a unit test.
+		path = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
 		json.NewEncoder(w).Encode(signResponse{Error: "test: not implemented"})
 	}))
 	defer srv.Close()
@@ -235,6 +239,86 @@ func TestRemoteTransactOpts(t *testing.T) {
 	}
 	if opts.Signer == nil {
 		t.Fatal("Signer should not be nil")
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     7,
+		To:        &to,
+		Gas:       100000,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000),
+		Value:     big.NewInt(12345),
+		Data:      []byte{0xde, 0xad, 0xbe, 0xef},
+	})
+
+	_, err := opts.Signer(addr, tx)
+	if err == nil {
+		t.Fatal("expected signer error")
+	}
+	if !strings.Contains(err.Error(), "test: not implemented") {
+		t.Fatalf("unexpected signer error: %v", err)
+	}
+
+	if path != "/api/v1/sign/"+addr.Hex()+"/transaction" {
+		t.Fatalf("unexpected request path: %s", path)
+	}
+
+	assertJSONInt64(t, body, "chain_id", 84532)
+	assertJSONUint64(t, body, "nonce", 7)
+	assertJSONUint64(t, body, "gas_limit", 100000)
+	assertJSONUint64(t, body, "max_fee_per_gas", 1000000000)
+	assertJSONUint64(t, body, "max_priority_fee_per_gas", 1000000)
+	assertJSONUint64(t, body, "value", 12345)
+	assertJSONString(t, body, "to", to.Hex())
+	assertJSONString(t, body, "data", "0xdeadbeef")
+}
+
+func assertJSONInt64(t *testing.T, body map[string]json.RawMessage, field string, want int64) {
+	t.Helper()
+	raw, ok := body[field]
+	if !ok {
+		t.Fatalf("missing field %q", field)
+	}
+
+	var got int64
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("field %q should be a JSON integer, got %s: %v", field, string(raw), err)
+	}
+	if got != want {
+		t.Fatalf("field %q = %d, want %d", field, got, want)
+	}
+}
+
+func assertJSONUint64(t *testing.T, body map[string]json.RawMessage, field string, want uint64) {
+	t.Helper()
+	raw, ok := body[field]
+	if !ok {
+		t.Fatalf("missing field %q", field)
+	}
+
+	var got uint64
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("field %q should be a JSON integer, got %s: %v", field, string(raw), err)
+	}
+	if got != want {
+		t.Fatalf("field %q = %d, want %d", field, got, want)
+	}
+}
+
+func assertJSONString(t *testing.T, body map[string]json.RawMessage, field, want string) {
+	t.Helper()
+	raw, ok := body[field]
+	if !ok {
+		t.Fatalf("missing field %q", field)
+	}
+
+	var got string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("field %q should be a JSON string, got %s: %v", field, string(raw), err)
+	}
+	if got != want {
+		t.Fatalf("field %q = %q, want %q", field, got, want)
 	}
 }
 

--- a/internal/erc8004/signer_test.go
+++ b/internal/erc8004/signer_test.go
@@ -59,8 +59,8 @@ func TestRemoteSigner_SignTransaction(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&tx); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if tx.ChainID != 84532 {
-			t.Errorf("chain_id = %d, want 84532", tx.ChainID)
+		if tx.ChainID != "84532" {
+			t.Errorf("chain_id = %q, want 84532", tx.ChainID)
 		}
 
 		json.NewEncoder(w).Encode(signResponse{
@@ -72,7 +72,7 @@ func TestRemoteSigner_SignTransaction(t *testing.T) {
 	signer := NewRemoteSigner(srv.URL)
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	signed, err := signer.SignTransaction(context.Background(), addr, SignTxRequest{
-		ChainID:              84532,
+		ChainID:              "84532",
 		To:                   "0x8004A818BFB912233c491871b3d84c89A494BD9e",
 		Nonce:                "0",
 		GasLimit:             "100000",
@@ -135,7 +135,7 @@ func TestRemoteSigner_SignTransaction_Error(t *testing.T) {
 
 	signer := NewRemoteSigner(srv.URL)
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	_, err := signer.SignTransaction(context.Background(), addr, SignTxRequest{ChainID: 1})
+	_, err := signer.SignTransaction(context.Background(), addr, SignTxRequest{ChainID: "1"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -150,7 +150,7 @@ func TestRemoteSigner_SignTransaction_HTTPError(t *testing.T) {
 
 	signer := NewRemoteSigner(srv.URL)
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	_, err := signer.SignTransaction(context.Background(), addr, SignTxRequest{ChainID: 1})
+	_, err := signer.SignTransaction(context.Background(), addr, SignTxRequest{ChainID: "1"})
 	if err == nil {
 		t.Fatal("expected error for HTTP 500")
 	}
@@ -216,6 +216,10 @@ func TestRemoteTransactOpts(t *testing.T) {
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	to := common.HexToAddress("0x8004A818BFB912233c491871b3d84c89A494BD9e")
 	chainID := big.NewInt(84532)
+	maxUint64 := new(big.Int).SetUint64(^uint64(0))
+	feeCap := new(big.Int).Add(new(big.Int).Set(maxUint64), big.NewInt(25))
+	tipCap := new(big.Int).Add(new(big.Int).Set(maxUint64), big.NewInt(7))
+	value := new(big.Int).Add(new(big.Int).Set(maxUint64), big.NewInt(12345))
 	var body map[string]json.RawMessage
 	var path string
 
@@ -246,9 +250,9 @@ func TestRemoteTransactOpts(t *testing.T) {
 		Nonce:     7,
 		To:        &to,
 		Gas:       100000,
-		GasFeeCap: big.NewInt(1000000000),
-		GasTipCap: big.NewInt(1000000),
-		Value:     big.NewInt(12345),
+		GasFeeCap: feeCap,
+		GasTipCap: tipCap,
+		Value:     value,
 		Data:      []byte{0xde, 0xad, 0xbe, 0xef},
 	})
 
@@ -264,46 +268,14 @@ func TestRemoteTransactOpts(t *testing.T) {
 		t.Fatalf("unexpected request path: %s", path)
 	}
 
-	assertJSONInt64(t, body, "chain_id", 84532)
-	assertJSONUint64(t, body, "nonce", 7)
-	assertJSONUint64(t, body, "gas_limit", 100000)
-	assertJSONUint64(t, body, "max_fee_per_gas", 1000000000)
-	assertJSONUint64(t, body, "max_priority_fee_per_gas", 1000000)
-	assertJSONUint64(t, body, "value", 12345)
+	assertJSONString(t, body, "chain_id", "84532")
+	assertJSONString(t, body, "nonce", "7")
+	assertJSONString(t, body, "gas_limit", "100000")
+	assertJSONString(t, body, "max_fee_per_gas", feeCap.String())
+	assertJSONString(t, body, "max_priority_fee_per_gas", tipCap.String())
+	assertJSONString(t, body, "value", value.String())
 	assertJSONString(t, body, "to", to.Hex())
 	assertJSONString(t, body, "data", "0xdeadbeef")
-}
-
-func assertJSONInt64(t *testing.T, body map[string]json.RawMessage, field string, want int64) {
-	t.Helper()
-	raw, ok := body[field]
-	if !ok {
-		t.Fatalf("missing field %q", field)
-	}
-
-	var got int64
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("field %q should be a JSON integer, got %s: %v", field, string(raw), err)
-	}
-	if got != want {
-		t.Fatalf("field %q = %d, want %d", field, got, want)
-	}
-}
-
-func assertJSONUint64(t *testing.T, body map[string]json.RawMessage, field string, want uint64) {
-	t.Helper()
-	raw, ok := body[field]
-	if !ok {
-		t.Fatalf("missing field %q", field)
-	}
-
-	var got uint64
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("field %q should be a JSON integer, got %s: %v", field, string(raw), err)
-	}
-	if got != want {
-		t.Fatalf("field %q = %d, want %d", field, got, want)
-	}
 }
 
 func assertJSONString(t *testing.T, body map[string]json.RawMessage, field, want string) {


### PR DESCRIPTION
## Summary
- keep the Go ERC-8004 signer on the canonical decimal-string request format
- remove uint64 truncation risk by serializing big integer transaction fields losslessly
- update the embedded ethereum-local-wallet helper and local API reference to the same contract
- extend regression coverage to assert the exact remote-signer payload, including values above uint64

## Why
The canonical request contract now lives in the remote-signer repo as the JSON Schema file `schema/sign-transaction-request.canonical.schema.json`. This PR switches obol-stack consumers back to that contract instead of hardcoding a temporary integer-only payload shape.

This depends on ObolNetwork/remote-signer#6 for server-side compatibility with decimal-string transaction numerics.

## Relationship to #357
This is the follow-up to #357. `#357` fixed the immediate production regression against the then-current remote-signer behavior; this PR aligns obol-stack with the now-standardized canonical string contract and removes the temporary integer-only request shape.