### PR TITLE
fix(erc8004): wait for read-side consistency before setMetadata

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -1888,6 +1888,14 @@ func registerDirectViaSigner(ctx context.Context, cfg *config.Config, u *ui.UI, 
 	u.Printf("    Agent ID: %s", agentID.String())
 	u.Printf("    Owner:    %s", addr.Hex())
 
+	// The Register tx is mined on the WRITE upstream, but a follow-up
+	// setMetadata estimateGas goes through the READ upstream which can lag
+	// (we observed ERC721NonexistentToken reverts when a stale eRPC route was
+	// pinned to a parallel Anvil fork). Block until the reader sees the token.
+	if _, err := client.WaitForAgent(ctx, agentID, 30*time.Second); err != nil {
+		u.Warnf("agent not visible to reader after register: %v", err)
+	}
+
 	// Set x402 metadata.
 	x402Meta := []byte(`{"x402":true}`)
 	if err := client.SetMetadataWithOpts(ctx, opts, agentID, "x402", x402Meta); err != nil {
@@ -1921,6 +1929,12 @@ func registerDirectWithKey(ctx context.Context, cfg *config.Config, u *ui.UI, ne
 	txAddr := crypto.PubkeyToAddress(key.PublicKey)
 	u.Printf("    Agent ID: %s", agentID.String())
 	u.Printf("    Owner:    %s", txAddr.Hex())
+
+	// Wait for the chain READER to catch up to the freshly-minted agent id;
+	// see comment in registerWithRemoteSigner for the rationale.
+	if _, err := client.WaitForAgent(ctx, agentID, 30*time.Second); err != nil {
+		u.Warnf("agent not visible to reader after register: %v", err)
+	}
 
 	x402Meta := []byte(`{"x402":true}`)
 	if err := client.SetMetadata(ctx, key, agentID, "x402", x402Meta); err != nil {

--- a/internal/erc8004/client.go
+++ b/internal/erc8004/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -292,6 +293,57 @@ func (c *Client) SetMetadata(ctx context.Context, key *ecdsa.PrivateKey, agentID
 		return fmt.Errorf("erc8004: wait mined: %w", err)
 	}
 	return nil
+}
+
+// AgentWallet returns the registered wallet for an agent id via the ERC-8004
+// `getAgentWallet` view, or an error if the READER reports a revert (the
+// pre-mint case appears as ERC721NonexistentToken). Used by WaitForAgent to
+// confirm the chain READER has caught up to a recent register tx before
+// follow-up calls (setMetadata, setAgentURI) try to estimate gas against a
+// state where the token id is still unknown.
+func (c *Client) AgentWallet(ctx context.Context, agentID *big.Int) (common.Address, error) {
+	var out []interface{}
+	if err := c.contract.Call(&bind.CallOpts{Context: ctx}, &out, "getAgentWallet", agentID); err != nil {
+		return common.Address{}, fmt.Errorf("erc8004: getAgentWallet: %w", err)
+	}
+	if len(out) == 0 {
+		return common.Address{}, fmt.Errorf("erc8004: getAgentWallet: empty return")
+	}
+	addr, ok := out[0].(common.Address)
+	if !ok {
+		return common.Address{}, fmt.Errorf("erc8004: getAgentWallet: unexpected type %T", out[0])
+	}
+	return addr, nil
+}
+
+// WaitForAgent polls AgentWallet until the chain READER reports the agent id
+// as owned (any address). Returns when it does, or err on timeout. This closes
+// the read-side staleness window after Register: the Register tx confirms via
+// WaitMined on the WRITE upstream, but a subsequent setMetadata estimateGas
+// goes through the READ upstream which may still be a block or two behind
+// (we hit this in production when a stale eRPC route was pinned to a
+// parallel Anvil fork — the simulation reverted with ERC721NonexistentToken).
+func (c *Client) WaitForAgent(ctx context.Context, agentID *big.Int, timeout time.Duration) (common.Address, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		addr, err := c.AgentWallet(ctx, agentID)
+		if err == nil {
+			return addr, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return common.Address{}, fmt.Errorf("erc8004: waitForAgent %s timed out after %s: %w", agentID, timeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return common.Address{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 // GetMetadata reads metadata for the given key from the agent NFT.

--- a/internal/erc8004/client_test.go
+++ b/internal/erc8004/client_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -632,4 +633,94 @@ func TestGetMetadata_EmptyResult(t *testing.T) {
 // parseABI is a helper that parses the embedded ABI for use in tests.
 func parseABI() (abi.ABI, error) {
 	return abi.JSON(strings.NewReader(identityRegistryABI))
+}
+
+// TestWaitForAgent_RetriesUntilOwnerVisible verifies that WaitForAgent keeps
+// polling ownerOf until the reader returns a successful result, simulating
+// the read-side staleness window between Register's WaitMined (write upstream)
+// and a subsequent setMetadata estimateGas (read upstream).
+func TestWaitForAgent_RetriesUntilOwnerVisible(t *testing.T) {
+	var attempts int
+	owner := common.HexToAddress("0x2FbFe6cF08Ac224f97915ecF07eE29Be0b213f51")
+
+	parsedABI, err := parseABI()
+	if err != nil {
+		t.Fatalf("parseABI: %v", err)
+	}
+
+	handlers := map[string]func([]json.RawMessage) (json.RawMessage, error){
+		"eth_chainId": func(_ []json.RawMessage) (json.RawMessage, error) {
+			return json.RawMessage(`"0x14a34"`), nil
+		},
+		"eth_call": func(_ []json.RawMessage) (json.RawMessage, error) {
+			attempts++
+			if attempts < 3 {
+				// Simulate ERC721NonexistentToken on first two calls (read
+				// upstream not yet caught up).
+				return nil, fmt.Errorf("execution reverted")
+			}
+			// Third call: encode owner as ownerOf return.
+			ownerBytes, encErr := parsedABI.Methods["getAgentWallet"].Outputs.Pack(owner)
+			if encErr != nil {
+				return nil, encErr
+			}
+			return json.RawMessage(fmt.Sprintf("%q", "0x"+common.Bytes2Hex(ownerBytes))), nil
+		},
+	}
+
+	srv := mockRPC(t, handlers)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := NewClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	got, err := client.WaitForAgent(ctx, big.NewInt(5196), 20*time.Second)
+	if err != nil {
+		t.Fatalf("WaitForAgent: %v after %d attempts", err, attempts)
+	}
+	if got != owner {
+		t.Errorf("expected owner %s, got %s", owner, got)
+	}
+	if attempts < 3 {
+		t.Errorf("expected at least 3 attempts (2 reverts + 1 success), got %d", attempts)
+	}
+}
+
+// TestWaitForAgent_TimeoutReturnsError verifies that persistent reverts
+// surface as a timeout error.
+func TestWaitForAgent_TimeoutReturnsError(t *testing.T) {
+	handlers := map[string]func([]json.RawMessage) (json.RawMessage, error){
+		"eth_chainId": func(_ []json.RawMessage) (json.RawMessage, error) {
+			return json.RawMessage(`"0x14a34"`), nil
+		},
+		"eth_call": func(_ []json.RawMessage) (json.RawMessage, error) {
+			return nil, fmt.Errorf("execution reverted")
+		},
+	}
+
+	srv := mockRPC(t, handlers)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := NewClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.WaitForAgent(ctx, big.NewInt(5196), 3*time.Second)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected 'timed out' in error, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a `setMetadata` revert observed on **live Base Sepolia** during `obol sell register`:

```
[base-sepolia] (chain ID 84532)
    Registry: 0x8004A818BFB912233c491871b3d84c89A494BD9e
    Using direct on-chain registration via remote-signer...
    Wallet:   0x2FbFe6cF08Ac224f97915ecF07eE29Be0b213f51
    Agent ID: 5196
    Owner:    0x2FbFe6cF08Ac224f97915ecF07eE29Be0b213f51
  ! failed to set x402 metadata: erc8004: setMetadata tx: execution reverted
    CAIP-10:  eip155:84532:0x8004A818BFB912233c491871b3d84c89A494BD9e
  ✓ Agent registered on 1/1 networks.
```

## Diagnosis

| Check | Result |
|---|---|
| `cast nonce 0x2FbFe6cF... --rpc-url https://sepolia.base.org` (post-incident) | nonce advanced — only `register` broadcast |
| `cast call ownerOf(5196)` (or `getAgentWallet(5196)`) on the registry | returns `0x2FbFe6cF...` ✓ token IS minted |
| `cast call setMetadata(5196, "x402", '{"x402":true}') --from 0x2FbFe6cF` (today, live) | returns `0x` — would succeed |
| `cast call setMetadata(999999999, "x402", 0x01) --from 0x2FbFe6cF` | reverts with data `0x7e273289…` |
| `cast 4byte 0x7e273289` | **`ERC721NonexistentToken(uint256)`** |

So the colleague's diagnosis is correct: the revert came from **`eth_estimateGas` simulation, not on-chain**. The simulation hit a state where token 5196 didn't yet exist.

```
        register tx                            setMetadata
            │                                      │
            ▼                                      ▼
   ┌────────────────────┐               ┌────────────────────┐
   │   WRITE upstream   │               │   READ upstream    │
   │   (eRPC primary)   │               │  (eRPC fallback,   │
   │                    │               │   public RPC, OR a │
   │   Register lands   │               │   stale Anvil fork │
   │   in block N       │               │   pinned by a prior│
   │                    │               │   flow-12/13 run)  │
   └────────────────────┘               └────────────────────┘
            │                                      │
            └─── WaitMined ✓                       └── eth_estimateGas
                                                       at "latest", which
                                                       on the reader side is
                                                       still block N-1 OR a
                                                       fork without 5196 →
                                                       ERC721NonexistentToken
```

The aggravated form: a leftover `obol network add base-sepolia --endpoint http://...:anvil-port` from flow-12/flow-13 leaves a custom upstream pinned for chain 84532; the simulation routes there and the fork has its own ERC-721 storage where 5196 was never minted. (We hit exactly this on a test bench.)

## Fix

- **`internal/erc8004/client.go`** — add `Client.AgentWallet(ctx, agentID)` that calls the ERC-8004 `getAgentWallet` view (the registry's ABI exposes this; the standard ERC-721 `ownerOf` isn't in the embedded ABI). Also add `Client.WaitForAgent(ctx, agentID, timeout)` that polls `AgentWallet` until the reader returns a non-revert response (default 30s budget, 2s poll interval).
- **`cmd/obol/sell.go`** — in both `registerDirectWithKey` and `registerWithRemoteSigner`, after `Register` / `RegisterWithOpts` succeeds, call `client.WaitForAgent(ctx, agentID, 30*time.Second)` BEFORE `SetMetadata` / `SetMetadataWithOpts`. If the reader doesn't catch up within the budget, we log a `Warnf` and let the existing setMetadata error path proceed (still a soft warning, not a hard failure of the registration command).

```diff
   agentID, err := client.Register(...)
   ...
+  // Wait for the chain READER to catch up to the freshly-minted token.
+  if _, err := client.WaitForAgent(ctx, agentID, 30*time.Second); err != nil {
+      u.Warnf("agent not visible to reader after register: %v", err)
+  }
   if err := client.SetMetadata(ctx, key, agentID, "x402", x402Meta); err != nil {
       u.Warnf("failed to set x402 metadata: %v", err)
   }
```

## Tests

Two new unit tests in `internal/erc8004/client_test.go`, using the existing `mockRPC` httptest scaffold:

- `TestWaitForAgent_RetriesUntilOwnerVisible` — mock reader returns `"execution reverted"` twice, then a valid `getAgentWallet` ABI-encoded response on the third call. Asserts `WaitForAgent` returns the expected wallet after at least 3 attempts.
- `TestWaitForAgent_TimeoutReturnsError` — mock reader always returns revert; assert `WaitForAgent` returns a `timed out` error within the budget.

```
$ go test -count=1 ./internal/erc8004/... ./cmd/obol/...
ok  	github.com/ObolNetwork/obol-stack/internal/erc8004	9.455s
ok  	github.com/ObolNetwork/obol-stack/cmd/obol	2.678s
```

## Out of scope

- **`obol network status` upstream-reachability check** — would surface a leftover stale custom upstream that's pointed at a dead Anvil fork. The colleague's incident traced to this scenario; would benefit from a warning at network-list time. Separate PR.
- **flow-12 / flow-13 cleanup-trap teardown of the base-sepolia network pin** — flow-13's trap kills its anvil + facilitator processes but doesn't `obol network remove base-sepolia` from the cluster. Should be added so back-to-back live runs don't inherit the pin. Separate flow PR (#386 already updated the obol-stack-dev skill with the recipe).
- **Generic `bind.Transact` retry on transient reverts** — could be added in `internal/erc8004/client.go` (e.g. retry once on `ERC721NonexistentToken` even after `WaitForAgent`), but the deterministic fix is the wait, and a generic retry could mask real bugs. Not adding speculatively.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/erc8004/... ./cmd/obol/...` clean (includes the two new tests)
- [ ] reviewer reproduces the static-call revert against live Base Sepolia (`cast call setMetadata(<unminted-id>, ...)`) and confirms `WaitForAgent` short-circuits the read-side staleness window in their environment

## Cross-references

- Upstream report and full investigation log: see PR #386 §"setMetadata revert investigation"
- `obol-stack-dev` SKILL.md "setMetadata revert during simulation (live Base Sepolia)" section (introduced in #386) — keep both PRs aligned.
