### PR TITLE
obol model prefer work

### DIFF
--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -27,6 +27,7 @@ func modelCommand(cfg *config.Config) *cli.Command {
 			modelSyncCommand(cfg),
 			modelPullCommand(),
 			modelListCommand(cfg),
+			modelPreferCommand(cfg),
 			modelRemoveCommand(cfg),
 		},
 	}
@@ -194,12 +195,33 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 	}
 
 	if len(models) == 0 {
-		// Sensible defaults
+		// Per-provider defaults — kept in sync with what the providers
+		// document as their current chat-tuned flagship. Bumping these is a
+		// small follow-up PR when frontier models drop, and it isolates the
+		// "what's good today" maintenance to one place.
+		var defaultModel string
 		switch provider {
 		case "anthropic":
-			models = []string{"claude-sonnet-4-6"}
+			defaultModel = "claude-sonnet-4-6"
 		case "openai":
-			models = []string{"gpt-4.1"}
+			defaultModel = "gpt-5.5"
+		}
+
+		// Interactive: let the user override the default with a free-text
+		// entry. Non-interactive (no TTY): silently use the default — the
+		// caller can always pass --model to be explicit.
+		chosen := defaultModel
+		if defaultModel != "" && u.IsTTY() && !u.IsJSON() {
+			input, err := u.Input(fmt.Sprintf("Model for %s", provider), defaultModel)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(input) != "" {
+				chosen = strings.TrimSpace(input)
+			}
+		}
+		if chosen != "" {
+			models = []string{chosen}
 		}
 	}
 
@@ -489,6 +511,34 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 			}
 
 			return nil
+		},
+	}
+}
+
+func modelPreferCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:      "prefer",
+		Usage:     "Pull one or more models to the head of the LiteLLM model_list (the head becomes the agent's primary)",
+		ArgsUsage: "<model-name> [<model-name> ...]",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "no-sync", Usage: "Skip the agent model sync (batch with other model commands, then run `obol model sync` once)"},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u := getUI(cmd)
+
+			names := cmd.Args().Slice()
+			if len(names) == 0 {
+				return errors.New("at least one model name is required\n\nUsage: obol model prefer <model-name> [<model-name> ...]\n\nList configured models with: obol model list")
+			}
+
+			if err := model.PreferModels(cfg, u, names); err != nil {
+				return err
+			}
+
+			if cmd.Bool("no-sync") {
+				return nil
+			}
+			return syncAgentModels(cfg, u)
 		},
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -577,6 +577,130 @@ func hotDeleteModel(cfg *config.Config, u *ui.UI, modelName string) error {
 	return nil
 }
 
