### PR TITLE
chore(openclaw): bump remote-signer chart to 0.3.1

### DIFF
--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -50,7 +50,7 @@ const (
 
 	// remoteSignerChartVersion pins the remote-signer Helm chart version.
 	// renovate: datasource=helm depName=remote-signer registryUrl=https://obolnetwork.github.io/helm-charts/
-	remoteSignerChartVersion = "0.3.0"
+	remoteSignerChartVersion = "0.3.1"
 )
 
 // openclawVersionRaw is the single source of truth for the upstream OpenClaw


### PR DESCRIPTION
## Summary
- Bumps `remoteSignerChartVersion` from `0.3.0` → `0.3.1` in `internal/openclaw/openclaw.go`
- Depends on helm-charts PR: https://github.com/ObolNetwork/helm-charts/pull/276 (chart `0.3.1`, `appVersion: v0.2.0`)
- Rolls openclaw deployments onto the new remote-signer `v0.2.0` image (canonical string transaction schema + supply-chain hardening)

## Test plan
- [ ] Merge only after helm-charts#276 is merged and `remote-signer-0.3.1` is published at https://obolnetwork.github.io/helm-charts/
- [ ] `go build ./...` (verified locally)
- [ ] `helm repo update && helm show chart obol/remote-signer --version 0.3.1` resolves
- [ ] `openclaw` end-to-end deploy brings up `remote-signer` with `ghcr.io/obolnetwork/remote-signer:v0.2.0`