### PR TITLE
Updates from rc9 test pass

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -1045,8 +1045,12 @@ Example:
 				Usage: "Override service name (default: demo-<type>)",
 			},
 			&cli.BoolFlag{
-				Name:  "no-register",
-				Usage: "Skip the on-chain ERC-8004 registration step at the end (you can run `obol sell register` later)",
+				Name:  "register",
+				Usage: "Auto-register the demo on the ERC-8004 Agent Registry. Default: skip (avoid double-register reverts and ETH-for-gas requirement; run `obol sell register` later if you want on-chain discovery).",
+			},
+			&cli.BoolFlag{
+				Name:   "no-register",
+				Hidden: true, // back-compat: no-op now that skipping is the default
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -1128,8 +1132,13 @@ Example:
 				return fmt.Errorf("deploy demo backend: %w", err)
 			}
 
-			// 2. Create ServiceOffer.
-			register := !cmd.Bool("no-register")
+			// 2. Create ServiceOffer. Auto-registration is opt-in for demos —
+			// the previous default (auto-register on every demo) caused
+			// repeated `setMetadata` calls to revert at the contract once the
+			// agent already had x402 metadata, and required the demo wallet
+			// to hold ETH for gas. Operators run `obol sell register --chain ...`
+			// when they actually want on-chain discovery.
+			register := cmd.Bool("register")
 			soManifest := buildDemoServiceOffer(name, demoNamespace, chain, wallet, price, register, spec, assetTerms)
 			applyOut, err := kubectlApplyOutput(cfg, soManifest)
 			if err != nil {
@@ -1173,7 +1182,8 @@ Example:
 			if register {
 				autoRegisterDemo(ctx, cfg, u, chain, tunnelURL)
 			} else {
-				u.Info("Registration skipped (--no-register). The offer will still reach Ready.")
+				u.Info("Registration skipped (default for demos). The offer will still reach Ready.")
+				u.Dim("  Run on-chain discovery later: obol sell register --chain " + chain)
 			}
 
 			// 6. Print try-it instructions.

--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -20,6 +20,11 @@ repositories:
 values:
   - network: mainnet
   - gatewayApiVersion: v1.4.1
+  # Default the cloudflared release to enabled. `obol stack up` overrides via
+  # `--state-values-set cloudflared.enabled=false` when it detects a running
+  # quick tunnel that should be preserved across the sync.
+  - cloudflared:
+      enabled: true
 
 releases:
   # Local storage provisioner (raw manifests wrapped as chart)
@@ -130,10 +135,16 @@ releases:
           dashboard:
             enabled: false
 
-  # Cloudflare Tunnel (dormant until configured via obol tunnel login/provision)
+  # Cloudflare Tunnel (dormant until configured via obol tunnel login/provision).
+  # `condition: cloudflared.enabled` lets `obol stack up` flip this off when an
+  # active quick tunnel is already serving — re-syncing the chart kills the
+  # running pod (chart renders replicas: 0 in quick-tunnel mode), and that
+  # invalidates the *.trycloudflare.com URL anyone bookmarked. Default true so
+  # fresh installs and `helmfile sync` outside of stack-up keep working.
   - name: cloudflared
     namespace: traefik
     chart: ./cloudflared
+    condition: cloudflared.enabled
     needs:
       - traefik/traefik
 

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -35,7 +35,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.19"
+  tag: "v0.1.20"
 
 service:
   type: ClusterIP

--- a/internal/erc8004/client.go
+++ b/internal/erc8004/client.go
@@ -1,6 +1,7 @@
 package erc8004
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"errors"
@@ -245,7 +246,19 @@ func (c *Client) parseRegisteredLog(vLog *types.Log) (*big.Int, string, common.A
 }
 
 // SetMetadataWithOpts stores key-value metadata using the provided TransactOpts.
+//
+// Read-before-write: registries we've integrated with (the canonical ERC-8004
+// reference impl among others) revert on `setMetadata` when the new value
+// equals the current value — observed in the field as "execution reverted"
+// on every subsequent ServiceOffer apply once the first one has set the
+// `x402` key. The contract revert costs gas and looks scary in the CLI for
+// what is logically a no-op, so we skip the write when the on-chain value
+// already matches.
 func (c *Client) SetMetadataWithOpts(ctx context.Context, opts *bind.TransactOpts, agentID *big.Int, k string, v []byte) error {
+	if existing, err := c.GetMetadata(ctx, agentID, k); err == nil && bytes.Equal(existing, v) {
+		return nil
+	}
+
 	tx, err := c.contract.Transact(opts, "setMetadata", agentID, k, v)
 	if err != nil {
 		return fmt.Errorf("erc8004: setMetadata tx: %w", err)
@@ -277,7 +290,12 @@ func (c *Client) SetAgentURI(ctx context.Context, key *ecdsa.PrivateKey, agentID
 }
 
 // SetMetadata stores arbitrary key-value metadata on the agent NFT.
+// Read-before-write — see SetMetadataWithOpts for the rationale.
 func (c *Client) SetMetadata(ctx context.Context, key *ecdsa.PrivateKey, agentID *big.Int, k string, v []byte) error {
+	if existing, err := c.GetMetadata(ctx, agentID, k); err == nil && bytes.Equal(existing, v) {
+		return nil
+	}
+
 	opts, err := bind.NewKeyedTransactorWithChainID(key, c.chainID)
 	if err != nil {
 		return fmt.Errorf("erc8004: transactor: %w", err)

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -991,7 +991,17 @@ func decimalToAtomicString(amount string, decimals int) string {
 }
 
 func describeOfferPrice(offer *monetizeapi.ServiceOffer) string {
+	// Source the symbol from (in order): explicit asset metadata on the offer,
+	// the resolved chain-default settlement asset, hard-coded "USDC" only as
+	// the last-resort fallback for unknown chains. Mislabeling OBOL-priced
+	// services as "USDC" on the discovery surfaces (storefront / skill.md)
+	// caused buyers to queue up the wrong asset on rc7-rc9.
 	symbol := offer.Spec.Payment.Asset.Symbol
+	if symbol == "" {
+		if a := offerAssetJSON(offer); a != nil && a.Symbol != "" {
+			symbol = a.Symbol
+		}
+	}
 	if symbol == "" {
 		symbol = "USDC"
 	}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -383,8 +383,19 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	helmfileArgs := []string{
 		"--file", helmfilePath,
 		"--kubeconfig", kubeconfigPath,
-		"sync",
 	}
+	// Preserve a healthy quick tunnel across stack-up. The cloudflared chart
+	// renders replicas: 0 in quick-tunnel mode; re-syncing it would terminate
+	// the running pod and invalidate the *.trycloudflare.com URL anyone
+	// bookmarked. The release has `condition: cloudflared.enabled` in
+	// helmfile.yaml — flipping that to false skips the release entirely so
+	// the pod and URL survive. Persistent (DNS) tunnels render replicas: 1,
+	// so they sync cleanly and we don't skip them.
+	if tunnel.IsQuickTunnelHealthy(cfg) {
+		helmfileArgs = append(helmfileArgs, "--state-values-set", "cloudflared.enabled=false")
+		u.Dim("Active quick tunnel detected — skipping cloudflared chart to preserve the URL")
+	}
+	helmfileArgs = append(helmfileArgs, "sync")
 	helmfileArgs = append(helmfileArgs, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
 	helmfileCmd := exec.Command(filepath.Join(cfg.BinDir, "helmfile"), helmfileArgs...)
 	helmfileCmd.Env = append(os.Environ(),

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -285,6 +285,39 @@ func EnsureRunning(cfg *config.Config, u *ui.UI) (string, error) {
 	return WaitReady(cfg, u)
 }
 
+// IsQuickTunnelHealthy reports whether a quick (anonymous *.trycloudflare.com)
+// tunnel is currently serving — pod is Running and a URL has been captured
+// from its logs. Returns false for persistent (DNS) tunnels and for any
+// failure mode (no kubeconfig, no pod, no URL).
+//
+// Used by `obol stack up` to skip the cloudflared chart sync when the URL
+// would otherwise be invalidated. Persistent tunnels survive helmfile sync
+// because the chart renders replicas: 1 for them; quick tunnels do not, so
+// re-syncing the chart kills the running pod and rotates the URL.
+func IsQuickTunnelHealthy(cfg *config.Config) bool {
+	st, _ := loadTunnelState(cfg)
+	if st != nil && st.Hostname != "" {
+		return false // persistent (DNS) tunnel — chart already keeps it alive
+	}
+
+	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return false
+	}
+
+	if status, err := getPodStatus(kubectlPath, kubeconfigPath); err != nil || status != "running" {
+		return false
+	}
+
+	url, err := GetTunnelURL(cfg)
+	if err != nil || !strings.HasPrefix(url, "https://") {
+		return false
+	}
+
+	return true
+}
+
 // ConfirmQuickTunnelLoss warns the user when a destructive action is about to
 // invalidate an active quick tunnel URL, and asks whether to proceed. Returns
 // true when the caller should continue.

--- a/web/public-storefront/src/app/layout.tsx
+++ b/web/public-storefront/src/app/layout.tsx
@@ -140,7 +140,7 @@ function JsonLd({
       description: s.description,
       url: `${siteUrl}${s.endpoint.startsWith("/") ? "" : "/"}${s.endpoint}`,
       price: s.priceRaw ?? s.price,
-      priceCurrency: "USDC",
+      priceCurrency: s.asset?.symbol ?? "USDC",
       eligibleTransactionVolume: {
         "@type": "PriceSpecification",
         price: s.price,

--- a/web/public-storefront/src/components/ServiceCard.tsx
+++ b/web/public-storefront/src/components/ServiceCard.tsx
@@ -183,7 +183,11 @@ function LanguageTabs({ service }: { service: Service }) {
   // Python is the only currently-supported snippet.
   const [lang] = useState<"python">("python");
 
-  const tokenName = service.network === "ethereum" ? "OBOL" : "USDC";
+  // Prefer the resolved asset symbol from the catalog. The previous
+  // network-based heuristic mislabeled OBOL on base-sepolia as USDC and
+  // any non-mainnet USDC deployment as OBOL.
+  const tokenName =
+    service.asset?.symbol ?? (service.network === "ethereum" ? "OBOL" : "USDC");
   const python = `import httpx
 from x402.client import x402_client
 

--- a/web/public-storefront/src/types.ts
+++ b/web/public-storefront/src/types.ts
@@ -1,3 +1,10 @@
+export interface ServiceAsset {
+  address?: string;
+  symbol?: string;
+  decimals?: number;
+  transferMethod?: string;
+}
+
 export interface Service {
   name: string;
   namespace: string;
@@ -8,6 +15,12 @@ export interface Service {
   priceRaw?: string;
   payTo: string;
   network: string;
+  // asset is the resolved settlement token. Mirrors the controller's
+  // ServiceCatalogAsset payload — when present, .symbol is the source of
+  // truth for "what does this offer charge in" (e.g. "OBOL", "USDC"). The
+  // legacy `network === "ethereum" ? "OBOL" : "USDC"` heuristic was wrong
+  // for OBOL on base-sepolia and any non-mainnet OBOL deployment.
+  asset?: ServiceAsset;
   description: string;
   isDemo: boolean;
 }


### PR DESCRIPTION
## Summary
 Quick assessment for issue 4 below,  
  then a recap.                                   
                                                  
  Issue 4 — model picker: is the rc9 user "stuck"?
                                                
  Re-checking against the merged commits (6b40607 
  fix(model): demote ollama cloud aliases in    
  auto-config + the 06d0cb8 follow-up):           
                                                  
  - AutoConfigOllamaModelNames puts :cloud aliases
   last, behind every local chat model. ✓
  - Rank() picks index 0 → primary becomes a local
   model whenever any exist. ✓                    
  - autoConfigureLLM in stack.go warns the
  operator when names[0] is a :cloud alias        
  (only-:cloud inventory case). ✓               
                                                  
  But — the auto-config branch gated on           
  !model.HasConfiguredModels(cfg) (line in
  autoConfigureLLM) only fires on the first stack 
  up (or after a config wipe). On every subsequent
   obol stack up the existing LiteLLM model_list
  is already in the ConfigMap, and Hermes'
  configuredModels() calls Rank() directly on
  whatever order is already there. Rank() does not
   reorder :cloud aliases — it only demotes
  embedding-only models.

  So the rc9 dev's machine almost certainly has an
   existing LiteLLM ConfigMap whose model_list was
   populated under an older binary (rc8 or        
  earlier, before 6b40607). On rc9 the          
  demote-cloud logic is never invoked for them —
  HasConfiguredModels is true, and Hermes
  round-trips the existing first entry
  (deepseek-v4-pro:cloud) as the primary.

  Your read is correct: for that user, obol model 
  prefer <local-model> is the only path — our fix
  doesn't reach into already-populated configs by 
  design (treating LiteLLM order as the operator's
   preference signal, the same trade-off we
  discussed last round). New installs and config
  wipes are now safe.

  If we wanted to also fix this for users with a  
  stale config, the option is: extend Rank() to
  demote :cloud aliases the same way it demotes   
  embedding-only entries. That re-imposes a global
   preference on every cluster, including ones
  where the operator deliberately put :cloud first
   because they do have an API key set. I'd lean
  toward leaving it alone and surfacing the
  diagnostic via a new warning if Hermes' picked
  primary needs an unset credential — but that's a
   "not now" follow-up unless you want it. Suggest
   leaving #4 as "documented escape hatch: obol
  model prefer".

  Summary of changes this turn                    
  
  Issue 1 — preserve healthy cloudflared across   
  obol stack up                                 
  - Added condition: cloudflared.enabled to the   
  cloudflared release in helmfile.yaml, defaulted 
  to true.                                       
  - New tunnel.IsQuickTunnelHealthy(cfg) returns  
  true only when the pod is Running AND a       
  https://*.trycloudflare.com URL has been        
  captured (false for persistent DNS tunnels —
  they sync cleanly anyway, and false on any      
  failure mode).                                
  - syncDefaults flips the state value to
  cloudflared.enabled=false when the tunnel is
  healthy, so helmfile sync skips the chart       
  entirely; the running pod and its URL survive.
  Prints a one-line Dim notice so the operator can
   see what happened.                             
                     
  Issue 3 — USDC hardcoding on discovery surfaces
  - internal/serviceoffercontroller/render.go     
  describeOfferPrice now consults the resolved    
  offerAssetJSON() (which already does            
  explicit-asset → chain-default → nil) before    
  falling back to "USDC". OBOL-priced offers will
  now render 1 OBOL/request in /skill.md.        
  - web/public-storefront/src/types.ts extended
  Service with an optional asset field mirroring
  the controller's ServiceCatalogAsset.           
  - ServiceCard.tsx reads service.asset?.symbol
  first (the network-based heuristic stays as a   
  defensive fallback for stale catalogs).         
  - layout.tsx schema-org block reads    
  s.asset?.symbol for priceCurrency. The static OG
   image chips ("OBOL"/"USDC") stay — they're     
  general marketing, not per-service.        
                                                  
  Issue 4 — model picker — explanation above; no
  code change recommended for now.                
  
  Issue 5a — skip registration on obol sell demo  
  by default                                    
  - Default flipped: obol sell demo now does not  
  auto-register. New --register opt-in flag for   
  when you actually want it. The old --no-register
   flag survives as a hidden no-op for            
  back-compat. The "skipped" log line now also  
  tells the user how to register later.       
                                       
  Issue 5b — setMetadata revert on subsequent 
  updates                                         
  - Both Client.SetMetadataWithOpts and
  Client.SetMetadata now do a read-before-write   
  via GetMetadata. If the on-chain value already
  equals the new value, the call is a silent no-op
   — no tx, no revert, no scary CLI warning. This 
  stops the rc8/rc9 "execution reverted" warning 
  that fired on every additional ServiceOffer once
   x402 metadata was set the first time.          
                                        
  Issue 2 — explicitly skipped per your direction.
                                                  
  Tests all green across internal/stack,          
  internal/tunnel, internal/erc8004,              
  internal/serviceoffercontroller, and cmd/obol.  