### PR TITLE
chore: bump frontend image to v0.1.17-rc.5

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.17-rc.4 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.17-rc.5 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
## Summary

Bumps the frontend image referenced by `dev-frontend-reset` from `v0.1.17-rc.4` → `v0.1.17-rc.5`.

## What's new in v0.1.17-rc.5 (over rc.4)

- ObolNetwork/obol-stack-front-end#270 — fix hermes agent deeplinks
- ObolNetwork/obol-stack-front-end#272 — ci: integration/* publishes immutability-safe `<version>-dev-<sha>` images
- ObolNetwork/obol-stack-front-end#253 — deps: @tanstack/react-query 5.100.1 → 5.100.5

## Test plan

- [ ] `just dev-frontend-reset` pulls the new image