### PR TITLE
test(x402-buyer): make ConfirmSpendFailure test work under uid 0

### DIFF
--- a/internal/x402/buyer/proxy_test.go
+++ b/internal/x402/buyer/proxy_test.go
@@ -1831,15 +1831,19 @@ func TestProxy_UpstreamSuccessWithSettlementHeader_DoesNotIncrementUnsettledMetr
 
 func TestProxy_ConfirmSpendFailure_IncrementsMetric(t *testing.T) {
 	dir := t.TempDir()
-	stateDir := filepath.Join(dir, "state")
-	if err := os.MkdirAll(stateDir, 0o500); err != nil {
-		t.Fatalf("mkdir state dir: %v", err)
-	}
-	statePath := filepath.Join(stateDir, "consumed.json")
+	statePath := filepath.Join(dir, "consumed.json")
 
 	st, err := LoadStateStore(statePath)
 	if err != nil {
 		t.Fatalf("LoadStateStore: %v", err)
+	}
+
+	// Force StateStore.writeLocked to fail deterministically by pre-creating
+	// the target state path as a directory: os.Rename(tmpfile, dir) returns
+	// EISDIR, which root cannot bypass. The previous 0o500-dir approach was
+	// silently skipped under CAP_DAC_OVERRIDE when tests run as uid 0.
+	if err := os.Mkdir(statePath, 0o755); err != nil {
+		t.Fatalf("block state path: %v", err)
 	}
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fix `TestProxy_ConfirmSpendFailure_IncrementsMetric` so it actually exercises the confirm-spend failure path when tests run as `uid 0` (CI containers, dev sandboxes).

## Root cause

The test forced `StateStore.writeLocked` to fail by creating its state directory with mode `0o500`. That works for non-root uids but is silently bypassed under `CAP_DAC_OVERRIDE` when tests run as root — the write goes through, `ConfirmSpend` returns nil, the `OnConfirmSpendFailure` callback never fires, the metric family is never registered, and the test fails with `missing metric family` at `proxy_test.go:1897`.

Reproducible on every commit on `main` in a root-uid container, e.g.:

```
--- FAIL: TestProxy_ConfirmSpendFailure_IncrementsMetric (0.00s)
    proxy_test.go:1897: missing metric family
FAIL    github.com/ObolNetwork/obol-stack/internal/x402/buyer
```

## Fix

After `LoadStateStore` succeeds, pre-create the target state path as a **directory**. The final `os.Rename(tmpfile, statePath)` in `writeLocked` then returns `EEXIST`/`EISDIR`, which root cannot bypass — it's a filesystem semantic, not a DAC check. Permission-independent failure injection without touching production code.

## Test plan

- [x] `go test -run TestProxy_ConfirmSpendFailure_IncrementsMetric -v ./internal/x402/buyer/` — PASS (log shows `confirm spend: rename state: … file exists`, confirming the intended path fires)
- [x] `go test ./internal/x402/buyer/` — PASS (full package)
- [x] `go vet ./internal/x402/buyer/` — clean
- [x] `go build ./...` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvwxj189zRhabAA8YJT2kY)_