### PR TITLE
feat(x402): advertise eip2612GasSponsoring on OBOL mainnet 402

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ obol sell delete ollama-gated -n llm
 
 **serviceoffer-controller** (`internal/serviceoffercontroller/`): Watches ServiceOffers and RegistrationRequests, adds finalizers, creates Middleware + HTTPRoute, publishes registration resources, and drives tombstone cleanup on delete.
 
-**ERC-8004**: Registration publication is isolated behind `RegistrationRequest`. The controller serves `/.well-known/agent-registration.json` from dedicated child resources and optionally registers/tombstones on Base Sepolia when an ERC-8004 signing key is configured.
+**ERC-8004**: Registration publication is isolated behind `RegistrationRequest`. The controller serves `/.well-known/agent-registration.json` from dedicated child resources and watches the chain selected by the offer's `payment.network` (`mainnet`, `base`, `base-sepolia`) for the matching registration tx — submitted by the operator via `obol sell register`, never by the controller. Per-chain RPC is routed through the in-cluster eRPC at `http://erpc.erpc.svc.cluster.local/rpc/<alias>` (override base via `ERC8004_RPC_BASE` env on the controller). The CLI `--chain` default is `mainnet`.
 
 **RBAC**: The controller owns child-resource and registration write access. The agent retains read access plus minimal ServiceOffer CRUD for compatibility commands only.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,18 +182,21 @@ k3d: 1 server, ports 80:80 + 8080:80 + 443:443 + 8443:443, `rancher/k3s:v1.35.1-
 
 ### Dev Registry Cache
 
-When `OBOL_DEVELOPMENT=true`, `obol stack up` creates pull-through k3d registry caches and wires new clusters to use them on image pulls:
+When `OBOL_DEVELOPMENT=true`, `obol stack up` creates pull-through k3d registry caches and a local push target, and wires new clusters to use them:
 
-- `docker.io` -> `k3d-obol-docker-io.localhost:54100`
-- `ghcr.io` -> `k3d-obol-ghcr-io.localhost:54101`
-- `quay.io` -> `k3d-obol-quay-io.localhost:54102`
+- `docker.io` -> `k3d-obol-docker-io.localhost:54100` (pull-through)
+- `ghcr.io` -> `k3d-obol-ghcr-io.localhost:54101` (pull-through)
+- `quay.io` -> `k3d-obol-quay-io.localhost:54102` (pull-through)
+- `localhost:54103` -> `k3d-obol-local.localhost:54103` (local push target, no upstream proxy)
 
 The generated k3d registry config is written to `$OBOL_CONFIG_DIR/registries.yaml`. Cache data is stored under `~/.local/state/obol/registry-cache/` by default, or under `OBOL_REGISTRY_CACHE_DIR` when set.
 
+The local push target lets `just dev-frontend` swap layered diffs into the cluster via `docker push localhost:54103/...` (and a deployment image of `localhost:54103/...:dev`) — only changed layers transfer, vs. `k3d image import`'s full-tarball round-trip.
+
 Important caveats:
 
-- This is a pull-through cache for upstream registries, not a first-class local build registry workflow.
-- It is only set up during cluster creation. If `obol stack up` is just starting an existing k3d cluster, registry setup is skipped.
+- The pull-through caches do not help local-build flows like `just dev-frontend` because `docker build` runs on the host daemon and `k3d image import` bypasses registries entirely. The local push target above is what speeds up local-build redeploys.
+- Registries are only set up during cluster creation. If `obol stack up` is just starting an existing k3d cluster, registry setup is skipped — recreate the cluster (`obol stack down && obol stack up`) once to pick up new registry entries.
 
 ## LLM Routing
 

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -2168,15 +2168,15 @@ Uses the remote-signer wallet by default. Supports sponsored (zero-gas)
 registration on networks that offer it (e.g. ethereum mainnet).
 
 Examples:
-  obol sell register                                    # interactive, defaults to base
+  obol sell register                                    # interactive, defaults to mainnet
   obol sell register --chain base                       # register on base
   obol sell register --chain mainnet,base               # register on multiple chains
   obol sell register --chain mainnet --sponsored        # zero-gas on ethereum mainnet`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "chain",
