### PR TITLE
fix(flows): verify Bob funding confirms + eRPC reflects it before buy

### DIFF
--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -449,18 +449,43 @@ except: pass
 " 2>&1)
 if [ -n "$BOB_SIGNER_ADDR" ]; then
     echo "  Remote-signer wallet: $BOB_SIGNER_ADDR"
-    # Send USDC (0.05 USDC = 50000 micro-units) from .env key
-    env -u CHAIN cast send --private-key "$SIGNER_KEY" \
+    # Send USDC (0.05 USDC = 50000 micro-units) from .env key.
+    # `cast send` (no --async) waits for inclusion; capture the receipt so we
+    # can verify status=1 instead of relying on grep||true to mask failures.
+    send_out=$(env -u CHAIN cast send --private-key "$SIGNER_KEY" \
         0x036CbD53842c5426634e7929541eC2318f3dCF7e \
         "transfer(address,uint256)" "$BOB_SIGNER_ADDR" 50000 \
-        --rpc-url https://sepolia.base.org 2>&1 | grep -E "status" || true
+        --rpc-url https://sepolia.base.org 2>&1 || true)
+    if ! echo "$send_out" | grep -qE "^status\s+1 \(success\)"; then
+        fail "Funding tx did not confirm status=1 — ${send_out:0:300}"
+        emit_metrics; exit 1
+    fi
+    # Poll the direct Base Sepolia RPC until the balance reflects the transfer.
+    # This avoids a race where step 32's agent sees 0 USDC because eRPC's
+    # eth_call cache (10s TTL) still holds the pre-funding result.
+    POST_FUND_BOB_SIGNER_USDC=0
+    for _ in $(seq 1 12); do
+        POST_FUND_BOB_SIGNER_USDC=$(env -u CHAIN cast call 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+            "balanceOf(address)(uint256)" "$BOB_SIGNER_ADDR" --rpc-url https://sepolia.base.org 2>/dev/null | grep -oE '^[0-9]+' | head -1)
+        [ -n "$POST_FUND_BOB_SIGNER_USDC" ] && [ "$POST_FUND_BOB_SIGNER_USDC" -ge 50000 ] 2>/dev/null && break
+        sleep 2
+    done
+    if [ -z "$POST_FUND_BOB_SIGNER_USDC" ] || [ "$POST_FUND_BOB_SIGNER_USDC" -lt 50000 ]; then
+        fail "Bob's on-chain USDC did not reach 50000 — got ${POST_FUND_BOB_SIGNER_USDC:-0}"
+        emit_metrics; exit 1
+    fi
     POST_FUND_ALICE_USDC=$(env -u CHAIN cast call 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
         "balanceOf(address)(uint256)" "$ALICE_WALLET" --rpc-url https://sepolia.base.org 2>/dev/null | grep -oE '^[0-9]+' | head -1)
-    POST_FUND_BOB_SIGNER_USDC=$(env -u CHAIN cast call 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
-        "balanceOf(address)(uint256)" "$BOB_SIGNER_ADDR" --rpc-url https://sepolia.base.org 2>/dev/null | grep -oE '^[0-9]+' | head -1)
-    pass "Funded $BOB_SIGNER_ADDR with 0.05 USDC"
+    pass "Funded $BOB_SIGNER_ADDR with 0.05 USDC (on-chain: $POST_FUND_BOB_SIGNER_USDC)"
+
+    # Wait for Bob's in-pod buy.py (via eRPC with 10s cache) to catch up so
+    # the AI agent in step 32 sees the funded balance, not a stale zero.
+    poll_step_grep "Bob: eRPC reflects funding" "0.05" 18 5 bob kubectl exec \
+        -n openclaw-obol-agent deploy/openclaw -c openclaw -- \
+        python3 /data/.openclaw/skills/buy-inference/scripts/buy.py balance
 else
     fail "Could not determine Bob's remote-signer address"
+    emit_metrics; exit 1
 fi
 
 # ═════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Flow-11 step 28 (fund Bob's remote-signer with 0.05 USDC) had two bugs that caused a `32/33` false-green ~50% of the time:

1. **Unconditional PASS** — the `cast send ... | grep status || true` pipe masked silently-dropped funding txs. The `pass` line ran regardless.
2. **eRPC cache race** — even when the tx confirmed, the AI agent's `buy.py` in step 32 queries balance through eRPC, which has a 10s `eth_call` cache TTL. If the agent polled during the cache window it saw `0 USDC`, declined the buy verbosely, and step 32's `>100 chars` heuristic mistook the refusal for success. Step 33 then failed: `PurchaseRequest CR not ready: No resources found`.

## Fix

- Capture `cast send` output; require `status   1 (success)` in the receipt, fail-fast otherwise.
- Poll direct Base Sepolia RPC until Bob's on-chain USDC ≥ 50000 (bypasses eRPC — confirms the tx is actually mined).
- New step: poll Bob's in-pod `buy.py balance` via eRPC until it reports `0.05`. This is the exact path the AI agent will take in step 32, so passing here guarantees no zero-balance race.

## Verification

- Before the patch: rounds 1 and 2 both hit `FAIL: [33]` with the `Balance: 0 USDC` refusal in the agent response.
- After the patch: round 3 → **42/42** green (tally grew by 1 because of the new explicit "eRPC reflects funding" step).

## Test plan

- [x] Run `./flows/flow-11-dual-stack.sh` with a fresh `.env` key — 42/42.
- [ ] Run two more times against varying Base Sepolia congestion to confirm the poll budget (36s direct + 90s eRPC) is tight enough to catch real drops without false-failing slow mempools.