### PR TITLE
test(flows): tighten live OBOL smoke

### DIFF
--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -1,481 +1,140 @@
 ---
 name: obol-stack-dev
-description: Obol Stack development, testing, and validation. Covers LLM routing through LiteLLM, x402 payment flow (sell/buy), BDD integration tests (Gherkin/godog), ERC-8004 registration, and obol CLI wrappers.
+description: Obol Stack development and QA runbook. Use when working on obol-stack flows, x402 seller/buyer tests, live Base Sepolia OBOL smoke tests, Anvil fork regressions, ERC-8004 registration, LiteLLM paid routing, release-smoke, cloudflared, Renovate image bumps, or remote QA worktrees.
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
   domain: infrastructure
-  triggers: obol, litellm, openclaw, inference, integration test, model routing, smart routing, LLM proxy, provider setup, x402, sell, buy, BDD, gherkin, payment, monetize
   role: specialist
   scope: development-and-testing
-  output-format: code-and-commands
-  related-skills: golang-pro, helm-chart-patterns
 ---
 
-# Obol Stack Dev & LLM Routing Validation
+# Obol Stack Dev
 
-Complete guide for developing, testing, and validating the Obol Stack's LLM routing through LiteLLM. Covers the dev environment, CLI wrappers, overlay generation, provider paths, paid `x402` routing, and integration testing.
+Treat this skill as an operational router. Load only the reference needed for the task.
 
-## When to Use This Skill
+## First Actions
 
-- Setting up the Obol Stack development environment
-- Testing LLM inference through LiteLLM (Ollama, Anthropic, OpenAI)
-- Writing or running integration tests for OpenClaw instances
-- Running BDD integration tests for the x402 sell→discover→buy payment flow
-- Debugging model routing issues (401s, 500s, provider misconfig)
-- Understanding the 2-tier LLM architecture (LiteLLM gateway + per-instance config)
-- Validating the paid remote-inference path through LiteLLM + `x402-buyer`
-- Testing x402 payment gating, ERC-8004 registration, OASF metadata
-- Deploying and validating OpenClaw instances with different providers
-- Working with the `obol` CLI wrappers (kubectl, helm, helmfile, k9s)
+1. Inspect current files before changing anything.
+2. Prefer existing repo flows/helpers over new ad hoc scripts.
+3. Use separate QA worktrees on remote machines.
+4. Never leak hostnames, personal paths, passwords, or private keys into skill files or PR text.
+5. Validate with the narrowest command set that covers the change.
 
-## Architecture Overview
+## Reference Router
 
-The stack uses a **2-tier LLM routing** architecture:
-
-```
-Tier 2: Per-Instance                Tier 1: Cluster-Wide Gateway
-(OpenClaw in openclaw-<id> ns)      (LiteLLM in llm ns)
-
-+---------------------------+       +---------------------------+
-| OpenClaw                  |       | LiteLLM (port 4000)       |
-| model: openai/<model-id>  | ----> | Routes by model_list:     |
-| api: openai-completions   |       |   ollama_chat/* -> Ollama  |
-| baseUrl: litellm:4000/v1  |       |   claude-*  -> Anthropic   |
-+---------------------------+       |   gpt-*     -> OpenAI      |
-                                    +---------------------------+
-                                          |       |       |
-                                          v       v       v
-                                       Ollama  Anthropic OpenAI
-                                       (host)   (cloud)  (cloud)
-```
-
-**Key insight**: All traffic routes through LiteLLM regardless of provider. OpenClaw uses the `openai` provider slot (since LiteLLM speaks the OpenAI API protocol) with `openai-completions` API format. LiteLLM resolves the actual upstream provider by model name via its `model_list` config.
-
-## Quick Reference
-
-| Task | Reference |
-|------|-----------|
+| Need | Read |
+|------|------|
+| Live OBOL smoke, flow choice, token, Bob pre-funded wallet, release smoke | `references/live-obol-qa.md` |
+| Remote QA worktrees, tmux launch, scoped cleanup | `references/remote-qa.md` |
+| x402 paid routing, ERC-8004, token additions, flow gotchas | `references/paid-commerce.md` |
+| LiteLLM routing architecture | `references/litellm-routing.md` |
+| CLI wrappers and env layout | `references/obol-cli.md` |
 | Dev environment setup | `references/dev-environment.md` |
-| LLM routing architecture | `references/litellm-routing.md` |
-| CLI wrappers and commands | `references/obol-cli.md` |
-| Overlay generation (values-obol.yaml) | `references/overlay-generation.md` |
-| Integration testing | `references/integration-testing.md` |
-| Troubleshooting | `references/troubleshooting.md` |
+| Integration tests and BDD tests | `references/integration-testing.md` |
+| Overlay generation | `references/overlay-generation.md` |
+| General troubleshooting | `references/troubleshooting.md` |
 
-## Dev Registry Cache
+## Flow Selection
 
-When `OBOL_DEVELOPMENT=true`, `obol stack up` provisions pull-through k3d registry caches before creating a new cluster. Current mirrors:
+Default assumptions:
 
-- `docker.io` -> `k3d-obol-docker-io.localhost:54100`
-- `ghcr.io` -> `k3d-obol-ghcr-io.localhost:54101`
-- `quay.io` -> `k3d-obol-quay-io.localhost:54102`
+- Live OBOL seller/buyer smoke uses Base Sepolia, deployed OBOL, and public facilitator.
+- Anvil is only for explicit fork regression testing.
+- Release gating should name live and fork checks separately.
 
-The generated registry config lives at `$OBOL_CONFIG_DIR/registries.yaml`. Cached image layers are stored under `~/.local/state/obol/registry-cache/` by default, or under `OBOL_REGISTRY_CACHE_DIR` if set.
+| Flow | Run when |
+|------|----------|
+| `flows/flow-11-dual-stack.sh` | USDC seller/buyer baseline |
+| `flows/flow-14-live-obol-base-sepolia.sh` | live OBOL smoke/demo gate |
+| `flows/flow-13-dual-stack-obol.sh` | Anvil fork OBOL Permit2 regression |
 
-Use this mental model:
-
-- Fresh dev cluster: new cluster creation gets `--registry-config` and `--registry-use` entries, so pulls benefit from the cache.
-- Existing dev cluster: `obol stack up` only starts the cluster and does not re-run registry setup.
-- This is an upstream pull cache, not a dedicated local-build publishing workflow.
-
-## Existing Dev Stack Refresh
-
-When testing a new frontend or stack branch against an already-initialized `.workspace/config`, rebuild the local CLI before `stack up`. Current `obol stack up` refreshes `$OBOL_CONFIG_DIR/defaults` when the embedded infrastructure digest, backend, or stack ID changes, then preserves mutable LiteLLM model entries across Helm sync. If testing raw file edits without rebuilding the CLI, patch the generated defaults copy manually or re-run after rebuilding.
+Release-smoke flags:
 
 ```bash
-# Prefer origin-only fetches in this checkout. Some Radicle remotes may be stale
-# and can make `git fetch --all` fail after GitHub has already fetched.
-git fetch origin --prune
-
-# Rebuild the local CLI from the current branch.
-go build -o .workspace/bin/obol ./cmd/obol
-
-# For a released frontend image, verify and pull the exact tag first.
-docker manifest inspect obolnetwork/obol-stack-front-end:v0.1.17-rc.5 >/dev/null
-docker pull obolnetwork/obol-stack-front-end:v0.1.17-rc.5
-
-# Confirm the embedded source has the intended image tag before rebuilding.
-rg -n 'obol-stack-front-end|tag:' internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
-
-OBOL_CONFIG_DIR="$PWD/.workspace/config" \
-OBOL_BIN_DIR="$PWD/.workspace/bin" \
-OBOL_DATA_DIR="$PWD/.workspace/data" \
-  .workspace/bin/obol stack up
+RELEASE_SMOKE_INCLUDE_OBOL=true       # live flow-14
+RELEASE_SMOKE_INCLUDE_OBOL_FORK=true  # fork flow-13
 ```
 
-Expected verification for frontend image refresh:
+## Critical Invariants
+
+Live OBOL token default:
 
 ```bash
-OBOL_CONFIG_DIR="$PWD/.workspace/config" OBOL_BIN_DIR="$PWD/.workspace/bin" OBOL_DATA_DIR="$PWD/.workspace/data" \
-  .workspace/bin/obol kubectl -n obol-frontend get deploy obol-frontend-obol-app \
-  -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
-
-OBOL_CONFIG_DIR="$PWD/.workspace/config" OBOL_BIN_DIR="$PWD/.workspace/bin" OBOL_DATA_DIR="$PWD/.workspace/data" \
-  .workspace/bin/obol kubectl -n obol-frontend rollout status deploy/obol-frontend-obol-app --timeout=180s
-
-curl -sS -I --max-time 10 http://obol.stack
-curl -sS --max-time 15 http://obol.stack/api/agents/instances
+OBOL_TOKEN_BASE_SEPOLIA=0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4
 ```
 
-Known existing-stack migration failures:
+Buyer wallet invariant:
 
-- `Namespace "hermes-obol-agent" ... exists and cannot be imported into the current release`: the namespace or monetize RBAC predated Helm ownership. Current `obol stack up` adopts known base-owned resources before Helm sync. If doing it manually, label and annotate the existing resource with `app.kubernetes.io/managed-by=Helm`, `meta.helm.sh/release-name=base`, and `meta.helm.sh/release-namespace=kube-system`.
-- `conflict with "kubectl-patch" ... llm/litellm-config .data.config.yaml`: older writers used a non-Helm field manager for `data.config.yaml`, which conflicts with Helm server-side apply. Current writers use Helm's field manager. During `obol stack up`, the existing LiteLLM config is backed up and previous model entries are merged into the new chart config; if a non-Helm manager is detected, the ConfigMap is deleted before Helm sync so ownership is recreated cleanly.
-- `/etc/hosts` updates require interactive sudo. Codex cannot satisfy the password prompt in non-interactive execution; if DNS fails in the browser, run `obol stack up` or `obol agent sync obol-agent` from a normal terminal, or manually add `127.0.0.1 obol-agent.obol.stack` and flush local DNS.
+- `flow-11` and `flow-14` derive Bob from `.env` `REMOTE_SIGNER_PRIVATE_KEY`.
+- Bob is the second deterministic derived key.
+- The flow must pre-seed Bob's remote-signer before Bob `stack up`.
+- The flow must assert `bobSigner == BOB_WALLET`.
+- Do not transfer funds to a generated signer to make the test pass.
 
-## 4 Inference Paths (All Through LiteLLM)
+Token/auth invariant:
 
-| Path | Model Name | LiteLLM model_list | Example |
-|------|-----------|-------------------|---------|
-| **Ollama** (default) | `<model>` | `ollama_chat/<model>` → Ollama svc | `llama3.2:3b` |
-| **Anthropic** (cloud) | `<claude-model>` | `<claude-model>` → Anthropic API | `claude-sonnet-4-5-20250929` |
-| **OpenAI** (cloud) | `<gpt-model>` | `<gpt-model>` → OpenAI API | `gpt-4o` |
-| **Paid x402 remote** | `paid/<model>` | `paid/*` → `openai/*` → `x402-buyer` sidecar | `paid/qwen3.5:9b` |
+- Use `obol agent auth --runtime <runtime> obol-agent`.
+- Do not use `obol hermes token obol-agent`; it can print CLI usage text and poison the Bearer token.
 
-All 4 paths use the same OpenClaw config pattern:
-- Provider slot: `openai` (LiteLLM is OpenAI-API-compatible)
-- API: `openai-completions`
-- Base URL: `http://litellm.llm.svc.cluster.local:4000/v1`
-- API key: LiteLLM master key (`sk-obol-<cluster-id>`)
+Payment assertion invariant:
 
-### Paid Routing Notes
+- Do not rely on agent wording.
+- Assert `PurchaseRequest Ready=True`, paid inference HTTP 200, settlement `Transfer`, and exact balance deltas.
 