-				Usage: "Registration chain(s), comma-separated (base, base-sepolia, mainnet)",
-				Value: "base",
+				Usage: "Registration chain(s), comma-separated (mainnet, base, base-sepolia)",
+				Value: "mainnet",
 			},
 			&cli.BoolFlag{
 				Name:  "sponsored",

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -399,7 +399,7 @@ func TestSellRegister_Flags(t *testing.T) {
 		"endpoint", "name", "description", "image",
 	)
 
-	assertStringDefault(t, flags, "chain", "base")
+	assertStringDefault(t, flags, "chain", "mainnet")
 	assertStringDefault(t, flags, "name", "Obol Agent")
 	assertStringDefault(t, flags, "description", "Obol Stack AI agent with x402 payment-gated services")
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/helmcmd"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -302,7 +303,8 @@ func Sync(cfg *config.Config, u *ui.UI, deploymentIdentifier string) error {
 	u.Detail("Deployment ID", id)
 
 	// Execute helmfile sync
-	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
+	syncArgs := append([]string{"-f", helmfilePath, "sync"}, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
+	cmd := exec.Command(helmfileBinary, syncArgs...)
 	cmd.Dir = deploymentDir
 
 	cmd.Env = append(os.Environ(),

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -35,7 +35,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.18"
+  tag: "v0.1.19"
 
 service:
   type: ClusterIP

--- a/internal/embed/skills/buy-x402/SKILL.md
+++ b/internal/embed/skills/buy-x402/SKILL.md
@@ -11,7 +11,9 @@ Purchase access to remote x402-gated services. There are two flows, picked by us
 - **`pay <url>`** — single-shot. Probe the URL, sign **one** payment authorization, attach `X-PAYMENT`, send the request, return the response. Stateless. Use for `type:http` services and any one-off purchase. Max loss = price of one request.
 - **`buy <name>`** — pre-payment budget. Pre-sign **N** authorizations, declare them in a `PurchaseRequest` CR, let the `x402-buyer` sidecar spend them transparently as the agent calls the model through LiteLLM at `paid/<remote-model>`. Use for long-running paid inference. Max loss = N × price; runtime path holds zero signer access.
 
-Both flows auto-detect the token + transfer method from the seller's 402 response. Currently supported: **USDC via EIP-3009** (Base Sepolia, Base Mainnet, Ethereum) and **OBOL via Permit2** (Ethereum Mainnet).
+Both flows auto-detect the token + transfer method from the seller's 402 response. Currently supported: **USDC via EIP-3009** (Base Sepolia, Base Mainnet, Ethereum Mainnet) and **OBOL via Permit2** (Ethereum Mainnet).
+
+Chain names follow the eRPC project aliases: `mainnet`, `base`, `base-sepolia`. CAIP-2 strings (`eip155:1`, `eip155:8453`, `eip155:84532`) and the alias `ethereum` are accepted on input and normalized internally. Unknown chains fail loudly with the supported list — buy.py will not silently sign against base-sepolia when the seller is on mainnet.
 
 ## Gasless Payments
 
@@ -29,6 +31,20 @@ in any of these commands. The seller's `x402-verifier` middleware
 coordinates with the facilitator after verifying your `X-PAYMENT` header.
 The default Obol-operated facilitator at `https://x402.gcp.obol.tech`
 covers `eip155:1`, `eip155:8453`, and `eip155:84532`.
+
+## First-Time Permit2 Approval (one-time per token+wallet)
+
+Permit2-based x402 payments (e.g. OBOL, USDC on chains where the seller selects `assetTransferMethod=permit2`) require the agent's wallet to have approved the Permit2 router on the token *before any payment can settle*. Without it, `buy.py pay`/`buy` pre-signs a valid voucher, the seller's facilitator submits the on-chain `transferFrom`, and it reverts with no clear error — usually surfacing as an opaque HTTP 503 from the seller.
+
+`buy.py` now pre-flights this check and aborts with the exact remediation command. If you see the error, run:
+
+```bash
+python3 ${OBOL_SKILLS_DIR:-/data/.openclaw/skills}/ethereum-local-wallet/scripts/signer.py send-tx \
+    --from <agent-wallet> --to <token-address> \
+    --data <approve-calldata-printed-by-buy.py> --network <chain>
+```
+
+This is one tx, ~46k gas, valid forever (unless the user later revokes). EIP-3009 flows (USDC `TransferWithAuthorization`) do **not** need this approval. Sellers that advertise `eip2612GasSponsoring` in their 402 extensions also bypass it (per-request signed permits).
 
 ## Pitfalls
 

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -60,25 +60,27 @@ BUYER_NS = "llm"
 LITELLM_DEPLOY = "litellm"
 BUYER_PORT = 8402
 
-USDC_CONTRACTS = {
-    "base-sepolia": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-    "base": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    "ethereum": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+# Canonical chain names match eRPC project aliases (see
+# internal/embed/infrastructure/values/erpc.yaml.gotmpl). Any other label
+# (CAIP-2, "ethereum", chain-id string) is normalized via _resolve_chain
+# before it reaches an eRPC URL or an EIP-712 domain.
+CHAIN_INFO = {
+    "mainnet":      {"chain_id": 1,        "usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"},
+    "base":         {"chain_id": 8453,     "usdc": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"},
+    "base-sepolia": {"chain_id": 84532,    "usdc": "0x036CbD53842c5426634e7929541eC2318f3dCF7e"},
+    "sepolia":      {"chain_id": 11155111, "usdc": None},
+    "hoodi":        {"chain_id": 560048,   "usdc": None},
 }
 
-CHAIN_IDS = {
-    "base-sepolia": 84532,
-    "base": 8453,
-    "ethereum": 1,
-    "mainnet": 1,
-    "sepolia": 11155111,
-}
-
-CAIP2_TO_CHAIN = {
-    "eip155:84532": "base-sepolia",
-    "eip155:8453": "base",
-    "eip155:1": "ethereum",
-    "eip155:11155111": "sepolia",
+CHAIN_ALIASES = {
+    # Friendly aliases that resolve to canonical eRPC names.
+    "ethereum":         "mainnet",
+    "eth":              "mainnet",
+    "eip155:1":         "mainnet",
+    "eip155:8453":      "base",
+    "eip155:84532":     "base-sepolia",
+    "eip155:11155111":  "sepolia",
+    "eip155:560048":    "hoodi",
 }
 
 # EIP-712 domain for USDC TransferWithAuthorization
@@ -89,6 +91,8 @@ X402_EXACT_PERMIT2_PROXY = "0x402085c248EeA27D92E8b30b2C58ed07f9E20001"
 
 SEL_BALANCE_OF = "70a08231"
 SEL_NONCES = "7ecebe00"
+SEL_ALLOWANCE = "dd62ed3e"
+SEL_APPROVE = "095ea7b3"
 
 DEFAULT_BUDGET = "100000000"  # 100 USDC in micro-units
 DEFAULT_AUTH_COUNT = 100      # Pre-sign 100 auths by default
@@ -111,16 +115,44 @@ def _normalize_endpoint(url):
     return base
 
 
+def _resolve_chain(value):
+    """Map any chain label (canonical, alias, CAIP-2) to a canonical eRPC name.
+
+    Raises ValueError on unknown chains so callers fail loudly instead of
+    silently signing against the wrong chain. Use this everywhere a chain
+    string crosses an eRPC URL or an EIP-712 domain.
+    """
+    if value is None:
+        raise ValueError("chain is required")
+    label = str(value).strip()
+    if label in CHAIN_INFO:
+        return label
+    if label in CHAIN_ALIASES:
+        return CHAIN_ALIASES[label]
+    supported = ", ".join(sorted(CHAIN_INFO.keys()))
+    raise ValueError(f"Unknown chain {value!r}. Supported: {supported}")
+
+
 def _normalize_chain_name(network):
-    """Map facilitator/network identifiers to the local eRPC network name."""
-    return CAIP2_TO_CHAIN.get(network, network)
+    """Map facilitator/network identifiers to the canonical eRPC name."""
+    return _resolve_chain(network)
+
+
+def _chain_id(chain):
+    return CHAIN_INFO[_resolve_chain(chain)]["chain_id"]
+
+
+def _canonical_usdc(chain):
+    """Return the canonical USDC address for a chain, or None if not defined."""
+    return CHAIN_INFO[_resolve_chain(chain)].get("usdc")
 
 
 def _asset_display_meta(asset, extra=None):
     """Best-effort display metadata for user-facing balance/price output."""
     extra = extra or {}
     asset_lower = (asset or "").lower()
-    if asset_lower in {addr.lower() for addr in USDC_CONTRACTS.values()}:
+    known_usdcs = {info["usdc"].lower() for info in CHAIN_INFO.values() if info.get("usdc")}
+    if asset_lower in known_usdcs:
         return ("USDC", 6, "micro-units")
     if extra.get("name") == "Obol Network":
         return ("OBOL", 18, "base-units")
@@ -557,6 +589,67 @@ def _supports_erc20_permit(address, token_contract, chain=None):
         return False
 
 
+def _get_token_allowance(owner, token_contract, spender, chain=None):
+    """ERC20.allowance(owner, spender) via eth_call. Returns int or None on RPC failure."""
+    owner_hex = owner.lower().replace("0x", "").zfill(64)
+    spender_hex = spender.lower().replace("0x", "").zfill(64)
+    calldata = f"0x{SEL_ALLOWANCE}{owner_hex}{spender_hex}"
+    try:
+        result = _rpc_call("eth_call", [{"to": token_contract, "data": calldata}, "latest"], chain)
+    except SystemExit:
+        return None
+    if not result or result == "0x":
+        return 0
+    return int(result, 16)
+
+
+def _approve_max_calldata(spender):
+    """ERC20 approve(spender, max_uint256) calldata."""
+    spender_hex = spender.lower().replace("0x", "").zfill(64)
+    return f"0x{SEL_APPROVE}{spender_hex}{'f' * 64}"
+
+
+def _ensure_permit2_allowance(signer_address, asset, chain, transfer_method, extensions=None):
+    """Pre-flight: confirm Permit2 has an allowance on the asset.
+
+    Permit2 pulls tokens via transferFrom, which requires a one-time
+    `approve(Permit2, max)` from the owner. EIP-3009 / direct-transfer flows
+    don't need this. EIP-2612 gas-sponsoring extensions cover it per-request.
+    Without this check, a missing allowance surfaces as an opaque 503 from the
+    seller after the agent has already pre-signed.
+    """
+    if transfer_method != "permit2":
+        return
+    if extensions and "eip2612GasSponsoring" in extensions:
+        return
+    allowance = _get_token_allowance(signer_address, asset, PERMIT2_ADDRESS, chain)
+    if allowance is None:
+        return  # RPC unavailable — let downstream surface the real error
+    if allowance > 0:
+        return
+
+    approve_data = _approve_max_calldata(PERMIT2_ADDRESS)
+    print(
+        "\nError: Permit2 has no allowance on this token for your wallet.\n"
+        "Permit2-based x402 payments require a one-time approve(Permit2, max)\n"
+        "from the owner before any payment can settle.\n",
+        file=sys.stderr,
+    )
+    print(f"  Wallet:   {signer_address}", file=sys.stderr)
+    print(f"  Token:    {asset}", file=sys.stderr)
+    print(f"  Permit2:  {PERMIT2_ADDRESS}", file=sys.stderr)
+    print(f"  Chain:    {chain}", file=sys.stderr)
+    print("\nFix this with one transaction (one-time per token+wallet, ~46k gas):\n", file=sys.stderr)
+    print(
+        "  python3 ${OBOL_SKILLS_DIR:-/data/.openclaw/skills}/ethereum-local-wallet/scripts/signer.py send-tx \\\n"
+        f"    --from {signer_address} --to {asset} \\\n"
+        f"    --data {approve_data} --network {chain}",
+        file=sys.stderr,
+    )
+    print("\nThen re-run this command.", file=sys.stderr)
+    sys.exit(1)
+
+
 def _validate_contract_exists(contract_address, chain=None):
     """Verify that a contract exists at the given address via eth_getCode.
 
@@ -576,7 +669,8 @@ def _validate_contract_exists(contract_address, chain=None):
 
 def _presign_auths(signer_address, pay_to, price, chain, usdc_addr, count, payment=None, extensions=None):
     """Pre-sign N x402 payment payloads, defaulting to legacy ERC-3009 USDC."""
-    chain_id = CHAIN_IDS.get(chain, 84532)
+    chain = _resolve_chain(chain)
+    chain_id = _chain_id(chain)
     auths = []
     payment = payment or {}
     extensions = extensions or {}
@@ -877,10 +971,20 @@ def _reconcile_purchase_autorefill(pr, live_status, signer_address):
         return False
 
     payment = spec.get("payment") or {}
-    chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    try:
+        chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    except ValueError as exc:
+        print(f"{name}: {exc}; skipping", file=sys.stderr)
+        return False
     pay_to = payment.get("payTo", "")
     price = str(payment.get("price", "0"))
-    asset = payment.get("asset") or USDC_CONTRACTS.get(chain, USDC_CONTRACTS["base-sepolia"])
+    asset = payment.get("asset") or _canonical_usdc(chain)
+    if not asset:
+        print(
+            f"{name}: payment.asset missing and no canonical USDC for {chain}; skipping",
+            file=sys.stderr,
+        )
+        return False
     if not pay_to or not price:
         print(f"{name}: incomplete payment config; skipping")
         return False
@@ -1062,9 +1166,13 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
 
     payment = accepts[0]
     pay_to = payment.get("payTo", "")
-    chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    try:
+        chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     price = str(payment.get("amount", payment.get("maxAmountRequired", "0")))
-    asset = payment.get("asset", USDC_CONTRACTS.get(chain, ""))
+    asset = payment.get("asset") or _canonical_usdc(chain)
     extra = payment.get("extra", {}) or {}
     payment_meta = {
         "assetTransferMethod": extra.get("assetTransferMethod", ""),
@@ -1082,7 +1190,14 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
     print(f"  Wallet: {signer_address}")
 
     # 3. Validate token contract and check balance.
-    usdc_addr = asset or USDC_CONTRACTS.get(chain, USDC_CONTRACTS["base-sepolia"])
+    usdc_addr = asset or _canonical_usdc(chain)
+    if not usdc_addr:
+        print(
+            f"Error: 402 response did not include payment.asset and no canonical "
+            f"USDC contract is configured for chain {chain}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if not _validate_contract_exists(usdc_addr, chain):
         print(f"Error: no contract at {usdc_addr} on chain {chain}.", file=sys.stderr)
         print(f"The token may not be deployed on this chain.", file=sys.stderr)
@@ -1156,7 +1271,16 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
         print(f"  Warning: balance ({balance}) < total cost ({total_cost}). "
               "Proceeding with --force — some auths may fail on-chain.", file=sys.stderr)
 
-    # 5. Pre-sign authorizations locally (via remote-signer in same namespace).
+    # 5. Pre-flight: verify Permit2 allowance for permit2-based payments.
+    _ensure_permit2_allowance(
+        signer_address,
+        usdc_addr,
+        chain,
+        extra.get("assetTransferMethod", "eip3009"),
+        extensions=pricing.get("extensions", {}) or {},
+    )
+
+    # 6. Pre-sign authorizations locally (via remote-signer in same namespace).
     auths = _presign_auths(
         signer_address,
         pay_to,
@@ -1352,8 +1476,19 @@ def cmd_status(name):
 
 def cmd_balance(chain=None):
     """Check USDC balance for the agent wallet."""
-    net = chain or DEFAULT_CHAIN
-    usdc_addr = USDC_CONTRACTS.get(net, USDC_CONTRACTS.get("base-sepolia"))
+    try:
+        net = _resolve_chain(chain or DEFAULT_CHAIN)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    usdc_addr = _canonical_usdc(net)
+    if not usdc_addr:
+        print(
+            f"Error: no canonical USDC contract for chain {net}. "
+            "Pass --chain mainnet|base|base-sepolia.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     keys_data = _signer_get("/api/v1/keys")
     keys = keys_data.get("keys", [])
@@ -1397,9 +1532,13 @@ def cmd_pay(url, method="GET", data=None, kind="http"):
 
     payment = accepts[0]
     pay_to = payment.get("payTo", "")
-    chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    try:
+        chain = _normalize_chain_name(payment.get("network", DEFAULT_CHAIN))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     price = str(payment.get("amount", payment.get("maxAmountRequired", "0")))
-    asset = payment.get("asset", USDC_CONTRACTS.get(chain, ""))
+    asset = payment.get("asset") or _canonical_usdc(chain)
 
     if not pay_to:
         print("Error: 402 response missing payTo.", file=sys.stderr)
@@ -1409,10 +1548,26 @@ def cmd_pay(url, method="GET", data=None, kind="http"):
     signer_address = _get_signer_address()
     print(f"  Wallet: {signer_address}")
 
-    usdc_addr = asset or USDC_CONTRACTS.get(chain, USDC_CONTRACTS["base-sepolia"])
+    if not asset:
+        print(
+            f"Error: 402 response did not include payment.asset and no canonical "
+            f"USDC contract is configured for chain {chain}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    usdc_addr = asset
     if not _validate_contract_exists(usdc_addr, chain):
         print(f"Error: token contract {usdc_addr} not found on {chain}.", file=sys.stderr)
         sys.exit(1)
+
+    extra = payment.get("extra", {}) or {}
+    _ensure_permit2_allowance(
+        signer_address,
+        usdc_addr,
+        chain,
+        extra.get("assetTransferMethod", "eip3009"),
+        extensions=pricing.get("extensions", {}) or {},
+    )
 
     print(f"Pre-signing 1 payment authorization for {price} micro-units on {chain} ...")
     auths = _presign_auths(signer_address, pay_to, price, chain, usdc_addr, 1, payment=payment)

--- a/internal/embed/skills/ethereum-local-wallet/SKILL.md
+++ b/internal/embed/skills/ethereum-local-wallet/SKILL.md
@@ -56,6 +56,7 @@ python3 scripts/signer.py send-tx \
 | `sign-tx --from --to [--value] [--data] [--gas] [--nonce] [--network]` | Sign an EIP-1559 transaction |
 | `send-tx --from --to [--value] [--data] [--network]` | Sign AND broadcast a transaction via eRPC |
 | `sign-typed <address> <json>` | Sign EIP-712 typed data |
+| `gas-info [--network]` | Print recommended base/tip/max fees from `eth_feeHistory` |
 
 ## Transaction Submission Flow
 
@@ -80,7 +81,20 @@ python3 scripts/signer.py send-tx --network hoodi \
   --from 0x... --to 0x... --value 1000000000000000000
 ```
 
-Supported networks: `mainnet`, `hoodi`, `sepolia`, `base-sepolia` (depends on eRPC configuration).
+Supported networks: `mainnet`, `base`, `base-sepolia`, `hoodi`, `sepolia` (depends on eRPC configuration). The aliases `ethereum` and `eip155:<id>` resolve to the canonical name. Unknown values fail with an explicit error rather than silently signing against chain id 1.
+
+## Gas & Tip Selection
+
+`sign-tx` and `send-tx` auto-fill `maxPriorityFeePerGas` and `maxFeePerGas` using `eth_feeHistory(20, latest, [50])` — the median 50th-percentile tip across the last 20 blocks, plus a base-fee headroom of `2*baseFee`. Per-chain bounds clip the tip so quiet mainnet stays at ~0.05 gwei (instead of overpaying 1 gwei) and L2 stays sub-gwei.
+
+To inspect what the oracle would choose without signing:
+
+```bash
+python3 scripts/signer.py gas-info --network mainnet
+python3 scripts/signer.py gas-info --network base
+```
+
+If `eth_feeHistory` is unavailable, the oracle falls back to per-chain safe defaults rather than failing the transaction outright. Override with `--max-fee` and `--max-priority` only when you have a specific reason (e.g. cancelling a stuck tx).
 
 ## Environment Variables
 

--- a/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
+++ b/internal/embed/skills/ethereum-local-wallet/scripts/signer.py
@@ -20,13 +20,88 @@ SIGNER_URL = os.environ.get("REMOTE_SIGNER_URL", "http://remote-signer:9000")
 ERPC_BASE = os.environ.get("ERPC_URL", "http://erpc.erpc.svc.cluster.local/rpc")
 NETWORK = os.environ.get("ERPC_NETWORK", "mainnet")
 
-# Chain IDs for known networks.
+# Canonical chain names match eRPC project aliases (see
+# internal/embed/infrastructure/values/erpc.yaml.gotmpl).
 CHAIN_IDS = {
-    "mainnet": 1,
-    "hoodi": 560048,
-    "sepolia": 11155111,
+    "mainnet":      1,
+    "base":         8453,
     "base-sepolia": 84532,
+    "sepolia":      11155111,
+    "hoodi":        560048,
 }
+
+# Friendly aliases that resolve to canonical eRPC names.
+CHAIN_ALIASES = {
+    "ethereum":         "mainnet",
+    "eth":              "mainnet",
+    "eip155:1":         "mainnet",
+    "eip155:8453":      "base",
+    "eip155:84532":     "base-sepolia",
+    "eip155:11155111":  "sepolia",
+    "eip155:560048":    "hoodi",
+}
+
+_GWEI = 1_000_000_000
+
+# Per-chain fee bounds in wei. Keep mainnet tips tight enough to avoid
+# overpaying during quiet periods (Feb 2026: base ~0.05 gwei, tip 0.01-0.05
+# gwei) but with enough ceiling for a moderate spike. L2 base fees are
+# essentially zero, so tips can be near-zero too.
+FEE_BOUNDS = {
+    "mainnet": {
+        "min_tip":       10_000_000,        # 0.01 gwei
+        "max_tip":        2 * _GWEI,         # 2 gwei (cap during spike)
+        "fallback_base": 100_000_000,        # 0.1 gwei  (safe-ish guess if RPC is down)
+        "fallback_tip":   50_000_000,        # 0.05 gwei
+        "fallback_max":   2 * _GWEI,
+        "min_max_fee":   100_000_000,
+    },
+    "base": {
+        "min_tip":        1_000_000,         # 0.001 gwei
+        "max_tip":       50_000_000,         # 0.05 gwei
+        "fallback_base":  5_000_000,
+        "fallback_tip":   1_000_000,
+        "fallback_max":  50_000_000,
+        "min_max_fee":    5_000_000,
+    },
+    "base-sepolia": {
+        "min_tip":        1_000_000,
+        "max_tip":       50_000_000,
+        "fallback_base":  5_000_000,
+        "fallback_tip":   1_000_000,
+        "fallback_max":  50_000_000,
+        "min_max_fee":    5_000_000,
+    },
+    "sepolia": {
+        "min_tip":         1 * _GWEI,
+        "max_tip":         5 * _GWEI,
+        "fallback_base":   5 * _GWEI,
+        "fallback_tip":    1 * _GWEI,
+        "fallback_max":   20 * _GWEI,
+        "min_max_fee":     5 * _GWEI,
+    },
+    "hoodi": {
+        "min_tip":         1 * _GWEI,
+        "max_tip":         5 * _GWEI,
+        "fallback_base":   5 * _GWEI,
+        "fallback_tip":    1 * _GWEI,
+        "fallback_max":   20 * _GWEI,
+        "min_max_fee":     5 * _GWEI,
+    },
+}
+
+
+def _resolve_chain(value):
+    """Map any chain label (canonical, alias, CAIP-2) to a canonical eRPC name."""
+    if value is None:
+        raise ValueError("network is required")
+    label = str(value).strip()
+    if label in CHAIN_IDS:
+        return label
+    if label in CHAIN_ALIASES:
+        return CHAIN_ALIASES[label]
+    supported = ", ".join(sorted(CHAIN_IDS.keys()))
+    raise ValueError(f"Unknown network {value!r}. Supported: {supported}")
 
 
 def _signer_get(path):
@@ -131,11 +206,67 @@ def cmd_sign_typed(address, typed_data_json):
     print(data.get("signature", ""))
 
 
+def _suggest_fees(network):
+    """Suggest (base_fee, tip, max_fee) in wei using eth_feeHistory.
+
+    base_fee is the predicted next-block base fee (last entry of
+    baseFeePerGas, which feeHistory pads with one extra forward-looking
+    value). tip is the median 50th-percentile reward across the window.
+    max_fee = 2*base_fee + tip leaves headroom for a base-fee bump.
+
+    Per-chain min/max bounds clip the tip so quiet mainnet stays ~0.01 gwei
+    instead of 1 gwei, and L2 stays near-zero. If feeHistory is unavailable
+    the function returns the per-chain fallback values.
+    """
+    canonical = _resolve_chain(network)
+    bounds = FEE_BOUNDS[canonical]
+
+    try:
+        history = _rpc_call(
+            "eth_feeHistory",
+            [hex(20), "latest", [50]],
+            canonical,
+        )
+    except SystemExit:
+        return bounds["fallback_base"], bounds["fallback_tip"], bounds["fallback_max"]
+
+    base_list = (history or {}).get("baseFeePerGas", []) or []
+    rewards = (history or {}).get("reward", []) or []
+
+    if not base_list:
+        return bounds["fallback_base"], bounds["fallback_tip"], bounds["fallback_max"]
+
+    base_fee = int(base_list[-1], 16)
+
+    tips = []
+    for row in rewards:
+        if not row:
+            continue
+        try:
+            tips.append(int(row[0], 16))
+        except (TypeError, ValueError):
+            continue
+    if tips:
+        tips.sort()
+        tip = tips[len(tips) // 2]
+    else:
+        tip = bounds["fallback_tip"]
+
+    tip = max(bounds["min_tip"], min(bounds["max_tip"], tip))
+    max_fee = base_fee * 2 + tip
+    max_fee = max(bounds["min_max_fee"], max_fee)
+    return base_fee, tip, max_fee
+
+
 def cmd_sign_tx(args):
     """Sign an EIP-1559 transaction. Auto-fills nonce, gas, and fees from eRPC."""
     opts = _parse_tx_flags(args)
-    network = opts.get("network", NETWORK)
-    chain_id = CHAIN_IDS.get(network, 1)
+    try:
+        network = _resolve_chain(opts.get("network", NETWORK))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    chain_id = CHAIN_IDS[network]
     from_addr = opts["from"]
     to_addr = opts["to"]
     value = opts.get("value", "0x0")
@@ -149,24 +280,19 @@ def cmd_sign_tx(args):
     else:
         nonce = int(nonce)
 
-    # Auto-fill gas fees.
-    max_fee = opts.get("max_fee")
-    max_priority = opts.get("max_priority")
-    if max_fee is None or max_priority is None:
-        base_fee_hex = _rpc_call("eth_gasPrice", [], network)
-        base_fee = int(base_fee_hex, 16)
-        if max_priority is None:
-            try:
-                priority_hex = _rpc_call("eth_maxPriorityFeePerGas", [], network)
-                max_priority = int(priority_hex, 16)
-            except SystemExit:
-                max_priority = 1_000_000_000  # 1 gwei fallback
+    # Auto-fill gas fees via percentile-based fee oracle.
+    max_fee_opt = opts.get("max_fee")
+    max_priority_opt = opts.get("max_priority")
+    if max_fee_opt is None or max_priority_opt is None:
+        base_fee, suggested_tip, suggested_max = _suggest_fees(network)
+        max_priority = int(max_priority_opt) if max_priority_opt is not None else suggested_tip
+        if max_fee_opt is not None:
+            max_fee = int(max_fee_opt)
         else:
-            max_priority = int(max_priority)
-        if max_fee is None:
-            max_fee = base_fee * 2 + max_priority
-        else:
-            max_fee = int(max_fee)
+            max_fee = max(suggested_max, base_fee * 2 + max_priority)
+    else:
+        max_priority = int(max_priority_opt)
+        max_fee = int(max_fee_opt)
 
     # Auto-fill gas limit.
     gas_limit = opts.get("gas")
@@ -214,6 +340,24 @@ def cmd_sign_tx(args):
     return signed_tx
 
 
+def cmd_gas_info(args):
+    """Print recommended fee values for a network so the agent doesn't have to guess."""
+    opts = _parse_tx_flags(args)
+    try:
+        network = _resolve_chain(opts.get("network", NETWORK))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    base_fee, tip, max_fee = _suggest_fees(network)
+    print(f"Network:           {network} (chain_id={CHAIN_IDS[network]})")
+    print(f"Base fee:          {base_fee} wei  ({base_fee / 1e9:.6f} gwei)")
+    print(f"Suggested tip:     {tip} wei  ({tip / 1e9:.6f} gwei)")
+    print(f"Suggested max fee: {max_fee} wei  ({max_fee / 1e9:.6f} gwei)")
+    print()
+    print("Pass these to send-tx as --max-priority and --max-fee, or omit them")
+    print("and send-tx will compute the same values automatically.")
+
+
 def cmd_send_tx(args):
     """Sign and broadcast a transaction."""
     signed_tx = cmd_sign_tx(args)
@@ -221,7 +365,11 @@ def cmd_send_tx(args):
         sys.exit(1)
 
     opts = _parse_tx_flags(args)
-    network = opts.get("network", NETWORK)
+    try:
+        network = _resolve_chain(opts.get("network", NETWORK))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"\nBroadcasting to {network}...")
     tx_hash = _rpc_call("eth_sendRawTransaction", [signed_tx], network)
@@ -272,6 +420,7 @@ def usage():
     print("                                       Sign an EIP-1559 transaction")
     print("  send-tx [same flags as sign-tx]      Sign AND broadcast via eRPC")
     print("  sign-typed <address> <typed-data-json>  Sign EIP-712 typed data")
+    print("  gas-info [--network <name>]          Print recommended base/tip/max fees")
 
 
 if __name__ == "__main__":
@@ -318,6 +467,8 @@ if __name__ == "__main__":
             print("Usage: sign-typed <address> <typed-data-json>")
             sys.exit(1)
         cmd_sign_typed(args[0], args[1])
+    elif cmd == "gas-info":
+        cmd_gas_info(args)
     else:
         print(f"Unknown command: {cmd}")
         usage()

--- a/internal/embed/skills/ethereum-networks/SKILL.md
+++ b/internal/embed/skills/ethereum-networks/SKILL.md
@@ -18,7 +18,7 @@ Query Ethereum blockchain data through the local eRPC gateway. Supports any JSON
 
 ## When NOT to Use
 
-- Sending transactions, signing, or deploying contracts — wallet support coming soon
+- Sending transactions, signing, or deploying contracts — use `ethereum-local-wallet`
 - Validator monitoring — use `distributed-validators`
 - Kubernetes pod diagnostics — use `obol-stack`
 
@@ -37,6 +37,37 @@ To see which networks are connected:
 ```bash
 curl -s http://erpc.erpc.svc.cluster.local/ | python3 -m json.tool
 ```
+
+## Write Transactions: Protected Routing & Revert Protection
+
+When a signed tx is broadcast (via `ethereum-local-wallet`'s `send-tx`, or
+directly via `eth_sendRawTransaction`), eRPC pins the call to Obol's protected
+upstream — `obol-rpc-mainnet` for chain 1, `obol-rpc-base` for chain 8453. Read
+methods still fan out across all configured upstreams; only writes are pinned.
+
+Two consequences worth knowing:
+
+1. **No front-running on the way to the mempool.** Writes don't hit a public
+   transaction pool first, so searchers cannot reorder them around your trade.
+2. **Revert protection is on.** The protected upstream refuses to include
+   transactions that would revert at the head block. This saves callers from
+   wasting gas on a guaranteed failure, but it also means a "transaction that
+   vanished" may simply have been rejected upstream as known-to-revert.
+
+If a tx you broadcast never lands and `eth_getTransactionByHash` keeps returning
+`null`, **simulate before retrying** — bumping gas or nonce won't help when the
+upstream is filtering on simulation outcome:
+
+```bash
+# Dry-run the call against current state with the same args you'd send
+sh scripts/rpc.sh call <to> "<sig>" <args...>
+
+# Or estimate gas — also reverts when the call would revert
+sh scripts/rpc.sh estimate <to> "<sig>" <args...>
+```
+
+If either reverts, fix the inputs (allowance, deadline, slippage, etc.) before
+re-broadcasting.
 
 ## Quick Start (cast)
 

--- a/internal/embed/skills/gas/SKILL.md
+++ b/internal/embed/skills/gas/SKILL.md
@@ -87,6 +87,21 @@ Spikes (10-50 gwei) happen during major events but last minutes to hours, not da
 
 ## Checking Gas Programmatically
 
+If you're about to sign a transaction, the deterministic fee oracle in
+`ethereum-local-wallet` is the simplest path — no inference required:
+
+```bash
+python3 scripts/signer.py gas-info --network mainnet
+python3 scripts/signer.py gas-info --network base
+```
+
+It samples `eth_feeHistory` (median 50th-percentile tip across the last 20
+blocks) and clamps to per-chain bounds, so quiet mainnet stays around 0.05 gwei
+and L2s stay sub-gwei. `sign-tx` / `send-tx` apply the same logic
+automatically; `gas-info` is for inspection.
+
+For ad-hoc reads:
+
 `cast` is available inside OpenClaw pods. Use the `ethereum-networks` skill for convenience:
 
 ```bash

--- a/internal/erc8004/abi.go
+++ b/internal/erc8004/abi.go
@@ -15,8 +15,12 @@ const (
 	// ValidationRegistryBaseSepolia is the ERC-8004 Validation Registry on Base Sepolia.
 	ValidationRegistryBaseSepolia = "0x8004CB39f29c09145F24Ad9dDe2A108C1A2cdfC5"
 
-	// DefaultRPCURL is the default JSON-RPC endpoint for Base Sepolia.
-	DefaultRPCURL = "https://sepolia.base.org"
+	// DefaultRPCBase is the default JSON-RPC base URL the controller uses to
+	// build per-chain ERC-8004 clients. It points at the in-cluster eRPC
+	// service; per-chain endpoints are derived as
+	//   <base>/<NetworkConfig.ERPCNetwork>
+	// (see erc8004.NewClientForNetwork). Override with ERC8004_RPC_BASE.
+	DefaultRPCBase = "http://erpc.erpc.svc.cluster.local/rpc"
 
 	// BaseSepoliaChainID is the EIP-155 chain ID for Base Sepolia.
 	BaseSepoliaChainID = 84532

--- a/internal/helmcmd/helmcmd.go
+++ b/internal/helmcmd/helmcmd.go
@@ -1,0 +1,65 @@
+// Package helmcmd contains small helpers for invoking the pinned helm binary.
+//
+// The main job here is keeping `helmfile sync` working across helm major
+// versions. Helm 4 turned server-side apply on by default; SSA introduces
+// field-ownership conflicts (the apiserver synthesises a "before-first-apply"
+// manager for any field that pre-existed the first SSA call) that helm 4
+// only takes over when --force-conflicts is passed. Helm 3 used client-side
+// apply, has no SSA and rejects --force-conflicts as an unknown flag, so the
+// flag must only be appended on helm 4+.
+package helmcmd
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// versionRE matches the major number in `helm version --short` output, e.g.
+//
+//	v4.1.3+gc94d381
+//	v3.20.1+g4d04eef
+var versionRE = regexp.MustCompile(`^v(\d+)\.`)
+
+// MajorVersion runs `<helmBinary> version --short` and returns the major
+// version integer (3, 4, ...). Returns an error if helm cannot be invoked
+// or the output is unparseable.
+func MajorVersion(helmBinary string) (int, error) {
+	out, err := exec.Command(helmBinary, "version", "--short").Output()
+	if err != nil {
+		return 0, fmt.Errorf("invoke %s version: %w", helmBinary, err)
+	}
+	return parseMajor(string(out))
+}
+
+func parseMajor(short string) (int, error) {
+	m := versionRE.FindStringSubmatch(strings.TrimSpace(short))
+	if len(m) != 2 {
+		return 0, fmt.Errorf("parse helm version %q: no leading vN. found", short)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, fmt.Errorf("parse helm major %q: %w", m[1], err)
+	}
+	return major, nil
+}
+
+// SyncFlagsForVersion returns the extra `helmfile sync` flags needed for the
+// detected helm version. On helm 4+ this is --sync-args=--force-conflicts so
+// helm's SSA upgrade can take ownership of fields previously written by other
+// managers (e.g. `kubectl apply`, the `obol model setup` patch on
+// litellm-config.data.config.yaml, or fields recorded under the synthetic
+// "before-first-apply" manager). On helm 3 this returns nil — helm 3 uses
+// client-side apply and rejects --force-conflicts.
+//
+// Detection failures degrade silently to nil so a missing/old helm binary
+// doesn't block the user; the helmfile sync will still surface the real error.
+func SyncFlagsForVersion(helmBinary string) []string {
+	major, err := MajorVersion(helmBinary)
+	if err != nil || major < 4 {
+		return nil
+	}
+	return []string{"--sync-args=--force-conflicts"}
+}

--- a/internal/helmcmd/helmcmd_test.go
+++ b/internal/helmcmd/helmcmd_test.go
@@ -1,0 +1,33 @@
+package helmcmd
+
+import "testing"
+
+func TestParseMajor(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"v4.1.3+gc94d381", 4, true},
+		{"v3.20.1+g4d04eef", 3, true},
+		{"v3.20.1\n", 3, true},
+		{"v10.0.0", 10, true},
+		{"helm v4.0.0", 0, false},
+		{"", 0, false},
+		{"v.1.2", 0, false},
+	}
+	for _, tc := range cases {
+		got, err := parseMajor(tc.in)
+		if tc.ok && err != nil {
+			t.Errorf("parseMajor(%q) errored: %v", tc.in, err)
+			continue
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("parseMajor(%q) = %d, want error", tc.in, got)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseMajor(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/dns"
 	obolembed "github.com/ObolNetwork/obol-stack/internal/embed"
+	"github.com/ObolNetwork/obol-stack/internal/helmcmd"
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
@@ -230,7 +231,8 @@ func Sync(cfg *config.Config, id string, u *ui.UI) error {
 	}
 
 	helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
-	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
+	syncArgs := append([]string{"-f", helmfilePath, "sync"}, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
+	cmd := exec.Command(helmfileBinary, syncArgs...)
 	cmd.Dir = deploymentDir
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -119,15 +119,6 @@ func TestGenerateConfig_UsesLiteLLMCustomProvider(t *testing.T) {
 	}
 }
 
-func TestGenerateHelmfile_DoesNotUseHelm4OnlyServerSideFlags(t *testing.T) {
-	out := generateHelmfile("hermes-obol-agent")
-	for _, flag := range []string{"--server-side", "--force-conflicts"} {
-		if strings.Contains(out, flag) {
-			t.Fatalf("generated Hermes helmfile contains Helm-version-sensitive flag %s", flag)
-		}
-	}
-}
-
 func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 	values := generateValues(
 		"hermes-obol-agent",

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/dns"
 	obolembed "github.com/ObolNetwork/obol-stack/internal/embed"
+	"github.com/ObolNetwork/obol-stack/internal/helmcmd"
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
@@ -438,7 +439,8 @@ func doSync(cfg *config.Config, id string, u *ui.UI) error {
 	u.Infof("Syncing OpenClaw: %s/%s", appName, id)
 	u.Detail("Deployment directory", deploymentDir)
 
-	cmd := exec.Command(helmfileBinary, "-f", helmfilePath, "sync")
+	syncArgs := append([]string{"-f", helmfilePath, "sync"}, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
+	cmd := exec.Command(helmfileBinary, syncArgs...)
 	cmd.Dir = deploymentDir
 
 	cmd.Env = append(os.Environ(),

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -77,9 +77,11 @@ type Controller struct {
 	// instead of the in-cluster litellm Service DNS. Empty in production.
 	litellmURLOverride string
 
-	registrationRPCURL string
-	baseURLOverride    string
-	defaultBaseURL     string
+	// registrationRPCBase is the eRPC base URL; per-chain clients dial
+	// <base>/<NetworkConfig.ERPCNetwork>. Override with ERC8004_RPC_BASE.
+	registrationRPCBase string
+	baseURLOverride     string
+	defaultBaseURL      string
 }
 
 func New(cfg *rest.Config) (*Controller, error) {
@@ -122,7 +124,7 @@ func New(cfg *rest.Config) (*Controller, error) {
 		registrationQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		purchaseQueue:        workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		httpClient:           &http.Client{Timeout: 3 * time.Second},
-		registrationRPCURL:   getenvDefault("ERC8004_RPC_URL", erc8004.DefaultRPCURL),
+		registrationRPCBase:  getenvDefault("ERC8004_RPC_BASE", erc8004.DefaultRPCBase),
 		baseURLOverride:      strings.TrimRight(os.Getenv("AGENT_BASE_URL"), "/"),
 		defaultBaseURL:       "http://obol.stack:8080",
 	}
@@ -742,13 +744,20 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 	// `obol sell http`) via the agent's remote-signer — never by the
 	// controller. The controller only publishes the registration document
 	// and watches for the registration tx to land on-chain so it can mark
-	// the request Ready=True.
+	// the request Ready=True. Each offer's payment.network selects which
+	// chain to watch; the client dials <eRPC base>/<network alias>.
 	var client *erc8004.Client
 	if agentID == "" {
-		client, err = erc8004.NewClient(ctx, c.registrationRPCURL)
+		network, lookupErr := erc8004.ResolveNetwork(offer.Spec.Payment.Network)
+		if lookupErr != nil {
+			status.Phase = registrationPhaseAwaitingExternal
+			status.Message = truncateMessage(fmt.Sprintf("Unsupported registration chain %q: %v", offer.Spec.Payment.Network, lookupErr))
+			return c.updateRegistrationStatus(ctx, raw, status)
+		}
+		client, err = erc8004.NewClientForNetwork(ctx, c.registrationRPCBase, network)
 		if err != nil {
 			status.Phase = registrationPhaseAwaitingExternal
-			status.Message = truncateMessage(fmt.Sprintf("Waiting for ERC-8004 RPC connectivity: %v", err))
+			status.Message = truncateMessage(fmt.Sprintf("Waiting for ERC-8004 RPC connectivity on %s: %v", network.Name, err))
 			return c.updateRegistrationStatus(ctx, raw, status)
 		}
 		defer client.Close()

--- a/internal/stack/dev_registry.go
+++ b/internal/stack/dev_registry.go
@@ -33,6 +33,12 @@ var devRegistryMirrors = []registryMirror{
 	{upstreamHost: "docker.io", remoteURL: "https://registry-1.docker.io", name: "obol-docker-io.localhost", port: 54100},
 	{upstreamHost: "ghcr.io", remoteURL: "https://ghcr.io", name: "obol-ghcr-io.localhost", port: 54101},
 	{upstreamHost: "quay.io", remoteURL: "https://quay.io", name: "obol-quay-io.localhost", port: 54102},
+	// Local push target (no upstream proxy). Lets `just dev-frontend` swap
+	// layered diffs into the cluster via `docker push localhost:54103/...`
+	// instead of `k3d image import`'s full-tarball round-trip. The host
+	// reaches it on localhost:54103; the k3d node sees the same image name
+	// resolved via this mirror to http://k3d-obol-local.localhost:5000.
+	{upstreamHost: "localhost:54103", name: "obol-local.localhost", port: 54103},
 }
 
 func ensureDevRegistries(cfg *config.Config, u *ui.UI) (*devRegistrySetup, error) {
@@ -95,15 +101,16 @@ func ensureDevRegistry(cfg *config.Config, k3dBinary string, mirror registryMirr
 		_ = runCommand(exec.Command("docker", "rm", "-f", containerName))
 	}
 
-	createCmd := exec.Command(
-		k3dBinary,
+	createArgs := []string{
 		"registry", "create", mirror.name,
 		"--port", strconv.Itoa(mirror.port),
-		"--proxy-remote-url", mirror.remoteURL,
 		"--volume", fmt.Sprintf("%s:/var/lib/registry", registryCacheDir(mirror)),
 		"--no-help",
-	)
-	if err := runCommand(createCmd); err != nil {
+	}
+	if mirror.remoteURL != "" {
+		createArgs = append(createArgs, "--proxy-remote-url", mirror.remoteURL)
+	}
+	if err := runCommand(exec.Command(k3dBinary, createArgs...)); err != nil {
 		return fmt.Errorf("create registry %s: %w", mirror.name, err)
 	}
 
@@ -160,7 +167,12 @@ func registryContainerName(mirror registryMirror) string {
 }
 
 func registryCacheDir(mirror registryMirror) string {
-	return filepath.Join(devRegistryCacheRoot(), mirror.upstreamHost)
+	// Colons in the upstream host (e.g. "localhost:54103" for the local push
+	// registry) would land in the on-disk path; replace with underscore so the
+	// dir name is plain ASCII. Existing entries (docker.io, ghcr.io, quay.io)
+	// have no colons so their cache paths are unchanged.
+	safe := strings.ReplaceAll(mirror.upstreamHost, ":", "_")
+	return filepath.Join(devRegistryCacheRoot(), safe)
 }
 
 func devRegistryCacheRoot() string {

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	stackdefaults "github.com/ObolNetwork/obol-stack/internal/defaults"
 	"github.com/ObolNetwork/obol-stack/internal/dns"
+	"github.com/ObolNetwork/obol-stack/internal/helmcmd"
 	"github.com/ObolNetwork/obol-stack/internal/hermes"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/model"
@@ -362,25 +363,18 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 		u.Warnf("Failed to preserve LiteLLM config across Helm sync: %v", err)
 	}
 
-	// Release runtime field ownership of litellm-config.data.config.yaml so the
-	// upcoming Helm upgrade can reclaim it without an SSA conflict. This keeps
-	// Helm 3 compatible; do not rely on Helm 4-only --server-side flags in
-	// embedded helmfiles.
-	if err := releaseLiteLLMConfigOwnership(cfg, kubeconfigPath); err != nil {
-		u.Warnf("Failed to release LiteLLM config field ownership: %v", err)
-	}
-
 	// Compatibility migration
 	if err := migrateDefaultsHTTPRouteHostnames(helmfilePath); err != nil {
 		u.Warnf("Failed to migrate defaults helmfile hostnames: %v", err)
 	}
 
-	helmfileCmd := exec.Command(
-		filepath.Join(cfg.BinDir, "helmfile"),
+	helmfileArgs := []string{
 		"--file", helmfilePath,
 		"--kubeconfig", kubeconfigPath,
 		"sync",
-	)
+	}
+	helmfileArgs = append(helmfileArgs, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
+	helmfileCmd := exec.Command(filepath.Join(cfg.BinDir, "helmfile"), helmfileArgs...)
 	helmfileCmd.Env = append(os.Environ(),
 		"KUBECONFIG="+kubeconfigPath,
 		"STACK_DATA_DIR="+dataDir,
@@ -913,33 +907,6 @@ func preserveLiteLLMConfigForHelm(cfg *config.Config, kubeconfigPath string) (st
 		return "", nil
 	}
 	return raw, nil
-}
-
-// releaseLiteLLMConfigOwnership strips managedFields from the litellm-config
-// ConfigMap so the next helm upgrade can claim ownership of every field
-// without an SSA conflict. Helm tracks release ownership via the
-// meta.helm.sh/release-name annotation, not managedFields, so clearing
-// managedFields does not detach the resource from its release.
-func releaseLiteLLMConfigOwnership(cfg *config.Config, kubeconfigPath string) error {
-	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
-
-	// Skip if the configmap doesn't exist (first install).
-	if _, err := kubectl.Output(kubectlBinary, kubeconfigPath,
-		"get", "configmap", "litellm-config", "-n", "llm", "-o", "name"); err != nil {
-		return nil
-	}
-
-	cmd := exec.Command(kubectlBinary,
-		"patch", "configmap", "litellm-config",
-		"-n", "llm",
-		"--type=merge",
-		"--patch", `{"metadata":{"managedFields":[{}]}}`,
-	)
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("kubectl patch managedFields: %w\n%s", err, string(out))
-	}
-	return nil
 }
 
 func restoreLiteLLMConfig(cfg *config.Config, kubeconfigPath, raw string) error {

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -463,24 +463,6 @@ func TestHelmfile_IncludesBuyerPodMonitor(t *testing.T) {
 	}
 }
 
-func TestHelmfile_DoesNotUseHelm4OnlyServerSideFlags(t *testing.T) {
-	projectRoot := findProjectRoot()
-	if projectRoot == "" {
-		t.Fatal("project root not found")
-	}
-
-	data, err := os.ReadFile(filepath.Join(projectRoot, "internal/embed/infrastructure/helmfile.yaml"))
-	if err != nil {
-		t.Fatalf("read helmfile: %v", err)
-	}
-
-	out := string(data)
-	for _, flag := range []string{"--server-side", "--force-conflicts"} {
-		if strings.Contains(out, flag) {
-			t.Fatalf("embedded helmfile contains Helm-version-sensitive flag %s", flag)
-		}
-	}
-}
 
 func TestLLMTemplate_IncludesPaidRouteAndBuyerSidecar(t *testing.T) {
 	projectRoot := findProjectRoot()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/app"
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	stackdefaults "github.com/ObolNetwork/obol-stack/internal/defaults"
+	"github.com/ObolNetwork/obol-stack/internal/helmcmd"
 	"github.com/ObolNetwork/obol-stack/internal/network"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/ObolNetwork/obol-stack/internal/version"
@@ -189,6 +190,7 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 	}
 
 	helmfileArgs = append(helmfileArgs, "sync")
+	helmfileArgs = append(helmfileArgs, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
 	helmfileCmd := exec.Command(
 		filepath.Join(cfg.BinDir, "helmfile"),
 		helmfileArgs...,

--- a/internal/x402/chains.go
+++ b/internal/x402/chains.go
@@ -43,6 +43,13 @@ type AssetInfo struct {
 	TransferMethod string
 	EIP712Name     string
 	EIP712Version  string
+
+	// EIP2612GasSponsoring is true when the token supports ERC20Permit and
+	// the facilitator can batch permit() with transferFrom on settle, letting
+	// buyers skip the one-time approve(Permit2, max) tx. Surfaced to buyers
+	// via the top-level `extensions.eip2612GasSponsoring` field on the 402
+	// response.
+	EIP2612GasSponsoring bool
 }
 
 // Chain constants — USDC addresses verified against coinbase/x402/go v2.7.0
@@ -251,7 +258,32 @@ func ResolveAssetInfo(chain ChainInfo, rule *RouteRule) AssetInfo {
 	if rule.EIP712Version != "" {
 		asset.EIP712Version = rule.EIP712Version
 	}
+
+	// Re-derive registry-driven flags (gasless approve, etc.) from the token
+	// registry. The CR doesn't carry these — the token registry is the source
+	// of truth — so we look up by (symbol, chain) and require the resolved
+	// address to match before honoring the flag, to avoid a malicious offer
+	// claiming a known symbol with a foreign contract address.
+	if entry, ok := ResolveToken(asset.Symbol, chain.Name); ok {
+		if strings.EqualFold(entry.Address, asset.Address) {
+			asset.EIP2612GasSponsoring = entry.EIP2612GasSponsoring
+		}
+	}
 	return asset
+}
+
+// BuildExtensionsForAsset returns the top-level x402 extensions that should be
+// advertised on the 402 response for a given asset. Currently sets
+// `eip2612GasSponsoring` when the asset supports gasless approve via Permit2
+// + ERC20Permit (e.g. OBOL on mainnet). Returns nil when no extensions apply
+// — the caller's `omitempty` JSON tag drops the field entirely.
+func BuildExtensionsForAsset(asset AssetInfo) map[string]any {
+	if !asset.EIP2612GasSponsoring {
+		return nil
+	}
+	return map[string]any{
+		"eip2612GasSponsoring": map[string]any{},
+	}
 }
 
 // BuildV1Requirement creates a v1 PaymentRequirementsV1 for USDC payment on

--- a/internal/x402/chains_test.go
+++ b/internal/x402/chains_test.go
@@ -103,6 +103,37 @@ func TestResolveAssetInfo_Override(t *testing.T) {
 	if asset.EIP712Name != "Obol Network" || asset.EIP712Version != "1" {
 		t.Fatalf("asset EIP-712 metadata = %q/%q", asset.EIP712Name, asset.EIP712Version)
 	}
+	if !asset.EIP2612GasSponsoring {
+		t.Fatalf("EIP2612GasSponsoring = false, want true (re-derived from registry for OBOL on mainnet)")
+	}
+}
+
+// A ServiceOffer that claims symbol OBOL with a foreign contract address must
+// NOT inherit the gasless-approve flag from the registry, otherwise a buyer
+// would skip the on-chain approve and the payment would fail at settlement.
+func TestResolveAssetInfo_RejectAddressMismatch(t *testing.T) {
+	asset := ResolveAssetInfo(ChainEthereumMainnet, &RouteRule{
+		AssetAddress:        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		AssetSymbol:         "OBOL",
+		AssetDecimals:       18,
+		AssetTransferMethod: "permit2",
+		EIP712Name:          "Obol Network",
+		EIP712Version:       "1",
+	})
+
+	if asset.EIP2612GasSponsoring {
+		t.Fatal("EIP2612GasSponsoring leaked to a foreign address claiming the OBOL symbol")
+	}
+}
+
+func TestBuildExtensionsForAsset(t *testing.T) {
+	if got := BuildExtensionsForAsset(AssetInfo{EIP2612GasSponsoring: false}); got != nil {
+		t.Errorf("expected nil extensions when flag is false, got %v", got)
+	}
+	got := BuildExtensionsForAsset(AssetInfo{EIP2612GasSponsoring: true})
+	if _, ok := got["eip2612GasSponsoring"]; !ok {
+		t.Errorf("expected eip2612GasSponsoring key, got %v", got)
+	}
 }
 
 func TestBuildV2RequirementWithAsset(t *testing.T) {

--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -34,6 +34,12 @@ type ForwardAuthConfig struct {
 	// NewForwardAuthMiddleware logs a loud warning when VerifyOnly is false
 	// so operators who flip this in x402-pricing.yaml notice in logs.
 	VerifyOnly bool
+
+	// Extensions, if non-nil, is emitted as the top-level `extensions` field
+	// on 402 responses. Used to advertise capabilities like
+	// `eip2612GasSponsoring` (gasless Permit2 approve) so buyers take the
+	// matching flow. See BuildExtensionsForAsset for how this is populated.
+	Extensions map[string]any
 }
 
 // facilitatorVerifyRequest is the JSON body sent to POST /verify and /settle.
@@ -96,7 +102,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			paymentHeader := r.Header.Get("X-PAYMENT")
 			if paymentHeader == "" {
-				sendPaymentRequired(w, r, requirements)
+				sendPaymentRequired(w, r, requirements, cfg.Extensions)
 				return
 			}
 
@@ -118,7 +124,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 
 			matchedReq, found := findMatchingRequirementV1(payload, requirements)
 			if !found {
-				sendPaymentRequired(w, r, requirements)
+				sendPaymentRequired(w, r, requirements, cfg.Extensions)
 				return
 			}
 
@@ -132,7 +138,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 
 			if !verifyResp.IsValid {
 				log.Printf("x402: payment invalid: %s", verifyResp.InvalidReason)
-				sendPaymentRequired(w, r, requirements)
+				sendPaymentRequired(w, r, requirements, cfg.Extensions)
 				return
 			}
 
@@ -153,7 +159,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 
 					if !settleResp.Success {
 						log.Printf("x402: settlement unsuccessful: %s", settleResp.ErrorReason)
-						sendPaymentRequired(w, r, requirements)
+						sendPaymentRequired(w, r, requirements, cfg.Extensions)
 						return false
 					}
 
@@ -173,7 +179,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 }
 
 // sendPaymentRequired writes a 402 response with v2 payment requirements.
-func sendPaymentRequired(w http.ResponseWriter, r *http.Request, requirements []x402types.PaymentRequirements) {
+func sendPaymentRequired(w http.ResponseWriter, r *http.Request, requirements []x402types.PaymentRequirements, extensions map[string]any) {
 	resource := &x402types.ResourceInfo{
 		URL:         buildResourceURL(r),
 		Description: "Payment required for " + r.URL.Path,
@@ -183,6 +189,7 @@ func sendPaymentRequired(w http.ResponseWriter, r *http.Request, requirements []
 		Error:       "Payment required for this resource",
 		Resource:    resource,
 		Accepts:     requirements,
+		Extensions:  extensions,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/x402/forwardauth_test.go
+++ b/internal/x402/forwardauth_test.go
@@ -83,7 +83,7 @@ func testRequirements() []x402types.PaymentRequirements {
 	}
 }
 
-func TestForwardAuth_NoPayment_Returns402(t *testing.T) {
+func TestForwardAuth_NoPayment_Returns402_AdvertisesExtensions(t *testing.T) {
 	var verifyCalled, settleCalled atomic.Int32
 	fac := mockFacilitatorV1(true, true, &verifyCalled, &settleCalled)
 	defer fac.Close()
@@ -91,6 +91,9 @@ func TestForwardAuth_NoPayment_Returns402(t *testing.T) {
 	mw := NewForwardAuthMiddleware(ForwardAuthConfig{
 		FacilitatorURL: fac.URL,
 		VerifyOnly:     true,
+		Extensions: map[string]any{
+			"eip2612GasSponsoring": map[string]any{},
+		},
 	}, testRequirements())
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -112,6 +115,9 @@ func TestForwardAuth_NoPayment_Returns402(t *testing.T) {
 	}
 	if len(body.Accepts) == 0 {
 		t.Error("402 body has no accepts")
+	}
+	if _, ok := body.Extensions["eip2612GasSponsoring"]; !ok {
+		t.Errorf("402 body extensions missing eip2612GasSponsoring, got %v", body.Extensions)
 	}
 	if verifyCalled.Load() != 0 {
 		t.Error("facilitator.Verify should not be called when no payment header")

--- a/internal/x402/tokens.go
+++ b/internal/x402/tokens.go
@@ -28,6 +28,14 @@ type TokenEntry struct {
 
 	// EIP712Version is the EIP-712 domain version for signing.
 	EIP712Version string
+
+	// EIP2612GasSponsoring is true when the token implements EIP-2612
+	// (ERC20Permit) and the configured facilitator can batch the permit() call
+	// with the on-chain transferFrom during settlement, sponsoring gas. When
+	// true, the seller's 402 advertises `eip2612GasSponsoring` in extensions
+	// so buyers skip the one-time approve(Permit2, max) step. Only relevant
+	// for permit2 transfer methods.
+	EIP2612GasSponsoring bool
 }
 
 // tokenRegistry maps (uppercased token symbol, canonical chain name) → TokenEntry.
@@ -46,7 +54,10 @@ var tokenRegistry = map[string]map[string]TokenEntry{
 		"arbitrum-sepolia": {Address: ChainArbitrumSepolia.USDCAddress, Symbol: "USDC", Decimals: 6, TransferMethod: "eip3009", EIP712Name: "USD Coin", EIP712Version: "2"},
 	},
 	"OBOL": {
-		"ethereum": {Address: "0x0B010000b7624eb9B3DfBC279673C76E9D29D5F7", Symbol: "OBOL", Decimals: 18, TransferMethod: "permit2", EIP712Name: "Obol Network", EIP712Version: "1"},
+		// OBOL implements ERC20Permit ("Obol Network", v1). The Obol-operated
+		// facilitator at https://x402.gcp.obol.tech batches permit() with
+		// transferFrom on settle, so buyers don't need a one-time approve.
+		"ethereum": {Address: "0x0B010000b7624eb9B3DfBC279673C76E9D29D5F7", Symbol: "OBOL", Decimals: 18, TransferMethod: "permit2", EIP712Name: "Obol Network", EIP712Version: "1", EIP2612GasSponsoring: true},
 	},
 }
 

--- a/internal/x402/tokens_test.go
+++ b/internal/x402/tokens_test.go
@@ -59,6 +59,24 @@ func TestResolveToken_OBOL_Ethereum(t *testing.T) {
 	if entry.EIP712Version != "1" {
 		t.Errorf("EIP712Version = %q", entry.EIP712Version)
 	}
+	if !entry.EIP2612GasSponsoring {
+		t.Error("EIP2612GasSponsoring = false, want true (OBOL implements ERC20Permit and the Obol facilitator batches permit() with transferFrom)")
+	}
+}
+
+func TestResolveToken_USDC_NoGasSponsoring(t *testing.T) {
+	// USDC settles via EIP-3009 (transferWithAuthorization), not Permit2,
+	// so EIP2612GasSponsoring is irrelevant and must stay false to avoid
+	// advertising a no-op extension on USDC routes.
+	for _, chain := range []string{"ethereum", "base", "base-sepolia"} {
+		entry, ok := ResolveToken("USDC", chain)
+		if !ok {
+			t.Fatalf("ResolveToken(USDC, %s) not found", chain)
+		}
+		if entry.EIP2612GasSponsoring {
+			t.Errorf("USDC on %s: EIP2612GasSponsoring = true, want false", chain)
+		}
+	}
 }
 
 func TestResolveToken_OBOL_NotOnBase(t *testing.T) {

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -88,7 +88,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 
 	cfg := v.config.Load()
 
-	rule, requirement, _, ok := v.matchPaidRoute(cfg, uri)
+	rule, requirement, extensions, _, ok := v.matchPaidRoute(cfg, uri)
 	if !ok {
 		// No pricing rule matches — route is free.
 		w.WriteHeader(http.StatusOK)
@@ -118,6 +118,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	middleware := NewForwardAuthMiddleware(ForwardAuthConfig{
 		FacilitatorURL: cfg.FacilitatorURL,
 		VerifyOnly:     cfg.VerifyOnly,
+		Extensions:     extensions,
 	}, []x402types.PaymentRequirements{requirement})
 
 	upstreamAuth := rule.UpstreamAuth
@@ -149,7 +150,7 @@ func (v *Verifier) HandleVerify(w http.ResponseWriter, r *http.Request) {
 func (v *Verifier) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	cfg := v.config.Load()
 
-	rule, requirement, labels, ok := v.matchPaidRoute(cfg, r.URL.Path)
+	rule, requirement, extensions, labels, ok := v.matchPaidRoute(cfg, r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
 		return
@@ -167,6 +168,7 @@ func (v *Verifier) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	middleware := NewForwardAuthMiddleware(ForwardAuthConfig{
 		FacilitatorURL: cfg.FacilitatorURL,
 		VerifyOnly:     false,
+		Extensions:     extensions,
 	}, []x402types.PaymentRequirements{requirement})
 
 	hadPayment := r.Header.Get("X-PAYMENT") != ""
@@ -208,10 +210,10 @@ func (v *Verifier) MetricsHandler() http.Handler {
 	return v.metrics.handler()
 }
 
-func (v *Verifier) matchPaidRoute(cfg *PricingConfig, uri string) (*RouteRule, x402types.PaymentRequirements, prometheus.Labels, bool) {
+func (v *Verifier) matchPaidRoute(cfg *PricingConfig, uri string) (*RouteRule, x402types.PaymentRequirements, map[string]any, prometheus.Labels, bool) {
 	rule := matchRoute(cfg.Routes, uri)
 	if rule == nil {
-		return nil, x402types.PaymentRequirements{}, nil, false
+		return nil, x402types.PaymentRequirements{}, nil, nil, false
 	}
 
 	wallet := cfg.Wallet
@@ -228,12 +230,13 @@ func (v *Verifier) matchPaidRoute(cfg *PricingConfig, uri string) (*RouteRule, x
 	chain, ok := (*chains)[chainName]
 	if !ok {
 		log.Printf("x402-verifier: chain %q not pre-resolved for route %q", chainName, rule.Pattern)
-		return nil, x402types.PaymentRequirements{}, nil, false
+		return nil, x402types.PaymentRequirements{}, nil, nil, false
 	}
 
 	asset := ResolveAssetInfo(chain, rule)
 	requirement := BuildV2RequirementWithAsset(chain, asset, rule.Price, wallet)
-	return rule, requirement, prometheusLabels(rule), true
+	extensions := BuildExtensionsForAsset(asset)
+	return rule, requirement, extensions, prometheusLabels(rule), true
 }
 
 func buildUpstreamProxy(rule *RouteRule) (http.Handler, error) {

--- a/justfile
+++ b/justfile
@@ -37,37 +37,38 @@ down:
 
 # Path to the frontend repo (override with FRONTEND_DIR=../path just dev-frontend)
 frontend_dir := env("FRONTEND_DIR", justfile_directory() / "../obol-stack-front-end")
-dev_image    := "obolnetwork/obol-stack-front-end:dev"
+# Push target = the obol-local k3d registry mirror set up during `obol stack up`
+# (see internal/stack/dev_registry.go). Pushing only transfers changed layers,
+# which is much faster than `k3d image import`'s full-tarball round-trip.
+dev_image    := "localhost:54103/obol-stack-front-end:dev"
 
-# Build frontend from local source, import into k3d, and restart the pod
+# Build frontend from local source, push to local registry, and restart the pod
 dev-frontend:
     #!/usr/bin/env bash
     set -e
-    CLUSTER_ID=$(cat .workspace/config/.stack-id 2>/dev/null || cat ~/.config/obol/.stack-id)
     echo "→ Building {{ dev_image }} from {{ frontend_dir }}"
     docker build -t {{ dev_image }} {{ frontend_dir }}
-    echo "→ Importing image into k3d cluster obol-stack-${CLUSTER_ID}"
-    k3d image import {{ dev_image }} -c "obol-stack-${CLUSTER_ID}"
+    echo "→ Pushing {{ dev_image }} to local registry"
+    docker push {{ dev_image }}
     echo "→ Restarting frontend deployment"
     obol kubectl set image deployment/obol-frontend-obol-app \
         obol-app={{ dev_image }} -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
-    echo "✓ Frontend dev build live at http://obol.stack"
+    echo "✓ Frontend dev build live at http://obol.stack:8080"
 
 # Rebuild and hot-swap frontend (skip docker cache for faster iteration)
 dev-frontend-rebuild:
     #!/usr/bin/env bash
     set -e
-    CLUSTER_ID=$(cat .workspace/config/.stack-id 2>/dev/null || cat ~/.config/obol/.stack-id)
     echo "→ Rebuilding {{ dev_image }} (no cache)"
     docker build --no-cache -t {{ dev_image }} {{ frontend_dir }}
-    echo "→ Importing image into k3d cluster obol-stack-${CLUSTER_ID}"
-    k3d image import {{ dev_image }} -c "obol-stack-${CLUSTER_ID}"
+    echo "→ Pushing {{ dev_image }} to local registry"
+    docker push {{ dev_image }}
     echo "→ Restarting frontend deployment"
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
-    echo "✓ Frontend dev build live at http://obol.stack"
+    echo "✓ Frontend dev build live at http://obol.stack:8080"
 
 # Reset frontend back to the released image
 dev-frontend-reset:

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.17-rc.5 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.19 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
## Summary

Surface gasless-approve
  capability via top-level
  `extensions` on
  the 402 response so buyers skip
  the one-time approve(Permit2,
  max)
  when the configured facilitator
  can batch permit() with
  transferFrom.

  Includes paired skill updates
  (buy-x402,
  ethereum-local-wallet,
  ethereum-networks, gas) for the
  buyer-side flow.