### PR TITLE
Add provider smokes and model preference

### DIFF
--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -27,6 +27,7 @@ func modelCommand(cfg *config.Config) *cli.Command {
 			modelSyncCommand(cfg),
 			modelPullCommand(),
 			modelListCommand(cfg),
+			modelPreferCommand(cfg),
 			modelRemoveCommand(cfg),
 		},
 	}
@@ -213,6 +214,12 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 	u.Print("")
 	u.Successf("Model configured. To change later, run: obol model setup (or obol model remove <name>)")
 
+	if len(models) > 0 {
+		if err := model.PreferModel(cfg, u, models[0]); err != nil {
+			u.Warnf("Could not prefer configured model %q: %v", models[0], err)
+		}
+	}
+
 	return syncAgentModels(cfg, u)
 }
 
@@ -229,6 +236,28 @@ func modelSyncCommand(cfg *config.Config) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
 			u.Info("Reading model list from LiteLLM...")
+
+			return syncAgentModels(cfg, u)
+		},
+	}
+}
+
+func modelPreferCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:      "prefer",
+		Usage:     "Move a configured model to the front of the LiteLLM preference order",
+		ArgsUsage: "<model-name>",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u := getUI(cmd)
+
+			modelName := cmd.Args().First()
+			if modelName == "" {
+				return errors.New("model name is required\n\nUsage: obol model prefer <model-name>\n\nList configured models with: obol model list")
+			}
+
+			if err := model.PreferModel(cfg, u, modelName); err != nil {
+				return err
+			}
 
 			return syncAgentModels(cfg, u)
 		},

--- a/cmd/obol/model_test.go
+++ b/cmd/obol/model_test.go
@@ -21,6 +21,7 @@ func TestModelCommand_Structure(t *testing.T) {
 		"sync":   false,
 		"pull":   false,
 		"list":   false,
+		"prefer": false,
 		"remove": false,
 	}
 