-- The paid path uses the **Obol LiteLLM fork** because paid-model lifecycle relies on the config-only model management API.
-- `litellm-config` carries one static route: `paid/* -> openai/* -> http://127.0.0.1:8402/v1`.
-- `x402-buyer` runs as a **sidecar in the LiteLLM pod**, not as a separate Service.
-- `buy.py buy` signs auths locally and creates a `PurchaseRequest`; the controller writes per-upstream buyer files and keeps LiteLLM model entries in sync.
-- The currently validated local OSS model is `qwen3.5:9b`. Prefer that exact model in live commerce tests.
-- In `flow-11-dual-stack.sh`, do not confuse the derived `BOB_WALLET` with the wallet that actually buys. Alice sells/registers with the `.env` `REMOTE_SIGNER_PRIVATE_KEY`, while Bob's agent signs through the Bob stack's `remote-signer` key. The flow scaffolds Bob's default agent with `obol openclaw onboard --id obol-agent --no-sync`, pre-seeds the second deterministic derived key with `obol wallet import --instance obol-agent --private-key-file ... --force` before `stack up`, asserts `bobSigner == BOB_WALLET`, and spends from that already-funded wallet. Do not reintroduce a funding transfer to a generated throwaway signer.
+## Remote QA Rules
 
-## Essential Commands
+- Use two generic QA machines with sudo access; do not write their names into docs.
+- Assume parallel tests are running.
+- Always create a per-run worktree.
+- Clean only clusters whose stack IDs are recorded in that worktree.
+- Move root-owned stale worktrees aside; do not broad-delete host paths.
+
+Read `references/remote-qa.md` before running SSH/tmux cleanup or live smoke remotely.
+
+## Common Commands
+
+Local syntax/config:
 
 ```bash
-# --- Dev Environment ---
-OBOL_DEVELOPMENT=true ./obolup.sh      # Bootstrap dev mode
-go build -o .workspace/bin/obol ./cmd/obol  # Build binary
+bash -n flows/*.sh
+git diff --check
+jq empty renovate.json
+```
 
-# --- Stack Lifecycle ---
-obol stack init && obol stack up        # Start cluster
-obol stack down                         # Stop (preserves data)
-obol stack purge -f                     # Destroy everything
+Chart/image checks:
 
-# --- Model Provider Setup (Tier 1: LiteLLM) ---
-obol model setup --provider anthropic --api-key sk-ant-...
-obol model setup --provider openai --api-key sk-proj-...
-obol model setup --provider ollama      # Auto-discovers local models
-obol model status                       # Show enabled providers
+```bash
+helm lint internal/embed/infrastructure/cloudflared
+helm template cloudflared internal/embed/infrastructure/cloudflared | rg 'cloudflare/cloudflared:'
+docker manifest inspect cloudflare/cloudflared:2026.3.0
+```
 
-# --- OpenClaw Instance Management (Tier 2) ---
-obol openclaw onboard --id my-agent     # Interactive deploy
-obol openclaw sync <id>                 # Deploy/update instance
-obol openclaw token <id>                # Get gateway Bearer token
-obol openclaw list                      # Show all instances
-obol openclaw delete --force <id>       # Remove instance
-obol openclaw dashboard <id>            # Open web UI
+Focused Go checks:
 
-# --- Debugging ---
-obol kubectl get pods -n openclaw-<id>
-obol kubectl logs -n openclaw-<id> -l app.kubernetes.io/instance=openclaw
-obol kubectl port-forward -n openclaw-<id> svc/openclaw 18789:18789
+```bash
+go test ./cmd/obol ./internal/tunnel ./internal/stack -count=1
+go test ./cmd/obol ./internal/stack ./internal/hermes -count=1
+```
 
-# --- Testing ---
-go test ./internal/openclaw/                                    # Unit tests
-go test -tags integration -v -timeout 10m ./internal/openclaw/  # Integration tests
+Integration checks:
 
-# --- Validated paid commerce loop (qwen3.5:9b) ---
-# Reuse a running cluster by pointing OBOL_CONFIG_DIR at that cluster's .workspace/config
+```bash
+go test -tags integration -v -run TestBDDIntegration -timeout 10m ./internal/x402/
 go test -tags integration -v -run TestIntegration_Tunnel_SellDiscoverBuySidecar_QuotaAndBalance -timeout 30m ./internal/openclaw/
 ```
 
-## Agent Skills System
+## Editing Guidance
 
-Skills are SKILL.md files (with optional scripts and references) that give the agent domain-specific capabilities. Hermes receives embedded Obol skills through native `skills.external_dirs` at `/data/.hermes/obol-skills` with `OBOL_SKILLS_DIR` set. OpenClaw receives embedded skills through host-path PVC injection to `/data/.openclaw/skills/`.
+Do:
 
-### Default Embedded Skills
+- Keep `SKILL.md` short and operational.
+- Add detailed flow notes to `references/*.md`.
+- Add fragile repeated shell sequences to `scripts/` if they grow beyond one short command block.
+- Keep references one hop from `SKILL.md`.
 
-| Skill | Contents | Purpose |
-|-------|----------|---------|
-| `hello` | `SKILL.md` | Smoke test |
-| `obol-blockchain` | `SKILL.md`, `scripts/rpc.py`, `references/` | Ethereum JSON-RPC, ERC-20, ENS via eRPC |
-| `obol-k8s` | `SKILL.md`, `scripts/kube.py` | K8s cluster diagnostics via ServiceAccount API |
-| `obol-dvt` | `SKILL.md`, `references/api-examples.md` | DVT monitoring via Obol API |
+Do not:
 
