### PR TITLE
chore: bump frontend image to v0.1.17-rc.4

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.16 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.17-rc.4 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
## Summary

Bumps the released frontend image referenced by `dev-frontend-reset` from `v0.1.16` to `v0.1.17-rc.4`.

## What's in v0.1.17-rc.4

Folded from ObolNetwork/obol-stack-front-end#269:

- **deps**: prettier 3.8.3, eslint-config-next 16.2.4, @next/eslint-plugin-next 16.2.4, next 16.2.4, @tanstack/react-query 5.100.1, @copilotkit/{react-core,react-ui,runtime} 1.56.3
- **chat**: runtime-aware agent dashboard chat (PR #267 in front-end), supports both Hermes and OpenClaw instances
- **ci**: integration/* branches now publish `-dev` images (e.g. `obolnetwork/obol-stack-front-end:0.1.17-rc.4-dev`)

## Test plan

- [ ] `just dev-frontend-reset` pulls the new image successfully