+// reorderModelList is the pure-function core of PreferModels. It moves the
+// named entries to the head of the list (in the order given) and returns
+// the new slice, plus a boolean indicating whether the input was already in
+// the requested order (the caller should treat that as a no-op so it can
+// skip the kubectl patch + LiteLLM rollout). Unknown or duplicate names
+// produce an error so typos surface loudly.
+func reorderModelList(entries []ModelEntry, names []string) ([]ModelEntry, bool, error) {
+	indexByName := make(map[string]int, len(entries))
+	for i, entry := range entries {
+		indexByName[entry.ModelName] = i
+	}
+
+	var missing []string
+	picked := make(map[string]bool, len(names))
+	for _, name := range names {
+		if _, ok := indexByName[name]; !ok {
+			missing = append(missing, name)
+			continue
+		}
+		if picked[name] {
+			return nil, false, fmt.Errorf("duplicate model in prefer args: %q", name)
+		}
+		picked[name] = true
+	}
+	if len(missing) > 0 {
+		return nil, false, fmt.Errorf("model(s) not found in LiteLLM config: %s\n  Run 'obol model list' to see available entries", strings.Join(missing, ", "))
+	}
+
+	alreadyAtHead := true
+	for i, name := range names {
+		if i >= len(entries) || entries[i].ModelName != name {
+			alreadyAtHead = false
+			break
+		}
+	}
+
+	reordered := make([]ModelEntry, 0, len(entries))
+	for _, name := range names {
+		reordered = append(reordered, entries[indexByName[name]])
+	}
+	for _, entry := range entries {
+		if picked[entry.ModelName] {
+			continue
+		}
+		reordered = append(reordered, entry)
+	}
+	return reordered, alreadyAtHead, nil
+}
+
+// PreferModels reorders LiteLLM's model_list so the named entries appear at
+// the head, in the order given. Remaining entries keep their original
+// relative order. This is the operator-facing primitive that lets
+// model.Rank's "first chat-capable wins" rule pick a specific primary
+// without a remove/re-add cycle.
+//
+// Returns an error if any of the requested names is not present in the
+// current model_list — typos should be loud, not silent no-ops.
+//
+// LiteLLM has no model_list reorder API, so after the ConfigMap patch this
+// rolls the LiteLLM Deployment so the new order takes effect (the
+// /v1/models listing follows model_list order, and hermes/openclaw read
+// the ConfigMap directly via GetConfiguredModels for the agent primary).
+func PreferModels(cfg *config.Config, u *ui.UI, names []string) error {
+	if len(names) == 0 {
+		return errors.New("at least one model name is required")
+	}
+
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return errors.New("cluster not running. Run 'obol stack up' first")
+	}
+
+	raw, err := kubectl.Output(kubectlBinary, kubeconfigPath,
+		"get", "configmap", configMapName, "-n", namespace, "-o", "jsonpath={.data.config\\.yaml}")
+	if err != nil {
+		return fmt.Errorf("failed to read LiteLLM config: %w", err)
+	}
+
+	var litellmConfig LiteLLMConfig
+	if err := yaml.Unmarshal([]byte(raw), &litellmConfig); err != nil {
+		return fmt.Errorf("failed to parse config.yaml: %w", err)
+	}
+
+	reordered, alreadyAtHead, err := reorderModelList(litellmConfig.ModelList, names)
+	if err != nil {
+		return err
+	}
+	if alreadyAtHead {
+		u.Infof("Model(s) already at the head of the model_list, no change")
+		return nil
+	}
+	litellmConfig.ModelList = reordered
+
+	updated, err := yaml.Marshal(&litellmConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	escapedYAML, err := json.Marshal(string(updated))
+	if err != nil {
+		return fmt.Errorf("failed to escape YAML: %w", err)
+	}
+	patchJSON := fmt.Sprintf(`{"data":{"config.yaml":%s}}`, escapedYAML)
+
+	u.Infof("Promoting %s to head of LiteLLM model_list", strings.Join(names, ", "))
+	if err := kubectl.Run(kubectlBinary, kubeconfigPath,
+		"patch", "configmap", configMapName, "-n", namespace,
+		"-p", patchJSON, "--type=merge", "--field-manager=helm"); err != nil {
+		return fmt.Errorf("failed to patch ConfigMap: %w", err)
+	}
+
+	// LiteLLM has no reorder API; restart the deployment so the new order
+	// takes effect (mostly cosmetic for /v1/models listings — agent primary
+	// is read from the ConfigMap directly via GetConfiguredModels, which is
+	// already correct after the patch above).
+	if err := RestartLiteLLM(cfg, u, "prefer"); err != nil {
+		u.Warnf("LiteLLM rollout failed: %v", err)
+		u.Dim("  The ConfigMap is updated; agent will pick up the new primary on next sync.")
+	}
+
+	return nil
+}
+
 // RemoveModel removes a model entry from the LiteLLM ConfigMap (persistence)
 // and hot-deletes it from the running router via the API (immediate effect).
 // No pod restart is required.
@@ -1123,16 +1247,10 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 		}
 	case ProviderAnthropic:
 		cachePoints := anthropicCacheControlPoints()
