### PR TITLE
fix(stack): reuse cached dev images on stack up

### DIFF
--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -35,6 +35,11 @@
 #   FLOW11_BOB_HTTPS_PORT  FLOW11_BOB_HTTPS_ALT_PORT
 source "$(dirname "$0")/lib.sh"
 
+# This flow is a smoke/validation harness, not a source-editing loop. Reuse
+# already-cached local dev images when available so repeated runs don't block on
+# unnecessary rebuilds or cold pulls during `obol stack up`.
+export OBOL_REUSE_LOCAL_DEV_IMAGES="${OBOL_REUSE_LOCAL_DEV_IMAGES:-true}"
+
 # ═════════════════════════════════════════════════════════════════
 # PREFLIGHT
 # ═════════════════════════════════════════════════════════════════

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -623,8 +623,8 @@ func devPreloadImages() []string {
 	return images
 }
 
-func forceRebuildLocalImages() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES")), "true")
+func reuseLocalDevImages() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_REUSE_LOCAL_DEV_IMAGES")), "true")
 }
 
 func dockerImageAvailableLocally(tag string) bool {
@@ -652,7 +652,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
-	forceRebuild := forceRebuildLocalImages()
+	reuseCachedImages := reuseLocalDevImages()
 
 	for _, img := range baseLocalImages {
 		contextDir := projectRoot
@@ -672,8 +672,8 @@ func buildAndImportLocalImages(cfg *config.Config) {
 			continue // Dockerfile not present (production install without source)
 		}
 
-		if !forceRebuild && dockerImageAvailableLocally(img.tag) {
-			fmt.Printf("Reusing existing local image %s (set OBOL_FORCE_REBUILD_LOCAL_IMAGES=true to rebuild from source)...\n", img.tag)
+		if reuseCachedImages && dockerImageAvailableLocally(img.tag) {
+			fmt.Printf("Reusing existing local image %s (set OBOL_REUSE_LOCAL_DEV_IMAGES=true to opt into cache reuse)...\n", img.tag)
 			if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
 				fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
 			}
@@ -700,7 +700,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 	}
 
 	for _, ref := range devPreloadImages() {
-		if dockerImageAvailableLocally(ref) {
+		if reuseCachedImages && dockerImageAvailableLocally(ref) {
 			fmt.Printf("Reusing cached image %s for cluster %s...\n", ref, clusterName)
 			if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
 				fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -622,6 +623,17 @@ func devPreloadImages() []string {
 	return images
 }
 
+func forceRebuildLocalImages() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES")), "true")
+}
+
+func dockerImageAvailableLocally(tag string) bool {
+	inspectCmd := exec.Command("docker", "image", "inspect", tag)
+	inspectCmd.Stdout = io.Discard
+	inspectCmd.Stderr = io.Discard
+	return inspectCmd.Run() == nil
+}
+
 // buildAndImportLocalImages builds Docker images from source and imports them
 // into the k3d cluster. This ensures images are available even when the GHCR
 // publish workflow hasn't run. Non-fatal: logs warnings on failure.
@@ -640,6 +652,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
+	forceRebuild := forceRebuildLocalImages()
 
 	for _, img := range baseLocalImages {
 		contextDir := projectRoot
@@ -657,6 +670,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 		}
 		if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 			continue // Dockerfile not present (production install without source)
+		}
+
+		if !forceRebuild && dockerImageAvailableLocally(img.tag) {
+			fmt.Printf("Reusing existing local image %s (set OBOL_FORCE_REBUILD_LOCAL_IMAGES=true to rebuild from source)...\n", img.tag)
+			if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
+			}
+			continue
 		}
 
 		fmt.Printf("Building %s from %s...\n", img.tag, img.dockerfile)
@@ -679,6 +700,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 	}
 
 	for _, ref := range devPreloadImages() {
+		if dockerImageAvailableLocally(ref) {
+			fmt.Printf("Reusing cached image %s for cluster %s...\n", ref, clusterName)
+			if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)
+			}
+			continue
+		}
+
 		fmt.Printf("Preloading %s into cluster %s...\n", ref, clusterName)
 		pullCmd := exec.Command("docker", "pull", ref)
 		pullCmd.Stdout = os.Stdout

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -635,7 +635,7 @@ func TestHasLiveK3dCluster(t *testing.T) {
 	}
 }
 
-func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
+func TestBuildAndImportLocalImages_DefaultBuildsEvenWhenImageExists(t *testing.T) {
 	root := t.TempDir()
 	cfgDir := filepath.Join(root, "config")
 	binDir := filepath.Join(root, "bin")
@@ -692,7 +692,7 @@ func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	defer os.Chdir(oldWD)
-	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "false")
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "false")
 
 	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
 
