### PR TITLE
Allow hermes messaging

### DIFF
--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -844,15 +844,16 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
                   fi
                   cd "$install_dir"
                   # Reinstall when the venv is missing the hermes binary OR
-                  # when the dashboard's web extra (fastapi/uvicorn) is absent.
-                  # The upstream image installs ".[all]" (which pulls in
-                  # ".[web]"); we re-create the venv from a fresh clone, so
-                  # the extras must be re-requested explicitly here.
+                  # any selected extra is absent. The upstream image installs
+                  # ".[all]"; we re-create the venv from a fresh clone, so the
+                  # extras must be re-requested explicitly. The import check
+                  # picks one module per extra so existing PVCs trigger a
+                  # rebuild when we add a new extra to the install line.
                   if [ ! -x "$install_dir/venv/bin/hermes" ] || \
-                     ! "$install_dir/venv/bin/python3" -c "import fastapi, uvicorn" >/dev/null 2>&1; then
+                     ! "$install_dir/venv/bin/python3" -c "import fastapi, uvicorn, telegram, mcp, ptyprocess, simple_term_menu, googleapiclient" >/dev/null 2>&1; then
                     rm -rf "$install_dir/venv"
                     uv venv --python python3 --system-site-packages venv
-                    VIRTUAL_ENV="$install_dir/venv" uv pip install -e ".[web]"
+                    VIRTUAL_ENV="$install_dir/venv" uv pip install -e ".[web,messaging,mcp,pty,cli,acp,google]"
                   fi
                   if [ -f /data/.hermes/state.db ]; then
                     if ! python3 - <<'PY'


### PR DESCRIPTION
>  Diffing [all] against [web,messaging], here are the  
>   extras you'd be adding. Grouped by likely usefulness 
>   for obol-stack: 
> 
>   Probably worth turning on                            
>   - mcp — Model Context Protocol client; lets Hermes
>   consume MCP servers                                  
>   - pty — ptyprocess for better terminal subprocess
>   handling                                             
>   - cli — simple-term-menu for interactive menus in    
>   hermes CLI                                       
>   - acp — agent-client-protocol (the hermes-acp        
>   entrypoint)                                  
>   - google — Gmail/Calendar/Drive/Sheets/Docs (used by 
>   the google-workspace skill)
>                                