-		// Wildcard: routes any anthropic model without explicit registration
-		entries = append(entries, ModelEntry{
-			ModelName: "anthropic/*",
-			LiteLLMParams: LiteLLMParams{
-				Model:                       "anthropic/*",
-				APIKey:                      "os.environ/ANTHROPIC_API_KEY",
-				CacheControlInjectionPoints: cachePoints,
-			},
-		})
-		// Explicit entries for requested models (better /v1/models listing)
+		// Explicit entries first so the user-selected model is the primary
+		// under model.Rank's "first chat-capable wins" rule. Hermes cannot
+		// send `model: anthropic/*` literally (LiteLLM doesn't resolve a
+		// wildcard to a default), so the wildcard must never sit at index 0.
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
 				ModelName: m,
@@ -1143,17 +1261,27 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 				},
 			})
 		}
-	case ProviderOpenAI:
+		// Wildcard: routes any anthropic model without explicit registration.
 		entries = append(entries, ModelEntry{
-			ModelName:     "openai/*",
-			LiteLLMParams: LiteLLMParams{Model: "openai/*", APIKey: "os.environ/OPENAI_API_KEY"},
+			ModelName: "anthropic/*",
+			LiteLLMParams: LiteLLMParams{
+				Model:                       "anthropic/*",
+				APIKey:                      "os.environ/ANTHROPIC_API_KEY",
+				CacheControlInjectionPoints: cachePoints,
+			},
 		})
+	case ProviderOpenAI:
+		// Explicit-before-wildcard, same rationale as Anthropic above.
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
 				ModelName:     m,
 				LiteLLMParams: LiteLLMParams{Model: "openai/" + m, APIKey: "os.environ/OPENAI_API_KEY"},
 			})
 		}