-### Skills CLI
-
-```bash
-obol openclaw skills list                   # list installed skills
-obol openclaw skills sync                   # re-inject embedded defaults
-obol openclaw skills sync --from ./custom   # push custom skills
-obol openclaw skills add <package>          # add via openclaw CLI in pod
-obol openclaw skills remove <name>          # remove skill from pod
-```
-
-### Skills Delivery Flow
-
-1. `stageDefaultSkills(deploymentDir)` — copies embedded skills to deployment dir
-2. `injectSkillsToVolume(cfg, id, deploymentDir)` — copies to host PVC path (`$DATA_DIR/openclaw-<id>/openclaw-data/.openclaw/skills/`)
-3. `doSync()` — helmfile sync; OpenClaw file watcher discovers skills on startup
-
-### Skills Testing
-
-```bash
-# Unit tests (embedding + injection)
-go test -v -run TestGetEmbeddedSkillNames ./internal/embed/
-go test -v -run TestInjectSkillsToVolume ./internal/openclaw/
-
-# Integration tests (requires running cluster)
-go test -tags integration -v -run TestIntegration_Skills -timeout 10m ./internal/openclaw/
-
-# In-pod smoke tests (piped via kubectl exec)
-obol kubectl exec -i -n openclaw-<id> deploy/openclaw -c openclaw -- python3 - < tests/skills_smoke_test.py
-```
-
-## Key Source Files
-
-| File | Purpose |
-|------|---------|
-| `internal/openclaw/openclaw.go` | `Onboard()`, `Sync()`, `Delete()`, `buildLiteLLMRoutedOverlay()`, `generateOverlayValues()`, `SyncOverlayModels()` |
-| `internal/openclaw/import.go` | `DetectExistingConfig()`, `TranslateToOverlayYAML()` |
-| `internal/openclaw/overlay_test.go` | Unit tests for overlay generation |
-| `internal/openclaw/integration_test.go` | Full-cluster integration tests (build tag: `integration`) |
-| `internal/model/model.go` | `ConfigureLiteLLM()` — patches LiteLLM ConfigMap + Secret + restart |
-| `cmd/obol/model.go` | `obol model setup` CLI command (also syncs OpenClaw overlays) |
-| `cmd/obol/openclaw.go` | `obol openclaw` CLI commands (including `skills` subcommands) |
-| `internal/embed/infrastructure/base/templates/llm.yaml` | LiteLLM + Ollama Kubernetes resources |
-| `internal/embed/skills/` | Embedded default skills |
-| `internal/embed/embed.go` | `CopySkills()`, `GetEmbeddedSkillNames()` |
-
-## Constraints
-
-### MUST DO
-- Always route through `obol` CLI verbs in tests (covers CLI + helmfile + helm chart)
-- Preserve failing exit codes when logging or filtering command output. Use `set -o pipefail` or capture `PIPESTATUS` for any pipeline such as `flow.sh | tee log`, `obol stack up 2>&1 | tail`, or `helmfile ... | tee`; otherwise Helm/obol failures can be masked by the final command in the pipe.
-- Use `obol openclaw token <id>` to get Bearer token before API calls
-- Set `Authorization: Bearer <token>` on all `/v1/chat/completions` requests
-- Use `obol model setup --provider <name> --api-key <key>` for cloud provider config
-- Wait for pod readiness AND HTTP readiness before sending inference requests
-- Clean up test instances with `obol openclaw delete --force <id>` (flag BEFORE arg)
-- Set env vars for dev mode: `OBOL_DEVELOPMENT=true`, `OBOL_CONFIG_DIR`, `OBOL_BIN_DIR`, `OBOL_DATA_DIR`
-- Prefer `qwen3.5:9b` when validating the current local paid-inference route
-- Use unique buy-side names in reused-cluster commerce tests so the sidecar cannot inherit stale in-memory spend counters
-- Use narrow review/delegation scopes for x402 changes. Name the exact files and invariants to verify, such as "controller never signs or reads remote-signer", "agent write RBAC is namespace-scoped", "paid route uses real obol CLI/human flow", and "tests support x402 v2 amount fields".
-- Before pushing, ensure the branch name is not `codex/*`. In this repo, never push `codex/`-prefixed branches to GitHub; rename or switch to a `<username>/`, `feat/`, `fix/`, `research/`, or other non-codex branch first.
-
-### MUST NOT DO
-- Call internal Go functions directly when testing the deployment path
-- Skip the gateway token (causes 401 Unauthorized)
-- Put `--force` flag after the argument in `obol openclaw delete` (urfave/cli v2 quirk)
-- Assume TCP connectivity means HTTP is ready (port-forward warmup race)
-- Use `app.kubernetes.io/instance=openclaw-<id>` for pod labels (Helm uses `openclaw`)
-- Run multiple integration tests without cleaning up between them (pod sandbox errors)
-- Delegate or accept broad "review the architecture" findings without converting them into concrete file-level checks and reproducible tests.
-- Push `codex/`-prefixed branches to GitHub from this repository.
-
-## Adding a New Payment Token
-
-The `--token` flag (`obol sell inference`, `obol sell http`) selects the payment token from a whitelist registry in `internal/x402/tokens.go`. To add support for a new ERC-20 token:
-
-1. **Add registry entry** in `internal/x402/tokens.go` — one entry per (token, chain) pair:
-   ```go
-   "WETH": {
-       "base": {Address: "0x4200000000000000000000000000000000000006", Symbol: "WETH", Decimals: 18, TransferMethod: "permit2", EIP712Name: "Wrapped Ether", EIP712Version: "1"},
-   },
-   ```
-
-2. **Determine the transfer method**:
-   - `eip3009` — token natively implements `transferWithAuthorization` (USDC, EURC)
-   - `permit2` — uses Uniswap Permit2 (`0x000000000022D473030F116dDEE9F6B43aC78BA3`) for authorization; works with any ERC-20
-
-3. **Per-chain considerations**:
-   - Verify the token contract is deployed on each target chain (the buy-side validates this via `eth_getCode` before signing)
-   - Verify the EIP-712 domain name/version match the on-chain contract — wrong values produce invalid signatures
-   - The x402 facilitator must have the target chain configured (check `obol-infrastructure/helm-charts/x402-facilitator/templates/configmap.yaml` for `eip155:<chainId>` entries)
-   - The x402 ExactPermit2Proxy (`0x402085c248EeA27D92E8b30b2C58ed07f9E20001`) must be deployed on the chain for Permit2 tokens
-
-4. **Add tests** in `internal/x402/tokens_test.go`:
-   - Verify `ResolveToken("WETH", "base")` returns the correct entry
-   - Verify `ResolveToken("WETH", "ethereum")` returns false if not registered there
-
-5. **No CLI changes needed** — `--token WETH` resolves automatically from the registry.
-
-6. **buy.py handles both paths** — it reads `extra.assetTransferMethod` from the 402 response and auto-selects the ERC-3009 or Permit2 signing flow. Contract existence is validated before signing.
-
-## Sell-Side Monetize Lifecycle
-
-### Architecture
-
-The monetize subsystem enables pay-per-request access to local compute via x402:
-
-```
-ServiceOffer CR → monetize.py reconciliation → Middleware + HTTPRoute + pricing route
-                                                       │
-Client request ──► Traefik ──► x402-verifier (ForwardAuth) ──► backend (Ollama)
-                                    │                              │
-                               402 (no payment)              200 (valid payment)
-                               Payment requirements          Inference response
-```
-
-### Three-Layer Integration
-
-1. **monetize.py** (OpenClaw skill) — Creates Middleware, HTTPRoute, pricing ConfigMap route
-2. **x402-verifier** (ForwardAuth) — Checks X-PAYMENT header against facilitator
-3. **Traefik Gateway API** — Routes traffic; requires ClusterIP backends (not ExternalName)
-4. **x402-buyer sidecar** — Serves static `paid/<model>` aliases from LiteLLM and spends one pre-signed authorization per request
-
-### Testing the Monetize Flow
-
-```bash
-# Prerequisites
-obol stack up && obol agent init
-
-# Create offer (--wallet not --pay-to; --chain not --network; no --model flag)
-obol sell http qwen35 \
-  --upstream ollama --port 11434 --namespace llm --health-path /api/tags \
-  --per-request "0.001" --chain "base-sepolia" --wallet "0x<wallet>"
-
-# Trigger reconciliation from the default Hermes agent pod
-obol kubectl exec -n hermes-obol-agent deploy/hermes -c hermes -- \
-  python3 /data/.hermes/obol-skills/monetize/scripts/monetize.py process qwen35 --namespace llm
-
-# Verify 402
-curl -X POST http://obol.stack:8080/services/qwen35/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"qwen3.5:35b","messages":[{"role":"user","content":"hi"}],"stream":false}'
-
-# Run e2e test (with mock facilitator)
-export OBOL_DEVELOPMENT=true OBOL_CONFIG_DIR=$(pwd)/.workspace/config OBOL_BIN_DIR=$(pwd)/.workspace/bin
-go test -tags integration -v -run TestIntegration_PaymentGate_FullLifecycle -timeout 5m ./internal/x402/
-
-# Run the full paid commerce loop (real facilitator, discovery, buy.py, sidecar, quota, USDC settlement)
-go test -tags integration -v -run TestIntegration_Tunnel_SellDiscoverBuySidecar_QuotaAndBalance -timeout 30m ./internal/openclaw/
-```
-
-### Known Gotchas
-
-- **ExternalName services**: Traefik Gateway API rejects ExternalName as HTTPRoute backends → 500 after valid payment. Use ClusterIP+Endpoints.
-- **Model pull timeout**: monetize.py checks `/api/tags` before `/api/pull` to avoid hanging on cached models.
-- **Facilitator HTTPS**: URLs must be HTTPS except localhost, 127.0.0.1, host.k3d.internal, host.docker.internal.
-- **ConfigMap propagation**: File watcher takes 60-120s. Force restart verifier for immediate effect.
-- **Projected ConfigMap refresh**: the LiteLLM pod can take ~60s to reflect updated buyer ConfigMaps in the sidecar.
-- **eRPC balance lag**: `buy.py balance` uses `eth_call` through eRPC, and the default unfinalized cache TTL is 10s. After a paid request, poll until the reported balance catches up with the on-chain delta.
-- **kubectl exec shell quoting**: NEVER use `sh -c` with `fmt.Sprintf` to embed JSON or secrets in shell commands passed via `kubectl exec`. JSON body or auth tokens containing single quotes will break the shell. Instead, pass args directly: `kubectl exec ... -- wget -qO- --post-data=<json> --header=Authorization:\ Bearer\ <key> <url>`. Each argument goes as a separate argv element, bypassing shell interpretation entirely.
-
-## Running Flows on Remote Hosts (spark1/spark2/CI)
-
-A long flow (`flow-11`, `flow-13`) launched from an SSH session needs to survive the SSH connection ending. Don't trust `nohup` or `setsid -f` — both have been observed to die mid-flow over Cloudflare-tunneled SSH (the parent-shell SIGHUP propagates regardless). Use the canonical wrapper:
-
-```bash
-ssh host "cd ~/obol-stack-src && bash flows/run-detached.sh flow-11-dual-stack.sh"
-# Prints the log path; tail it from a new SSH session to follow.
-```
-
-`flows/run-detached.sh` tries `tmux` → `screen` → `setsid -f` in that order. Tmux is by far the most reliable; spark hosts already have it.
-
-### Mandatory environment for non-login shells
-
-A bash shell launched by `nohup`/`setsid`/cron does NOT source `.bashrc` and so will not see `~/.foundry/bin` (cast/anvil/forge) or `~/.local/bin` (kubectl/helm/k3d). `flows/lib.sh` exports the canonical PATH at source time — every flow must `source "$(dirname "$0")/lib.sh"` before its first `cast`/`kubectl` call. If you write a new flow, source lib.sh first, never inline.
-
-### `.env` parsing
-
-The flow harness extracts `REMOTE_SIGNER_PRIVATE_KEY` with an anchored regex (`^[[:space:]]*REMOTE_SIGNER_PRIVATE_KEY=`) and `cut -d= -f2-`. A loose `grep REMOTE_SIGNER_PRIVATE_KEY` matches comment lines too and produces multi-line junk that `cast wallet address --private-key` then chokes on. Keep the anchored form when copy-pasting into new flows.
-
-### Probing in-cluster from outside containers
-
-eRPC, x402-verifier, x402-buyer, and Hermes API-server are all distroless — no `wget`/`curl`/`nc` baked in. Don't `kubectl exec deploy/erpc -- wget …`; it always fails. Instead spin up a transient probe pod:
-
-```bash
-kubectl run flow-probe-$RANDOM --rm -i --restart=Never --image=busybox:1.36 --quiet \
-    -- sh -c "wget -qO- --timeout=5 http://erpc.erpc.svc.cluster.local:4000 \
-        --post-data='{...}' --header='Content-Type: application/json'"
-```
-
-This is what `flows/flow-13-dual-stack-obol.sh` does for the `host.k3d.internal` reachability checks.
-
-### Polling pod readiness in multi-container pods
-
-`kubectl get pods` STATUS column collapses a `1/2 CrashLoopBackOff` pod to "CrashLoopBackOff" even when the container we care about is happily Running. For the buyer's API-server check on Hermes (where `hermes-dashboard` may be unhealthy), poll the *specific* container's `containerStatuses[?(@.name==<name>)].ready` instead of the pod-summary column:
-
-```bash
-poll_step_grep "Bob: Hermes API-server ready" "true" 36 5 \
-    bob kubectl get pods -n "$BOB_AGENT_NS" -l "$BOB_AGENT_LABEL" \
-        -o "jsonpath={range .items[*].status.containerStatuses[?(@.name=='${BOB_AGENT_CONTAINER}')]}{.ready}{'\n'}{end}"
-```
-
-Use `BOB_AGENT_*` vars exported by `detect_buyer_runtime` (added to `flows/lib.sh`). Don't hardcode `openclaw-obol-agent` / `app.kubernetes.io/name=openclaw` — those break on Hermes.
-
-### Hermes dashboard requires `GATEWAY_ALLOW_ALL_USERS=true` in dev
-
-The `hermes-dashboard` container in the upstream `nousresearch/hermes-agent` image refuses to start without an allowlist:
-
-```
-WARNING gateway.run: No user allowlists configured. All unauthorized users will be denied.
-Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, or
-configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id).
-```
-
-The chart at `internal/hermes/hermes.go` injects `GATEWAY_ALLOW_ALL_USERS=true` for the dashboard container only — safe in a local k3d cluster (no public messaging endpoint to defend), required to override in production.
-
-### Anvil fork hosting
-
-Anvil binds 127.0.0.1 by default. For a k3d cluster to reach it via `host.k3d.internal`, start with `--host 0.0.0.0`:
-
-```bash
-anvil --fork-url https://sepolia.base.org --port "$ANVIL_PORT" --host 0.0.0.0
-```
-
-Both Alice's and Bob's clusters share the same Anvil through `host.k3d.internal:$ANVIL_PORT`, but each cluster's eRPC must be pinned to the custom upstream:
-
-```bash
-alice network add base-sepolia --endpoint "http://host.k3d.internal:$ANVIL_PORT" --allow-writes
-# Then patch eRPC to drop the public Base Sepolia upstream so requests hit only the fork.
-# pin_erpc_chain_single_upstream is a flow-13 helper; mirror it for new flows.
-```
-
-### x402-rs facilitator scheme config
-
-There is NO standalone `v2-eip155-permit2` scheme. OBOL Permit2 / EIP-2612 gas sponsoring is enabled by adding `config.eip2612_gas_sponsoring=true` to the `v2-eip155-exact` scheme entry — same as `internal/testutil/facilitator_real.go::writeRealFacilitatorConfig` does. The `/supported` endpoint will list `v1+v2 exact` for `base-sepolia`/`eip155:84532`; the buyer-side is what produces the Permit2 payload.
-
-### Cloudflared is lazy
-
-`obol stack up` does NOT deploy cloudflared. The deployment is created on demand by `obol sell http` (which calls `tunnel.EnsureTunnelForSell`). If a flow applies a ServiceOffer YAML directly (because the CLI doesn't expose the asset metadata flags it needs), it must call `obol tunnel restart` (or equivalent) to bring cloudflared up explicitly before `obol tunnel status` can return a URL. flow-13 does this.
-
-### `--namespace` on `obol sell http` is overloaded
-
-`--namespace` sets BOTH the ServiceOffer CR namespace AND the upstream service namespace (the chart can't separate them on this command). Pass the same `-n <ns>` to every follow-up `sell status|stop|delete`. The CLI prints the correct namespace after creation; copy from there.
-
-### Cloudflared image stalls on aarch64 hosts
-
-On some aarch64 hosts (we've seen this on a Spark with NVIDIA stack), the k3d registry mirror gets stuck on `cloudflare/cloudflared:2026.1.2` — manifest HEAD returns 200 but no blob GETs follow and kubelet sits in `ContainerCreating` forever. Workaround in `flows/lib.sh::ensure_image_in_k3d`: pull via host docker, save tarball, ctr-import directly into the k3d node:
-
-```bash
-ensure_image_in_k3d cloudflare/cloudflared:2026.1.2 obol-stack-<petname>
-```
-
-Run this before `obol stack up` finishes pulling the chart, or right after if you observe the stall.
-
-### Don't trust agent natural-language responses as test assertions
-
-LLM agents (OpenClaw or Hermes) give different wording across runs. `grep -qE "purchase complete|successful|paid"` is brittle — once we hit "Successfully purchased N tokens" (Hermes) it didn't match the regex aimed at OpenClaw and we got a false FAIL even though the on-chain state was correct. Treat the agent's natural-language output as informational; assert on **structural** state (`PurchaseRequest.status.Ready=True`, `cast logs Transfer(...)` receipt with status=0x1) instead.
-
-### ERC-8004 registration prerequisites in flows
-
-The serviceoffer-controller never signs on-chain. All ERC-8004 registration goes through the CLI (`obol sell http`, `obol sell register`), which delegates signing to the agent's remote-signer pod — the CLI never sees raw key material. If the ServiceOffer has `registration.enabled: true`, the controller will publish the registration document and watch the chain, but it depends on the operator (or a flow script) to land the on-chain register tx via the CLI.
-
-Two paths to satisfy that for a flow:
-
-1. **Via `obol sell http`** — `obol agent init` (or `obol stack up`'s default-agent setup) must have created a Hermes remote-signer with a usable wallet. If you need a specific test wallet, run `obol wallet import --instance obol-agent --private-key-file <file> --force` first, then `obol sell http` will sign register/setMetadata via that imported key. The CLI also calls `EnsureTunnelForSell` so the controller gets the tunnel URL in the `obol-stack-config` ConfigMap. flow-11 and flow-14 take this path.
-2. **YAML-apply with `registration.enabled: false`** — skip ERC-8004 entirely. Suitable for tests that exercise only the payment path. flow-13 does this; cross-cluster discovery falls back to skill.md / a known-URL hand-off.
-
-If you apply a ServiceOffer YAML with `registration.enabled: true` and never run the CLI register step, the request parks at `AwaitingExternalRegistration` and `Ready` stays False. Either run `obol sell register` or drop the flag.
-
-### setMetadata revert during simulation (live Base Sepolia)
-
-`erc8004.Client.SetMetadata` writes via `setMetadata(uint256,string,bytes)` on the registry contract. If the `eth_estimateGas` simulation reverts, the broadcast is aborted (only `register` lands; the wallet nonce only goes 0→1). The dominant cause we hit is **read-side staleness**: eRPC's read upstream returns `ERC721NonexistentToken` for the freshly-minted agent ID even though the register tx already landed on the write upstream. PR #387 closes this window by inserting `Client.WaitForAgent` between `Register` and `SetMetadata`, which polls `ownerOf(agentID)` until the reader catches up — that's the right fix and is now wired into both `registerSponsored` and `registerDirectViaSigner`.
-
-Other less-common causes worth ruling out:
-
-1. The eRPC chain route is pinned to a stale Anvil fork from a prior flow-12/13 run that didn't unwind. Verify with `obol kubectl get cm erpc-config -n erpc -o yaml` — if the `base-sepolia` upstream points anywhere other than the public RPC (`https://sepolia.base.org`), the simulation runs against a dead fork. `obol network sync` or `obol network remove base-sepolia && obol network add base-sepolia --allow-writes` to reset.
-2. Contract-level: the registry's `setMetadata` checks ownership of the agent ID. If the registration tx and the setMetadata simulation use different `from` addresses (e.g. signer-key mismatch between commands), the revert is "not owner". `cast call --from <signer> 0x8004... "setMetadata(uint256,string,bytes)" <agentId> "x402.supported" 0x01 --rpc-url https://sepolia.base.org` reproduces it cheaply.
-3. Encoding: `[]byte{1}` for `x402.supported` is the historical convention but the on-chain ERC-8004 spec may require a string `"true"` or a typed value. Check the registry source on Basescan if the static call's revert reason mentions schema/length.
-
-When in doubt, run the static `cast call --from $SIGNER ...` first; the revert reason it surfaces is the same one the CLI sees from `eth_estimateGas`.
+- Add README-style docs inside the skill folder.
+- Duplicate the same procedure in `SKILL.md` and references.
+- Bury safety constraints below examples.
+- Add host-specific names, credentials, or copied logs.

--- a/.agents/skills/obol-stack-dev/references/live-obol-qa.md
+++ b/.agents/skills/obol-stack-dev/references/live-obol-qa.md
@@ -1,0 +1,66 @@
+# Live OBOL QA
+
+Use this reference for `flow-14-live-obol-base-sepolia.sh`, release smoke OBOL checks, and demo-gate validation.
+
+## Flow Selection
+
+| Flow | Use for | Network | Token | Facilitator |
+|------|---------|---------|-------|-------------|
+| `flows/flow-11-dual-stack.sh` | USDC baseline | Base Sepolia | USDC | configured x402 facilitator |
+| `flows/flow-14-live-obol-base-sepolia.sh` | default live OBOL smoke/demo gate | Base Sepolia | deployed OBOL | `https://x402.gcp.obol.tech` |
+| `flows/flow-13-dual-stack-obol.sh` | OBOL Permit2 regression without live funds | Anvil fork | fork-local OBOL | local x402-rs |
+
+Default to live Base Sepolia for OBOL. Start Anvil only when explicitly testing the fork regression.
+
+## Live Token
+
+```bash
+OBOL_TOKEN_BASE_SEPOLIA=0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4
+```
+
+`flow-14` defaults to this token. Override only when validating a different deployment.
+
+## Required Funding
+
+`REMOTE_SIGNER_PRIVATE_KEY` is Alice's seller/register key and must hold Base Sepolia ETH.
+
+Bob is the deterministic second-derived key from `REMOTE_SIGNER_PRIVATE_KEY`; it must already hold Base Sepolia OBOL. `flow-14` pre-seeds Bob's remote-signer with this key before `stack up`. Do not fund a generated signer inside the flow.
+
+Derive/check Bob:
+
+```bash
+SIGNER_KEY=$(grep -E '^[[:space:]]*REMOTE_SIGNER_PRIVATE_KEY=' .env | head -1 | cut -d= -f2-)
+BOB_PRIVATE_KEY=$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 2)")
+BOB_WALLET=$(env -u CHAIN cast wallet address --private-key "$BOB_PRIVATE_KEY")
+cast call "$OBOL_TOKEN_BASE_SEPOLIA" "balanceOf(address)(uint256)" "$BOB_WALLET" --rpc-url "${BASE_SEPOLIA_RPC:-https://sepolia.base.org}"
+```
+
+## Success Criteria
+
+- OBOL metadata reads as `Obol Network` / `OBOL` / 18 decimals and exposes `DOMAIN_SEPARATOR()`.
+- Alice ServiceOffer reaches `Ready=True`.
+- Alice is registered in ERC-8004.
+- Bob remote-signer equals the deterministic `BOB_WALLET`.
+- Bob in-cluster eRPC sees Bob's OBOL balance.
+- Bob buys auths; `PurchaseRequest` reaches `Ready=True`.
+- LiteLLM exposes `paid/qwen3.5:9b`.
+- Paid inference returns HTTP 200.
+- A Base Sepolia OBOL `Transfer(Bob signer -> Alice, 1000000000000000)` receipt is archived.
+- Alice balance increases and Bob signer balance decreases by exactly `1000000000000000` wei.
+
+## Release Smoke
+
+- `RELEASE_SMOKE_INCLUDE_OBOL=true` runs live `flow-14`.
+- `RELEASE_SMOKE_INCLUDE_OBOL_FORK=true` runs fork `flow-13`.
+- Keep these paths explicit. Do not hide live/fork behavior behind one selector name.
+
+## Local Checks
+
+```bash
+bash -n flows/*.sh
+git diff --check
+helm lint internal/embed/infrastructure/cloudflared
+helm template cloudflared internal/embed/infrastructure/cloudflared | rg 'cloudflare/cloudflared:'
+go test ./cmd/obol ./internal/tunnel ./internal/stack -count=1
+```
+

--- a/.agents/skills/obol-stack-dev/references/live-obol-qa.md
+++ b/.agents/skills/obol-stack-dev/references/live-obol-qa.md
@@ -26,6 +26,13 @@ OBOL_TOKEN_BASE_SEPOLIA=0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4
 
 Bob is the deterministic second-derived key from `REMOTE_SIGNER_PRIVATE_KEY`; it must already hold Base Sepolia OBOL. `flow-14` pre-seeds Bob's remote-signer with this key before `stack up`. Do not fund a generated signer inside the flow.
 
+Current canonical live QA pair:
+
+- Alice/register key address: `0xC0De030F6C37f490594F93fB99e2756703c4297E`
+- Bob/buyer derived address: `0x57b0eF875DeB5A37301F1640E469a2129Da9490E`
+
+Keep live OBOL funding on the canonical Bob address. Do not maintain a second live QA key set unless a test explicitly needs an isolated wallet pair.
+
 Derive/check Bob:
 
 ```bash
@@ -63,4 +70,3 @@ helm lint internal/embed/infrastructure/cloudflared
 helm template cloudflared internal/embed/infrastructure/cloudflared | rg 'cloudflare/cloudflared:'
 go test ./cmd/obol ./internal/tunnel ./internal/stack -count=1
 ```
-

--- a/.agents/skills/obol-stack-dev/references/paid-commerce.md
+++ b/.agents/skills/obol-stack-dev/references/paid-commerce.md
@@ -1,0 +1,84 @@
+# Paid Commerce And Flow Gotchas
+
+Use this reference for x402 seller/buyer flows, paid LiteLLM routing, ERC-8004, token additions, and flow failures.
+
+## Paid Routing
+
+- All inference paths go through LiteLLM.
+- `paid/*` routes to the `x402-buyer` sidecar in the LiteLLM pod.
+- The sidecar spends one pre-signed authorization per paid request.
+- The currently validated local OSS model is `qwen3.5:9b`.
+- Agent natural-language output is informational. Assert structural state instead:
+  - `PurchaseRequest.status.conditions[Ready]=True`
+  - sidecar auth count changes
+  - ERC-20 `Transfer` receipt is present and status is success
+  - balance deltas match expected amount
+
+## Buyer Wallet Invariant
+
+For `flow-11` and `flow-14`:
+
+- Alice sells/registers with `.env` `REMOTE_SIGNER_PRIVATE_KEY`.
+- Bob is the second deterministic derived key from that signer.
+- Before Bob `stack up`, scaffold the default Hermes agent and import Bob's key:
+
+```bash
+obol agent new --runtime hermes --id obol-agent --no-sync
+obol wallet import --instance obol-agent --private-key-file <file> --force
+```
+
+- After Bob starts, assert `bobSigner == BOB_WALLET`.
+- Do not transfer funds to a generated signer to make the test pass.
+
+## Token Support
+
+Payment tokens live in `internal/x402/tokens.go`.
+
+Add one registry entry per `(symbol, chain)` pair:
+
+```go
+"WETH": {
+    "base": {
+        Address: "0x4200000000000000000000000000000000000006",
+        Symbol: "WETH",
+        Decimals: 18,
+        TransferMethod: "permit2",
+        EIP712Name: "Wrapped Ether",
+        EIP712Version: "1",
+    },
+},
+```
+
+Check:
+
+- `eip3009` for native `transferWithAuthorization` tokens such as USDC/EURC.
+- `permit2` for Uniswap Permit2.
+- EIP-712 name/version match the on-chain contract.
+- Facilitator advertises the chain in `/supported`.
+- ExactPermit2Proxy exists on the chain for Permit2 tokens.
+- Add `internal/x402/tokens_test.go` coverage.
+
+## ERC-8004 Registration
+
+The serviceoffer-controller does not sign on-chain. Registration is landed by CLI commands that use the agent remote-signer.
+
+Valid paths:
+
+1. `obol sell http` after remote-signer has the intended wallet.
+2. Apply YAML with `registration.enabled: false` when testing payment only.
+3. If YAML has `registration.enabled: true`, run `obol sell register`; otherwise the offer parks at `AwaitingExternalRegistration`.
+
+`setMetadata` simulation reverts are usually read-side staleness after `register`. The correct fix is to wait for `ownerOf(agentID)` before `setMetadata`.
+
+## Operational Gotchas
+
+- Source `flows/lib.sh` first in every flow so PATH and helpers are loaded.
+- Parse `.env` with anchored regexes; loose `grep REMOTE_SIGNER_PRIVATE_KEY` can read comments.
+- eRPC, verifier, buyer, and Hermes API-server images are often distroless. Use transient probe pods instead of assuming `curl` or `wget` exists in those containers.
+- Poll specific container readiness in multi-container pods. Do not trust only the pod summary status.
+- `obol stack up` leaves cloudflared at zero replicas. Flows that apply ServiceOffer YAML directly must explicitly scale/restart cloudflared before reading tunnel status.
+- `--namespace` on `obol sell http` sets both ServiceOffer namespace and upstream service namespace. Use the same namespace for follow-up `sell status|stop|delete`.
+- For Anvil fork flows, bind Anvil to `0.0.0.0` and point each cluster eRPC at `host.k3d.internal:$ANVIL_PORT`.
+- x402-rs Permit2 support is configured by `eip2612_gas_sponsoring=true` on `v2-eip155-exact`; there is no standalone `v2-eip155-permit2` scheme.
+- On aarch64 GPU hosts, if cloudflared image pulls stall through the k3d mirror, use `flows/lib.sh::ensure_image_in_k3d cloudflare/cloudflared:2026.3.0 obol-stack-<stack-id>`.
+

--- a/.agents/skills/obol-stack-dev/references/remote-qa.md
+++ b/.agents/skills/obol-stack-dev/references/remote-qa.md
@@ -1,0 +1,82 @@
+# Remote QA Worktrees
+
+Use this reference when running flows on the two remote QA machines with sudo access.
+
+## Rules
+
+- Never use the shared source checkout directly for QA.
+- Always create a separate worktree per run.
+- Assume parallel stack tests may already be running.
+- Never run broad host cleanup such as global Docker/k3d purges.
+- Delete only stacks whose stack IDs are recorded in the QA worktree.
+- Do not record hostnames, personal paths, or secrets in the skill.
+
+## Create Worktree
+
+```bash
+BASE=${OBOL_QA_BASE:-$HOME/obol-stack-src}
+QA_PARENT=${OBOL_QA_PARENT:-$HOME}
+TOOL_ROOT=${OBOL_QA_TOOL_ROOT:-$HOME/.workspace/bin}
+FOUNDRY_BIN=${FOUNDRY_BIN:-$HOME/.foundry/bin}
+SHA=$(git -C "$BASE" rev-parse --short HEAD)
+QA=$QA_PARENT/obol-stack-qa-$(date +%Y%m%d-%H%M%S)-$SHA
+
+git -C "$BASE" worktree add --detach "$QA" HEAD
+cp "$BASE/.env" "$QA/.env"
+chmod 600 "$QA/.env"
+mkdir -p "$QA/.workspace/bin"
+for tool in kubectl helm helmfile k3d k9s openclaw obol; do
+  [ -x "$TOOL_ROOT/$tool" ] && ln -sf "$TOOL_ROOT/$tool" "$QA/.workspace/bin/$tool"
+done
+```
+
+If the source checkout is not `$HOME/obol-stack-src`, set `OBOL_QA_BASE`.
+
+## Launch Live OBOL Smoke
+
+```bash
+cd "$QA"
+export PATH="$QA/.workspace/bin:$FOUNDRY_BIN:$TOOL_ROOT:$PATH"
+ts=$(date +%Y%m%d-%H%M%S)
+log="$QA/.tmp/flow-14-$ts.log"
+art="$QA/.tmp/flow-14-$ts-artifacts"
+mkdir -p "$art"
+
+tmux new-session -d -s "qa-flow14-$ts" \
+  "cd $QA && PATH=$PATH OBOL_DEVELOPMENT=true OBOL_NONINTERACTIVE=true OBOL_REUSE_LOCAL_DEV_IMAGES=true FLOW14_ARTIFACT_DIR=$art bash flows/flow-14-live-obol-base-sepolia.sh > $log 2>&1; rc=\$?; printf '\n__FLOW14_DONE_RC__=%s\n' \"\$rc\" >> $log"
+```
+
+Monitor:
+
+```bash
+tmux has-session -t "qa-flow14-$ts" 2>/dev/null && echo RUNNING || echo NOT_RUNNING
+tail -n 200 "$log"
+```
+
+## Cleanup
+
+```bash
+cd "$QA"
+export PATH="$QA/.workspace/bin:$FOUNDRY_BIN:$TOOL_ROOT:$PATH"
+
+for ws in .workspace .workspace-alice .workspace-bob; do
+  if [ -f "$ws/config/.stack-id" ]; then
+    sid=$(tr -d '[:space:]' < "$ws/config/.stack-id")
+    [ -n "$sid" ] && k3d cluster delete "obol-stack-$sid" >/dev/null 2>&1 || true
+  fi
+done
+```
+
+After saving needed logs/artifacts:
+
+```bash
+if ! git -C "$BASE" worktree remove --force "$QA"; then
+  stale_root="$QA_PARENT/.obol-qa-stale"
+  mkdir -p "$stale_root"
+  mv "$QA" "$stale_root/$(basename "$QA")-$(date +%Y%m%d-%H%M%S)"
+  git -C "$BASE" worktree prune
+fi
+```
+
+Root-owned runtime files can block deletion. Move stale worktrees aside instead of deleting arbitrary host paths.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,150 @@
+## Summary
+
+What changed:
+
+Why it matters:
+
+Risk level: <!-- low / medium / high -->
+
+Commit under test:
+
+Base branch:
+
+## Scope
+
+- [ ] Code
+- [ ] Charts / manifests
+- [ ] Flows / QA scripts
+- [ ] Docs / skills
+- [ ] Images / dependencies
+- [ ] Other:
+
+## Validation
+
+CI checks:
+
+| Check | Status | Link |
+|-------|--------|------|
+|       |        |      |
+
+Unit tests:
+
+```text
+<!-- command, result, commit/SHA -->
+```
+
+Integration tests:
+
+```text
+<!-- command, result, commit/SHA -->
+```
+
+Flow tests:
+
+| Flow | Network | QA machine label | Worktree | Result | Artifacts |
+|------|---------|------------------|----------|--------|-----------|
+|      |         |                  |          |        |           |
+
+Release smoke:
+
+```text
+<!-- command, flags, result -->
+```
+
+## Live Chain Evidence
+
+Do not include private keys, seed phrases, passwords, hostnames, personal paths, or raw bearer tokens.
+
+Network:
+
+RPC/provider:
+
+Facilitator:
+
+Contracts and tokens:
+
+| Name | Address | Version / notes |
+|------|---------|-----------------|
+|      |         |                 |
+
+Wallet roles:
+
+| Role | Address | Source |
+|------|---------|--------|
+| Alice / seller / register | | |
+| Bob / buyer / payer | | |
+| Facilitator / receiver | | |
+
+Balances:
+
+| Token | Address | Before | After | Expected delta | Actual delta |
+|-------|---------|--------|-------|----------------|--------------|
+|       |         |        |       |                |              |
+
+Transaction receipts:
+
+| Purpose | Tx hash | From | To | Amount / event | Status |
+|---------|---------|------|----|----------------|--------|
+| ERC-8004 registration | | | | | |
+| Metadata / service offer | | | | | |
+| Approval / permit | | | | | |
+| Purchase request | | | | | |
+| Settlement transfer | | | | | |
+
+## Runtime Evidence
+
+QA environment:
+
+| Item | Value |
+|------|-------|
+| OS / arch | |
+| Backend | |
+| Tool versions | |
+| QA agent/model | |
+
+Images:
+
+| Component | Image | Tag / digest | Source |
+|-----------|-------|--------------|--------|
+|           |       |              |        |
+
+Kubernetes / stack:
+
+| Item | Value |
+|------|-------|
+| Stack IDs | |
+| Namespaces | |
+| Pod readiness | |
+| Cleanup result | |
+
+Model and routing:
+
+| Item | Value |
+|------|-------|
+| Agent/model used | |
+| LiteLLM route | |
+| Paid endpoint status | |
+| Auth token source | |
+
+Artifacts and logs:
+
+| Artifact | Location / link | Notes |
+|----------|-----------------|-------|
+|          |                 |       |
+
+Demo readiness:
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Seller visible / registered | | |
+| Buyer discovery works | | |
+| Paid route works | | |
+| Settlement visible on-chain | | |
+
+## Review Notes
+
+Known gaps:
+
+Follow-ups:
+
+Reviewer focus:

--- a/flows/README.md
+++ b/flows/README.md
@@ -18,6 +18,7 @@ idempotent and exits non-zero on failure.
 - `flow-11-dual-stack.sh` — Dual-Stack: Alice sells, Bob discovers via ERC-8004 and buys.
 - `flow-12-obol-payment.sh` — OBOL payment asset over the existing USDC commerce baseline.
 - `flow-13-dual-stack-obol.sh` — Dual-Stack OBOL: Alice sells, Bob discovers and buys, but the payment asset is a fork-local OBOL ERC20Permit token and the facilitator is a local x402-rs build (not the public Obol facilitator). Use this when you want to validate the OBOL Permit2 path end-to-end without depending on the public Obol facilitator or any USDC contract. Both obol stacks share ONE local Anvil fork of Base Sepolia via `host.k3d.internal:$ANVIL_PORT`. Requires `cast` + `anvil` + `forge` and an `X402_FACILITATOR_BIN` (or `X402_RS_DIR`) pointing at an x402-rs build with `eip2612GasSponsoring`; the script skips with a single PASS if neither is set.
+- `flow-14-live-obol-base-sepolia.sh` — Live Base Sepolia OBOL dual-stack: Alice registers/sells, Bob discovers/buys, and settlement is verified against the deployed OBOL ERC20Permit token and public Obol facilitator. Requires `REMOTE_SIGNER_PRIVATE_KEY` funded with Base Sepolia ETH and the second deterministic derived Bob key funded with OBOL; `OBOL_TOKEN_BASE_SEPOLIA` defaults to the current live Base Sepolia OBOL token (`0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4`) and can be overridden.
 
 `lib.sh` is shared helpers; `release-smoke.sh` is the release gate.
 

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -35,6 +35,11 @@
 #   FLOW11_BOB_HTTPS_PORT  FLOW11_BOB_HTTPS_ALT_PORT
 source "$(dirname "$0")/lib.sh"
 
+# This flow is a smoke/validation harness, not a source-editing loop. Reuse
+# already-cached local dev images when available so repeated runs don't block on
+# unnecessary rebuilds or cold pulls during `obol stack up`.
+export OBOL_REUSE_LOCAL_DEV_IMAGES="${OBOL_REUSE_LOCAL_DEV_IMAGES:-true}"
+
 # ═════════════════════════════════════════════════════════════════
 # PREFLIGHT
 # ═════════════════════════════════════════════════════════════════

--- a/flows/flow-13-dual-stack-obol.sh
+++ b/flows/flow-13-dual-stack-obol.sh
@@ -1050,11 +1050,11 @@ fi
 # ═════════════════════════════════════════════════════════════════
 
 step "Bob: get $BOB_AGENT_RUNTIME API server token"
-BOB_TOKEN=$(bob "$BOB_AGENT_RUNTIME" token obol-agent 2>/dev/null || true)
-if [ -z "$BOB_TOKEN" ]; then
-    fail "Could not get Bob's gateway token"
+if ! BOB_TOKEN_OUT=$(agent_auth_token bob "$BOB_AGENT_RUNTIME" obol-agent 2>&1); then
+    fail "Could not get Bob's gateway token: ${BOB_TOKEN_OUT:0:200}"
     emit_metrics; exit 1
 fi
+BOB_TOKEN="$BOB_TOKEN_OUT"
 pass "Token: ${BOB_TOKEN:0:10}..."
 
 step "Bob: $BOB_AGENT_RUNTIME API port-forward"

--- a/flows/flow-14-live-obol-base-sepolia.sh
+++ b/flows/flow-14-live-obol-base-sepolia.sh
@@ -15,9 +15,10 @@
 #     address is supplied via OBOL_TOKEN_BASE_SEPOLIA. Flow-14 only confirms
 #     it is reachable, captures its on-chain metadata (name/symbol/decimals/
 #     DOMAIN_SEPARATOR), and asserts decimals == 18.
-#   - No `cast send <forkOBOL>.mint(...)`. Bob's wallet must already hold real
-#     OBOL on Base Sepolia. The script reads the balance and fails fast with
-#     an actionable message if it's below the buy threshold.
+#   - No `cast send <forkOBOL>.mint(...)`. Bob's deterministic second-derived
+#     wallet must already hold real OBOL on Base Sepolia. The script pre-seeds
+#     Bob's remote-signer with that key before stack up, reads the balance, and
+#     fails fast with an actionable message if it's below the buy threshold.
 #   - ERC-8004 registration is enabled on Alice's seller path (live Base
 #     Sepolia registry 0x8004A818BFB912233c491871b3d84c89A494BD9e). This
 #     exercises PR #387's WaitForAgent fix on the OBOL path.
@@ -25,19 +26,16 @@
 #     the ServiceOffer is published — fails fast if the token name does not
 #     match what the controller will sign.
 #
-# Required env (the script fails fast if any are unset):
+# Required env (the script fails fast if unset):
 #   REMOTE_SIGNER_PRIVATE_KEY    Alice's seller key (must hold Base Sepolia ETH
 #                                for ERC-8004 register + metadata-set gas).
-#   OBOL_TOKEN_BASE_SEPOLIA      Address of the deployed OBOL ERC20Permit token
-#                                on Base Sepolia (chainId 84532).
-#   BOB_FUNDING_PRIVATE_KEY      Buyer key. Must already hold real OBOL on
-#                                Base Sepolia (>= OBOL_PRICE_WEI * 5). Distinct
-#                                from REMOTE_SIGNER_PRIVATE_KEY because live
-#                                OBOL on Base Sepolia is scarce and we don't
-#                                want to assume Alice has any.
+#                                Bob is derived deterministically from this key
+#                                using the same second-key derivation as flow-11
+#                                and must hold OBOL on Base Sepolia.
 #
 # Optional overrides:
 #   BASE_SEPOLIA_RPC                          default: https://sepolia.base.org
+#   OBOL_TOKEN_BASE_SEPOLIA                   default: 0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4
 #   FLOW14_ALICE_HTTP_PORT, _ALT, _HTTPS_PORT, _HTTPS_ALT_PORT
 #   FLOW14_BOB_HTTP_PORT,   _ALT, _HTTPS_PORT, _HTTPS_ALT_PORT
 #   FLOW14_ARTIFACT_DIR                       where receipts + logs land
@@ -70,6 +68,9 @@ BOB_HTTPS_ALT_PORT="${FLOW14_BOB_HTTPS_ALT_PORT:-$(pick_free_port)}"
 # Live Base Sepolia RPC + public Obol facilitator. No host.k3d.internal pin.
 BASE_SEPOLIA_RPC="${BASE_SEPOLIA_RPC:-https://sepolia.base.org}"
 FACILITATOR_URL="https://x402.gcp.obol.tech"
+
+DEFAULT_OBOL_TOKEN_BASE_SEPOLIA="0x54AE82bc871a4E3E8E2FE1173Cb864B8563D44D4"
+OBOL_TOKEN_BASE_SEPOLIA="${OBOL_TOKEN_BASE_SEPOLIA:-$DEFAULT_OBOL_TOKEN_BASE_SEPOLIA}"
 
 ERC8004_IDENTITY_REGISTRY_BASE_SEPOLIA="0x8004A818BFB912233c491871b3d84c89A494BD9e"
 
@@ -157,6 +158,10 @@ bob() {
     "$BOB_DIR/bin/obol" "$@"
 }
 
+lower_addr() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 rewrite_k3d_ports() {
     local config_path="$1"
     local http_port="$2"
@@ -193,6 +198,7 @@ stack_init_and_up_with_retry() {
     local label="$1"
     local runner="$2"
     local dir="$3"
+    local pre_up_hook="${4:-}"
     local attempt out rc
 
     for attempt in 1 2 3; do
@@ -206,6 +212,9 @@ stack_init_and_up_with_retry() {
             rewrite_k3d_ports "$dir/config/k3d.yaml" \
                 "$BOB_HTTP_PORT" "$BOB_HTTP_ALT_PORT" "$BOB_HTTPS_PORT" "$BOB_HTTPS_ALT_PORT"
             pass "Bob ports set to $BOB_HTTP_PORT/$BOB_HTTP_ALT_PORT/$BOB_HTTPS_PORT/$BOB_HTTPS_ALT_PORT"
+        fi
+        if [ -n "$pre_up_hook" ]; then
+            "$pre_up_hook"
         fi
 
         step "$label: stack up"
@@ -234,6 +243,56 @@ stack_init_and_up_with_retry() {
         emit_metrics
         exit "$rc"
     done
+}
+
+preseed_bob_wallet() {
+    local deploy_dir existing import_out key_file onboard_out rc
+
+    deploy_dir="$BOB_DIR/config/applications/hermes/obol-agent"
+    if [ ! -f "$deploy_dir/helmfile.yaml" ]; then
+        step "Bob: scaffold default agent before stack up"
+        set +e
+        onboard_out=$(bob agent new --runtime hermes --id obol-agent --no-sync 2>&1)
+        rc=$?
+        set -e
+        echo "$onboard_out" | tail -8
+        if [ "$rc" -ne 0 ]; then
+            fail "Could not scaffold Bob agent before stack up: ${onboard_out:0:300}"
+            emit_metrics; exit "$rc"
+        fi
+        pass "Bob default agent scaffolded"
+    fi
+
+    existing=$(bob agent wallet address --runtime hermes obol-agent 2>/dev/null || true)
+    if [ "$(lower_addr "$existing")" = "$(lower_addr "$BOB_WALLET")" ]; then
+        pass "Bob wallet preseeded: $existing"
+        return 0
+    fi
+
+    step "Bob: import derived buyer wallet before stack up"
+    key_file=$(mktemp)
+    chmod 600 "$key_file"
+    printf '%s\n' "$BOB_PRIVATE_KEY" > "$key_file"
+    set +e
+    import_out=$(bob wallet import \
+        --instance obol-agent \
+        --private-key-file "$key_file" \
+        --force 2>&1)
+    rc=$?
+    set -e
+    rm -f "$key_file"
+    echo "$import_out" | tail -8
+    if [ "$rc" -ne 0 ]; then
+        fail "Could not preseed Bob buyer wallet: ${import_out:0:300}"
+        emit_metrics; exit "$rc"
+    fi
+
+    existing=$(bob agent wallet address --runtime hermes obol-agent 2>/dev/null || true)
+    if [ "$(lower_addr "$existing")" != "$(lower_addr "$BOB_WALLET")" ]; then
+        fail "Bob preseeded wallet mismatch — metadata=$existing expected=$BOB_WALLET"
+        emit_metrics; exit 1
+    fi
+    pass "Bob wallet preseeded: $existing"
 }
 
 tunnel_hostname() {
@@ -429,14 +488,10 @@ if [ -z "${OBOL_TOKEN_BASE_SEPOLIA:-}" ]; then
     echo "OBOL_TOKEN_BASE_SEPOLIA must be set to a deployed Base Sepolia ERC20Permit token address" >&2
     exit 2
 fi
-if [ -z "${BOB_FUNDING_PRIVATE_KEY:-}" ]; then
-    echo "BOB_FUNDING_PRIVATE_KEY must be set to a Base Sepolia private key already funded with real OBOL (>= 5 * OBOL_PRICE_WEI)" >&2
-    exit 2
-fi
 OBOL_TOKEN="$OBOL_TOKEN_BASE_SEPOLIA"
 # Re-export so lib.sh's generic ERC-20 helpers can scan our OBOL Transfer logs.
 export USDC_ADDRESS_BASE_SEPOLIA="$OBOL_TOKEN"
-pass "OBOL_TOKEN_BASE_SEPOLIA=$OBOL_TOKEN, BOB_FUNDING_PRIVATE_KEY set"
+pass "OBOL_TOKEN_BASE_SEPOLIA=$OBOL_TOKEN"
 
 step "Preflight: .env signer key (Alice seller / register payer)"
 SIGNER_KEY=$(grep -E '^[[:space:]]*REMOTE_SIGNER_PRIVATE_KEY=' "$OBOL_ROOT/.env" 2>/dev/null | head -1 | cut -d= -f2-)
@@ -448,7 +503,9 @@ if [ -z "$SIGNER_KEY" ]; then
     emit_metrics; exit 1
 fi
 ALICE_WALLET=$(env -u CHAIN cast wallet address --private-key "$SIGNER_KEY" 2>/dev/null)
-pass "Alice (seller payTo + funded EOA): $ALICE_WALLET"
+BOB_PRIVATE_KEY=$(env -u CHAIN cast keccak "$(env -u CHAIN cast abi-encode 'f(bytes32,uint256)' "$SIGNER_KEY" 2)")
+BOB_WALLET=$(env -u CHAIN cast wallet address --private-key "$BOB_PRIVATE_KEY" 2>/dev/null)
+pass "Alice (seller payTo + funded EOA): $ALICE_WALLET, Bob (derived buyer): $BOB_WALLET"
 
 step "Preflight: host ports free (Alice/Bob ingress)"
 busy=$(require_ports_free \
@@ -563,28 +620,23 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════
-# 9. BOB: prerequisite OBOL balance check (NO mint on live network)
+# 9. BOB: prerequisite OBOL balance check (NO mint/funding transfer on live network)
 # ═════════════════════════════════════════════════════════════════
 
-step "Bob: prerequisite OBOL balance check (BOB_FUNDING_PRIVATE_KEY)"
-BOB_FUNDING_ADDR=$(env -u CHAIN cast wallet address --private-key "$BOB_FUNDING_PRIVATE_KEY" 2>/dev/null)
-if [ -z "$BOB_FUNDING_ADDR" ]; then
-    fail "Could not derive address from BOB_FUNDING_PRIVATE_KEY"
-    emit_metrics; exit 1
-fi
+step "Bob: derived buyer wallet has OBOL"
 bob_obol_bal=$(env -u CHAIN cast call "$OBOL_TOKEN" "balanceOf(address)(uint256)" \
-    "$BOB_FUNDING_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
+    "$BOB_WALLET" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
 required_min=$(python3 -c "print($OBOL_PRICE_WEI * 5)")
 if [ -z "$bob_obol_bal" ]; then
-    fail "Could not read OBOL balance for $BOB_FUNDING_ADDR (network/contract issue)"
+    fail "Could not read OBOL balance for derived Bob wallet $BOB_WALLET (network/contract issue)"
     emit_metrics; exit 1
 fi
 bob_below=$(python3 -c "print(1 if int('$bob_obol_bal') < int('$required_min') else 0)")
 if [ "$bob_below" = "1" ]; then
-    fail "Bob funding wallet $BOB_FUNDING_ADDR holds $bob_obol_bal OBOL (wei); need >= $required_min wei (5 * OBOL_PRICE_WEI). Top up real OBOL on Base Sepolia before running flow-14."
+    fail "Derived Bob wallet $BOB_WALLET holds $bob_obol_bal OBOL wei; need >= $required_min wei (5 * OBOL_PRICE_WEI). Top up this deterministic wallet on Base Sepolia before running flow-14."
     emit_metrics; exit 1
 fi
-pass "Bob funding wallet $BOB_FUNDING_ADDR holds $bob_obol_bal OBOL wei (>= $required_min)"
+pass "Derived Bob wallet $BOB_WALLET holds $bob_obol_bal OBOL wei (>= $required_min)"
 
 # ═════════════════════════════════════════════════════════════════
 # 10-15. ALICE STACK
@@ -902,7 +954,7 @@ for tool in kubectl helm helmfile k3d k9s openclaw; do
 done
 pass "Bob workspace ready"
 
-stack_init_and_up_with_retry "Bob" bob "$BOB_DIR"
+stack_init_and_up_with_retry "Bob" bob "$BOB_DIR" preseed_bob_wallet
 
 # Repoint Bob's LiteLLM at the external GPU LLM via the canonical CLI when
 # OBOL_LLM_ENDPOINT is set. Critical for the agent's autonomous discover+buy
@@ -948,10 +1000,10 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════
-# 25-26. BOB SIGNER ADDRESS + LIVE OBOL FUNDING (operator pre-funded)
+# 25-26. BOB SIGNER ADDRESS + PRE-FUNDED LIVE OBOL BALANCE
 # ═════════════════════════════════════════════════════════════════
 
-step "Bob: locate remote-signer wallet address"
+step "Bob: remote-signer uses preseeded buyer wallet"
 BOB_SIGNER_ADDR=""
 for candidate_path in \
     "$BOB_DIR/config/applications/$BOB_AGENT_RUNTIME/obol-agent/wallet.json" \
@@ -972,65 +1024,26 @@ if [ -z "$BOB_SIGNER_ADDR" ]; then
     fail "Could not determine Bob's remote-signer address"
     emit_metrics; exit 1
 fi
-pass "Bob signer wallet: $BOB_SIGNER_ADDR"
-
-step "Bob: fund remote-signer with real OBOL from BOB_FUNDING_PRIVATE_KEY"
-# The buy.py path signs Permit2 auths from the remote-signer key, not the
-# operator-supplied funding key. So we transfer real OBOL from the operator-
-# funded BOB_FUNDING_ADDR into the in-cluster signer wallet via a normal ERC20
-# transfer on live Base Sepolia. No mint(), no fork tricks.
-five_units=$(python3 -c "print($OBOL_PRICE_WEI * 5)")
-FUNDING_START_BLOCK=$(env -u CHAIN cast block-number --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | tr -d ' ' || true)
-fund_out=$(env -u CHAIN cast send --json "$OBOL_TOKEN" \
-    "transfer(address,uint256)" "$BOB_SIGNER_ADDR" "$five_units" \
-    --rpc-url "$BASE_SEPOLIA_RPC" --private-key "$BOB_FUNDING_PRIVATE_KEY" 2>&1 || true)
-FUNDING_TX=$(echo "$fund_out" | python3 -c 'import json,sys
-try:
-    d=json.loads(sys.stdin.read())
-    print(d.get("transactionHash",""))
-except Exception:
-    pass' || true)
-if [ -n "$FUNDING_TX" ] && archive_receipt funding "$FUNDING_TX" 30 4; then
-    pass "Funding receipt archived: $FUNDING_TX"
-else
-    # Fallback: confirm balance even if tx-hash extraction or receipt poll failed.
-    bob_signer_bal=$(env -u CHAIN cast call "$OBOL_TOKEN" "balanceOf(address)(uint256)" \
-        "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || true)
-    if [ -n "$bob_signer_bal" ] && [ "$bob_signer_bal" != "0" ]; then
-        pass "Bob signer OBOL balance: $bob_signer_bal (transfer succeeded; receipt extraction skipped)"
-    else
-        fail "Could not archive Bob signer funding receipt and balance check returned 0 — ${fund_out:0:300}"
-        emit_metrics; exit 1
-    fi
+if [ "$(lower_addr "$BOB_SIGNER_ADDR")" != "$(lower_addr "$BOB_WALLET")" ]; then
+    fail "Bob remote-signer wallet mismatch — signer=$BOB_SIGNER_ADDR expected=$BOB_WALLET"
+    emit_metrics; exit 1
 fi
+pass "Bob remote-signer uses funded derived wallet: $BOB_SIGNER_ADDR"
 
-step "Bob: signer holds funded OBOL balance (live on-chain, poll up to 24s)"
-# Poll the public RPC because Base Sepolia public endpoints fan out to read
-# replicas that can be a block or two behind the writer. Same pattern flow-11
-# uses for USDC. Without this, a single-shot balanceOf right after a fresh
-# transfer often returns 0 even when the tx is mined.
-got_balance="0"
-for _ in $(seq 1 12); do
-    got_balance=$(env -u CHAIN cast call "$OBOL_TOKEN" "balanceOf(address)(uint256)" \
-        "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || echo 0)
-    [ -n "$got_balance" ] && [ "$got_balance" != "0" ] && \
-        python3 -c "import sys; sys.exit(0 if int('$got_balance') >= int('$OBOL_PRICE_WEI') else 1)" && break
-    sleep 2
-done
+step "Bob: signer holds pre-funded OBOL balance"
+got_balance=$(env -u CHAIN cast call "$OBOL_TOKEN" "balanceOf(address)(uint256)" \
+    "$BOB_SIGNER_ADDR" --rpc-url "$BASE_SEPOLIA_RPC" 2>/dev/null | grep -oE '^[0-9]+' | head -1 || echo 0)
 if [ -n "$got_balance" ] && python3 -c "import sys; sys.exit(0 if int('$got_balance') >= int('$OBOL_PRICE_WEI') else 1)"; then
     pass "Bob signer OBOL balance: $got_balance wei (>= 1 OBOL_PRICE_WEI)"
 else
-    fail "Bob signer OBOL balance $got_balance wei is below $OBOL_PRICE_WEI after 24s of polling"
+    fail "Bob signer OBOL balance $got_balance wei is below $OBOL_PRICE_WEI"
     emit_metrics; exit 1
 fi
 
-# Now wait for Bob's in-cluster eRPC view to reflect the funding too. The
-# buyer sidecar reads through eRPC (10s eth_call cache TTL); without this
-# poll the next step's AI-agent-driven buy often runs against a stale view
-# and short-circuits with no PurchaseRequest CR. We probe OBOL balanceOf
-# directly via JSON-RPC against eRPC because buy.py's `balance` subcommand
-# is hardcoded to USDC.
-step "Bob: eRPC reflects funding (direct OBOL balanceOf eth_call >= price)"
+# The buyer sidecar reads through eRPC. Probe OBOL balanceOf directly via
+# JSON-RPC against eRPC because buy.py's `balance` subcommand is hardcoded to
+# USDC.
+step "Bob: eRPC reflects pre-funded signer balance (direct OBOL balanceOf eth_call >= price)"
 erpc_balance_output=""
 erpc_balance_wei=""
 for attempt in $(seq 1 18); do
@@ -1038,7 +1051,7 @@ for attempt in $(seq 1 18); do
     if echo "$erpc_balance_output" | grep -qE '^[0-9]+$'; then
         erpc_balance_wei="$erpc_balance_output"
         if python3 -c "import sys; sys.exit(0 if int('$erpc_balance_wei') >= int('$OBOL_PRICE_WEI') else 1)"; then
-            pass "Bob: eRPC reflects funding (attempt $attempt, balance $erpc_balance_wei wei)"
+            pass "Bob: eRPC reflects signer balance (attempt $attempt, balance $erpc_balance_wei wei)"
             break
         fi
     fi
@@ -1059,11 +1072,11 @@ ALICE_BAL_BEFORE_PAID=$(env -u CHAIN cast call "$OBOL_TOKEN" "balanceOf(address)
 # ═════════════════════════════════════════════════════════════════
 
 step "Bob: get $BOB_AGENT_RUNTIME API server token"
-BOB_TOKEN=$(bob "$BOB_AGENT_RUNTIME" token obol-agent 2>/dev/null || true)
-if [ -z "$BOB_TOKEN" ]; then
-    fail "Could not get Bob's gateway token"
+if ! BOB_TOKEN_OUT=$(agent_auth_token bob "$BOB_AGENT_RUNTIME" obol-agent 2>&1); then
+    fail "Could not get Bob's gateway token: ${BOB_TOKEN_OUT:0:200}"
     emit_metrics; exit 1
 fi
+BOB_TOKEN="$BOB_TOKEN_OUT"
 pass "Token: ${BOB_TOKEN:0:10}..."
 
 step "Bob: $BOB_AGENT_RUNTIME API port-forward"
@@ -1237,20 +1250,7 @@ fi
 if [ "$BOB_SIGNER_BAL_AFTER" = "$expected_bob_after" ]; then
     pass "Bob signer balance decreased by exactly $OBOL_PRICE_WEI wei"
 else
-    # The Bob-signer-side delta is informational. Alice's delta + the on-chain
-    # settlement Transfer event (asserted strictly above) are the canonical
-    # proofs that settlement happened correctly. The Bob-signer-side check
-    # can drift if the funding tx in step 35 races the public RPC's read
-    # replicas — step 36's polled "before" reading can land a block before
-    # the funding has propagated, and the "after" reading later sees the
-    # post-funding total minus the settlement, looking like the signer
-    # gained funds. Mathematically this is consistent with funding +
-    # settle, just not with a strict pre/post diff. Don't fail the flow on
-    # it; surface the discrepancy and move on.
-    bob_diff=$(python3 -c "
-got = int('${BOB_SIGNER_BAL_AFTER:-0}'); want = int('$expected_bob_after')
-print(got - want)" 2>/dev/null)
-    pass "Bob signer balance differs from naive delta by $bob_diff wei (race with funding tx; settlement correctness already asserted via Alice delta + Transfer event)"
+    fail "Bob signer balance delta wrong (expected $expected_bob_after, got ${BOB_SIGNER_BAL_AFTER:-unknown})"
 fi
 
 # ═════════════════════════════════════════════════════════════════
@@ -1288,13 +1288,11 @@ if FLOW14_ARTIFACT_DIR="$FLOW14_ARTIFACT_DIR" \
    FLOW14_COMMIT="$(git -C "$OBOL_ROOT" rev-parse HEAD 2>/dev/null || true)" \
    FLOW14_AGENT_ID="${AGENT_ID:-}" \
    FLOW14_ALICE="$ALICE_WALLET" \
-   FLOW14_BOB="${BOB_SIGNER_ADDR:-}" \
+   FLOW14_BOB="${BOB_WALLET:-}" \
    FLOW14_BOB_SIGNER="${BOB_SIGNER_ADDR:-}" \
-   FLOW14_BOB_FUNDING="${BOB_FUNDING_ADDR:-}" \
    FLOW14_TUNNEL="${TUNNEL_URL:-}" \
    FLOW14_REGISTRATION_TX="${REGISTRATION_TX:-}" \
    FLOW14_METADATA_TX="${METADATA_TX:-}" \
-   FLOW14_FUNDING_TX="${FUNDING_TX:-}" \
    FLOW14_SETTLEMENT_TX="${SETTLEMENT_TX:-}" \
    FLOW14_OBOL_TOKEN="${OBOL_TOKEN:-}" \
    FLOW14_OBOL_TOKEN_NAME="${OBOL_TOKEN_NAME:-}" \
@@ -1312,7 +1310,6 @@ summary = {
     "alice": os.environ.get("FLOW14_ALICE", ""),
     "bob": os.environ.get("FLOW14_BOB", ""),
     "bobSigner": os.environ.get("FLOW14_BOB_SIGNER", ""),
-    "bobFunding": os.environ.get("FLOW14_BOB_FUNDING", ""),
     "tunnel": os.environ.get("FLOW14_TUNNEL", ""),
     "obolToken": os.environ.get("FLOW14_OBOL_TOKEN", ""),
     "obolTokenName": os.environ.get("FLOW14_OBOL_TOKEN_NAME", ""),
@@ -1323,7 +1320,6 @@ summary = {
     "transactions": {
         "registration": os.environ.get("FLOW14_REGISTRATION_TX", ""),
         "metadata": os.environ.get("FLOW14_METADATA_TX", ""),
-        "funding": os.environ.get("FLOW14_FUNDING_TX", ""),
         "settlement": os.environ.get("FLOW14_SETTLEMENT_TX", ""),
     },
 }

--- a/flows/lib.sh
+++ b/flows/lib.sh
@@ -192,6 +192,32 @@ fail() {
     return 0
 }
 
+agent_auth_token() {
+    local obol_cmd="$1"
+    local runtime="$2"
+    local agent="${3:-obol-agent}"
+    local out rc token had_errexit=0
+
+    case $- in
+        *e*) had_errexit=1 ;;
+    esac
+
+    set +e
+    out=$("$obol_cmd" agent auth --runtime "$runtime" "$agent" 2>&1)
+    rc=$?
+    if [ "$had_errexit" -eq 1 ]; then
+        set -e
+    fi
+
+    token=$(printf '%s\n' "$out" | tail -1 | tr -d '\r')
+    if [ "$rc" -ne 0 ] || [ -z "$token" ] || printf '%s' "$token" | grep -qi '^usage:'; then
+        printf '%s\n' "$out"
+        return 1
+    fi
+
+    printf '%s\n' "$token"
+}
+
 # Run a command; pass if exit 0, fail otherwise. Captures output.
 run_step() {
     local desc="$1"; shift

--- a/flows/release-smoke.sh
+++ b/flows/release-smoke.sh
@@ -59,7 +59,8 @@ append_report_footer() {
 - The runner uses the real \`obol\` CLI and the flow scripts as black-box release checks.
 - Any \`FAIL:\` line is release-gating, even when a child script exits zero.
 - \`flow-11-dual-stack.sh\` writes on-chain receipt artifacts under \`$ARTIFACT_DIR/flow-11-receipts\`.
-- Set \`RELEASE_SMOKE_INCLUDE_OBOL=true\` to run \`flow-12-obol-payment.sh\`, which requires a current x402-rs facilitator binary.
+- Set \`RELEASE_SMOKE_INCLUDE_OBOL=true\` to run \`flow-14-live-obol-base-sepolia.sh\`.
+- Set \`RELEASE_SMOKE_INCLUDE_OBOL_FORK=true\` to run \`flow-13-dual-stack-obol.sh\`.
 EOF
 }
 
@@ -98,6 +99,10 @@ run_flow() {
     set +e
     if [ "$name" = "flow-11-dual-stack" ]; then
         FLOW11_ARTIFACT_DIR="$ARTIFACT_DIR/flow-11-receipts" bash "$flow" 2>&1 | tee "$log"
+    elif [ "$name" = "flow-13-dual-stack-obol" ]; then
+        FLOW13_ARTIFACT_DIR="$ARTIFACT_DIR/flow-13-receipts" bash "$flow" 2>&1 | tee "$log"
+    elif [ "$name" = "flow-14-live-obol-base-sepolia" ]; then
+        FLOW14_ARTIFACT_DIR="$ARTIFACT_DIR/flow-14-receipts" bash "$flow" 2>&1 | tee "$log"
     else
         bash "$flow" 2>&1 | tee "$log"
     fi
@@ -157,7 +162,13 @@ main() {
     fi
 
     if [ "${RELEASE_SMOKE_INCLUDE_OBOL:-false}" = "true" ]; then
-        if ! run_flow "$SCRIPT_DIR/flow-12-obol-payment.sh"; then
+        if ! run_flow "$SCRIPT_DIR/flow-14-live-obol-base-sepolia.sh"; then
+            failed=$((failed + 1))
+        fi
+    fi
+
+    if [ "${RELEASE_SMOKE_INCLUDE_OBOL_FORK:-false}" = "true" ]; then
+        if ! run_flow "$SCRIPT_DIR/flow-13-dual-stack-obol.sh"; then
             failed=$((failed + 1))
         fi
     fi

--- a/internal/embed/infrastructure/cloudflared/values.yaml
+++ b/internal/embed/infrastructure/cloudflared/values.yaml
@@ -2,7 +2,7 @@ mode: auto
 
 image:
   repository: cloudflare/cloudflared
-  tag: "2026.1.2"
+  tag: "2026.3.0"
 
 metrics:
   address: "0.0.0.0:2000"

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -623,8 +623,8 @@ func devPreloadImages() []string {
 	return images
 }
 
-func forceRebuildLocalImages() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES")), "true")
+func reuseLocalDevImages() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_REUSE_LOCAL_DEV_IMAGES")), "true")
 }
 
 func dockerImageAvailableLocally(tag string) bool {
@@ -652,7 +652,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
-	forceRebuild := forceRebuildLocalImages()
+	reuseCachedImages := reuseLocalDevImages()
 
 	for _, img := range baseLocalImages {
 		contextDir := projectRoot
@@ -672,8 +672,8 @@ func buildAndImportLocalImages(cfg *config.Config) {
 			continue // Dockerfile not present (production install without source)
 		}
 
-		if !forceRebuild && dockerImageAvailableLocally(img.tag) {
-			fmt.Printf("Reusing existing local image %s (set OBOL_FORCE_REBUILD_LOCAL_IMAGES=true to rebuild from source)...\n", img.tag)
+		if reuseCachedImages && dockerImageAvailableLocally(img.tag) {
+			fmt.Printf("Reusing existing local image %s (set OBOL_REUSE_LOCAL_DEV_IMAGES=true to opt into cache reuse)...\n", img.tag)
 			if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
 				fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
 			}
@@ -700,7 +700,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 	}
 
 	for _, ref := range devPreloadImages() {
-		if dockerImageAvailableLocally(ref) {
+		if reuseCachedImages && dockerImageAvailableLocally(ref) {
 			fmt.Printf("Reusing cached image %s for cluster %s...\n", ref, clusterName)
 			if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
 				fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -622,6 +623,17 @@ func devPreloadImages() []string {
 	return images
 }
 
+func forceRebuildLocalImages() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES")), "true")
+}
+
+func dockerImageAvailableLocally(tag string) bool {
+	inspectCmd := exec.Command("docker", "image", "inspect", tag)
+	inspectCmd.Stdout = io.Discard
+	inspectCmd.Stderr = io.Discard
+	return inspectCmd.Run() == nil
+}
+
 // buildAndImportLocalImages builds Docker images from source and imports them
 // into the k3d cluster. This ensures images are available even when the GHCR
 // publish workflow hasn't run. Non-fatal: logs warnings on failure.
@@ -640,6 +652,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
+	forceRebuild := forceRebuildLocalImages()
 
 	for _, img := range baseLocalImages {
 		contextDir := projectRoot
@@ -657,6 +670,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 		}
 		if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 			continue // Dockerfile not present (production install without source)
+		}
+
+		if !forceRebuild && dockerImageAvailableLocally(img.tag) {
+			fmt.Printf("Reusing existing local image %s (set OBOL_FORCE_REBUILD_LOCAL_IMAGES=true to rebuild from source)...\n", img.tag)
+			if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
+			}
+			continue
 		}
 
 		fmt.Printf("Building %s from %s...\n", img.tag, img.dockerfile)
@@ -679,6 +700,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 	}
 
 	for _, ref := range devPreloadImages() {
+		if dockerImageAvailableLocally(ref) {
+			fmt.Printf("Reusing cached image %s for cluster %s...\n", ref, clusterName)
+			if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)
+			}
+			continue
+		}
+
 		fmt.Printf("Preloading %s into cluster %s...\n", ref, clusterName)
 		pullCmd := exec.Command("docker", "pull", ref)
 		pullCmd.Stdout = os.Stdout

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -622,6 +623,17 @@ func devPreloadImages() []string {
 	return images
 }
 
+func reuseLocalDevImages() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("OBOL_REUSE_LOCAL_DEV_IMAGES")), "true")
+}
+
+func dockerImageAvailableLocally(tag string) bool {
+	inspectCmd := exec.Command("docker", "image", "inspect", tag)
+	inspectCmd.Stdout = io.Discard
+	inspectCmd.Stderr = io.Discard
+	return inspectCmd.Run() == nil
+}
+
 // buildAndImportLocalImages builds Docker images from source and imports them
 // into the k3d cluster. This ensures images are available even when the GHCR
 // publish workflow hasn't run. Non-fatal: logs warnings on failure.
@@ -640,6 +652,7 @@ func buildAndImportLocalImages(cfg *config.Config) {
 
 	clusterName := "obol-stack-" + stackID
 	k3dBinary := filepath.Join(cfg.BinDir, "k3d")
+	reuseCachedImages := reuseLocalDevImages()
 
 	for _, img := range baseLocalImages {
 		contextDir := projectRoot
@@ -657,6 +670,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 		}
 		if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 			continue // Dockerfile not present (production install without source)
+		}
+
+		if reuseCachedImages && dockerImageAvailableLocally(img.tag) {
+			fmt.Printf("Reusing existing local image %s (set OBOL_REUSE_LOCAL_DEV_IMAGES=true to opt into cache reuse)...\n", img.tag)
+			if err := importImageToCluster(k3dBinary, clusterName, img.tag); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", img.tag, err)
+			}
+			continue
 		}
 
 		fmt.Printf("Building %s from %s...\n", img.tag, img.dockerfile)
@@ -679,6 +700,14 @@ func buildAndImportLocalImages(cfg *config.Config) {
 	}
 
 	for _, ref := range devPreloadImages() {
+		if reuseCachedImages && dockerImageAvailableLocally(ref) {
+			fmt.Printf("Reusing cached image %s for cluster %s...\n", ref, clusterName)
+			if err := importImageToCluster(k3dBinary, clusterName, ref); err != nil {
+				fmt.Printf("Warning: failed to import %s into k3d: %v\n", ref, err)
+			}
+			continue
+		}
+
 		fmt.Printf("Preloading %s into cluster %s...\n", ref, clusterName)
 		pullCmd := exec.Command("docker", "pull", ref)
 		pullCmd.Stdout = os.Stdout

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -634,3 +634,151 @@ func TestHasLiveK3dCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAndImportLocalImages_DefaultBuildsEvenWhenImageExists(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 97\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "false")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild even when the local image exists, log:\n%s", log)
+	}
+	if strings.Contains(log, "Reusing existing local image ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild instead of reusing cache, log:\n%s", log)
+	}
+}
+
+func TestBuildAndImportLocalImages_ReusesExistingImageWhenOptedIn(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "true")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "docker build -f") {
+		t.Fatalf("expected opt-in cache reuse to skip docker build, log:\n%s", log)
+	}
+	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
+		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
+	}
+}

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -635,7 +635,7 @@ func TestHasLiveK3dCluster(t *testing.T) {
 	}
 }
 
-func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
+func TestBuildAndImportLocalImages_DefaultBuildsEvenWhenImageExists(t *testing.T) {
 	root := t.TempDir()
 	cfgDir := filepath.Join(root, "config")
 	binDir := filepath.Join(root, "bin")
@@ -692,7 +692,7 @@ func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	defer os.Chdir(oldWD)
-	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "false")
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "false")
 
 	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
 
@@ -701,18 +701,15 @@ func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	if strings.Contains(log, "docker build -f") {
-		t.Fatalf("expected existing local image to skip docker build, log:\n%s", log)
+	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild even when the local image exists, log:\n%s", log)
 	}
-	if !strings.Contains(log, "docker image inspect ghcr.io/obolnetwork/x402-verifier:latest") {
-		t.Fatalf("expected docker image inspect for x402 verifier, log:\n%s", log)
-	}
-	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
-		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
+	if strings.Contains(log, "Reusing existing local image ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected default dev path to rebuild instead of reusing cache, log:\n%s", log)
 	}
 }
 
-func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
+func TestBuildAndImportLocalImages_ReusesExistingImageWhenOptedIn(t *testing.T) {
 	root := t.TempDir()
 	cfgDir := filepath.Join(root, "config")
 	binDir := filepath.Join(root, "bin")
@@ -769,7 +766,7 @@ func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	defer os.Chdir(oldWD)
-	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "true")
+	t.Setenv("OBOL_REUSE_LOCAL_DEV_IMAGES", "true")
 
 	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
 
@@ -778,10 +775,10 @@ func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
-		t.Fatalf("expected forced rebuild to call docker build, log:\n%s", log)
+	if strings.Contains(log, "docker build -f") {
+		t.Fatalf("expected opt-in cache reuse to skip docker build, log:\n%s", log)
 	}
 	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
-		t.Fatalf("expected k3d import for rebuilt x402 verifier image, log:\n%s", log)
+		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
 	}
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -634,3 +634,154 @@ func TestHasLiveK3dCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAndImportLocalImages_ReusesExistingImage(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 97\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "false")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "docker build -f") {
+		t.Fatalf("expected existing local image to skip docker build, log:\n%s", log)
+	}
+	if !strings.Contains(log, "docker image inspect ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected docker image inspect for x402 verifier, log:\n%s", log)
+	}
+	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
+		t.Fatalf("expected k3d import for cached x402 verifier image, log:\n%s", log)
+	}
+}
+
+func TestBuildAndImportLocalImages_ForceRebuildsWhenRequested(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile.x402-verifier"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ] && [ \"${3:-}\" = \"ghcr.io/obolnetwork/x402-verifier:latest\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"build\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_IMAGES", "true")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir})
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "docker build -f ") || !strings.Contains(log, "Dockerfile.x402-verifier -t ghcr.io/obolnetwork/x402-verifier:latest") {
+		t.Fatalf("expected forced rebuild to call docker build, log:\n%s", log)
+	}
+	if !strings.Contains(log, "k3d image import ghcr.io/obolnetwork/x402-verifier:latest -c obol-stack-test-stack") {
+		t.Fatalf("expected k3d import for rebuilt x402 verifier image, log:\n%s", log)
+	}
+}

--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,19 @@
     },
     {
       "customType": "regex",
+      "description": "Update cloudflared image tag",
+      "matchStrings": [
+        "repository:\\s*cloudflare/cloudflared\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[\\w.-]+)[\"']?"
+      ],
+      "fileMatch": [
+        "^internal/embed/infrastructure/cloudflared/values\\.yaml$"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "cloudflare/cloudflared",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "Update pinned tool versions in obolup.sh",
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\nreadonly\\s+\\w+=\"(?<currentValue>[^\"]+)\""
@@ -260,6 +273,22 @@
         "before 6am on monday"
       ],
       "groupName": "LiteLLM updates"
+    },
+    {
+      "description": "Group cloudflared updates",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "cloudflare/cloudflared"
+      ],
+      "labels": [
+        "renovate/cloudflared"
+      ],
+      "schedule": [
+        "before 6am on monday"
+      ],
+      "groupName": "cloudflared updates"
     },
     {
       "description": "Batch obolup.sh tool version updates into a single PR",


### PR DESCRIPTION
## Summary
- supersedes #400 by including the dev-image cache reuse opt-in for smoke runs
- makes live OBOL release smoke explicit via `flow-14-live-obol-base-sepolia.sh`, with the Anvil fork path kept separately as `flow-13-dual-stack-obol.sh`
- switches `flow-14` back to the deterministic Bob buyer wallet model used by `flow-11`; the flow now pre-seeds Bob's remote-signer and no longer funds a generated signer
- adds the shared runtime-aware `agent_auth_token` helper for OBOL flows
- bumps `cloudflare/cloudflared` to `2026.3.0` and adds Renovate tracking for that image
- compresses the Obol stack dev skill into a compact router with focused references for live OBOL QA, remote QA worktrees, and paid-commerce gotchas

## Validation
- `git diff --check`
- `bash -n flows/*.sh`
- `jq empty renovate.json`
- `helm lint internal/embed/infrastructure/cloudflared`
- `helm template cloudflared internal/embed/infrastructure/cloudflared | rg 'cloudflare/cloudflared:2026\\.3\\.0'`
- `go test ./internal/stack -run 'TestBuildAndImportLocalImages_(DefaultBuildsEvenWhenImageExists|ReusesExistingImageWhenOptedIn)' -count=1`
- `go test ./cmd/obol ./internal/tunnel ./internal/stack ./internal/hermes -count=1`

## QA Notes
A prior remote run of `flow-14` passed end-to-end on Base Sepolia with the deployed OBOL token and public facilitator, including purchase, paid inference, settlement transfer, exact balance deltas, and cleanup. After the deterministic-Bob correction in this PR, I did not rerun the full live flow because both QA machines' deterministic Bob wallets currently have `0` OBOL, so the updated flow would fail early until those wallets are topped up.
