### PR TITLE
fix(tunnel): warn before invalidating active quick tunnel URL

### DIFF
--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -263,6 +263,15 @@ func Down(cfg *config.Config, u *ui.UI) error {
 		return fmt.Errorf("failed to load backend: %w", err)
 	}
 
+	// Cluster delete invalidates any active quick tunnel URL. Warn first so
+	// users with sellers registered against the URL aren't blindsided.
+	currentURL, _ := tunnel.GetTunnelURL(cfg)
+	if !tunnel.ConfirmQuickTunnelLoss(cfg, u, currentURL, "obol stack down") {
+		u.Info("Aborted.")
+
+		return nil
+	}
+
 	// Stop the DNS resolver container
 	dns.Stop()
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -285,6 +285,36 @@ func EnsureRunning(cfg *config.Config, u *ui.UI) (string, error) {
 	return WaitReady(cfg, u)
 }
 
+// ConfirmQuickTunnelLoss warns the user when a destructive action is about to
+// invalidate an active quick tunnel URL, and asks whether to proceed. Returns
+// true when the caller should continue.
+//
+// Quick tunnels get a fresh *.trycloudflare.com URL on every cluster recreate
+// or `obol tunnel restart`, so anyone who bookmarked or registered the old URL
+// will see 530 errors until they re-discover via /skill.md. Persistent (DNS)
+// tunnels are stable across these events and skip the warning.
+//
+// Pass currentURL as discovered from the running cloudflared pod (or "" when
+// none). In non-interactive sessions, Confirm returns its default (true), so
+// automation and CI flows print the warning but do not block.
+func ConfirmQuickTunnelLoss(cfg *config.Config, u *ui.UI, currentURL, action string) bool {
+	if st, _ := loadTunnelState(cfg); st != nil && st.Hostname != "" {
+		return true
+	}
+
+	if currentURL == "" {
+		return true
+	}
+
+	u.Blank()
+	u.Warnf("Quick tunnel URL will be invalidated: %s", currentURL)
+	u.Dim(fmt.Sprintf("  After `%s`, the next `obol sell http` brings up a fresh URL.", action))
+	u.Dim("  Buyers using the old URL will see 530 errors.")
+	u.Dim("  For a permanent URL: obol tunnel login --hostname stack.example.com")
+
+	return u.Confirm("Continue?", true)
+}
+
 // Restart restarts the cloudflared deployment and propagates the new tunnel
 // URL to dependent resources (obol-stack-config ConfigMap, agent overlay,
 // storefront HTTPRoute hostname pin). Quick tunnels get a new URL on every