@@ -701,18 +701,15 @@ func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	if strings.Contains(log, "docker build -f") {
-		t.Fatalf("expected existing local image to skip docker build, log:\n%s", log)
+	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild even when the local image exists, log:\n%s", log)
 	}
-	if !strings.Contains(log, "docker image inspect ghcr.io/obolnetwork/x402-verifier:latest") {
-		t.Fatalf("expected docker image inspect for x402 verifier, log:\n%s", log)
-	}
-	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
-		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
+	if strings.Contains(log, "Reusing existing local image ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild instead of reusing cache, log:\n%s", log)
 	}
 }
 
-func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
+func TestBuildAndImportLocalImages_ReusesExistingImageWhenOptedIn(t *testing.T) {
 	root := t.TempDir()
 	cfgDir := filepath.Join(root, "config")
 	binDir := filepath.Join(root, "bin")
@@ -769,7 +766,7 @@ func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	defer os.Chdir(oldWD)
-	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "true")
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "true")
 
 	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
 
@@ -778,10 +775,10 @@ func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
-		t.Fatalf("expected forced rebuild to call docker build, log:\n%s", log)
+	if strings.Contains(log, "docker build -f") {
+		t.Fatalf("expected opt-in cache reuse to skip docker build, log:\n%s", log)
 	}
 	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
-		t.Fatalf("expected k3d import for rebuilt x402 verifier image, log:\n%s", log)
+		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
 	}
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -634,3 +634,154 @@ func TestHasLiveK3dCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 97\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "false")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "docker build -f") {
+		t.Fatalf("expected existing local image to skip docker build, log:\n%s", log)
+	}
+	if !strings.Contains(log, "docker image inspect ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected docker image inspect for x402 verifier, log:\n%s", log)
+	}
+	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
+		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
+	}
+}
+
+func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "true")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected forced rebuild to call docker build, log:\n%s", log)
+	}
+	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
+		t.Fatalf("expected k3d import for rebuilt x402 verifier image, log:\n%s", log)
+	}
+}


### PR DESCRIPTION
## Summary
- keep `internal/stack` default dev semantics deterministic: source-backed local images still rebuild on normal `obol stack up`
- add an explicit opt-in cache-reuse path via `OBOL_REUSE_LOCAL_DEV_IMAGES=true`
- have `flows/flow-11-dual-stack.sh` opt into that behavior because it is a smoke/validation harness rather than a source-editing loop
- add regression tests for both behaviors: default rebuild vs opt-in cache reuse

## Why
The original stall I hit on latest `main` happened during Alice `stack up` in `flow-11`: `buildAndImportLocalImages()` tried to rebuild `ghcr.io/obolnetwork/x402-verifier:latest` even though that tag was already present locally, and the rebuild blocked while resolving `golang:1.25-alpine`.

I agree that making cache reuse the default in `internal/stack/stack.go` felt too smoke-test-driven and could hide fresh local source changes during normal development. This revision keeps the product-path default unchanged and moves the smoke-specific policy to the smoke harness.

## Design
- `internal/stack/stack.go`
  - add `OBOL_REUSE_LOCAL_DEV_IMAGES=true` as an explicit opt-in
  - when set, reuse already-cached local/preload images if present
  - otherwise keep current behavior: rebuild local repo images / pull preload refs
- `flows/flow-11-dual-stack.sh`
  - exports `OBOL_REUSE_LOCAL_DEV_IMAGES=true` by default for that flow only

## Test Plan
- `bash -n flows/flow-11-dual-stack.sh`
- `go test ./internal/stack -run 'TestBuildAndImportLocalImages_(DefaultBuildsEvenWhenImageExists|ReusesExistingImageWhenOptedIn)' -count=1`
- `go test ./internal/hermes -run 'TestImportPrivateKeyWalletCmd_(ApplyClusterTrueRollsPod|ApplyClusterFalseSkipsCluster|SyncFailureSkipsRestart)' -count=1`
- `go test ./cmd/obol ./internal/stack ./internal/hermes -count=1`
- manual smoke: reran the `flow-11` setup path from this branch and confirmed the earlier `docker build ... Dockerfile.x402-verifier` stall no longer appeared; with the flow opting into cache reuse, Alice `stack up` advanced to a cold `docker pull nousresearch/hermes-agent:v2026.4.23` instead of hanging on the verifier rebuild
