### PR TITLE
chore(openclaw): bump to v2026.4.21 + chart 0.4.0

### DIFF
--- a/internal/openclaw/OPENCLAW_VERSION
+++ b/internal/openclaw/OPENCLAW_VERSION
@@ -1,3 +1,3 @@
 # renovate: datasource=github-releases depName=openclaw/openclaw
 # Pins the upstream OpenClaw version to build and publish.
-v2026.4.15
+v2026.4.21

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -46,7 +46,7 @@ const (
 	userSecretsK8sSecretRef = "openclaw-user-secrets"
 	// chartVersion pins the openclaw Helm chart version from the obol repo.
 	// renovate: datasource=helm depName=openclaw registryUrl=https://obolnetwork.github.io/helm-charts/
-	chartVersion = "0.1.7"
+	chartVersion = "0.4.0"
 
 	// remoteSignerChartVersion pins the remote-signer Helm chart version.
 	// renovate: datasource=helm depName=remote-signer registryUrl=https://obolnetwork.github.io/helm-charts/

--- a/obolup.sh
+++ b/obolup.sh
@@ -70,7 +70,7 @@ readonly HELM_DIFF_VERSION="3.15.4"
 readonly OLLAMA_VERSION="0.20.2"
 # Must match internal/openclaw/OPENCLAW_VERSION (without "v" prefix).
 # Tested by TestOpenClawVersionConsistency.
-readonly OPENCLAW_VERSION="2026.4.15"
+readonly OPENCLAW_VERSION="2026.4.21"
 
 # Repository URL for building from source
 readonly OBOL_REPO_URL="git@github.com:ObolNetwork/obol-stack.git"


### PR DESCRIPTION
## Summary

Bumps the OpenClaw pins to their current latest:

| Pin | Before | After |
|---|---|---|
| OpenClaw binary (pod image) | `v2026.4.15` | `v2026.4.21` |
| `openclaw` Helm chart | `0.1.7` | `0.4.0` |

All three pin sites (`internal/openclaw/OPENCLAW_VERSION`, the embedded `openclawImageTag()`, and `obolup.sh`) move together — `TestOpenClawVersionConsistency` keeps them in sync.

## Why chart `0.4.0`

`0.4.0` is the latest published at `https://obolnetwork.github.io/helm-charts/`. The maintainer's bump policy is minor-tick per release (`0.1.7 → 0.2.0 → 0.3.0 → 0.4.0`); `0.1.8` was never cut.

Diff `0.1.7 → 0.4.0` is 4 files / ~18 lines:
- `version` bump
- default `image.tag` in `values.yaml` (irrelevant — our overlay writes `image.tag` explicitly)
- `values.schema.json` description text + a **relaxation** on `models.openai.models` (object-array → any-array)
- no value keys our overlay writes were renamed or removed

## Validation

### Static / unit

- `TestOpenClawVersionConsistency` passes (all three pins agree on `2026.4.21`)
- `go build ./...` clean
- `go test -race -count=1 -timeout 10m ./...` — all 20 packages pass
- `helm template` dry-run of chart `0.4.0` against an overlay shaped like `buildLiteLLMRoutedOverlay` renders cleanly (no schema errors, produces expected Deployment/Service/Role/etc., pod image = `openclaw:2026.4.21`)

### Single-stack live smoke

On an isolated k3d cluster with `OBOL_DEVELOPMENT=true`:

- `helm list -A` — `openclaw-0.4.0` (app `2026.3.2`) + `remote-signer-0.3.0` both deployed
- All expected chart resources rendered: Deployment, Service, HTTPRoute:18789, 2x Role/Binding, PVC, ConfigMaps, Secrets, ServiceAccounts
- Pod spec references the bumped `ghcr.io/obolnetwork/openclaw:2026.4.21`
- Openclaw pod 1/1 Ready; gateway binds `:18789`, 5 plugins, agent model resolves through LiteLLM (`openai/claude-sonnet-4-6`)
- `GET /` returns 200, `/__openclaw__/canvas/` returns 401 (auth enforced); `obol openclaw token obol-agent` returns a valid token
- Remote-signer (chart 0.3.0) 1/1 Ready; `/healthz` = `{"status":"ok"}`, keystore loaded on :9000
- All 20 skills visible in `/data/.openclaw/skills/` inside the pod; `buy.py` + `monetize.py` executable
- `obol sell http smoke-test` reconciled to 4/5 conditions; unpaid `POST /services/smoke-test/...` returns 402 with a well-formed x402 v2 body; delete cleaned up HTTPRoute + Middleware

### Dual-stack end-to-end (flow-11) — 42/42 steps passed

Full canonical seller/buyer-through-OpenClaw loop via `flows/flow-11-dual-stack.sh`, running alongside the single-stack smoke cluster on auto-picked ports (Alice `60718-60721`, Bob `60722-60725`). Alice sells, Bob's OpenClaw agent discovers Alice on-chain via ERC-8004 and buys inference through natural-language prompts, paid inference settles.

**Real on-chain receipts (Base Sepolia, chain id 84532):**

| Event | Hash |
|---|---|
| ERC-8004 registration, Agent ID **5127**, registry `0x8004A818BFB912233c491871b3d84c89A494BD9e` | [`0xef6cae9b39e664fea0c2abc2bc3cf2ed473c091a7f20b551711678f45d22b739`](https://sepolia.basescan.org/tx/0xef6cae9b39e664fea0c2abc2bc3cf2ed473c091a7f20b551711678f45d22b739) |
| USDC funding Alice to Bob-signer `0x3498Ed148AE998a13033483e09F2139DeC71028e`, 50 000 micro-USDC | [`0xed27c358b77ed313a0e52340df4b2b93ce48800c2cc275f655627efa60e7f7a7`](https://sepolia.basescan.org/tx/0xed27c358b77ed313a0e52340df4b2b93ce48800c2cc275f655627efa60e7f7a7) |
| x402 settlement Bob-signer to Alice, 1 000 micro-USDC (one paid inference call) | [`0xdc017e02a947d0692c843421e356c48ddd77945491c9450f9f83dd8472b08675`](https://sepolia.basescan.org/tx/0xdc017e02a947d0692c843421e356c48ddd77945491c9450f9f83dd8472b08675) |

Alice wallet `0xC0De030F6C37f490594F93fB99e2756703c4297E`, Bob's remote-signer `0x3498Ed148AE998a13033483e09F2139DeC71028e`, USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`.

**USDC balance reconciliation (micro-USDC):**

| Wallet | Pre-run | After funding only | Final | Delta |
|---|---:|---:|---:|---:|
| Alice | 9 660 000 | 9 610 000 | 9 611 000 | **+1 000** (settlement) |
| Bob signer | 0 | 50 000 | 49 000 | **-1 000** (spent) |

Reconciles exactly: 1 paid inference × 1 000 micro-USDC = $0.001 USDC.

**Flow milestones (OpenClaw-driven):**

- Alice registered on ERC-8004: **Agent ID 5127**, CAIP-10 `eip155:84532:0x8004A818BFB912233c491871b3d84c89A494BD9e`
- Tunnel: `https://elvis-psychological-amenities-keep.trycloudflare.com`
- 402 gate returns a well-formed x402 v2 body on unpaid requests
- Bob's OpenClaw agent, via a natural-language prompt to `/v1/chat/completions`, performs ERC-8004 registry discovery and finds Alice
- Second natural-language prompt drives `buy.py buy` inside the agent pod, signs 5 ERC-3009 auths, PurchaseRequest `Ready` on first reconcile attempt
- x402-buyer sidecar `/status` reports `alice-inference: remaining=5 spent=0 model=paid/qwen3.5:9b`
- Paid inference request through LiteLLM to buyer sidecar to Alice's tunnel to upstream Ollama, response with 200
- Cleanup: SO delete finalizer tears down HTTPRoutes + Middleware; both k3d clusters shut down; no stale state

### Known follow-ups (tracked separately, not blockers for this bump)

- **PR #369** - Renovate auto-PRs for both helm pins. The custom regex manager picks up the `// renovate:` hint comments this PR leaves in place.
- **PR #371** - `flow-11` auto-picks free ingress ports + `lib.sh` auto-loads `.env`. Made the dual-stack run above possible without guessing port numbers.
- **Issue #372** - `obol sell http` silently skips ERC-8004 registration when the 30 s cloudflared rollout timeout fires on a cold image pull. Root-cause + layered fix proposal filed. We hit this once on the first flow-11 run; the second run (once `cloudflare/cloudflared` was cached in the k3d docker-io registry mirror) passed cleanly, which is what the receipts above are from.