@@ -301,6 +331,13 @@ func Restart(cfg *config.Config, u *ui.UI) error {
 	// Check if kubeconfig exists.
 	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
 		return errors.New("stack not running, use 'obol stack up' first")
+	}
+
+	currentURL, _ := GetTunnelURL(cfg)
+	if !ConfirmQuickTunnelLoss(cfg, u, currentURL, "obol tunnel restart") {
+		u.Info("Aborted.")
+
+		return nil
 	}
 
 	cmd := exec.Command(kubectlPath,
@@ -531,13 +568,13 @@ func CreateStorefront(cfg *config.Config, tunnelURL string) error {
 					},
 					"spec": map[string]any{
 						"containers": []map[string]any{
-								{
-									"name":            "storefront",
-									"image":           images.Resolve("ghcr.io/obolnetwork/obol-stack-public-storefront"),
-									"imagePullPolicy": "IfNotPresent",
-									"ports": []map[string]any{
-										{"containerPort": 3000, "name": "http"},
-									},
+							{
+								"name":            "storefront",
+								"image":           images.Resolve("ghcr.io/obolnetwork/obol-stack-public-storefront"),
+								"imagePullPolicy": "IfNotPresent",
+								"ports": []map[string]any{
+									{"containerPort": 3000, "name": "http"},
+								},
 								"env": []map[string]string{
 									{"name": "SERVICES_URL", "value": "http://obol-skill-md.x402.svc:8080"},
 								},

--- a/internal/tunnel/tunnel_lifecycle_test.go
+++ b/internal/tunnel/tunnel_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/ui"
 )
 
 func testConfig(t *testing.T) *config.Config {
@@ -301,5 +302,34 @@ func TestTunnelState_UpdatedAtRefreshed(t *testing.T) {
 	got, _ := loadTunnelState(cfg)
 	if got.UpdatedAt.Before(before) {
 		t.Errorf("UpdatedAt %v should be after %v", got.UpdatedAt, before)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ConfirmQuickTunnelLoss
+// ---------------------------------------------------------------------------
+
+func TestConfirmQuickTunnelLoss_PersistentSkipsWarning(t *testing.T) {
+	cfg := testConfig(t)
+	if err := saveTunnelState(cfg, &tunnelState{Mode: "dns", Hostname: "stack.example.com"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if !ConfirmQuickTunnelLoss(cfg, ui.New(false), "https://old.trycloudflare.com", "test") {
+		t.Error("persistent DNS tunnel should skip the warning and return true")
+	}
+}
+
+func TestConfirmQuickTunnelLoss_EmptyURLSkips(t *testing.T) {
+	if !ConfirmQuickTunnelLoss(testConfig(t), ui.New(false), "", "test") {
+		t.Error("empty currentURL should skip the warning and return true")
+	}
+}
+
+func TestConfirmQuickTunnelLoss_NonInteractivePassesThrough(t *testing.T) {
+	// Tests run without a TTY, so Confirm short-circuits to its default (true).
+	// The helper still prints the warning; here we just verify it does not block.
+	if !ConfirmQuickTunnelLoss(testConfig(t), ui.New(false), "https://old.trycloudflare.com", "test") {
+		t.Error("non-interactive Confirm should pass through with default-yes")
 	}
 }


### PR DESCRIPTION
## Summary

`obol stack down` and `obol tunnel restart` both rotate the `*.trycloudflare.com` URL on quick tunnels (cluster delete kills the cloudflared pod; rollout restart starts a fresh one). Until now there was no warning before the rotation, so anyone with a seller registered against the URL would silently 530 after an RC upgrade or restart cycle.

Surfaced in the rc8 reviewer feedback (item #4):

> Quick-tunnel `*.trycloudflare.com` URLs are ephemeral and the cloudflared deployment is recreated during `obol stack up`. Our pre-upgrade URL `result-tactics-nyc-pittsburgh.trycloudflare.com` died and was replaced by `hospital-binding-centered-fact.trycloudflare.com`. […] anyone who previously bookmarked the old URL is now seeing 530s.

## Approach

- New `ConfirmQuickTunnelLoss(cfg, u, currentURL, action)` in `internal/tunnel`. Skips when `loadTunnelState` shows a persistent DNS tunnel (URL is stable across cluster recreates) or when no active quick tunnel URL is captured. Otherwise warns and prompts.
- Wired into `stack.Down()` before the cluster-delete path, and into `tunnel.Restart()` before the rollout-restart.
- Non-interactive sessions (CI, JSON output, no TTY) print the warning but pass through the default (yes), so automation is unaffected.
- Drive-by `gofmt` of unrelated indentation drift in `CreateStorefront` that the formatter caught while editing the same file.

## Behavior

| Scenario | Result |
|---|---|
| Persistent (DNS) tunnel configured | No warning, proceed |
| No active quick tunnel pod | No warning, proceed (best-effort) |
| Active quick tunnel + interactive TTY | Warn + `Continue? [Y/n]` (Enter = yes) |
| Active quick tunnel + non-interactive | Warning printed, proceed without prompt |

Sample output (interactive):

```
==> Stopping the Obol Stack
  ! Quick tunnel URL will be invalidated: https://hospital-binding-centered-fact.trycloudflare.com
  After `obol stack down`, the next `obol sell http` brings up a fresh URL.
  Buyers using the old URL will see 530 errors.
  For a permanent URL: obol tunnel login --hostname stack.example.com
Continue? [Y/n]
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/tunnel/ ./internal/stack/` pass
- [x] New unit tests in `tunnel_lifecycle_test.go`:
  - `TestConfirmQuickTunnelLoss_PersistentSkipsWarning` — DNS state set, helper short-circuits to true
  - `TestConfirmQuickTunnelLoss_EmptyURLSkips` — no captured URL, helper short-circuits to true
  - `TestConfirmQuickTunnelLoss_NonInteractivePassesThrough` — warning printed, default-yes pass-through
- [x] Manual: `obol stack up` → `obol sell http demo` → `obol stack down` shows the warning with the active quick URL
  - Verified on `spark2`; warning printed with active quick tunnel URL `https://surrounded-lucia-gulf-rapids.trycloudflare.com`
- [x] Manual: `obol tunnel restart` on a quick tunnel shows the warning
  - Verified on `spark2`; restart warned before rotating the active quick-tunnel URL
- [x] Manual: `obol tunnel login --hostname …` followed by `obol stack down` shows no warning (persistent path)
  - Verified on `spark1`; `obol tunnel login --hostname pr424-20260505163420-spark1.humanresearch.ai` completed, and subsequent `obol stack down` completed without the quick-tunnel invalidation warning
- [x] Manual: piping `obol stack down < /dev/null` does not block
  - Verified on `spark2`; command completed and tore down the stack without hanging

## Out of scope

- The reviewer's alternative suggestion ("skip recreating the cloudflared deployment if values are unchanged") would require the cluster to survive across upgrades, which is a much larger architectural shift. This PR addresses only the user-facing surprise.
- No on-chain re-registration on URL rotation — the existing `tunnel.Restart` / `SyncAgentBaseURL` / `SyncTunnelConfigMap` path already updates `/skill.md` and agent metadata to the new URL.
