### PR TITLE
Fix flow-11 buyer wallet reuse

### DIFF
--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -84,7 +84,7 @@ All 4 paths use the same OpenClaw config pattern:
 - `x402-buyer` runs as a **sidecar in the LiteLLM pod**, not as a separate Service.
 - `buy.py buy` signs auths locally and creates a `PurchaseRequest`; the controller writes per-upstream buyer files and keeps LiteLLM model entries in sync.
 - The currently validated local OSS model is `qwen3.5:9b`. Prefer that exact model in live commerce tests.
-- In `flow-11-dual-stack.sh`, do not confuse the derived `BOB_WALLET` with the wallet that actually buys. Alice sells/registers with the `.env` `REMOTE_SIGNER_PRIVATE_KEY`, while Bob's agent signs through the Bob stack's `remote-signer` key. The flow now imports the second deterministic derived key into Bob's remote-signer via `obol openclaw wallet import-private-key`, asserts `bobSigner == BOB_WALLET`, and spends from that already-funded wallet. Do not reintroduce a funding transfer to a generated throwaway signer.
+- In `flow-11-dual-stack.sh`, do not confuse the derived `BOB_WALLET` with the wallet that actually buys. Alice sells/registers with the `.env` `REMOTE_SIGNER_PRIVATE_KEY`, while Bob's agent signs through the Bob stack's `remote-signer` key. The flow scaffolds Bob's default agent with `obol openclaw onboard --id obol-agent --no-sync`, pre-seeds the second deterministic derived key with `obol wallet import --instance obol-agent --private-key-file ... --force` before `stack up`, asserts `bobSigner == BOB_WALLET`, and spends from that already-funded wallet. Do not reintroduce a funding transfer to a generated throwaway signer.
 
 ## Essential Commands
 

--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -84,6 +84,7 @@ All 4 paths use the same OpenClaw config pattern:
 - `x402-buyer` runs as a **sidecar in the LiteLLM pod**, not as a separate Service.
 - `buy.py buy` signs auths locally and creates a `PurchaseRequest`; the controller writes per-upstream buyer files and keeps LiteLLM model entries in sync.
 - The currently validated local OSS model is `qwen3.5:9b`. Prefer that exact model in live commerce tests.
+- In `flow-11-dual-stack.sh`, do not confuse the derived `BOB_WALLET` with the wallet that actually buys. Alice sells/registers with the `.env` `REMOTE_SIGNER_PRIVATE_KEY`, while Bob's agent signs through the Bob stack's `remote-signer` key. The flow now imports the second deterministic derived key into Bob's remote-signer via `obol openclaw wallet import-private-key`, asserts `bobSigner == BOB_WALLET`, and spends from that already-funded wallet. Do not reintroduce a funding transfer to a generated throwaway signer.
 
 ## Essential Commands
 

--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -43,6 +43,7 @@ COMMANDS:
      stack purge     Delete stack config (use --force to also delete data)
    Obol Agent:
      agent init      Initialize the Obol Agent
+     wallet import   Import an existing wallet for the Obol Agent
    Network Management:
      network list    List all networks (local nodes + remote RPCs)
      network install Install and deploy a local blockchain node
@@ -223,6 +224,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 					},
 				},
 			},
+			walletCommand(cfg),
 			// ============================================================
 			// Tunnel Management Commands
 			// ============================================================

--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -268,37 +268,11 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 					}
 
 					return openclaw.RestoreWalletCmd(cfg, id, openclaw.RestoreWalletOptions{
-						Input:       cmd.String("input"),
-						Passphrase:  cmd.String("passphrase"),
-						HasPassFlag: cmd.IsSet("passphrase"),
-						Force:       cmd.Bool("force"),
-					}, getUI(cmd))
-				},
-			},
-			{
-				Name:      "import-private-key",
-				Usage:     "Import a private key as an OpenClaw remote-signer wallet",
-				ArgsUsage: "[instance-name]",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "private-key-file",
-						Usage:    "Path to a file containing the 0x-prefixed private key",
-						Required: true,
-					},
-					&cli.BoolFlag{
-						Name:  "force",
-						Usage: "Overwrite existing wallet",
-					},
-				},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					id, _, err := openclaw.ResolveInstance(cfg, cmd.Args().Slice())
-					if err != nil {
-						return err
-					}
-
-					return openclaw.ImportPrivateKeyWalletCmd(cfg, id, openclaw.ImportPrivateKeyWalletOptions{
-						PrivateKeyFile: cmd.String("private-key-file"),
-						Force:          cmd.Bool("force"),
+						Input:        cmd.String("input"),
+						Passphrase:   cmd.String("passphrase"),
+						HasPassFlag:  cmd.IsSet("passphrase"),
+						Force:        cmd.Bool("force"),
+						ApplyCluster: true,
 					}, getUI(cmd))
 				},
 			},