+		entries = append(entries, ModelEntry{
+			ModelName:     "openai/*",
+			LiteLLMParams: LiteLLMParams{Model: "openai/*", APIKey: "os.environ/OPENAI_API_KEY"},
+		})
 	default:
 		for _, m := range models {
 			entries = append(entries, ModelEntry{

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -31,41 +31,42 @@ func TestBuildModelEntries(t *testing.T) {
 		}
 	})
 
-	t.Run("anthropic gets wildcard plus explicit entries", func(t *testing.T) {
+	t.Run("anthropic puts explicit before the wildcard", func(t *testing.T) {
 		entries := buildModelEntries("anthropic", []string{"claude-sonnet-4-5-20250929"})
 		if len(entries) != 2 {
-			t.Fatalf("got %d entries, want 2 (wildcard + explicit)", len(entries))
+			t.Fatalf("got %d entries, want 2 (explicit + wildcard)", len(entries))
 		}
-		// First entry is the wildcard
-		if entries[0].ModelName != "anthropic/*" {
-			t.Errorf("entries[0].ModelName = %q, want anthropic/*", entries[0].ModelName)
+		// Explicit first so model.Rank picks it as primary; Hermes can't
+		// send `model: anthropic/*` literally.
+		if entries[0].ModelName != "claude-sonnet-4-5-20250929" {
+			t.Errorf("entries[0].ModelName = %q, want explicit model", entries[0].ModelName)
 		}
-
-		if entries[0].LiteLLMParams.Model != "anthropic/*" {
-			t.Errorf("entries[0].Model = %q, want anthropic/*", entries[0].LiteLLMParams.Model)
+		if entries[0].LiteLLMParams.Model != "claude-sonnet-4-5-20250929" {
+			t.Errorf("entries[0].Model = %q", entries[0].LiteLLMParams.Model)
 		}
-		// Second entry is the explicit model
-		if entries[1].ModelName != "claude-sonnet-4-5-20250929" {
-			t.Errorf("entries[1].ModelName = %q", entries[1].ModelName)
+		if entries[0].LiteLLMParams.APIKey != "os.environ/ANTHROPIC_API_KEY" {
+			t.Errorf("api_key = %q, want os.environ/ANTHROPIC_API_KEY", entries[0].LiteLLMParams.APIKey)
 		}
-
-		if entries[1].LiteLLMParams.APIKey != "os.environ/ANTHROPIC_API_KEY" {
-			t.Errorf("api_key = %q, want os.environ/ANTHROPIC_API_KEY", entries[1].LiteLLMParams.APIKey)
+		// Wildcard appended last as catch-all.
+		if entries[1].ModelName != "anthropic/*" {
+			t.Errorf("entries[1].ModelName = %q, want anthropic/*", entries[1].ModelName)
 		}
 	})
 
-	t.Run("openai gets wildcard plus explicit entries", func(t *testing.T) {
+	t.Run("openai puts explicit before the wildcard", func(t *testing.T) {
 		entries := buildModelEntries("openai", []string{"gpt-4o"})
 		if len(entries) != 2 {
-			t.Fatalf("got %d entries, want 2 (wildcard + explicit)", len(entries))
+			t.Fatalf("got %d entries, want 2 (explicit + wildcard)", len(entries))
 		}
 
-		if entries[0].ModelName != "openai/*" {
-			t.Errorf("entries[0].ModelName = %q, want openai/*", entries[0].ModelName)
+		if entries[0].ModelName != "gpt-4o" {
+			t.Errorf("entries[0].ModelName = %q, want gpt-4o", entries[0].ModelName)
 		}
-
-		if entries[1].LiteLLMParams.Model != "openai/gpt-4o" {
-			t.Errorf("entries[1].Model = %q, want openai/gpt-4o", entries[1].LiteLLMParams.Model)
+		if entries[0].LiteLLMParams.Model != "openai/gpt-4o" {
+			t.Errorf("entries[0].Model = %q, want openai/gpt-4o", entries[0].LiteLLMParams.Model)
+		}
+		if entries[1].ModelName != "openai/*" {
+			t.Errorf("entries[1].ModelName = %q, want openai/*", entries[1].ModelName)
 		}
 	})
 
@@ -749,4 +750,123 @@ func TestPullOllamaModel_MockServer(t *testing.T) {
 			t.Fatal("expected error when server is not running")
 		}
 	})
+}
+
+func TestReorderModelList(t *testing.T) {
+	entries := []ModelEntry{
+		{ModelName: "anthropic/*"},
+		{ModelName: "claude-sonnet-4-6"},
+		{ModelName: "claude-opus-4-7"},
+		{ModelName: "openai/*"},
+		{ModelName: "gpt-5.5"},
+	}
+
+	t.Run("pulls a single model to the head", func(t *testing.T) {
+		got, already, err := reorderModelList(entries, []string{"claude-opus-4-7"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		if already {
+			t.Fatalf("expected alreadyAtHead = false")
+		}
+		want := []string{"claude-opus-4-7", "anthropic/*", "claude-sonnet-4-6", "openai/*", "gpt-5.5"}
+		assertOrder(t, got, want)
+	})
+
+	t.Run("pulls multiple models to the head in the given order", func(t *testing.T) {
+		got, _, err := reorderModelList(entries, []string{"gpt-5.5", "claude-opus-4-7"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		want := []string{"gpt-5.5", "claude-opus-4-7", "anthropic/*", "claude-sonnet-4-6", "openai/*"}
+		assertOrder(t, got, want)
+	})
+
+	t.Run("preserves relative order of unselected entries", func(t *testing.T) {
+		got, _, err := reorderModelList(entries, []string{"claude-opus-4-7"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		// anthropic/*, claude-sonnet-4-6, openai/*, gpt-5.5 should stay in
+		// that relative order behind the promoted entry.
+		want := []string{"claude-opus-4-7", "anthropic/*", "claude-sonnet-4-6", "openai/*", "gpt-5.5"}
+		assertOrder(t, got, want)
+	})
+
+	t.Run("flags already-at-head as no-op", func(t *testing.T) {
+		_, already, err := reorderModelList(entries, []string{"anthropic/*"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		if !already {
+			t.Fatalf("expected alreadyAtHead = true when first entry is requested")
+		}
+	})
+
+	t.Run("flags multi-arg already-at-head as no-op", func(t *testing.T) {
+		_, already, err := reorderModelList(entries, []string{"anthropic/*", "claude-sonnet-4-6"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		if !already {
+			t.Fatalf("expected alreadyAtHead = true when first two requested entries already lead")
+		}
+	})
+
+	t.Run("errors on missing names with full list", func(t *testing.T) {
+		_, _, err := reorderModelList(entries, []string{"claude-opus-4-7", "typo-1", "typo-2"})
+		if err == nil {
+			t.Fatal("expected error for missing names")
+		}
+		if !strings.Contains(err.Error(), "typo-1") || !strings.Contains(err.Error(), "typo-2") {
+			t.Fatalf("error should list every missing name, got: %v", err)
+		}
+	})
+
+	t.Run("errors on duplicate args", func(t *testing.T) {
+		_, _, err := reorderModelList(entries, []string{"claude-opus-4-7", "claude-opus-4-7"})
+		if err == nil {
+			t.Fatal("expected error for duplicate names")
+		}
+		if !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("error should mention duplicate, got: %v", err)
+		}
+	})
+
+	t.Run("preserves ModelEntry contents not just names", func(t *testing.T) {
+		entriesWithParams := []ModelEntry{
+			{ModelName: "a", LiteLLMParams: LiteLLMParams{Model: "openai/a", APIKey: "key-a"}},
+			{ModelName: "b", LiteLLMParams: LiteLLMParams{Model: "openai/b", APIKey: "key-b"}},
+		}
+		got, _, err := reorderModelList(entriesWithParams, []string{"b"})
+		if err != nil {
+			t.Fatalf("reorderModelList: %v", err)
+		}
+		if got[0].LiteLLMParams.APIKey != "key-b" {
+			t.Fatalf("promoted entry lost its params: got %+v", got[0])
+		}
+		if got[1].LiteLLMParams.APIKey != "key-a" {
+			t.Fatalf("trailing entry lost its params: got %+v", got[1])
+		}
+	})
+}
+
+func assertOrder(t *testing.T, got []ModelEntry, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got %v)", len(got), len(want), modelNames(got))
+	}
+	for i, w := range want {
+		if got[i].ModelName != w {
+			t.Fatalf("entry[%d] = %q, want %q (full order: %v)", i, got[i].ModelName, w, modelNames(got))
+		}
+	}
+}
+
+func modelNames(entries []ModelEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.ModelName
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

End state on fix/model-config-order — three files changed:

  File: internal/model/model.go
  Change: (a) buildModelEntries writes explicit models BEFORE the
    provider/* wildcard for anthropic/openai (so model.Rank's "first

    chat-capable wins" picks the user's selection, not the
  wildcard);
     (b) new PreferModels operator command + pure reorderModelList
    core that promotes named entries to the head of LiteLLM's
    model_list, errors on missing/duplicate names, no-ops when the
    order already matches, patches the ConfigMap with field-manager
    helm, and rolls LiteLLM so /v1/models reflects the new order
  ────────────────────────────────────────
  File: cmd/obol/model.go
  Change: (a) setupCloudProvider now interactively prompts for the
    model with per-provider defaults (claude-sonnet-4-6 for
    anthropic, gpt-5.5 for openai); non-TTY/JSON callers get the
    default silently; explicit --model always wins; (b) new obol
    model prefer <model> [<model> ...] subcommand wired up alongside

    setup/remove/etc., with a --no-sync flag for batching
  ────────────────────────────────────────
  File: internal/model/model_test.go
  Change: Updated buildModelEntries assertions for the new
    explicit-then-wildcard order; added TestReorderModelList
  covering
     single-arg promote, multi-arg order preservation,
    already-at-head no-op, missing-name error listing all typos,
    duplicate-arg error, and ModelEntry params survival

  The flow now is: user runs obol model setup --provider anthropic →
   interactive prompt offers claude-sonnet-4-6, override possible →
  ConfigureLiteLLM writes [claude-sonnet-4-6, anthropic/*] →
  model.Rank returns claude-sonnet-4-6 as primary → Hermes calls
  LiteLLM with model: claude-sonnet-4-6. Later, obol model prefer
  claude-opus-4-7 swaps the primary without re-running setup. 