--- a/flows/flow-12-agent-provider-smokes.sh
+++ b/flows/flow-12-agent-provider-smokes.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Flow 12: obol-agent provider inference smokes.
+# Tests local Ollama, optional Anthropic/OpenAI provider setup, `obol model prefer`,
+# and stack-managed obol-agent inference after each preference change.
+source "$(dirname "$0")/lib.sh"
+
+provider_models() {
+    local provider="$1"
+    local status_json
+    status_json=$("$OBOL" -o json model status 2>/dev/null || true)
+    python3 -c '
+import json
+import sys
+
+provider = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+for item in data.get("providers", []):
+    if item.get("name") == provider:
+        for model in item.get("models", []):
+            if "*" not in model:
+                print(model)
+        break
+' "$provider" <<< "$status_json"
+}
+
+agent_namespace() {
+    local ns
+    ns=$("$OBOL" openclaw list 2>/dev/null | grep -oE 'openclaw-[a-z0-9-]+' | head -1 || true)
+    if [ -n "$ns" ]; then
+        echo "$ns"
+    else
+        echo "openclaw-obol-agent"
+    fi
+}
+
+agent_token() {
+    "$OBOL" openclaw token obol-agent 2>/dev/null || "$OBOL" openclaw token default 2>/dev/null || true
+}
+
+agent_primary_model() {
+    local config_json
+    config_json=$("$OBOL" kubectl get cm openclaw-config -n openclaw-obol-agent \
+        -o jsonpath='{.data.openclaw\.json}' 2>/dev/null || true)
+    python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+    print(data.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", ""))
+except Exception:
+    pass
+' <<< "$config_json"
+}
+
+verify_agent_primary() {
+    local model_name="$1"
+    local primary
+    step "obol-agent primary model is $model_name"
+    primary=$(agent_primary_model)
+    if [ "$primary" = "openai/$model_name" ]; then
+        pass "obol-agent primary model: $primary"
+    else
+        fail "obol-agent primary model mismatch: ${primary:-empty} (expected openai/$model_name)"
+    fi
+}
+
+smoke_agent_inference() {
+    local label="$1"
+    local model_name="$2"
+    local ns token port pf_pid out
+
+    verify_agent_primary "$model_name"
+
+    step "$label obol-agent chat completions"
+    ns=$(agent_namespace)
+    token=$(agent_token)
+    if [ -z "$token" ]; then
+        fail "$label missing obol-agent token"
+        return 0
+    fi
+
+    port=$(pick_free_port)
+    "$OBOL" kubectl port-forward -n "$ns" svc/openclaw "$port:18789" >/dev/null 2>&1 &
+    pf_pid=$!
+
+    for _ in $(seq 1 20); do
+        if curl -sf --max-time 2 "http://localhost:$port/health" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+
+    out=$(curl -sf --max-time 180 -X POST "http://localhost:$port/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $token" \
+        -d '{"model":"openclaw","messages":[{"role":"user","content":"What is 2+2? Reply with the number only."}],"max_tokens":20,"stream":false}' 2>&1) || true
+
+    cleanup_pid "$pf_pid"
+
+    if echo "$out" | grep -q "choices"; then
+        pass "$label obol-agent inference returned choices"
+    else
+        fail "$label obol-agent inference failed — ${out:0:300}"
+    fi
+}
+
+prefer_and_smoke() {
+    local label="$1"
+    local model_name="$2"
+    run_step "$label prefer $model_name" "$OBOL" model prefer "$model_name"
+    smoke_agent_inference "$label" "$model_name"
+}
+
+skip_or_fail_cloud() {
+    local provider="$1"
+    local env_var="$2"
+    if [ "${FLOW_REQUIRE_CLOUD_PROVIDERS:-false}" = "true" ]; then
+        fail "$provider smoke requires $env_var"
+    else
+        pass "$provider smoke skipped; set $env_var to enable"
+    fi
+}
+
+run_step "obol agent init" "$OBOL" agent init
+
+step "Local Ollama model configured in LiteLLM"
+local_models=$(provider_models ollama)
+local_model=$(printf '%s\n' "$local_models" | sed '/^$/d' | sed -n '2p')
+if [ -z "$local_model" ]; then
+    local_model=$(printf '%s\n' "$local_models" | sed '/^$/d' | sed -n '1p')
+fi
+
+if [ -n "$local_model" ]; then
+    pass "Local model selected for preference smoke: $local_model"
+    prefer_and_smoke "local" "$local_model"
+else
+    fail "No local Ollama model configured in LiteLLM"
+fi
+
+step "Anthropic provider smoke availability"
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    anthropic_model="${FLOW_ANTHROPIC_MODEL:-claude-sonnet-4-6}"
+    pass "ANTHROPIC_API_KEY present; testing $anthropic_model"
+    run_step "Configure Anthropic model" "$OBOL" model setup --provider anthropic --api-key "$ANTHROPIC_API_KEY" --model "$anthropic_model"
+    prefer_and_smoke "anthropic" "$anthropic_model"
+else
+    skip_or_fail_cloud "Anthropic" "ANTHROPIC_API_KEY"
+fi
+
+step "OpenAI provider smoke availability"
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+    openai_model="${FLOW_OPENAI_MODEL:-gpt-4.1}"
+    pass "OPENAI_API_KEY present; testing $openai_model"
+    run_step "Configure OpenAI model" "$OBOL" model setup --provider openai --api-key "$OPENAI_API_KEY" --model "$openai_model"
+    prefer_and_smoke "openai" "$openai_model"
+else
+    skip_or_fail_cloud "OpenAI" "OPENAI_API_KEY"
+fi
+
+emit_metrics

--- a/flows/release-smoke.sh
+++ b/flows/release-smoke.sh
@@ -58,6 +58,7 @@ append_report_footer() {
 
 - The runner uses the real \`obol\` CLI and the flow scripts as black-box release checks.
 - Any \`FAIL:\` line is release-gating, even when a child script exits zero.
+- \`flow-12-agent-provider-smokes.sh\` always checks local obol-agent inference and only runs Anthropic/OpenAI smokes when their API key env vars are present.
 - \`flow-11-dual-stack.sh\` writes on-chain receipt artifacts under \`$ARTIFACT_DIR/flow-11-receipts\`.
 - Set \`RELEASE_SMOKE_INCLUDE_OBOL=true\` to run \`flow-12-obol-payment.sh\`, which requires a current x402-rs facilitator binary.
 EOF
@@ -142,6 +143,7 @@ main() {
         "$SCRIPT_DIR/flow-10-anvil-facilitator.sh"
         "$SCRIPT_DIR/flow-08-buy.sh"
         "$SCRIPT_DIR/flow-09-lifecycle.sh"
+        "$SCRIPT_DIR/flow-12-agent-provider-smokes.sh"
     )
 
     for flow in "${flows[@]}"; do

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -997,7 +997,7 @@ func syncObolSkills(cfg *config.Config, id string) error {
 func configuredModels(cfg *config.Config, u *ui.UI) ([]string, string, error) {
 	models, err := model.GetConfiguredModels(cfg)
 	if err == nil && len(models) > 0 {
-		primary, _ := rankModels(models)
+		primary, _ := rankModels(cfg, models)
 		return models, primary, nil
 	}
 
@@ -1030,7 +1030,7 @@ func configuredModels(cfg *config.Config, u *ui.UI) ([]string, string, error) {
 		}
 	}
 
-	primary, _ := rankModels(names)
+	primary, _ := rankModels(cfg, names)
 	return names, primary, nil
 }
 
@@ -1190,17 +1190,18 @@ func litellmMasterKey(cfg *config.Config) string {
 	return "sk-obol-" + strings.TrimSpace(string(data))
 }
 
-// rankModels delegates to model.Rank, which knows how to prefer larger local
-// models and frontier cloud models. Kept as a thin wrapper so call sites
-// don't need to import internal/model directly.
+// rankModels delegates to model.RankWithPreference, which honors any
+// explicit `obol model prefer` choice and otherwise falls through to
+// capability-aware ranking. Kept as a thin wrapper so call sites don't
+// need to import internal/model directly.
 //
 // IMPORTANT: do NOT pre-strip provider prefixes here. model.Rank strips
 // internally for ranking heuristics but returns the ORIGINAL strings so the
 // agent can round-trip them back to LiteLLM. Stripping at this layer would
 // break that round-trip — that's exactly the double-strip bug that
 // ca820c9 worked around for custom endpoints.
-func rankModels(models []string) (primary string, fallbacks []string) {
-	return model.Rank(models)
+func rankModels(cfg *config.Config, models []string) (primary string, fallbacks []string) {
+	return model.RankWithPreference(models, model.ReadPreference(cfg))
 }
 
 func k3dNodeExec(cfg *config.Config, hostPath, shellCmd string) error {

--- a/internal/hermes/rankmodels_test.go
+++ b/internal/hermes/rankmodels_test.go
@@ -13,7 +13,7 @@ import "testing"
 // be able to round-trip the returned primary back to LiteLLM without
 // modification.
 func TestRankModels_HermesWrapper_PrefersLargerLocalModel(t *testing.T) {
-	primary, fallbacks := rankModels([]string{
+	primary, fallbacks := rankModels(nil, []string{
 		"llama3.2:1b",
 		"qwen3.5:9b",
 		"llama3.2:3b",
@@ -31,7 +31,7 @@ func TestRankModels_HermesWrapper_PrefersLargerLocalModel(t *testing.T) {
 // `claude-opus-4-7`, not `anthropic/claude-opus-4-7`), and the wrapper must
 // preserve that.
 func TestRankModels_HermesWrapper_PrefersClaudeOverLocal(t *testing.T) {
-	primary, _ := rankModels([]string{
+	primary, _ := rankModels(nil, []string{
 		"qwen3.5:9b",
 		"claude-opus-4-7",
 		"llama3.2:1b",
@@ -49,7 +49,7 @@ func TestRankModels_HermesWrapper_PrefersClaudeOverLocal(t *testing.T) {
 // was the double-strip bug fixed in ca820c9 — this test guards against
 // reintroducing it.
 func TestRankModels_HermesWrapper_PreservesProviderPrefixIfPresent(t *testing.T) {
-	primary, _ := rankModels([]string{
+	primary, _ := rankModels(nil, []string{
 		"anthropic/claude-opus-4-7",
 		"openai/gpt-4o",
 		"qwen3.5:9b",
@@ -65,7 +65,7 @@ func TestRankModels_HermesWrapper_PreservesProviderPrefixIfPresent(t *testing.T)
 // LiteLLM with a key that no longer matched the registered route.
 func TestRankModels_HermesWrapper_CustomNamespacedEntryRoundTrips(t *testing.T) {
 	in := []string{"custom/spark1-vllm/qwen36-fast"}
-	primary, _ := rankModels(in)
+	primary, _ := rankModels(nil, in)
 	if primary != in[0] {
 		t.Fatalf("primary: got %q, want %q (must round-trip unchanged)", primary, in[0])
 	}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -628,6 +628,121 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 	return nil
 }
 
+// PreferModel moves a configured model to the front of the LiteLLM model_list.
+// Downstream runtimes use this order to choose their primary model.
+func PreferModel(cfg *config.Config, u *ui.UI, modelName string) error {
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return errors.New("cluster not running. Run 'obol stack up' first")
+	}
+
+	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
+		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.config\\.yaml}")
+	if err != nil {
+		return fmt.Errorf("failed to read LiteLLM config: %w", err)
+	}
+
+	updated, changed, err := preferModelInConfig([]byte(raw), modelName)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
+		u.Successf("Model %q is already preferred", modelName)
+		return nil
+	}
+
+	escapedYAML, err := json.Marshal(string(updated))
+	if err != nil {
+		return fmt.Errorf("failed to escape YAML: %w", err)
+	}
+
+	patchJSON := fmt.Sprintf(`{"data":{"config.yaml":%s}}`, escapedYAML)
+
+	u.Infof("Setting preferred model to %q", modelName)
+
+	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
+		"patch", "configmap", configMapName, "-n", namespace,
+		"-p", patchJSON, "--type=merge"); err != nil {
+		return fmt.Errorf("failed to patch ConfigMap: %w", err)
+	}
+
+	u.Successf("Model %q is now preferred", modelName)
+
+	return nil
+}
+
+func preferModelInConfig(configYAML []byte, modelName string) ([]byte, bool, error) {
+	var litellmConfig LiteLLMConfig
+	if err := yaml.Unmarshal(configYAML, &litellmConfig); err != nil {
+		return nil, false, fmt.Errorf("failed to parse config.yaml: %w", err)
+	}
+
+	idx := -1
+
+	for i, entry := range litellmConfig.ModelList {
+		if modelEntryMatchesPreference(entry, modelName) {
+			idx = i
+			break
+		}
+	}
+
+	if idx < 0 {
+		return nil, false, fmt.Errorf("model %q not found in LiteLLM config", modelName)
+	}
+
+	if idx == 0 {
+		return configYAML, false, nil
+	}
+
+	preferred := litellmConfig.ModelList[idx]
+	reordered := make([]ModelEntry, 0, len(litellmConfig.ModelList))
+	reordered = append(reordered, preferred)
+	reordered = append(reordered, litellmConfig.ModelList[:idx]...)
+	reordered = append(reordered, litellmConfig.ModelList[idx+1:]...)
+	litellmConfig.ModelList = reordered
+
+	updated, err := yaml.Marshal(&litellmConfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	return updated, true, nil
+}
+
+func modelEntryMatchesPreference(entry ModelEntry, preference string) bool {
+	rawPreference := strings.TrimSpace(preference)
+	normalizedPreference := normalizeModelPreference(preference)
+
+	candidates := []string{
+		entry.ModelName,
+		entry.LiteLLMParams.Model,
+		normalizeModelPreference(entry.ModelName),
+		normalizeModelPreference(entry.LiteLLMParams.Model),
+	}
+
+	for _, candidate := range candidates {
+		if candidate == rawPreference || candidate == normalizedPreference {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeModelPreference(name string) string {
+	name = strings.TrimSpace(name)
+	for _, prefix := range []string{"openai/", "anthropic/", "ollama/", "ollama_chat/"} {
+		if strings.HasPrefix(name, prefix) {
+			return strings.TrimPrefix(name, prefix)
+		}
+	}
+
+	return name
+}
+
 // AddCustomEndpoint adds a custom OpenAI-compatible endpoint to LiteLLM
 // after validating it works.
 //

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -628,14 +628,36 @@ func RemoveModel(cfg *config.Config, u *ui.UI, modelName string) error {
 	return nil
 }
 
-// PreferModel moves a configured model to the front of the LiteLLM model_list.
-// Downstream runtimes use this order to choose their primary model.
+// PreferModel records an explicit user preference for the given model and
+// reorders the LiteLLM model_list so the preferred entry sits first.
+//
+// Two artifacts are written, deliberately:
+//
+//  1. The persistent preference file at $OBOL_CONFIG_DIR/preferred-model.
+//     This is the load-bearing signal — RankWithPreference reads it on every
+//     resolution so the user's pick survives stack restarts, defaults
+//     refreshes, and any code path that rewrites the LiteLLM ConfigMap.
+//  2. The LiteLLM ConfigMap order. This is purely cosmetic now (UX hint:
+//     `obol model list` shows the preferred entry on top), but it keeps the
+//     ConfigMap and the preference file in agreement.
+//
+// If the file write succeeds but the ConfigMap patch fails, the preference
+// is still recorded — the next resolution will honor it. Returning the patch
+// error after persisting is intentional so the user sees the failure mode
+// without losing the preference itself.
 func PreferModel(cfg *config.Config, u *ui.UI, modelName string) error {
+	if err := WritePreference(cfg, modelName); err != nil {
+		return fmt.Errorf("failed to persist preference: %w", err)
+	}
+
 	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return errors.New("cluster not running. Run 'obol stack up' first")
+		// No live cluster — the preference file is enough. Future resolutions
+		// after `obol stack up` will honor it via RankWithPreference.
+		u.Successf("Model %q recorded as preferred (cluster not running; will apply on next stack up)", modelName)
+		return nil
 	}
 
 	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildModelEntries(t *testing.T) {
@@ -259,6 +261,149 @@ general_settings:
 		_, err := buildProviderStatus([]byte(`model_list: []`), []byte(`not json`))
 		if err == nil {
 			t.Fatal("expected error for invalid JSON")
+		}
+	})
+}
+
+func TestPreferModelInConfig(t *testing.T) {
+	t.Run("moves local model to front", func(t *testing.T) {
+		configYAML := []byte(`
+model_list:
+  - model_name: qwen3.5:9b
+    litellm_params:
+      model: ollama_chat/qwen3.5:9b
+      api_base: http://ollama.llm.svc.cluster.local:11434
+  - model_name: llama3.2:3b
+    litellm_params:
+      model: ollama_chat/llama3.2:3b
+      api_base: http://ollama.llm.svc.cluster.local:11434
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+`)
+
+		updated, changed, err := preferModelInConfig(configYAML, "llama3.2:3b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !changed {
+			t.Fatal("expected config change")
+		}
+
+		var got LiteLLMConfig
+		if err := yaml.Unmarshal(updated, &got); err != nil {
+			t.Fatalf("parse updated config: %v", err)
+		}
+
+		if got.ModelList[0].ModelName != "llama3.2:3b" {
+			t.Fatalf("first model = %q, want llama3.2:3b", got.ModelList[0].ModelName)
+		}
+
+		if got.ModelList[1].ModelName != "qwen3.5:9b" {
+			t.Fatalf("second model = %q, want qwen3.5:9b", got.ModelList[1].ModelName)
+		}
+	})
+
+	t.Run("matches routed model aliases", func(t *testing.T) {
+		configYAML := []byte(`
+model_list:
+  - model_name: qwen3.5:9b
+    litellm_params:
+      model: ollama_chat/qwen3.5:9b
+  - model_name: gpt-4.1
+    litellm_params:
+      model: openai/gpt-4.1
+      api_key: os.environ/OPENAI_API_KEY
+`)
+
+		updated, changed, err := preferModelInConfig(configYAML, "openai/gpt-4.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !changed {
+			t.Fatal("expected config change")
+		}
+
+		var got LiteLLMConfig
+		if err := yaml.Unmarshal(updated, &got); err != nil {
+			t.Fatalf("parse updated config: %v", err)
+		}
+
+		if got.ModelList[0].ModelName != "gpt-4.1" {
+			t.Fatalf("first model = %q, want gpt-4.1", got.ModelList[0].ModelName)
+		}
+	})
+
+	t.Run("moves explicit cloud model before wildcard", func(t *testing.T) {
+		configYAML := []byte(`
+model_list:
+  - model_name: anthropic/*
+    litellm_params:
+      model: anthropic/*
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-sonnet-4-6
+    litellm_params:
+      model: claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+`)
+
+		updated, changed, err := preferModelInConfig(configYAML, "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !changed {
+			t.Fatal("expected config change")
+		}
+
+		var got LiteLLMConfig
+		if err := yaml.Unmarshal(updated, &got); err != nil {
+			t.Fatalf("parse updated config: %v", err)
+		}
+
+		if got.ModelList[0].ModelName != "claude-sonnet-4-6" {
+			t.Fatalf("first model = %q, want claude-sonnet-4-6", got.ModelList[0].ModelName)
+		}
+
+		if got.ModelList[1].ModelName != "anthropic/*" {
+			t.Fatalf("second model = %q, want anthropic/*", got.ModelList[1].ModelName)
+		}
+	})
+
+	t.Run("already preferred model is unchanged", func(t *testing.T) {
+		configYAML := []byte(`
+model_list:
+  - model_name: qwen3.5:9b
+    litellm_params:
+      model: ollama_chat/qwen3.5:9b
+`)
+
+		_, changed, err := preferModelInConfig(configYAML, "qwen3.5:9b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if changed {
+			t.Fatal("expected no config change")
+		}
+	})
+
+	t.Run("unknown model errors", func(t *testing.T) {
+		configYAML := []byte(`
+model_list:
+  - model_name: qwen3.5:9b
+    litellm_params:
+      model: ollama_chat/qwen3.5:9b
+`)
+
+		_, _, err := preferModelInConfig(configYAML, "missing-model")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("error = %v, want not found", err)
 		}
 	})
 }

--- a/internal/model/preference.go
+++ b/internal/model/preference.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// preferenceFileName is the basename under cfg.ConfigDir where the user's
+// explicit `obol model prefer` choice is persisted. A separate file (rather
+// than a marker inside the LiteLLM ConfigMap) means the preference survives
+// every autoConfigureLLM / defaults-refresh path that rewrites the ConfigMap
+// — without that, rank-based selection would silently override the user's
+// explicit pick on every stack restart.
+const preferenceFileName = "preferred-model"
+
+// preferencePath returns the absolute path where the preferred-model marker
+// is stored. Empty cfg.ConfigDir returns "" so callers can treat that as
+// "no preference state available" without fabricating a path.
+func preferencePath(cfg *config.Config) string {
+	if cfg == nil || cfg.ConfigDir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.ConfigDir, preferenceFileName)
+}
+
+// WritePreference records the user's explicit model preference. The value is
+// trimmed; an empty value clears the preference (matching ClearPreference).
+func WritePreference(cfg *config.Config, name string) error {
+	path := preferencePath(cfg)
+	if path == "" {
+		return errors.New("config dir not set")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ClearPreference(cfg)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir preference dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(name+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write preference: %w", err)
+	}
+	return nil
+}
+
+// ReadPreference returns the user's persisted preferred model name, or "" if
+// no preference has been set. All errors (missing file, unreadable, garbled)
+// collapse to "" — callers treat absence and corruption identically because
+// the right behavior in either case is to fall back to capability ranking.
+func ReadPreference(cfg *config.Config) string {
+	path := preferencePath(cfg)
+	if path == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// ClearPreference removes the preference file. Missing file is not an error.
+func ClearPreference(cfg *config.Config) error {
+	path := preferencePath(cfg)
+	if path == "" {
+		return errors.New("config dir not set")
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove preference: %w", err)
+	}
+	return nil
+}

--- a/internal/model/preference_test.go
+++ b/internal/model/preference_test.go
@@ -1,0 +1,148 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+func newTestCfg(t *testing.T) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	return &config.Config{ConfigDir: dir, DataDir: dir, BinDir: dir}
+}
+
+// TestPreferenceRoundTrip verifies the basic write/read contract: what goes
+// in comes out, including whitespace trimming.
+func TestPreferenceRoundTrip(t *testing.T) {
+	cfg := newTestCfg(t)
+	if got := ReadPreference(cfg); got != "" {
+		t.Fatalf("read on empty: got %q, want empty", got)
+	}
+	if err := WritePreference(cfg, "  qwen3.5:9b  "); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := ReadPreference(cfg); got != "qwen3.5:9b" {
+		t.Fatalf("read after write: got %q, want qwen3.5:9b", got)
+	}
+}
+
+// TestPreferenceClear ensures explicit clear and writing an empty value both
+// remove the marker.
+func TestPreferenceClear(t *testing.T) {
+	cfg := newTestCfg(t)
+	if err := WritePreference(cfg, "claude-sonnet-4-6"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := ClearPreference(cfg); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := ReadPreference(cfg); got != "" {
+		t.Fatalf("after clear: got %q, want empty", got)
+	}
+	// Writing an empty value also clears.
+	if err := WritePreference(cfg, "claude-sonnet-4-6"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := WritePreference(cfg, "   "); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	if got := ReadPreference(cfg); got != "" {
+		t.Fatalf("after empty write: got %q, want empty", got)
+	}
+}
+
+// TestPreferenceSurvivesArbitraryFiles ensures a corrupt/garbled file is
+// treated as no-preference rather than panicking. Real-world: a future
+// version writes additional metadata, an old version reads it — must not
+// crash.
+func TestPreferenceSurvivesArbitraryFiles(t *testing.T) {
+	cfg := newTestCfg(t)
+	path := filepath.Join(cfg.ConfigDir, preferenceFileName)
+	if err := os.WriteFile(path, []byte("\x00\x01\x02"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got := ReadPreference(cfg)
+	if got != "\x00\x01\x02" {
+		// The contract is "trim whitespace, return whatever's left" — the
+		// downstream RankWithPreference will treat the result as a literal
+		// model name. modelMatchesPreference will then fail to match any
+		// real model and the call falls back to plain Rank. So binary
+		// junk passes through silently. The point of this test is "doesn't
+		// crash"; the literal-string behavior is asserted by the call.
+		t.Logf("note: read returned literal bytes %q (treated as opaque model name)", got)
+	}
+}
+
+// TestRankWithPreference_NoPreference is the regression guard for the
+// default path: when no preference is set, behavior is identical to plain
+// Rank. Cloud beats local.
+func TestRankWithPreference_NoPreference(t *testing.T) {
+	primary, fallbacks := RankWithPreference([]string{"llama3.2:3b", "claude-sonnet-4-6", "gpt-4.1"}, "")
+	if primary != "claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want claude-sonnet-4-6", primary)
+	}
+	want := []string{"gpt-4.1", "llama3.2:3b"}
+	if !reflect.DeepEqual(fallbacks, want) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, want)
+	}
+}
+
+// TestRankWithPreference_ExplicitPreferenceBeatsRank is THE regression guard
+// for the prefer-over-rank fix Oisin asked for. Without it, capability
+// rank would silently demote the user's pick on every restart.
+func TestRankWithPreference_ExplicitPreferenceBeatsRank(t *testing.T) {
+	// User explicitly prefers a local 3B model — must win over Claude.
+	primary, fallbacks := RankWithPreference(
+		[]string{"claude-sonnet-4-6", "gpt-4.1", "llama3.2:3b"},
+		"llama3.2:3b",
+	)
+	if primary != "llama3.2:3b" {
+		t.Fatalf("primary = %q, want llama3.2:3b (preference must beat capability)", primary)
+	}
+	// Fallbacks: cloud first (Claude > GPT), then any remaining locals.
+	want := []string{"claude-sonnet-4-6", "gpt-4.1"}
+	if !reflect.DeepEqual(fallbacks, want) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, want)
+	}
+}
+
+// TestRankWithPreference_ProviderPrefixToleranceguards the UX path: the user
+// types a bare model name (`claude-sonnet-4-6`), but the candidate list
+// carries provider-prefixed strings (`anthropic/claude-sonnet-4-6`) — they
+// must still match.
+func TestRankWithPreference_ProviderPrefixTolerance(t *testing.T) {
+	primary, _ := RankWithPreference(
+		[]string{"anthropic/claude-sonnet-4-6", "openai/gpt-4.1"},
+		"claude-sonnet-4-6",
+	)
+	if primary != "anthropic/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want anthropic/claude-sonnet-4-6 (bare preference must match prefixed candidate)", primary)
+	}
+}
+
+// TestRankWithPreference_StalePreferenceFallsBack covers the case where a
+// previously-preferred model has been removed from the candidate list. The
+// resolver must not crash and must not return an empty primary — it must
+// fall through to plain Rank.
+func TestRankWithPreference_StalePreferenceFallsBack(t *testing.T) {
+	primary, _ := RankWithPreference(
+		[]string{"claude-sonnet-4-6", "llama3.2:3b"},
+		"qwen3.5:9b", // not in candidates
+	)
+	if primary != "claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want claude-sonnet-4-6 (stale preference must fall back to rank)", primary)
+	}
+}
+
+// TestRankWithPreference_EmptyInput documents the edge case: nil/empty
+// candidate list returns empty primary, no panic.
+func TestRankWithPreference_EmptyInput(t *testing.T) {
+	primary, fallbacks := RankWithPreference(nil, "anything")
+	if primary != "" || len(fallbacks) != 0 {
+		t.Fatalf("got %q, %v; want empty, nil", primary, fallbacks)
+	}
+}

--- a/internal/model/rank.go
+++ b/internal/model/rank.go
@@ -69,6 +69,68 @@ func Rank(models []string) (primary string, fallbacks []string) {
 	return primary, fallbacks
 }
 
+// RankWithPreference is Rank, but a non-empty preferred model wins over the
+// capability ordering as long as it appears in the candidate list. Fallbacks
+// are the remaining models in capability order.
+//
+// Resolution order is therefore: explicit user preference → capability rank
+// → input order. This is the contract `obol model prefer` relies on: an
+// explicit pick must remain primary across stack restarts and defaults
+// refreshes, otherwise rank silently overrides the user every time.
+//
+// A preferred model that is not in the candidate list is treated as absent
+// (stale preference) and the function falls back to plain Rank — empty
+// preference is normal and produces the same result.
+func RankWithPreference(models []string, preferred string) (primary string, fallbacks []string) {
+	if len(models) == 0 {
+		return "", nil
+	}
+	preferred = strings.TrimSpace(preferred)
+	if preferred == "" {
+		return Rank(models)
+	}
+	matchIdx := -1
+	for i, m := range models {
+		if modelMatchesPreference(m, preferred) {
+			matchIdx = i
+			break
+		}
+	}
+	if matchIdx < 0 {
+		return Rank(models)
+	}
+	rest := make([]string, 0, len(models)-1)
+	rest = append(rest, models[:matchIdx]...)
+	rest = append(rest, models[matchIdx+1:]...)
+	_, restFallbacks := Rank(rest)
+	// Rank returns a non-empty primary for non-empty input; flatten primary +
+	// fallbacks back into the fallback list, capability-ordered.
+	if rp, _ := Rank(rest); rp != "" {
+		out := append([]string{rp}, restFallbacks...)
+		return models[matchIdx], out
+	}
+	return models[matchIdx], restFallbacks
+}
+
+// modelMatchesPreference returns true when candidate corresponds to the
+// preferred model name, ignoring provider prefix differences. The user can
+// type `claude-sonnet-4-6` and match `anthropic/claude-sonnet-4-6` or
+// `openai/claude-sonnet-4-6`; equally `qwen3.5:9b` matches itself or any
+// `ollama/qwen3.5:9b` variant.
+func modelMatchesPreference(candidate, preferred string) bool {
+	candidate = strings.TrimSpace(candidate)
+	preferred = strings.TrimSpace(preferred)
+	if candidate == "" || preferred == "" {
+		return false
+	}
+	if candidate == preferred {
+		return true
+	}
+	cb := stripProviderPrefix(candidate)
+	pb := stripProviderPrefix(preferred)
+	return cb == pb
+}
+
 // IsCloudModel reports whether a model name belongs to a frontier cloud
 // provider (Anthropic Claude, OpenAI GPT or o-series). The check is by
 // substring/prefix because LiteLLM model ids carry a provider prefix

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -1707,7 +1707,7 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 		}
 
 		// Patch ConfigMap with preferred primary model + fallbacks.
-		primary, fallbacks := rankModels(models)
+		primary, fallbacks := rankModels(cfg, models)
 		if primary != "" {
 			patchModelHierarchy(cfg, id, primary, fallbacks, u)
 		}
@@ -1718,12 +1718,13 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 	return nil
 }
 
-// rankModels delegates to model.Rank for capability-aware ranking, then
-// prefixes every entry with `openai/` for LiteLLM routing. Both runtimes used
-// to roll their own ranker that picked `local[0]` (whatever Ollama listed
-// first), which produced the llama3.2:1b regression — see internal/model/rank.go.
-func rankModels(models []string) (primary string, fallbacks []string) {
-	primary, fallbacks = model.Rank(models)
+// rankModels delegates to model.RankWithPreference for capability-aware
+// ranking that honors any explicit `obol model prefer` choice, then prefixes
+// every entry with `openai/` for LiteLLM routing. Both runtimes used to roll
+// their own ranker that picked `local[0]` (whatever Ollama listed first),
+// which produced the llama3.2:1b regression — see internal/model/rank.go.
+func rankModels(cfg *config.Config, models []string) (primary string, fallbacks []string) {
+	primary, fallbacks = model.RankWithPreference(models, model.ReadPreference(cfg))
 	if primary != "" {
 		primary = "openai/" + primary
 	}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -1669,10 +1669,7 @@ func cliViaKubectlExec(cfg *config.Config, namespace string, args []string) erro
 // current LiteLLM model list. For each LiteLLM-routed instance it:
 //  1. Patches the overlay YAML model list (for helm consistency)
 //  2. Writes a clean per-agent models.json to the host PVC
-//  3. Patches the openclaw-config ConfigMap with the best primary model
-//
-// Cloud models are promoted to primary (they're added because they're better
-// than local defaults). The previous primary becomes a fallback.
+//  3. Patches the openclaw-config ConfigMap with the preferred primary model
 func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 	ids, err := ListInstanceIDs(cfg)
 	if err != nil || len(ids) == 0 {
@@ -1709,7 +1706,7 @@ func SyncOverlayModels(cfg *config.Config, models []string, u *ui.UI) error {
 			u.Warnf("Failed to patch models.json for %s: %v", id, err)
 		}
 
-		// Patch ConfigMap with best primary model + fallbacks
+		// Patch ConfigMap with preferred primary model + fallbacks.
 		primary, fallbacks := rankModels(models)
 		if primary != "" {
 			patchModelHierarchy(cfg, id, primary, fallbacks, u)

--- a/internal/openclaw/overlay_test.go
+++ b/internal/openclaw/overlay_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/model"
 )
 
 // testConfig creates a temp config dir with a .stack-id file for testing.
@@ -434,25 +435,75 @@ erpc:
 	})
 }
 
-func TestRankModelsHonorsConfiguredOrder(t *testing.T) {
-	primary, fallbacks := rankModels([]string{"llama3.2:3b", "claude-sonnet-4-6", "gpt-4.1"})
-	if primary != "openai/llama3.2:3b" {
-		t.Fatalf("primary = %q, want openai/llama3.2:3b", primary)
+// TestRankModelsCapabilityWinsWithoutPreference is the corrected version of
+// the old TestRankModelsHonorsConfiguredOrder. The old test asserted that
+// rankModels picked models[0] regardless of capability — that was the exact
+// bug Oisin flagged: it meant `obol model prefer` was redundant because
+// rank already used input order, and any code path that re-sorted (e.g.
+// auto-config) would silently pick the wrong model.
+//
+// Correct contract: with NO explicit preference set, capability ranking
+// wins. Cloud frontier models (Claude/GPT) outrank local Ollama, regardless
+// of input order.
+func TestRankModelsCapabilityWinsWithoutPreference(t *testing.T) {
+	cfg := testConfig(t)
+
+	// llama listed first in input — should NOT win, capability rank picks Claude.
+	primary, fallbacks := rankModels(cfg, []string{"llama3.2:3b", "claude-sonnet-4-6", "gpt-4.1"})
+	if primary != "openai/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want openai/claude-sonnet-4-6 (cloud > local)", primary)
 	}
 
+	// Fallbacks: remaining cloud first, then local.
+	wantFallbacks := []string{"openai/gpt-4.1", "openai/llama3.2:3b"}
+	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
+	}
+
+	primary, fallbacks = rankModels(cfg, []string{"claude-sonnet-4-6", "llama3.2:3b"})
+	if primary != "openai/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want openai/claude-sonnet-4-6", primary)
+	}
+	wantFallbacks = []string{"openai/llama3.2:3b"}
+	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
+	}
+}
+
+// TestRankModelsHonorsExplicitPreference is the regression guard for the
+// prefer-over-rank fix. With a preference set on disk, rankModels must
+// return that model as primary even when capability ranking would pick
+// something else. This is what `obol model prefer` ships.
+func TestRankModelsHonorsExplicitPreference(t *testing.T) {
+	cfg := testConfig(t)
+
+	// User explicitly prefers llama3.2:3b — must win over Claude.
+	if err := model.WritePreference(cfg, "llama3.2:3b"); err != nil {
+		t.Fatalf("WritePreference: %v", err)
+	}
+
+	primary, fallbacks := rankModels(cfg, []string{"claude-sonnet-4-6", "gpt-4.1", "llama3.2:3b"})
+	if primary != "openai/llama3.2:3b" {
+		t.Fatalf("primary = %q, want openai/llama3.2:3b (preference must beat capability)", primary)
+	}
 	wantFallbacks := []string{"openai/claude-sonnet-4-6", "openai/gpt-4.1"}
 	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
 		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
 	}
+}
 
-	primary, fallbacks = rankModels([]string{"claude-sonnet-4-6", "llama3.2:3b"})
-	if primary != "openai/claude-sonnet-4-6" {
-		t.Fatalf("primary = %q, want openai/claude-sonnet-4-6", primary)
+// TestRankModelsStalePreferenceFallsBackToCapability covers the case where
+// the user's previously preferred model no longer appears in the candidate
+// list (e.g. they removed it). The preference file is silently ignored and
+// capability rank takes over — no error, no surprise primary.
+func TestRankModelsStalePreferenceFallsBackToCapability(t *testing.T) {
+	cfg := testConfig(t)
+	if err := model.WritePreference(cfg, "qwen3.5:9b"); err != nil {
+		t.Fatalf("WritePreference: %v", err)
 	}
-
-	wantFallbacks = []string{"openai/llama3.2:3b"}
-	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
-		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
+	primary, _ := rankModels(cfg, []string{"claude-sonnet-4-6", "llama3.2:3b"})
+	if primary != "openai/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want openai/claude-sonnet-4-6 (stale preference must fall back to rank)", primary)
 	}
 }
 

--- a/internal/openclaw/overlay_test.go
+++ b/internal/openclaw/overlay_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -431,6 +432,28 @@ erpc:
 			t.Errorf("missing model in updated overlay:\n%s", updated)
 		}
 	})
+}
+
+func TestRankModelsHonorsConfiguredOrder(t *testing.T) {
+	primary, fallbacks := rankModels([]string{"llama3.2:3b", "claude-sonnet-4-6", "gpt-4.1"})
+	if primary != "openai/llama3.2:3b" {
+		t.Fatalf("primary = %q, want openai/llama3.2:3b", primary)
+	}
+
+	wantFallbacks := []string{"openai/claude-sonnet-4-6", "openai/gpt-4.1"}
+	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
+	}
+
+	primary, fallbacks = rankModels([]string{"claude-sonnet-4-6", "llama3.2:3b"})
+	if primary != "openai/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want openai/claude-sonnet-4-6", primary)
+	}
+
+	wantFallbacks = []string{"openai/llama3.2:3b"}
+	if !reflect.DeepEqual(fallbacks, wantFallbacks) {
+		t.Fatalf("fallbacks = %#v, want %#v", fallbacks, wantFallbacks)
+	}
 }
 
 func TestPatchAgentModelsJSON(t *testing.T) {

--- a/internal/openclaw/rankmodels_test.go
+++ b/internal/openclaw/rankmodels_test.go
@@ -6,7 +6,7 @@ import "testing"
 // guard as the Hermes side, but exercising the openai/-prefix that OpenClaw
 // adds for LiteLLM routing through the openai-compatible provider slot.
 func TestRankModels_OpenClawWrapper_PrefersLargerLocalModel(t *testing.T) {
-	primary, fallbacks := rankModels([]string{
+	primary, fallbacks := rankModels(testConfig(t), []string{
 		"llama3.2:1b",
 		"qwen3.5:9b",
 		"llama3.2:3b",
@@ -23,7 +23,7 @@ func TestRankModels_OpenClawWrapper_KeepsOpenAIPrefixOnCloudPicks(t *testing.T) 
 	// Cloud models also get the openai/ prefix in OpenClaw because LiteLLM
 	// routes them through its openai-compatible adapter slot. The wrapper
 	// must wrap regardless of whether the underlying pick is cloud or local.
-	primary, _ := rankModels([]string{
+	primary, _ := rankModels(testConfig(t), []string{
 		"qwen3.5:9b",
 		"claude-opus-4-7",
 	})
@@ -33,7 +33,7 @@ func TestRankModels_OpenClawWrapper_KeepsOpenAIPrefixOnCloudPicks(t *testing.T) 
 }
 
 func TestRankModels_OpenClawWrapper_EmptyInput(t *testing.T) {
-	primary, fallbacks := rankModels(nil)
+	primary, fallbacks := rankModels(testConfig(t), nil)
 	if primary != "" || len(fallbacks) != 0 {
 		t.Fatalf("rankModels(nil): got %q,%v, want empty,nil", primary, fallbacks)
 	}


### PR DESCRIPTION
## Summary
- Add `obol model prefer <model-name>` to move a configured LiteLLM model to the front of the preference order and sync stack-managed agent model config.
- Honor LiteLLM model order when choosing OpenClaw primary/fallback models, while keeping cloud setup primary by preferring the configured cloud model.
- Add flow-12 provider smokes for local obol-agent inference plus optional Anthropic/OpenAI smokes when API keys are present.

## Tests
- `bash -n flows/flow-12-agent-provider-smokes.sh flows/release-smoke.sh`
- `go test ./cmd/obol ./internal/model ./internal/openclaw`
- `go test ./... -run ^'$' -count=0`

Closes #378