--- a/cmd/obol/openclaw.go
+++ b/cmd/obol/openclaw.go
@@ -276,6 +276,33 @@ func openclawWalletCommand(cfg *config.Config) *cli.Command {
 				},
 			},
 			{
+				Name:      "import-private-key",
+				Usage:     "Import a private key as an OpenClaw remote-signer wallet",
+				ArgsUsage: "[instance-name]",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "private-key-file",
+						Usage:    "Path to a file containing the 0x-prefixed private key",
+						Required: true,
+					},
+					&cli.BoolFlag{
+						Name:  "force",
+						Usage: "Overwrite existing wallet",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					id, _, err := openclaw.ResolveInstance(cfg, cmd.Args().Slice())
+					if err != nil {
+						return err
+					}
+
+					return openclaw.ImportPrivateKeyWalletCmd(cfg, id, openclaw.ImportPrivateKeyWalletOptions{
+						PrivateKeyFile: cmd.String("private-key-file"),
+						Force:          cmd.Bool("force"),
+					}, getUI(cmd))
+				},
+			},
+			{
 				Name:      "address",
 				Usage:     "Show the wallet address for an OpenClaw instance",
 				ArgsUsage: "[instance-name]",

--- a/cmd/obol/openclaw_test.go
+++ b/cmd/obol/openclaw_test.go
@@ -8,10 +8,11 @@ func TestOpenClawWalletCommand_Structure(t *testing.T) {
 	wallet := findSubcommand(t, cmd, "wallet")
 
 	expected := map[string]bool{
-		"backup":  false,
-		"restore": false,
-		"address": false,
-		"list":    false,
+		"backup":             false,
+		"restore":            false,
+		"import-private-key": false,
+		"address":            false,
+		"list":               false,
 	}
 
 	for _, sub := range wallet.Commands {

--- a/cmd/obol/openclaw_test.go
+++ b/cmd/obol/openclaw_test.go
@@ -8,11 +8,10 @@ func TestOpenClawWalletCommand_Structure(t *testing.T) {
 	wallet := findSubcommand(t, cmd, "wallet")
 
 	expected := map[string]bool{
-		"backup":             false,
-		"restore":            false,
-		"import-private-key": false,
-		"address":            false,
-		"list":               false,
+		"backup":  false,
+		"restore": false,
+		"address": false,
+		"list":    false,
 	}
 
 	for _, sub := range wallet.Commands {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -35,6 +36,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/ObolNetwork/obol-stack/internal/validate"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v3"
 )
@@ -1880,13 +1882,19 @@ func registerDirectViaSigner(ctx context.Context, cfg *config.Config, u *ui.UI, 
 	// Create TransactOpts that delegates signing to the remote-signer.
 	opts := signer.RemoteTransactOpts(ctx, addr, client.ChainID())
 
-	agentID, err := client.RegisterWithOpts(ctx, opts, agentURI)
+	startBlock := registrationRecoveryStartBlock(ctx, client, u)
+	agentID, txHash, err := registerWithRecovery(ctx, u, client, agentURI, addr, startBlock, func() (*big.Int, string, error) {
+		return client.RegisterWithOptsDetailed(ctx, opts, agentURI)
+	})
 	if err != nil {
 		return err
 	}
 
 	u.Printf("    Agent ID: %s", agentID.String())
 	u.Printf("    Owner:    %s", addr.Hex())
+	if txHash != "" {
+		u.Printf("    Tx:       %s", txHash)
+	}
 
 	// Set x402 metadata.
 	x402Meta := []byte(`{"x402":true}`)
@@ -1913,20 +1921,118 @@ func registerDirectWithKey(ctx context.Context, cfg *config.Config, u *ui.UI, ne
 	}
 	defer client.Close()
 
-	agentID, err := client.Register(ctx, key, agentURI)
+	txAddr := crypto.PubkeyToAddress(key.PublicKey)
+	startBlock := registrationRecoveryStartBlock(ctx, client, u)
+	agentID, txHash, err := registerWithRecovery(ctx, u, client, agentURI, txAddr, startBlock, func() (*big.Int, string, error) {
+		return client.RegisterDetailed(ctx, key, agentURI)
+	})
 	if err != nil {
 		return err
 	}
 
-	txAddr := crypto.PubkeyToAddress(key.PublicKey)
 	u.Printf("    Agent ID: %s", agentID.String())
 	u.Printf("    Owner:    %s", txAddr.Hex())
+	if txHash != "" {
+		u.Printf("    Tx:       %s", txHash)
+	}
 
 	x402Meta := []byte(`{"x402":true}`)
 	if err := client.SetMetadata(ctx, key, agentID, "x402", x402Meta); err != nil {
 		u.Warnf("failed to set x402 metadata: %v", err)
 	}
 	return nil
+}
+
+func registrationRecoveryStartBlock(ctx context.Context, client *erc8004.Client, u *ui.UI) uint64 {
+	startBlock, err := client.CurrentBlockNumber(ctx)
+	if err != nil {
+		u.Warnf("could not read registration recovery start block: %v", err)
+		return 0
+	}
+	return startBlock
+}
+
+func registerWithRecovery(
+	ctx context.Context,
+	u *ui.UI,
+	client *erc8004.Client,
+	agentURI string,
+	owner common.Address,
+	startBlock uint64,
+	submit func() (*big.Int, string, error),
+) (*big.Int, string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		agentID, txHash, err := submit()
+		if err == nil {
+			return agentID, txHash, nil
+		}
+		lastErr = err
+
+		if agentID, txHash, ok := recoverRegistrationByOwnerAndURI(ctx, client, owner, agentURI, startBlock); ok {
+			u.Warnf("registration submit returned an error but the on-chain event was recovered: %v", err)
+			return agentID, txHash, nil
+		}
+
+		if attempt == 3 || !isTransientRegistrationError(err) {
+			return nil, "", err
+		}
+
+		u.Warnf("registration attempt %d/3 failed: %v; retrying", attempt, err)
+		if !sleepWithContext(ctx, time.Duration(attempt*4)*time.Second) {
+			return nil, "", ctx.Err()
+		}
+	}
+	return nil, "", lastErr
+}
+
+func recoverRegistrationByOwnerAndURI(ctx context.Context, client *erc8004.Client, owner common.Address, agentURI string, startBlock uint64) (*big.Int, string, bool) {
+	for attempt := 1; attempt <= 4; attempt++ {
+		agentID, txHash, found, err := client.FindRegistrationByOwnerAndURI(ctx, owner, agentURI, startBlock)
+		if err == nil && found {
+			return agentID, txHash, true
+		}
+		if !sleepWithContext(ctx, 2*time.Second) {
+			return nil, "", false
+		}
+	}
+	return nil, "", false
+}
+
+func isTransientRegistrationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"500 internal server error",
+		"502 bad gateway",
+		"503 service unavailable",
+		"504 gateway timeout",
+		"timeout",
+		"deadline exceeded",
+		"temporarily unavailable",
+		"connection reset",
+		"eof",
+		"too many requests",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -416,6 +417,27 @@ func TestResolveX402Chain(t *testing.T) {
 			_, err := x402verifier.ResolveChainInfo(tt.name)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResolveChainInfo(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsTransientRegistrationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "rpc 500", err: errors.New("erc8004: register tx: 500 Internal Server Error"), want: true},
+		{name: "timeout", err: errors.New("context deadline exceeded while waiting for headers"), want: true},
+		{name: "revert", err: errors.New("erc8004: register tx: execution reverted"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientRegistrationError(tt.err); got != tt.want {
+				t.Fatalf("isTransientRegistrationError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/cmd/obol/wallet.go
+++ b/cmd/obol/wallet.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/openclaw"
+	"github.com/urfave/cli/v3"
+)
+
+const defaultWalletInstance = "obol-agent"
+
+func walletCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "wallet",
+		Usage: "Manage the Obol agent wallet",
+		Commands: []*cli.Command{
+			{
+				Name:  "import",
+				Usage: "Import a private key as the Obol agent wallet",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "private-key-file",
+						Usage:    "Path to a file containing the 0x-prefixed private key",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:  "instance",
+						Usage: "OpenClaw instance to update",
+						Value: defaultWalletInstance,
+					},
+					&cli.BoolFlag{
+						Name:  "force",
+						Usage: "Overwrite an existing wallet",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					instance := cmd.String("instance")
+					if instance == "" {
+						instance = defaultWalletInstance
+					}
+					return openclaw.ImportPrivateKeyWalletCmd(cfg, instance, openclaw.ImportPrivateKeyWalletOptions{
+						PrivateKeyFile: cmd.String("private-key-file"),
+						Force:          cmd.Bool("force"),
+						ApplyCluster:   walletClusterAvailable(cfg),
+					}, getUI(cmd))
+				},
+			},
+		},
+	}
+}
+
+func walletClusterAvailable(cfg *config.Config) bool {
+	if cfg == nil || cfg.ConfigDir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(cfg.ConfigDir, "kubeconfig.yaml"))
+	return err == nil
+}

--- a/cmd/obol/wallet_test.go
+++ b/cmd/obol/wallet_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWalletCommand_Structure(t *testing.T) {
+	cfg := newTestConfig(t)
+	cmd := walletCommand(cfg)
+
+	if cmd.Name != "wallet" {
+		t.Fatalf("command name = %q, want wallet", cmd.Name)
+	}
+
+	importCmd := findSubcommand(t, cmd, "import")
+	flags := flagMap(importCmd)
+
+	for _, name := range []string{"private-key-file", "instance", "force"} {
+		if _, ok := flags[name]; !ok {
+			t.Errorf("missing wallet import flag --%s", name)
+		}
+	}
+}
+
+func TestWalletClusterAvailable(t *testing.T) {
+	cfg := newTestConfig(t)
+	if walletClusterAvailable(cfg) {
+		t.Fatal("cluster should not be available without kubeconfig")
+	}
+
+	if err := os.WriteFile(filepath.Join(cfg.ConfigDir, "kubeconfig.yaml"), []byte("apiVersion: v1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !walletClusterAvailable(cfg) {
+		t.Fatal("cluster should be available with kubeconfig")
+	}
+}

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -10,7 +10,8 @@
 # Bob is through natural language prompts to his OpenClaw agent.
 #
 # Requires:
-#   - .env with REMOTE_SIGNER_PRIVATE_KEY (funded on Base Sepolia with ETH + USDC)
+#   - .env with REMOTE_SIGNER_PRIVATE_KEY funded with Base Sepolia ETH for Alice
+#   - second deterministic derived key funded with Base Sepolia USDC for Bob
 #   - Docker running, with the configured Alice/Bob ingress ports free
 #   - Ollama running (Alice serves local model inference)
 #   - cast (Foundry) for balance checks
@@ -59,7 +60,14 @@ FLOW11_ARTIFACT_DIR="${FLOW11_ARTIFACT_DIR:-$OBOL_ROOT/.tmp/flow-11-$(date +%Y%m
 BASE_SEPOLIA_RPC="${FLOW11_BASE_SEPOLIA_RPC:-https://sepolia.base.org}"
 USDC_ADDRESS_BASE_SEPOLIA="0x036CbD53842c5426634e7929541eC2318f3dCF7e"
 ERC8004_IDENTITY_REGISTRY_BASE_SEPOLIA="0x8004A818BFB912233c491871b3d84c89A494BD9e"
+FLOW11_BUY_COUNT="${FLOW11_BUY_COUNT:-5}"
+FLOW11_PRICE_MICRO_USDC=1000
+FLOW11_REQUIRED_BOB_USDC=$((FLOW11_BUY_COUNT * FLOW11_PRICE_MICRO_USDC))
 mkdir -p "$FLOW11_ARTIFACT_DIR"
+
+lower_addr() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
 
 rewrite_k3d_ports() {
     local config_path="$1"
@@ -128,7 +136,7 @@ curl_tunnel_402_code() {
     local host="$2"
     local ip="$3"
 
-    if [ -n "$host" ] && [ -n "$ip" ] && ! system_resolves_host "$host"; then
+    if [ -n "$host" ] && [ -n "$ip" ]; then
         curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
             --resolve "$host:443:$ip" \
             -X POST "$url" \
@@ -252,6 +260,56 @@ bob_buy_skill_balance() {
     bob kubectl exec \
         -n openclaw-obol-agent deploy/openclaw -c openclaw -- \
         python3 /data/.openclaw/skills/buy-inference/scripts/buy.py balance 2>&1 || true
+}
+
+wait_erpc_chain_id() {
+    local label="$1"
+    local runner="$2"
+    local network="$3"
+    local want="$4"
+    local port pf_log pf_pid
+
+    port=$(pick_free_port)
+    pf_log=$(mktemp)
+    "$runner" kubectl port-forward -n erpc svc/erpc "${port}:80" >"$pf_log" 2>&1 &
+    pf_pid=$!
+
+    for attempt in $(seq 1 24); do
+        if python3 - "$port" "$network" "$want" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+port, network, want = sys.argv[1:4]
+req = urllib.request.Request(
+    f"http://127.0.0.1:{port}/rpc/{network}",
+    data=json.dumps({"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+try:
+    resp = urllib.request.urlopen(req, timeout=5)
+    data = json.loads(resp.read())
+except Exception:
+    sys.exit(1)
+sys.exit(0 if data.get("result") == want else 1)
+PY
+        then
+            cleanup_pid "$pf_pid"
+            rm -f "$pf_log"
+            echo "  $label eRPC $network ready (attempt $attempt)"
+            return 0
+        fi
+        sleep 3
+    done
+
+    echo "  eRPC port-forward log:"
+    tail -20 "$pf_log" 2>/dev/null | sed 's/^/  /'
+    cleanup_pid "$pf_pid"
+    rm -f "$pf_log"
+    fail "$label eRPC $network did not return chainId $want"
+    emit_metrics
+    exit 1
 }
 
 run_tail_or_fail() {
@@ -528,9 +586,11 @@ if [ -z "$SIGNER_KEY" ]; then
     fail "REMOTE_SIGNER_PRIVATE_KEY not found in .env"
     emit_metrics; exit 1
 fi
-# Derive Alice (index 1) and Bob (index 2)
-ALICE_WALLET=$(env -u CHAIN cast wallet address --private-key "$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 1)")" 2>/dev/null)
-BOB_WALLET=$(env -u CHAIN cast wallet address --private-key "$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 2)")" 2>/dev/null)
+# Bob is the second deterministic derived key. The flow imports this key into
+# Bob's remote-signer so x402 purchases spend from the already-funded wallet,
+# not a generated throwaway wallet.
+BOB_PRIVATE_KEY=$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 2)")
+BOB_WALLET=$(env -u CHAIN cast wallet address --private-key "$BOB_PRIVATE_KEY" 2>/dev/null)
 # Use the .env key directly as Alice's seller wallet (it has ETH for registration gas)
 ALICE_WALLET=$(env -u CHAIN cast wallet address --private-key "$SIGNER_KEY" 2>/dev/null)
 pass "Alice=$ALICE_WALLET, Bob=$BOB_WALLET"
@@ -552,8 +612,8 @@ step "Preflight: Bob has USDC"
 bob_usdc_raw=$(env -u CHAIN cast call "$USDC_ADDRESS_BASE_SEPOLIA" \
     "balanceOf(address)(uint256)" "$BOB_WALLET" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null || true)
 bob_usdc=$(echo "$bob_usdc_raw" | grep -oE '^[0-9]+' | head -1 || true)
-if [ -z "$bob_usdc" ] || [ "$bob_usdc" = "0" ]; then
-    fail "Bob ($BOB_WALLET) has 0 USDC on Base Sepolia — fund first"
+if [ -z "$bob_usdc" ] || [ "$bob_usdc" -lt "$FLOW11_REQUIRED_BOB_USDC" ] 2>/dev/null; then
+    fail "Bob ($BOB_WALLET) has ${bob_usdc:-0} micro-USDC on Base Sepolia — need at least $FLOW11_REQUIRED_BOB_USDC"
     emit_metrics; exit 1
 fi
 pass "Bob has $bob_usdc micro-USDC"
@@ -682,6 +742,7 @@ alice network add base-sepolia --endpoint "$BASE_SEPOLIA_RPC" --allow-writes 2>&
 # eRPC needs a restart to pick up the new chain config
 alice kubectl rollout restart deployment/erpc -n erpc 2>/dev/null || true
 alice kubectl rollout status deployment/erpc -n erpc --timeout=60s 2>/dev/null || true
+wait_erpc_chain_id "Alice" alice base-sepolia 0x14a34
 pass "Base Sepolia RPC added to eRPC (with write access)"
 
 step "Alice: create ServiceOffer"
@@ -692,6 +753,7 @@ if [ -z "$REG_START_BLOCK" ]; then
 fi
 KEY_FILE=$(mktemp)
 echo "$SIGNER_KEY" > "$KEY_FILE"
+set +e
 sell_http_out=$(alice sell http alice-inference \
     --wallet "$ALICE_WALLET" \
     --chain base-sepolia \
@@ -705,8 +767,14 @@ sell_http_out=$(alice sell http alice-inference \
     --register-skills natural_language_processing/text_generation \
     --register-domains technology/artificial_intelligence \
     --private-key-file "$KEY_FILE" 2>&1)
+sell_http_rc=$?
+set -e
 printf '%s\n' "$sell_http_out" | tail -8
 rm -f "$KEY_FILE"
+if [ "$sell_http_rc" -ne 0 ]; then
+    fail "ServiceOffer create/register failed (exit $sell_http_rc): ${sell_http_out:0:300}"
+    emit_metrics; exit "$sell_http_rc"
+fi
 pass "ServiceOffer created"
 
 poll_step_grep "Alice: ServiceOffer Ready" "True" 24 5 \
@@ -735,6 +803,7 @@ for attempt in $(seq 1 24); do
 done
 if [ "$gate_code" != "402" ]; then
     fail "Alice: 402 gate returned ${gate_code:-no HTTP response} after 120s"
+    emit_metrics; exit 1
 fi
 step "Alice: ERC-8004 registration reflected in ServiceOffer"
 reg_out=$(alice sell status alice-inference -n llm 2>&1) || true
@@ -744,6 +813,7 @@ if echo "$reg_out" | grep -q "Agent ID:"; then
     pass "ERC-8004 registered: Agent ID $AGENT_ID"
 else
     fail "Registration not reflected in sell status: ${reg_out:0:200}"
+    emit_metrics; exit 1
 fi
 
 registry_logs=$(env -u CHAIN cast logs --json --rpc-url "$BASE_SEPOLIA_RPC" \
@@ -790,6 +860,7 @@ if [ -n "$REGISTRATION_TX" ] && receipt_status_ok "$REGISTRATION_TX"; then
     pass "Registration receipt archived: $REGISTRATION_TX"
 else
     fail "Could not archive registration receipt for Agent ID $AGENT_ID"
+    emit_metrics; exit 1
 fi
 if [ -n "$METADATA_TX" ] && receipt_status_ok "$METADATA_TX"; then
     write_receipt metadata "$METADATA_TX"
@@ -819,6 +890,7 @@ step "Bob: add Base Sepolia RPC to eRPC"
 bob network add base-sepolia --endpoint "$BASE_SEPOLIA_RPC" 2>&1 | tail -2
 bob kubectl rollout restart deployment/erpc -n erpc 2>/dev/null || true
 bob kubectl rollout status deployment/erpc -n erpc --timeout=60s 2>/dev/null || true
+wait_erpc_chain_id "Bob" bob base-sepolia 0x14a34
 pass "Bob eRPC configured for Base Sepolia"
 
 ensure_bob_tunnel_dns "$TUNNEL_HOST" "$TUNNEL_IP"
@@ -839,90 +911,72 @@ for attempt in $(seq 1 24); do
 done
 if [ "$bob_tunnel_code" != "402" ]; then
     fail "Bob: tunnel did not return 402 from agent pod — ${bob_tunnel_code:-no response}"
+    emit_metrics; exit 1
 fi
 
 # ═════════════════════════════════════════════════════════════════
-# BOB: FUND REMOTE-SIGNER WALLET (shortcut — see #331 for obol wallet import)
+# BOB: INJECT FUNDED BUYER WALLET INTO REMOTE-SIGNER
 # ═════════════════════════════════════════════════════════════════
 
-step "Bob: fund remote-signer wallet with USDC"
-# The remote-signer auto-generates a wallet during stack up.
-# We need to fund it from the .env key so buy.py can sign auths.
-# Read wallet address from wallet.json (most reliable source)
-BOB_SIGNER_ADDR=$(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$BOB_DIR/config/applications/openclaw/obol-agent/wallet.json'))
-    print(d.get('address',''))
-except: pass
-" 2>&1)
-if [ -n "$BOB_SIGNER_ADDR" ]; then
-    echo "  Remote-signer wallet: $BOB_SIGNER_ADDR"
-    # Send USDC (0.05 USDC = 50000 micro-units) from .env key.
-    # `cast send` (no --async) waits for inclusion; capture the receipt so we
-    # can verify status=1 instead of relying on grep||true to mask failures.
-    FUNDING_START_BLOCK=$(env -u CHAIN cast block-number --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | tr -d ' ' || true)
-    if [ -z "$FUNDING_START_BLOCK" ]; then
-        fail "Could not read Base Sepolia block number before funding"
-        emit_metrics; exit 1
-    fi
-    send_out=$(env -u CHAIN cast send --private-key "$SIGNER_KEY" \
-        "$USDC_ADDRESS_BASE_SEPOLIA" \
-        "transfer(address,uint256)" "$BOB_SIGNER_ADDR" 50000 \
-        --rpc-url "$BASE_SEPOLIA_RPC" 2>&1 || true)
-    if ! echo "$send_out" | grep -qE "^status\s+1 \(success\)"; then
-        fail "Funding tx did not confirm status=1 — ${send_out:0:300}"
-        emit_metrics; exit 1
-    fi
-    FUNDING_TX=$(echo "$send_out" | extract_tx_hash || true)
-    if [ -n "$FUNDING_TX" ] && archive_receipt funding "$FUNDING_TX"; then
-        pass "Funding receipt archived: $FUNDING_TX"
-    else
-        funding_match=$(wait_usdc_transfer_receipt funding "$ALICE_WALLET" "$BOB_SIGNER_ADDR" 50000 "$FUNDING_START_BLOCK" 30 2 || true)
-        FUNDING_TX=$(echo "$funding_match" | awk '{print $1; exit}')
-        if [ -n "$FUNDING_TX" ]; then
-            pass "Funding receipt archived from USDC Transfer log: $FUNDING_TX"
-        else
-            fail "Could not archive funding receipt"
-        fi
-    fi
-    # Poll the direct Base Sepolia RPC until the balance reflects the transfer.
-    # This avoids a race where step 32's agent sees 0 USDC because eRPC's
-    # eth_call cache (10s TTL) still holds the pre-funding result.
-    POST_FUND_BOB_SIGNER_USDC=0
-    for _ in $(seq 1 12); do
-        POST_FUND_BOB_SIGNER_USDC=$(env -u CHAIN cast call "$USDC_ADDRESS_BASE_SEPOLIA" \
-            "balanceOf(address)(uint256)" "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
-        [ -n "$POST_FUND_BOB_SIGNER_USDC" ] && [ "$POST_FUND_BOB_SIGNER_USDC" -ge 50000 ] 2>/dev/null && break
-        sleep 2
-    done
-    if [ -z "$POST_FUND_BOB_SIGNER_USDC" ] || [ "$POST_FUND_BOB_SIGNER_USDC" -lt 50000 ]; then
-        fail "Bob's on-chain USDC did not reach 50000 — got ${POST_FUND_BOB_SIGNER_USDC:-0}"
-        emit_metrics; exit 1
-    fi
-    POST_FUND_ALICE_USDC=$(env -u CHAIN cast call "$USDC_ADDRESS_BASE_SEPOLIA" \
-        "balanceOf(address)(uint256)" "$ALICE_WALLET" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
-    pass "Funded $BOB_SIGNER_ADDR with 0.05 USDC (on-chain: $POST_FUND_BOB_SIGNER_USDC)"
+step "Bob: import derived buyer wallet into remote-signer"
+BOB_KEY_FILE=$(mktemp)
+chmod 600 "$BOB_KEY_FILE"
+printf '%s\n' "$BOB_PRIVATE_KEY" > "$BOB_KEY_FILE"
+import_out=$(bob openclaw wallet import-private-key obol-agent \
+    --private-key-file "$BOB_KEY_FILE" \
+    --force 2>&1 || true)
+rm -f "$BOB_KEY_FILE"
+echo "$import_out" | tail -8
+if ! echo "$import_out" | grep -q "Wallet imported"; then
+    fail "Could not import Bob buyer wallet: ${import_out:0:300}"
+    emit_metrics; exit 1
+fi
 
-    # Wait for Bob's in-pod buy.py (via eRPC with 10s cache) to catch up so
-    # the AI agent in step 32 sees a usable funded balance, not a stale zero.
-    step "Bob: eRPC reflects funding"
-    erpc_balance_output=""
-    erpc_balance_micro=""
-    for attempt in $(seq 1 18); do
-        erpc_balance_output=$(bob_buy_skill_balance)
-        erpc_balance_micro=$(echo "$erpc_balance_output" | sed -n 's/.*(\([0-9][0-9]*\) micro-units).*/\1/p' | head -1)
-        if [ -n "$erpc_balance_micro" ] && [ "$erpc_balance_micro" -ge 50000 ] 2>/dev/null; then
-            pass "Bob: eRPC reflects funding (attempt $attempt, balance ${erpc_balance_micro} micro-USDC)"
-            break
-        fi
-        sleep 5
-    done
-    if [ -z "$erpc_balance_micro" ] || [ "$erpc_balance_micro" -lt 50000 ] 2>/dev/null; then
-        fail "Bob: eRPC balance did not reach 50000 micro-USDC — ${erpc_balance_output:0:200}"
-    fi
-else
+BOB_SIGNER_ADDR=$(bob openclaw wallet address obol-agent 2>/dev/null || true)
+if [ -z "$BOB_SIGNER_ADDR" ]; then
     fail "Could not determine Bob's remote-signer address"
+    emit_metrics; exit 1
+fi
+if [ "$(lower_addr "$BOB_SIGNER_ADDR")" != "$(lower_addr "$BOB_WALLET")" ]; then
+    fail "Bob remote-signer wallet mismatch — signer=$BOB_SIGNER_ADDR expected=$BOB_WALLET"
+    emit_metrics; exit 1
+fi
+pass "Bob remote-signer uses funded derived wallet: $BOB_SIGNER_ADDR"
+
+step "Bob: remote-signer rollout after wallet import"
+bob kubectl rollout status deployment/remote-signer -n openclaw-obol-agent --timeout=120s 2>&1 | tail -2
+pass "Bob remote-signer restarted with injected wallet"
+
+step "Bob: buyer wallet balance available"
+PRE_BUY_BOB_SIGNER_USDC=0
+for _ in $(seq 1 12); do
+    PRE_BUY_BOB_SIGNER_USDC=$(env -u CHAIN cast call "$USDC_ADDRESS_BASE_SEPOLIA" \
+        "balanceOf(address)(uint256)" "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
+    [ -n "$PRE_BUY_BOB_SIGNER_USDC" ] && [ "$PRE_BUY_BOB_SIGNER_USDC" -ge "$FLOW11_REQUIRED_BOB_USDC" ] 2>/dev/null && break
+    sleep 2
+done
+if [ -z "$PRE_BUY_BOB_SIGNER_USDC" ] || [ "$PRE_BUY_BOB_SIGNER_USDC" -lt "$FLOW11_REQUIRED_BOB_USDC" ] 2>/dev/null; then
+    fail "Bob buyer wallet has ${PRE_BUY_BOB_SIGNER_USDC:-0} micro-USDC — need $FLOW11_REQUIRED_BOB_USDC"
+    emit_metrics; exit 1
+fi
+pass "Bob buyer wallet has $PRE_BUY_BOB_SIGNER_USDC micro-USDC"
+
+# Wait for Bob's in-pod buy.py (via eRPC with 10s cache) to observe the
+# imported buyer wallet and funded balance before the agent signs auths.
+step "Bob: eRPC reflects buyer balance"
+erpc_balance_output=""
+erpc_balance_micro=""
+for attempt in $(seq 1 18); do
+    erpc_balance_output=$(bob_buy_skill_balance)
+    erpc_balance_micro=$(echo "$erpc_balance_output" | sed -n 's/.*(\([0-9][0-9]*\) micro-units).*/\1/p' | head -1)
+    if [ -n "$erpc_balance_micro" ] && [ "$erpc_balance_micro" -ge "$FLOW11_REQUIRED_BOB_USDC" ] 2>/dev/null; then
+        pass "Bob: eRPC reflects buyer balance (attempt $attempt, balance ${erpc_balance_micro} micro-USDC)"
+        break
+    fi
+    sleep 5
+done
+if [ -z "$erpc_balance_micro" ] || [ "$erpc_balance_micro" -lt "$FLOW11_REQUIRED_BOB_USDC" ] 2>/dev/null; then
+    fail "Bob: eRPC balance did not reach $FLOW11_REQUIRED_BOB_USDC micro-USDC — ${erpc_balance_output:0:200}"
     emit_metrics; exit 1
 fi
 
@@ -999,6 +1053,9 @@ if [ -n "$discover_content" ] && [ "${#discover_content}" -gt 100 ]; then
     pass "Agent discovered Alice's service"
 else
     fail "Discovery response: ${discover_response:0:300}"
+    cleanup_pid "$PF_AGENT"
+    rm -f "$PF_AGENT_LOG"
+    emit_metrics; exit 1
 fi
 
 step "Bob's agent: buy inference from Alice"
@@ -1011,7 +1068,7 @@ buy_response=$(curl -sf --max-time 300 \
         \"messages\": [
             {\"role\": \"user\", \"content\": \"Search the ERC-8004 registry on Base Sepolia for the agent named 'Dual-Stack Test Inference'. Report its endpoint.\"},
             {\"role\": \"assistant\", \"content\": \"I found the agent. Its endpoint is $TUNNEL_URL/services/alice-inference\"},
-            {\"role\": \"user\", \"content\": \"Now use the buy-inference skill to buy 5 inference tokens from Alice. Run exactly: python3 scripts/buy.py buy alice-inference --endpoint $TUNNEL_URL/services/alice-inference/v1/chat/completions --model qwen3.5:9b --count 5\"}
+            {\"role\": \"user\", \"content\": \"Now use the buy-inference skill to buy $FLOW11_BUY_COUNT inference tokens from Alice. Run exactly: python3 scripts/buy.py buy alice-inference --endpoint $TUNNEL_URL/services/alice-inference/v1/chat/completions --model qwen3.5:9b --count $FLOW11_BUY_COUNT\"}
         ],
         \"max_tokens\": 4000,
 	        \"stream\": false
@@ -1023,6 +1080,9 @@ if echo "$buy_content" | grep -qiE "purchase complete|PurchaseRequest created|pr
     pass "Agent bought Alice's inference"
 else
     fail "Buy response: ${buy_response:0:300}"
+    cleanup_pid "$PF_AGENT"
+    rm -f "$PF_AGENT_LOG"
+    emit_metrics; exit 1
 fi
 
 poll_step_grep "Bob: PurchaseRequest Ready" "True" 24 5 purchase_request_status
@@ -1086,18 +1146,18 @@ rm -f "$PF_AGENT_LOG"
 # ═════════════════════════════════════════════════════════════════
 
 step "On-chain: settlement tx receipt"
-settlement_match=$(wait_usdc_transfer_receipt settlement "$BOB_SIGNER_ADDR" "$ALICE_WALLET" 1000 "$BUY_START_BLOCK" 30 2 || true)
+settlement_match=$(wait_usdc_transfer_receipt settlement "$BOB_SIGNER_ADDR" "$ALICE_WALLET" "$FLOW11_PRICE_MICRO_USDC" "$BUY_START_BLOCK" 30 2 || true)
 SETTLEMENT_TX=$(echo "$settlement_match" | awk '{print $1; exit}')
 SETTLEMENT_AMOUNT=$(echo "$settlement_match" | awk '{print $2; exit}')
-if [ -n "$SETTLEMENT_TX" ] && [ "$SETTLEMENT_AMOUNT" = "1000" ]; then
+if [ -n "$SETTLEMENT_TX" ] && [ "$SETTLEMENT_AMOUNT" = "$FLOW11_PRICE_MICRO_USDC" ]; then
     echo "  tx=$SETTLEMENT_TX amount=$SETTLEMENT_AMOUNT"
     pass "Settlement receipt archived and transfer amount verified"
 else
     fail "No successful Bob-signer -> Alice USDC settlement receipt found after block $BUY_START_BLOCK"
+    emit_metrics; exit 1
 fi
 
 step "On-chain: balance changes"
-ALICE_AFTER_FUND_ONLY=$((PRE_ALICE_USDC - 50000))
 POST_ALICE_USDC=""
 POST_BOB_SIGNER_USDC=""
 for _ in $(seq 1 30); do
@@ -1105,26 +1165,27 @@ for _ in $(seq 1 30); do
         "balanceOf(address)(uint256)" "$ALICE_WALLET" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
     POST_BOB_SIGNER_USDC=$(env -u CHAIN cast call "$USDC_ADDRESS_BASE_SEPOLIA" \
         "balanceOf(address)(uint256)" "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
-    if [ -n "$POST_ALICE_USDC" ] && [ "$POST_ALICE_USDC" -gt "$ALICE_AFTER_FUND_ONLY" ] 2>/dev/null && \
-       [ -n "$POST_BOB_SIGNER_USDC" ] && [ "$POST_BOB_SIGNER_USDC" -lt "$POST_FUND_BOB_SIGNER_USDC" ] 2>/dev/null; then
+    if [ -n "$POST_ALICE_USDC" ] && [ "$POST_ALICE_USDC" -gt "$PRE_ALICE_USDC" ] 2>/dev/null && \
+       [ -n "$POST_BOB_SIGNER_USDC" ] && [ "$POST_BOB_SIGNER_USDC" -lt "$PRE_BUY_BOB_SIGNER_USDC" ] 2>/dev/null; then
         break
     fi
     sleep 2
 done
 echo "  Alice (pre-run):      $PRE_ALICE_USDC"
-echo "  Alice (expected after funding only): $ALICE_AFTER_FUND_ONLY"
 echo "  Alice (final):        ${POST_ALICE_USDC:-unknown}"
-echo "  Bob signer (after funding): $POST_FUND_BOB_SIGNER_USDC"
+echo "  Bob signer (pre-buy): $PRE_BUY_BOB_SIGNER_USDC"
 echo "  Bob signer (final):   ${POST_BOB_SIGNER_USDC:-unknown}"
-if [ -n "$POST_ALICE_USDC" ] && [ "$POST_ALICE_USDC" -gt "$ALICE_AFTER_FUND_ONLY" ] 2>/dev/null; then
+if [ -n "$POST_ALICE_USDC" ] && [ "$POST_ALICE_USDC" -gt "$PRE_ALICE_USDC" ] 2>/dev/null; then
     pass "Alice received USDC settlement"
 else
-    fail "Alice balance did not recover above funding-only expectation after polling (expected > $ALICE_AFTER_FUND_ONLY, got ${POST_ALICE_USDC:-unknown})"
+    fail "Alice balance did not increase after polling (expected > $PRE_ALICE_USDC, got ${POST_ALICE_USDC:-unknown})"
+    emit_metrics; exit 1
 fi
-if [ -n "$POST_BOB_SIGNER_USDC" ] && [ "$POST_BOB_SIGNER_USDC" -lt "$POST_FUND_BOB_SIGNER_USDC" ] 2>/dev/null; then
+if [ -n "$POST_BOB_SIGNER_USDC" ] && [ "$POST_BOB_SIGNER_USDC" -lt "$PRE_BUY_BOB_SIGNER_USDC" ] 2>/dev/null; then
     pass "Bob remote-signer spent USDC"
 else
-    fail "Bob remote-signer balance did not drop after polling (expected < $POST_FUND_BOB_SIGNER_USDC, got ${POST_BOB_SIGNER_USDC:-unknown})"
+    fail "Bob remote-signer balance did not drop after polling (expected < $PRE_BUY_BOB_SIGNER_USDC, got ${POST_BOB_SIGNER_USDC:-unknown})"
+    emit_metrics; exit 1
 fi
 
 # ═════════════════════════════════════════════════════════════════

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -262,6 +262,18 @@ bob_buy_skill_balance() {
         python3 /data/.openclaw/skills/buy-inference/scripts/buy.py balance 2>&1 || true
 }
 
+bob_remote_signer_address() {
+    bob kubectl exec -n openclaw-obol-agent deploy/openclaw -c openclaw -- \
+        python3 -c "
+import json
+import urllib.request
+
+resp = urllib.request.urlopen('http://remote-signer:9000/api/v1/keys', timeout=10)
+keys = json.loads(resp.read()).get('keys', [])
+print(keys[0] if keys else '')
+" 2>/dev/null || true
+}
+
 wait_erpc_chain_id() {
     local label="$1"
     local runner="$2"
@@ -354,11 +366,22 @@ stack_init_and_up_with_retry() {
     local label="$1"
     local runner="$2"
     local dir="$3"
+    local pre_up_hook="${4:-}"
     local attempt out rc
 
     for attempt in 1 2 3; do
         step "$label: stack init"
-        "$runner" stack init --force 2>&1 | tail -1
+        set +e
+        out=$("$runner" stack init --force 2>&1)
+        rc=$?
+        set -e
+        printf '%s\n' "$out" | tail -1
+        if [ "$rc" -ne 0 ]; then
+            printf '%s\n' "$out" | tail -120
+            fail "$label: stack init failed (exit $rc)"
+            emit_metrics
+            exit "$rc"
+        fi
         if [ "$label" = "Alice" ]; then
             rewrite_k3d_ports "$dir/config/k3d.yaml" \
                 "$ALICE_HTTP_PORT" "$ALICE_HTTP_ALT_PORT" "$ALICE_HTTPS_PORT" "$ALICE_HTTPS_ALT_PORT"
@@ -367,6 +390,9 @@ stack_init_and_up_with_retry() {
             rewrite_k3d_ports "$dir/config/k3d.yaml" \
                 "$BOB_HTTP_PORT" "$BOB_HTTP_ALT_PORT" "$BOB_HTTPS_PORT" "$BOB_HTTPS_ALT_PORT"
             pass "Bob ports set to $BOB_HTTP_PORT/$BOB_HTTP_ALT_PORT/$BOB_HTTPS_PORT/$BOB_HTTPS_ALT_PORT"
+        fi
+        if [ -n "$pre_up_hook" ]; then
+            "$pre_up_hook"
         fi
 
         step "$label: stack up"
@@ -402,6 +428,59 @@ stack_init_and_up_with_retry() {
         emit_metrics
         exit "$rc"
     done
+}
+
+preseed_bob_wallet() {
+    local deploy_dir existing import_out key_file onboard_out rc
+
+    deploy_dir="$BOB_DIR/config/applications/openclaw/obol-agent"
+    if [ ! -f "$deploy_dir/helmfile.yaml" ]; then
+        step "Bob: scaffold default agent before stack up"
+        set +e
+        onboard_out=$(bob openclaw onboard --id obol-agent --no-sync 2>&1)
+        rc=$?
+        set -e
+        echo "$onboard_out" | tail -8
+        if [ "$rc" -ne 0 ]; then
+            fail "Could not scaffold Bob agent before stack up: ${onboard_out:0:300}"
+            emit_metrics
+            exit "$rc"
+        fi
+        pass "Bob default agent scaffolded"
+    fi
+
+    existing=$(bob openclaw wallet address obol-agent 2>/dev/null || true)
+    if [ "$(lower_addr "$existing")" = "$(lower_addr "$BOB_WALLET")" ]; then
+        pass "Bob wallet preseeded: $existing"
+        return 0
+    fi
+
+    step "Bob: import derived buyer wallet before stack up"
+    key_file=$(mktemp)
+    chmod 600 "$key_file"
+    printf '%s\n' "$BOB_PRIVATE_KEY" > "$key_file"
+    set +e
+    import_out=$(bob wallet import \
+        --instance obol-agent \
+        --private-key-file "$key_file" \
+        --force 2>&1)
+    rc=$?
+    set -e
+    rm -f "$key_file"
+    echo "$import_out" | tail -8
+    if [ "$rc" -ne 0 ]; then
+        fail "Could not preseed Bob buyer wallet: ${import_out:0:300}"
+        emit_metrics
+        exit "$rc"
+    fi
+
+    existing=$(bob openclaw wallet address obol-agent 2>/dev/null || true)
+    if [ "$(lower_addr "$existing")" != "$(lower_addr "$BOB_WALLET")" ]; then
+        fail "Bob preseeded wallet mismatch — metadata=$existing expected=$BOB_WALLET"
+        emit_metrics
+        exit 1
+    fi
+    pass "Bob wallet preseeded: $existing"
 }
 
 litellm_paid_inference() {
@@ -586,9 +665,9 @@ if [ -z "$SIGNER_KEY" ]; then
     fail "REMOTE_SIGNER_PRIVATE_KEY not found in .env"
     emit_metrics; exit 1
 fi
-# Bob is the second deterministic derived key. The flow imports this key into
-# Bob's remote-signer so x402 purchases spend from the already-funded wallet,
-# not a generated throwaway wallet.
+# Bob is the second deterministic derived key. The flow pre-seeds this key
+# before Bob's stack starts so x402 purchases spend from the already-funded
+# wallet, not a generated throwaway wallet.
 BOB_PRIVATE_KEY=$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 2)")
 BOB_WALLET=$(env -u CHAIN cast wallet address --private-key "$BOB_PRIVATE_KEY" 2>/dev/null)
 # Use the .env key directly as Alice's seller wallet (it has ETH for registration gas)
@@ -881,7 +960,7 @@ for tool in kubectl helm helmfile k3d k9s openclaw; do
 done
 pass "Bob workspace ready"
 
-stack_init_and_up_with_retry "Bob" bob "$BOB_DIR"
+stack_init_and_up_with_retry "Bob" bob "$BOB_DIR" preseed_bob_wallet
 
 poll_step_grep "Bob: x402 pods running" "Running" 30 10 \
     bob kubectl get pods -n x402 --no-headers
@@ -915,37 +994,23 @@ if [ "$bob_tunnel_code" != "402" ]; then
 fi
 
 # ═════════════════════════════════════════════════════════════════
-# BOB: INJECT FUNDED BUYER WALLET INTO REMOTE-SIGNER
+# BOB: VERIFY PRESEEDED BUYER WALLET IN REMOTE-SIGNER
 # ═════════════════════════════════════════════════════════════════
 
-step "Bob: import derived buyer wallet into remote-signer"
-BOB_KEY_FILE=$(mktemp)
-chmod 600 "$BOB_KEY_FILE"
-printf '%s\n' "$BOB_PRIVATE_KEY" > "$BOB_KEY_FILE"
-import_out=$(bob openclaw wallet import-private-key obol-agent \
-    --private-key-file "$BOB_KEY_FILE" \
-    --force 2>&1 || true)
-rm -f "$BOB_KEY_FILE"
-echo "$import_out" | tail -8
-if ! echo "$import_out" | grep -q "Wallet imported"; then
-    fail "Could not import Bob buyer wallet: ${import_out:0:300}"
-    emit_metrics; exit 1
-fi
-
-BOB_SIGNER_ADDR=$(bob openclaw wallet address obol-agent 2>/dev/null || true)
-if [ -z "$BOB_SIGNER_ADDR" ]; then
-    fail "Could not determine Bob's remote-signer address"
-    emit_metrics; exit 1
-fi
+step "Bob: remote-signer uses preseeded buyer wallet"
+BOB_SIGNER_ADDR=""
+for attempt in $(seq 1 24); do
+    BOB_SIGNER_ADDR=$(bob_remote_signer_address)
+    if [ "$(lower_addr "$BOB_SIGNER_ADDR")" = "$(lower_addr "$BOB_WALLET")" ]; then
+        pass "Bob remote-signer uses funded derived wallet: $BOB_SIGNER_ADDR"
+        break
+    fi
+    sleep 5
+done
 if [ "$(lower_addr "$BOB_SIGNER_ADDR")" != "$(lower_addr "$BOB_WALLET")" ]; then
-    fail "Bob remote-signer wallet mismatch — signer=$BOB_SIGNER_ADDR expected=$BOB_WALLET"
+    fail "Bob remote-signer wallet mismatch — signer=${BOB_SIGNER_ADDR:-unknown} expected=$BOB_WALLET"
     emit_metrics; exit 1
 fi
-pass "Bob remote-signer uses funded derived wallet: $BOB_SIGNER_ADDR"
-
-step "Bob: remote-signer rollout after wallet import"
-bob kubectl rollout status deployment/remote-signer -n openclaw-obol-agent --timeout=120s 2>&1 | tail -2
-pass "Bob remote-signer restarted with injected wallet"
 
 step "Bob: buyer wallet balance available"
 PRE_BUY_BOB_SIGNER_USDC=0

--- a/internal/network/erpc_test.go
+++ b/internal/network/erpc_test.go
@@ -179,6 +179,107 @@ func TestPatchERPCConfig_Idempotent(t *testing.T) {
 	}
 }
 
+func TestUpsertCustomRPCUpstream_PrioritizesExplicitEndpoint(t *testing.T) {
+	configYAML := `projects:
+  - id: rpc
+    upstreams:
+      - id: base-sepolia-official
+        endpoint: https://sepolia.base.org
+        evm:
+          chainId: 84532
+      - id: custom-84532-0
+        endpoint: https://old.example
+        evm:
+          chainId: 84532
+    networks:
+      - architecture: evm
+        alias: base-sepolia
+        evm:
+          chainId: 84532
+`
+
+	var erpcConfig map[string]any
+	if err := yaml.Unmarshal([]byte(configYAML), &erpcConfig); err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	project := erpcConfig["projects"].([]any)[0].(map[string]any)
+	if err := upsertCustomRPCUpstream(project, 84532, "base-sepolia", "https://base-sepolia-rpc.publicnode.com", false); err != nil {
+		t.Fatalf("upsert custom rpc: %v", err)
+	}
+
+	upstreams := project["upstreams"].([]any)
+	if len(upstreams) != 2 {
+		t.Fatalf("upstreams = %d, want 2", len(upstreams))
+	}
+
+	first := upstreams[0].(map[string]any)
+	if first["id"] != "custom-84532-0" {
+		t.Fatalf("first upstream id = %v, want custom-84532-0", first["id"])
+	}
+	if first["endpoint"] != "https://base-sepolia-rpc.publicnode.com" {
+		t.Fatalf("first upstream endpoint = %v", first["endpoint"])
+	}
+	if _, ok := first["ignoreMethods"]; ok {
+		t.Fatal("write-enabled custom endpoint should not block write methods")
+	}
+
+	networks := project["networks"].([]any)
+	network := networks[0].(map[string]any)
+	policy, ok := network["selectionPolicy"].(map[string]any)
+	if !ok {
+		t.Fatal("write-enabled custom endpoint should install a write selection policy")
+	}
+	evalFunction, _ := policy["evalFunction"].(string)
+	if !strings.Contains(evalFunction, "eth_sendRawTransaction") {
+		t.Fatalf("selection policy = %q, want eth_sendRawTransaction guard", evalFunction)
+	}
+	if !strings.Contains(evalFunction, "custom-84532-0") {
+		t.Fatalf("selection policy = %q, want custom upstream pin", evalFunction)
+	}
+
+	second := upstreams[1].(map[string]any)
+	if second["id"] != "base-sepolia-official" {
+		t.Fatalf("second upstream id = %v, want base-sepolia-official", second["id"])
+	}
+}
+
+func TestUpsertCustomRPCUpstream_ReadOnlyRemovesCustomWritePolicy(t *testing.T) {
+	project := map[string]any{
+		"upstreams": []any{
+			map[string]any{
+				"id":       "custom-84532-0",
+				"endpoint": "https://old.example",
+				"evm":      map[string]any{"chainId": 84532},
+			},
+		},
+		"networks": []any{
+			map[string]any{
+				"architecture": "evm",
+				"alias":        "base-sepolia",
+				"evm":          map[string]any{"chainId": 84532},
+				"selectionPolicy": map[string]any{
+					"evalFunction": "return upstreams.filter(u => u.config.id === 'custom-84532-0')",
+				},
+			},
+		},
+	}
+
+	if err := upsertCustomRPCUpstream(project, 84532, "base-sepolia", "https://base-sepolia-rpc.publicnode.com", true); err != nil {
+		t.Fatalf("upsert custom rpc: %v", err)
+	}
+
+	upstream := project["upstreams"].([]any)[0].(map[string]any)
+	if _, ok := upstream["ignoreMethods"]; !ok {
+		t.Fatal("read-only custom endpoint should block write methods")
+	}
+
+	network := project["networks"].([]any)[0].(map[string]any)
+	if _, ok := network["selectionPolicy"]; ok {
+		t.Fatal("read-only custom endpoint should remove stale custom-only write selection policy")
+	}
+}
+
 func TestPatchERPCConfig_PreservesWriteOnlySelectionPolicy(t *testing.T) {
 	// The obol-stack eRPC config routes eth_sendRawTransaction exclusively
 	// to obol-rpc-mainnet. When a local node is registered, the selection

--- a/internal/network/rpc.go
+++ b/internal/network/rpc.go
@@ -138,6 +138,14 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string, r
 		return errors.New("eRPC config project[0] is not a map")
 	}
 
+	if err := upsertCustomRPCUpstream(project, chainID, chainName, endpoint, readOnly); err != nil {
+		return err
+	}
+
+	return writeERPCConfig(cfg, erpcConfig)
+}
+
+func upsertCustomRPCUpstream(project map[string]any, chainID int, chainName, endpoint string, readOnly bool) error {
 	// Remove any existing custom upstream for this chain ID.
 	existingUpstreams, _ := project["upstreams"].([]any)
 
@@ -169,12 +177,16 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string, r
 		upstream["ignoreMethods"] = writeMethods
 	}
 
-	filtered = append(filtered, upstream)
+	// Put explicit custom endpoints first. This makes --endpoint deterministic
+	// and, with --allow-writes, prevents flaky built-in/public upstreams from
+	// winning eth_sendRawTransaction routing before the user-selected RPC.
+	filtered = append([]any{upstream}, filtered...)
 	project["upstreams"] = filtered
 
 	// Ensure a network entry exists for this chain ID.
 	networksList, _ := project["networks"].([]any)
 	found := false
+	customID := fmt.Sprintf("custom-%d-0", chainID)
 
 	for _, n := range networksList {
 		nm, ok := n.(map[string]any)
@@ -185,13 +197,14 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string, r
 		if evm, ok := nm["evm"].(map[string]any); ok {
 			if yamlInt(evm["chainId"]) == chainID {
 				found = true
+				configureCustomWritePolicy(nm, customID, readOnly)
 				break
 			}
 		}
 	}
 
 	if !found {
-		networksList = append(networksList, map[string]any{
+		network := map[string]any{
 			"architecture": "evm",
 			"evm":          map[string]any{"chainId": chainID},
 			"alias":        sanitizeAlias(chainName),
@@ -199,11 +212,36 @@ func AddCustomRPC(cfg *config.Config, chainID int, chainName, endpoint string, r
 				"timeout": map[string]any{"duration": "30s"},
 				"retry":   map[string]any{"maxAttempts": 2, "delay": "100ms"},
 			},
-		})
+		}
+		configureCustomWritePolicy(network, customID, readOnly)
+		networksList = append(networksList, network)
 		project["networks"] = networksList
 	}
 
-	return writeERPCConfig(cfg, erpcConfig)
+	return nil
+}
+
+func configureCustomWritePolicy(network map[string]any, upstreamID string, readOnly bool) {
+	if readOnly {
+		if policy, ok := network["selectionPolicy"].(map[string]any); ok {
+			if eval, _ := policy["evalFunction"].(string); strings.Contains(eval, upstreamID) {
+				delete(network, "selectionPolicy")
+			}
+		}
+		return
+	}
+
+	network["selectionPolicy"] = map[string]any{
+		"evalInterval":  "1m",
+		"evalPerMethod": true,
+		"evalFunction": fmt.Sprintf(`(upstreams, method) => {
+  if (method === 'eth_sendRawTransaction') {
+    return upstreams.filter(u => u.config.id === '%s');
+  }
+  return upstreams;
+}
+`, upstreamID),
+	}
 }
 
 func validateRPCEndpoint(endpoint string) error {

--- a/internal/openclaw/wallet.go
+++ b/internal/openclaw/wallet.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/scrypt"
 	"golang.org/x/crypto/sha3"
@@ -102,6 +103,53 @@ func GenerateWallet(cfg *config.Config, id string, u *ui.UI) (*WalletInfo, error
 	return &WalletInfo{
 		Address:      address,
 		PublicKey:    pubKeyHex,
+		KeystoreUUID: keystoreID,
+		KeystorePath: keystorePath,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		Password:     password,
+	}, nil
+}
+
+// ImportWalletFromPrivateKey provisions an existing Ethereum private key as the
+// remote-signer wallet for an OpenClaw instance.
+func ImportWalletFromPrivateKey(cfg *config.Config, id, privateKeyHex string, u *ui.UI) (*WalletInfo, error) {
+	privateKeyHex = strings.TrimSpace(strings.TrimPrefix(privateKeyHex, "0x"))
+	if privateKeyHex == "" {
+		return nil, errors.New("private key is empty")
+	}
+
+	key, err := ethcrypto.HexToECDSA(privateKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %w", err)
+	}
+
+	privKey := ethcrypto.FromECDSA(key)
+	defer zeroBytes(privKey)
+
+	pubKeyWithPrefix := ethcrypto.FromECDSAPub(&key.PublicKey)
+	if len(privKey) != 32 || len(pubKeyWithPrefix) != 65 || pubKeyWithPrefix[0] != 0x04 {
+		return nil, errors.New("invalid private key material")
+	}
+
+	password, err := generateRandomPassword(32)
+	if err != nil {
+		return nil, fmt.Errorf("password generation failed: %w", err)
+	}
+
+	pubKey := pubKeyWithPrefix[1:]
+	keystoreJSON, keystoreID, err := encryptToV3Keystore(privKey, pubKey, password)
+	if err != nil {
+		return nil, fmt.Errorf("keystore encryption failed: %w", err)
+	}
+
+	keystorePath, err := provisionKeystoreToVolume(cfg, id, keystoreID, keystoreJSON, u)
+	if err != nil {
+		return nil, fmt.Errorf("keystore provisioning failed: %w", err)
+	}
+
+	return &WalletInfo{
+		Address:      ethcrypto.PubkeyToAddress(key.PublicKey).Hex(),
+		PublicKey:    "0x" + hex.EncodeToString(pubKeyWithPrefix),
 		KeystoreUUID: keystoreID,
 		KeystorePath: keystorePath,
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
@@ -306,6 +354,12 @@ func hmacEqual(a, b []byte) bool {
 	}
 
 	return result == 0
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
 }
 
 // generateRandomPassword creates a cryptographically random password using

--- a/internal/openclaw/wallet.go
+++ b/internal/openclaw/wallet.go
@@ -79,35 +79,9 @@ func GenerateWallet(cfg *config.Config, id string, u *ui.UI) (*WalletInfo, error
 	if err != nil {
 		return nil, fmt.Errorf("key generation failed: %w", err)
 	}
+	defer zeroBytes(privKey)
 
-	address := addressFromPublicKey(pubKey)
-
-	password, err := generateRandomPassword(32)
-	if err != nil {
-		return nil, fmt.Errorf("password generation failed: %w", err)
-	}
-
-	keystoreJSON, keystoreID, err := encryptToV3Keystore(privKey, pubKey, password)
-	if err != nil {
-		return nil, fmt.Errorf("keystore encryption failed: %w", err)
-	}
-
-	keystorePath, err := provisionKeystoreToVolume(cfg, id, keystoreID, keystoreJSON, u)
-	if err != nil {
-		return nil, fmt.Errorf("keystore provisioning failed: %w", err)
-	}
-
-	// Uncompressed public key with 04 prefix for the frontend.
-	pubKeyHex := "0x04" + hex.EncodeToString(pubKey)
-
-	return &WalletInfo{
-		Address:      address,
-		PublicKey:    pubKeyHex,
-		KeystoreUUID: keystoreID,
-		KeystorePath: keystorePath,
-		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
-		Password:     password,
-	}, nil
+	return provisionWalletFromKeyMaterial(cfg, id, privKey, pubKey, "", u)
 }
 
 // ImportWalletFromPrivateKey provisions an existing Ethereum private key as the
@@ -131,12 +105,32 @@ func ImportWalletFromPrivateKey(cfg *config.Config, id, privateKeyHex string, u 
 		return nil, errors.New("invalid private key material")
 	}
 
+	return provisionWalletFromKeyMaterial(
+		cfg,
+		id,
+		privKey,
+		pubKeyWithPrefix[1:],
+		ethcrypto.PubkeyToAddress(key.PublicKey).Hex(),
+		u,
+	)
+}
+
+func provisionWalletFromKeyMaterial(cfg *config.Config, id string, privKey, pubKey []byte, address string, u *ui.UI) (*WalletInfo, error) {
+	if len(privKey) != 32 {
+		return nil, errors.New("private key must be 32 bytes")
+	}
+	if len(pubKey) != 64 {
+		return nil, errors.New("public key must be 64 bytes without prefix")
+	}
+	if address == "" {
+		address = addressFromPublicKey(pubKey)
+	}
+
 	password, err := generateRandomPassword(32)
 	if err != nil {
 		return nil, fmt.Errorf("password generation failed: %w", err)
 	}
 
-	pubKey := pubKeyWithPrefix[1:]
 	keystoreJSON, keystoreID, err := encryptToV3Keystore(privKey, pubKey, password)
 	if err != nil {
 		return nil, fmt.Errorf("keystore encryption failed: %w", err)
@@ -148,8 +142,8 @@ func ImportWalletFromPrivateKey(cfg *config.Config, id, privateKeyHex string, u 
 	}
 
 	return &WalletInfo{
-		Address:      ethcrypto.PubkeyToAddress(key.PublicKey).Hex(),
-		PublicKey:    "0x" + hex.EncodeToString(pubKeyWithPrefix),
+		Address:      address,
+		PublicKey:    "0x04" + hex.EncodeToString(pubKey),
 		KeystoreUUID: keystoreID,
 		KeystorePath: keystorePath,
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),

--- a/internal/openclaw/wallet_backup.go
+++ b/internal/openclaw/wallet_backup.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
@@ -51,16 +52,18 @@ type BackupWalletOptions struct {
 
 // RestoreWalletOptions holds options for the restore command.
 type RestoreWalletOptions struct {
-	Input       string // Input file path
-	Passphrase  string // Decryption passphrase
-	HasPassFlag bool   // Whether --passphrase was explicitly set
-	Force       bool   // Overwrite existing wallet
+	Input        string // Input file path
+	Passphrase   string // Decryption passphrase
+	HasPassFlag  bool   // Whether --passphrase was explicitly set
+	Force        bool   // Overwrite existing wallet
+	ApplyCluster bool   // Update live cluster resources and restart remote-signer
 }
 
 // ImportPrivateKeyWalletOptions holds options for importing a raw private key.
 type ImportPrivateKeyWalletOptions struct {
 	PrivateKeyFile string // File containing a 0x-prefixed private key
 	Force          bool   // Overwrite existing wallet
+	ApplyCluster   bool   // Update live cluster resources and restart remote-signer
 }
 
 // BackupWallet creates a backup of the wallet for the given instance.
@@ -188,25 +191,13 @@ func ImportPrivateKeyWalletCmd(cfg *config.Config, id string, opts ImportPrivate
 		return err
 	}
 
-	if err := pruneOtherKeystores(cfg, id, wallet.KeystoreUUID); err != nil {
-		return fmt.Errorf("failed to prune old keystores: %w", err)
+	if err := finalizeWalletProvision(cfg, id, deployDir, existingWallet, wallet, wallet.Password, opts.ApplyCluster, u); err != nil {
+		return err
 	}
-
-	if err := writeKeystorePassword(deployDir, wallet.Password); err != nil {
-		return fmt.Errorf("failed to write keystore password: %w", err)
-	}
-
-	if err := WriteWalletMetadata(deployDir, wallet); err != nil {
-		return fmt.Errorf("failed to write wallet metadata: %w", err)
-	}
-	applyWalletMetadataConfigMap(cfg, id, deployDir)
-	applyKeystorePasswordSecret(cfg, id, wallet.Password, u)
 
 	u.Success("Wallet imported")
 	u.Detail("Address", wallet.Address)
 	u.Detail("Instance", id)
-
-	restartRemoteSigner(cfg, id, u)
 
 	return nil
 }
@@ -283,14 +274,6 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 		return fmt.Errorf("failed to write keystore: %w", err)
 	}
 	fixVolumeOwnership(cfg, keystoreDir, u)
-	if err := pruneOtherKeystores(cfg, id, w.KeystoreUUID); err != nil {
-		return fmt.Errorf("failed to prune old keystores: %w", err)
-	}
-
-	// Update values-remote-signer.yaml with restored password.
-	if err := writeKeystorePassword(deployDir, w.KeystorePassword); err != nil {
-		return fmt.Errorf("failed to write keystore password: %w", err)
-	}
 
 	// Update wallet.json metadata.
 	walletInfo := &WalletInfo{
@@ -300,17 +283,13 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 		KeystorePath: keystorePath,
 		CreatedAt:    w.CreatedAt,
 	}
-	if err := WriteWalletMetadata(deployDir, walletInfo); err != nil {
-		return fmt.Errorf("failed to write wallet metadata: %w", err)
+	if err := finalizeWalletProvision(cfg, id, deployDir, existingWallet, walletInfo, w.KeystorePassword, opts.ApplyCluster, u); err != nil {
+		return err
 	}
-	applyWalletMetadataConfigMap(cfg, id, deployDir)
-	applyKeystorePasswordSecret(cfg, id, w.KeystorePassword, u)
 
 	u.Success("Wallet restored")
 	u.Detail("Address", w.Address)
 	u.Detail("Instance", id)
-
-	restartRemoteSigner(cfg, id, u)
 
 	return nil
 }
@@ -384,29 +363,6 @@ func FindInstancesWithWallets(cfg *config.Config) []string {
 	return result
 }
 
-func pruneOtherKeystores(cfg *config.Config, id, keepUUID string) error {
-	dir := KeystoreVolumePath(cfg, id)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-
-	keep := keepUUID + ".json"
-	for _, entry := range entries {
-		if entry.IsDir() || entry.Name() == keep || !strings.HasSuffix(entry.Name(), ".json") {
-			continue
-		}
-		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func restartRemoteSigner(cfg *config.Config, id string, u *ui.UI) {
 	// Best-effort: the cluster may not be running when a wallet is pre-seeded.
 	namespace := fmt.Sprintf("%s-%s", appName, id)
@@ -421,6 +377,57 @@ func restartRemoteSigner(cfg *config.Config, id string, u *ui.UI) {
 	} else {
 		u.Success("Remote-signer restarted")
 	}
+}
+
+func finalizeWalletProvision(cfg *config.Config, id, deployDir string, existingWallet, wallet *WalletInfo, password string, applyCluster bool, u *ui.UI) error {
+	if err := writeKeystorePassword(deployDir, password); err != nil {
+		return fmt.Errorf("failed to write keystore password: %w", err)
+	}
+	if err := WriteWalletMetadata(deployDir, wallet); err != nil {
+		return fmt.Errorf("failed to write wallet metadata: %w", err)
+	}
+	if err := archiveReplacedKeystore(cfg, id, existingWallet, wallet.KeystoreUUID, u); err != nil {
+		return fmt.Errorf("failed to archive replaced keystore: %w", err)
+	}
+	if !applyCluster {
+		return nil
+	}
+
+	applyWalletMetadataConfigMap(cfg, id, deployDir)
+	applyKeystorePasswordSecret(cfg, id, password, u)
+	restartRemoteSigner(cfg, id, u)
+	return nil
+}
+
+func archiveReplacedKeystore(cfg *config.Config, id string, existingWallet *WalletInfo, keepUUID string, u *ui.UI) error {
+	if existingWallet == nil || existingWallet.KeystoreUUID == "" || existingWallet.KeystoreUUID == keepUUID {
+		return nil
+	}
+
+	dir := KeystoreVolumePath(cfg, id)
+	oldPath := filepath.Join(dir, existingWallet.KeystoreUUID+".json")
+	if _, err := os.Stat(oldPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	archiveDir := filepath.Join(dir, "replaced")
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		return err
+	}
+	archivePath := filepath.Join(
+		archiveDir,
+		fmt.Sprintf("%s-%s.json", existingWallet.KeystoreUUID, time.Now().UTC().Format("20060102T150405Z")),
+	)
+	if err := os.Rename(oldPath, archivePath); err != nil {
+		return err
+	}
+	if u != nil {
+		u.Warnf("Archived replaced keystore instead of deleting it: %s", archivePath)
+	}
+	return nil
 }
 
 func applyKeystorePasswordSecret(cfg *config.Config, id, password string, u *ui.UI) {

--- a/internal/openclaw/wallet_backup.go
+++ b/internal/openclaw/wallet_backup.go
@@ -1,6 +1,7 @@
 package openclaw
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -8,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
@@ -52,6 +55,12 @@ type RestoreWalletOptions struct {
 	Passphrase  string // Decryption passphrase
 	HasPassFlag bool   // Whether --passphrase was explicitly set
 	Force       bool   // Overwrite existing wallet
+}
+
+// ImportPrivateKeyWalletOptions holds options for importing a raw private key.
+type ImportPrivateKeyWalletOptions struct {
+	PrivateKeyFile string // File containing a 0x-prefixed private key
+	Force          bool   // Overwrite existing wallet
 }
 
 // BackupWallet creates a backup of the wallet for the given instance.
@@ -151,6 +160,57 @@ func BackupWalletCmd(cfg *config.Config, id string, opts BackupWalletOptions, u 
 	return nil
 }
 
+// ImportPrivateKeyWalletCmd imports an existing private key as an OpenClaw
+// remote-signer wallet.
+func ImportPrivateKeyWalletCmd(cfg *config.Config, id string, opts ImportPrivateKeyWalletOptions, u *ui.UI) error {
+	raw, err := os.ReadFile(opts.PrivateKeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to read private key file: %w", err)
+	}
+
+	privateKeyHex := strings.TrimSpace(string(raw))
+	if privateKeyHex == "" {
+		return errors.New("private key file is empty")
+	}
+
+	deployDir := DeploymentPath(cfg, id)
+	if _, err := os.Stat(deployDir); os.IsNotExist(err) {
+		return fmt.Errorf("instance %q not found — run 'obol openclaw onboard --id %s' first", id, id)
+	}
+
+	existingWallet, _ := ReadWalletMetadata(deployDir)
+	if existingWallet != nil && !opts.Force {
+		return fmt.Errorf("instance %q already has a wallet (address: %s)\nUse --force to overwrite", id, existingWallet.Address)
+	}
+
+	wallet, err := ImportWalletFromPrivateKey(cfg, id, privateKeyHex, u)
+	if err != nil {
+		return err
+	}
+
+	if err := pruneOtherKeystores(cfg, id, wallet.KeystoreUUID); err != nil {
+		return fmt.Errorf("failed to prune old keystores: %w", err)
+	}
+
+	if err := writeKeystorePassword(deployDir, wallet.Password); err != nil {
+		return fmt.Errorf("failed to write keystore password: %w", err)
+	}
+
+	if err := WriteWalletMetadata(deployDir, wallet); err != nil {
+		return fmt.Errorf("failed to write wallet metadata: %w", err)
+	}
+	applyWalletMetadataConfigMap(cfg, id, deployDir)
+	applyKeystorePasswordSecret(cfg, id, wallet.Password, u)
+
+	u.Success("Wallet imported")
+	u.Detail("Address", wallet.Address)
+	u.Detail("Instance", id)
+
+	restartRemoteSigner(cfg, id, u)
+
+	return nil
+}
+
 // RestoreWalletCmd restores a wallet from a backup file.
 func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, u *ui.UI) error {
 	// Read backup file.
@@ -223,6 +283,9 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 		return fmt.Errorf("failed to write keystore: %w", err)
 	}
 	fixVolumeOwnership(cfg, keystoreDir, u)
+	if err := pruneOtherKeystores(cfg, id, w.KeystoreUUID); err != nil {
+		return fmt.Errorf("failed to prune old keystores: %w", err)
+	}
 
 	// Update values-remote-signer.yaml with restored password.
 	if err := writeKeystorePassword(deployDir, w.KeystorePassword); err != nil {
@@ -240,25 +303,14 @@ func RestoreWalletCmd(cfg *config.Config, id string, opts RestoreWalletOptions, 
 	if err := WriteWalletMetadata(deployDir, walletInfo); err != nil {
 		return fmt.Errorf("failed to write wallet metadata: %w", err)
 	}
+	applyWalletMetadataConfigMap(cfg, id, deployDir)
+	applyKeystorePasswordSecret(cfg, id, w.KeystorePassword, u)
 
 	u.Success("Wallet restored")
 	u.Detail("Address", w.Address)
 	u.Detail("Instance", id)
 
-	// Restart the remote-signer so it picks up the new keystore.
-	// Best-effort: cluster may not be running.
-	namespace := fmt.Sprintf("%s-%s", appName, id)
-
-	kubectlBin, kubeconfig := kubectl.Paths(cfg)
-	if err := kubectl.RunSilent(kubectlBin, kubeconfig,
-		"rollout", "restart", "deployment/remote-signer", "-n", namespace,
-	); err != nil {
-		u.Blank()
-		u.Warnf("Could not restart remote-signer (cluster may not be running)")
-		u.Printf("Run 'obol openclaw sync %s' to apply changes to the cluster.", id)
-	} else {
-		u.Success("Remote-signer restarted")
-	}
+	restartRemoteSigner(cfg, id, u)
 
 	return nil
 }
@@ -330,6 +382,92 @@ func FindInstancesWithWallets(cfg *config.Config) []string {
 	}
 
 	return result
+}
+
+func pruneOtherKeystores(cfg *config.Config, id, keepUUID string) error {
+	dir := KeystoreVolumePath(cfg, id)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	keep := keepUUID + ".json"
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == keep || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func restartRemoteSigner(cfg *config.Config, id string, u *ui.UI) {
+	// Best-effort: the cluster may not be running when a wallet is pre-seeded.
+	namespace := fmt.Sprintf("%s-%s", appName, id)
+
+	kubectlBin, kubeconfig := kubectl.Paths(cfg)
+	if err := kubectl.RunSilent(kubectlBin, kubeconfig,
+		"rollout", "restart", "deployment/remote-signer", "-n", namespace,
+	); err != nil {
+		u.Blank()
+		u.Warnf("Could not restart remote-signer (cluster may not be running)")
+		u.Printf("Run 'obol openclaw sync %s' to apply changes to the cluster.", id)
+	} else {
+		u.Success("Remote-signer restarted")
+	}
+}
+
+func applyKeystorePasswordSecret(cfg *config.Config, id, password string, u *ui.UI) {
+	if password == "" {
+		return
+	}
+
+	raw, err := keystorePasswordSecretManifest(id, password)
+	if err != nil {
+		u.Warnf("Could not marshal remote-signer password Secret: %v", err)
+		return
+	}
+
+	kubectlBin, kubeconfig := kubectl.Paths(cfg)
+	cmd := exec.Command(kubectlBin, "apply", "-f", "-")
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	cmd.Stdin = bytes.NewReader(raw)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		u.Blank()
+		u.Warnf("Could not update remote-signer password Secret (cluster may not be running)")
+		u.Printf("Run 'obol openclaw sync %s' to apply changes to the cluster.", id)
+	}
+}
+
+func keystorePasswordSecretManifest(id, password string) ([]byte, error) {
+	namespace := fmt.Sprintf("%s-%s", appName, id)
+	manifest := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name":      "remote-signer-keystore-password",
+			"namespace": namespace,
+			"labels": map[string]string{
+				"app.kubernetes.io/component":  "remote-signer",
+				"app.kubernetes.io/managed-by": "obol",
+			},
+		},
+		"type": "Opaque",
+		"stringData": map[string]string{
+			"password": password,
+		},
+	}
+
+	return json.Marshal(manifest)
 }
 
 // resolvePassphrase determines the passphrase via flag or interactive prompt.

--- a/internal/openclaw/wallet_backup_test.go
+++ b/internal/openclaw/wallet_backup_test.go
@@ -203,6 +203,11 @@ func TestBackupRestoreEncryptedRoundTrip(t *testing.T) {
 func TestImportPrivateKeyWalletCmd_ReplacesExistingWallet(t *testing.T) {
 	cfg, id, origWallet := setupTestInstance(t)
 	deployDir := DeploymentPath(cfg, id)
+	manualKeystore := filepath.Join(KeystoreVolumePath(cfg, id), "manual-recovery.json")
+	if err := os.WriteFile(manualKeystore, []byte(`{"manual":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	keyFile := filepath.Join(t.TempDir(), "buyer.key")
 	keyHex := "0x0000000000000000000000000000000000000000000000000000000000000001"
 	if err := os.WriteFile(keyFile, []byte(keyHex+"\n"), 0o600); err != nil {
@@ -237,6 +242,19 @@ func TestImportPrivateKeyWalletCmd_ReplacesExistingWallet(t *testing.T) {
 	if wallet.Address == origWallet.Address {
 		t.Fatal("wallet address did not change after forced import")
 	}
+	if _, err := os.Stat(manualKeystore); err != nil {
+		t.Fatalf("manual keystore should not be deleted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(KeystoreVolumePath(cfg, id), origWallet.KeystoreUUID+".json")); !os.IsNotExist(err) {
+		t.Fatalf("old tracked keystore should be archived away from active dir, stat err=%v", err)
+	}
+	archived, err := filepath.Glob(filepath.Join(KeystoreVolumePath(cfg, id), "replaced", origWallet.KeystoreUUID+"-*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(archived) != 1 {
+		t.Fatalf("archived old keystores = %d, want 1", len(archived))
+	}
 
 	password, err := readKeystorePassword(deployDir)
 	if err != nil {
@@ -266,8 +284,8 @@ func TestImportPrivateKeyWalletCmd_ReplacesExistingWallet(t *testing.T) {
 			jsonKeystores++
 		}
 	}
-	if jsonKeystores != 1 {
-		t.Fatalf("keystore dir has %d JSON keystores, want 1", jsonKeystores)
+	if jsonKeystores != 2 {
+		t.Fatalf("keystore dir has %d JSON keystores, want new import plus manual file", jsonKeystores)
 	}
 }
 

--- a/internal/openclaw/wallet_backup_test.go
+++ b/internal/openclaw/wallet_backup_test.go
@@ -1,6 +1,7 @@
 package openclaw
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -196,6 +197,104 @@ func TestBackupRestoreEncryptedRoundTrip(t *testing.T) {
 
 	if restored.Address != origWallet.Address {
 		t.Errorf("address = %q, want %q", restored.Address, origWallet.Address)
+	}
+}
+
+func TestImportPrivateKeyWalletCmd_ReplacesExistingWallet(t *testing.T) {
+	cfg, id, origWallet := setupTestInstance(t)
+	deployDir := DeploymentPath(cfg, id)
+	keyFile := filepath.Join(t.TempDir(), "buyer.key")
+	keyHex := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	if err := os.WriteFile(keyFile, []byte(keyHex+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ImportPrivateKeyWalletCmd(cfg, id, ImportPrivateKeyWalletOptions{
+		PrivateKeyFile: keyFile,
+		Force:          false,
+	}, testUI())
+	if err == nil {
+		t.Fatal("expected import over existing wallet without force to fail")
+	}
+
+	err = ImportPrivateKeyWalletCmd(cfg, id, ImportPrivateKeyWalletOptions{
+		PrivateKeyFile: keyFile,
+		Force:          true,
+	}, testUI())
+	if err != nil {
+		t.Fatalf("import private key: %v", err)
+	}
+
+	wallet, err := ReadWalletMetadata(deployDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantAddr := "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+	if wallet.Address != wantAddr {
+		t.Errorf("address = %q, want %q", wallet.Address, wantAddr)
+	}
+	if wallet.Address == origWallet.Address {
+		t.Fatal("wallet address did not change after forced import")
+	}
+
+	password, err := readKeystorePassword(deployDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keystoreJSON, err := os.ReadFile(filepath.Join(KeystoreVolumePath(cfg, id), wallet.KeystoreUUID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := decryptV3Keystore(keystoreJSON, password)
+	if err != nil {
+		t.Fatalf("decrypt imported keystore: %v", err)
+	}
+	if got := "0x" + hex.EncodeToString(recovered); got != keyHex {
+		t.Errorf("recovered key = %q, want %q", got, keyHex)
+	}
+
+	entries, err := os.ReadDir(KeystoreVolumePath(cfg, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonKeystores := 0
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".json" {
+			jsonKeystores++
+		}
+	}
+	if jsonKeystores != 1 {
+		t.Fatalf("keystore dir has %d JSON keystores, want 1", jsonKeystores)
+	}
+}
+
+func TestKeystorePasswordSecretManifest(t *testing.T) {
+	raw, err := keystorePasswordSecretManifest("obol-agent", "secret-pass")
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+
+	if manifest["kind"] != "Secret" {
+		t.Fatalf("kind = %v, want Secret", manifest["kind"])
+	}
+	meta := manifest["metadata"].(map[string]any)
+	if meta["name"] != "remote-signer-keystore-password" {
+		t.Fatalf("secret name = %v", meta["name"])
+	}
+	if meta["namespace"] != "openclaw-obol-agent" {
+		t.Fatalf("namespace = %v, want openclaw-obol-agent", meta["namespace"])
+	}
+	stringData := manifest["stringData"].(map[string]any)
+	if stringData["password"] != "secret-pass" {
+		t.Fatalf("password = %v, want secret-pass", stringData["password"])
 	}
 }
 

--- a/internal/openclaw/wallet_test.go
+++ b/internal/openclaw/wallet_test.go
@@ -182,6 +182,40 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	}
 }
 
+func TestImportWalletFromPrivateKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{DataDir: tmpDir}
+
+	keyHex := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	wallet, err := ImportWalletFromPrivateKey(cfg, "imported", keyHex, testUI())
+	if err != nil {
+		t.Fatalf("import wallet: %v", err)
+	}
+
+	wantAddr := "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+	if wallet.Address != wantAddr {
+		t.Errorf("address = %q, want %q", wallet.Address, wantAddr)
+	}
+
+	if !strings.HasPrefix(wallet.PublicKey, "0x04") || len(wallet.PublicKey) != 132 {
+		t.Errorf("public key should be uncompressed 0x04-prefixed key, got %q", wallet.PublicKey)
+	}
+
+	keystoreJSON, err := os.ReadFile(wallet.KeystorePath)
+	if err != nil {
+		t.Fatalf("read keystore: %v", err)
+	}
+
+	recovered, err := decryptV3Keystore(keystoreJSON, wallet.Password)
+	if err != nil {
+		t.Fatalf("decrypt imported keystore: %v", err)
+	}
+
+	if got := "0x" + hex.EncodeToString(recovered); got != keyHex {
+		t.Errorf("recovered key = %q, want %q", got, keyHex)
+	}
+}
+
 func TestDecryptWrongPassword(t *testing.T) {
 	privKey, pubKey, err := generateKeypair()
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes flow-11 so Bob buys with the already-funded second deterministic wallet instead of a generated throwaway remote-signer wallet.

Key changes:
- Add `obol openclaw wallet import-private-key <instance> --private-key-file ... --force`.
- Import the second deterministic key into Bob's remote-signer during `flow-11-dual-stack.sh` and assert `bobSigner == BOB_WALLET`.
- Patch the in-cluster `remote-signer-keystore-password` Secret during wallet import/restore before restarting remote-signer.
- Pin eRPC write routing for explicit `network add --endpoint ... --allow-writes` RPCs so ERC-8004 transactions do not route to flaky built-ins.
- Add conservative ERC-8004 registration recovery/retry for transient RPC 5xx/timeouts.
- Remove the old throwaway-wallet funding path from flow-11 and update the Obol Stack development skill note.

## Flow

```mermaid
sequenceDiagram
  participant Env as .env REMOTE_SIGNER_PRIVATE_KEY
  participant Alice as Alice stack
  participant BobFlow as flow-11
  participant BobSigner as Bob remote-signer
  participant Buyer as buy.py / x402-buyer
  participant Chain as Base Sepolia

  Env->>Alice: first key sells/registers
  Alice->>Chain: ERC-8004 register + metadata
  Env->>BobFlow: derive second key
  BobFlow->>Chain: assert second key has USDC
  BobFlow->>BobSigner: import-private-key(second key)
  BobSigner-->>BobFlow: address == BOB_WALLET
  Buyer->>BobSigner: sign ERC-3009 auths
  Buyer->>Alice: paid inference via paid/qwen3.5:9b
  Alice->>Chain: settle 1000 micro-USDC
```

## Validation

- `bash -n flows/flow-11-dual-stack.sh`
- `go test ./cmd/obol -run 'TestIsTransientRegistrationError|TestSellRegister_Flags|TestOpenClawWalletCommand_Structure' -count=1`
- `go test ./internal/openclaw ./internal/network -count=1`
- `go test ./...`
- Live full flow: `FLOW11_BASE_SEPOLIA_RPC=https://base-sepolia-rpc.publicnode.com ./flows/flow-11-dual-stack.sh`

Live receipts from `.tmp/flow-11-20260424-230033/receipt-summary.json`:
- Agent ID: `5183`
- Alice: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
- Bob / Bob signer: `0x57b0eF875DeB5A37301F1640E469a2129Da9490E`
- Registration tx: `0x2a64bc1aeb27e077fef49e435b6349cca61ead598300e918c5cef8caebb5368f`
- Metadata tx: `0xe43d773ae7cfe7fff3b79dded65c7d38e190bc02d61940c02673b9b12ad2696f`
- Settlement tx: `0x9caf938393ef4b40bc6ff5817c4d620bb9847fef6ff72aac22ec113ad491f516`
- Funding tx: empty, because Bob used the pre-funded derived wallet
- Balance check: Alice `9167000 -> 9168000` micro-USDC, Bob signer `4997000 -> 4996000` micro-USDC
