### PR TITLE
Update with fixes

### DIFF
--- a/internal/erc8004/client.go
+++ b/internal/erc8004/client.go
@@ -261,7 +261,7 @@ func (c *Client) SetMetadataWithOpts(ctx context.Context, opts *bind.TransactOpt
 
 	tx, err := c.contract.Transact(opts, "setMetadata", agentID, k, v)
 	if err != nil {
-		return fmt.Errorf("erc8004: setMetadata tx: %w", err)
+		return wrapTransactError("erc8004: setMetadata tx", err)
 	}
 
 	if _, err := bind.WaitMined(ctx, c.eth, tx); err != nil {
@@ -280,7 +280,7 @@ func (c *Client) SetAgentURI(ctx context.Context, key *ecdsa.PrivateKey, agentID
 
 	tx, err := c.contract.Transact(opts, "setAgentURI", agentID, uri)
 	if err != nil {
-		return fmt.Errorf("erc8004: setAgentURI tx: %w", err)
+		return wrapTransactError("erc8004: setAgentURI tx", err)
 	}
 
 	if _, err := bind.WaitMined(ctx, c.eth, tx); err != nil {
@@ -304,7 +304,7 @@ func (c *Client) SetMetadata(ctx context.Context, key *ecdsa.PrivateKey, agentID
 
 	tx, err := c.contract.Transact(opts, "setMetadata", agentID, k, v)
 	if err != nil {
-		return fmt.Errorf("erc8004: setMetadata tx: %w", err)
+		return wrapTransactError("erc8004: setMetadata tx", err)
 	}
 
 	if _, err := bind.WaitMined(ctx, c.eth, tx); err != nil {

--- a/internal/erc8004/client_test.go
+++ b/internal/erc8004/client_test.go
@@ -35,6 +35,18 @@ type jsonrpcResp struct {
 	Error   json.RawMessage `json:"error,omitempty"`
 }
 
+// rpcMockDataError is the error type test handlers return when they want
+// the mock to attach a `data` field on the JSON-RPC error envelope. Geth and
+// Reth use the same envelope shape to carry revert payloads from
+// eth_call / eth_estimateGas; go-ethereum's rpc client surfaces that as an
+// rpc.DataError, which our decodeRevertReason picks up.
+type rpcMockDataError struct {
+	msg     string
+	dataHex string // 0x-prefixed hex bytes (e.g. ABI-encoded Error(string))
+}
+
+func (e *rpcMockDataError) Error() string { return e.msg }
+
 // mockRPC creates a test HTTP server that responds to JSON-RPC calls.
 // The handler map keys are method names; values return the hex-encoded result.
 func mockRPC(t *testing.T, handlers map[string]func(params []json.RawMessage) (json.RawMessage, error)) *httptest.Server {
@@ -64,10 +76,19 @@ func mockRPC(t *testing.T, handlers map[string]func(params []json.RawMessage) (j
 
 		result, err := handler(req.Params)
 		if err != nil {
+			// Allow handlers to attach a `data` field on the JSON-RPC error
+			// envelope (the spot Geth/Reth use to carry revert payloads). Plain
+			// errors continue to work, so existing tests are unaffected.
+			body := map[string]any{"code": -32000, "message": err.Error()}
+			var de *rpcMockDataError
+			if errors.As(err, &de) && de.dataHex != "" {
+				body["data"] = de.dataHex
+			}
+			b, _ := json.Marshal(body)
 			resp := jsonrpcResp{
 				JSONRPC: "2.0",
 				ID:      req.ID,
-				Error:   json.RawMessage(fmt.Sprintf(`{"code":-32000,"message":"%s"}`, err.Error())),
+				Error:   b,
 			}
 			json.NewEncoder(w).Encode(resp)
 
@@ -515,6 +536,88 @@ func TestSetMetadata_TransactRevert(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "erc8004: setMetadata tx: execution reverted") {
 		t.Fatalf("error = %q, want setMetadata tx execution reverted", err)
+	}
+}
+
+// When the node carries a revert payload on the JSON-RPC error envelope —
+// which Geth/Reth do for both eth_call and eth_estimateGas — the wrapped
+// CLI error must surface the decoded Solidity Error(string) message so an
+// operator can see *why* the contract is rejecting (the rc10 setMetadata
+// revert was opaque before this).
+func TestSetMetadata_RevertSurfacesErrorString(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stringT, _ := abi.NewType("string", "", nil)
+	args := abi.Arguments{{Type: stringT}}
+	encoded, err := args.Pack("MetadataKeyAlreadySet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revertHex := "0x08c379a0" + hex.EncodeToString(encoded)
+
+	handlers := txMockHandlers(common.HexToHash("0x2222"))
+	handlers["eth_estimateGas"] = func(_ []json.RawMessage) (json.RawMessage, error) {
+		return nil, &rpcMockDataError{msg: "execution reverted", dataHex: revertHex}
+	}
+
+	srv := mockRPC(t, handlers)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	err = client.SetMetadata(ctx, key, big.NewInt(42), "x402", []byte(`{"payment":"info"}`))
+	if err == nil {
+		t.Fatal("expected setMetadata revert error, got nil")
+	}
+	if !strings.Contains(err.Error(), "MetadataKeyAlreadySet") {
+		t.Fatalf("error = %q, want decoded revert reason in message", err)
+	}
+	if !strings.Contains(err.Error(), "erc8004: setMetadata tx") {
+		t.Fatalf("error = %q, lost the call-site prefix", err)
+	}
+}
+
+// Custom errors don't have an ABI we know in this package, so we surface the
+// 4-byte selector — enough for an operator to grep the contract source.
+func TestSetMetadata_RevertSurfacesCustomErrorSelector(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 4-byte selector for a hypothetical Forbidden() — pick anything that
+	// isn't 0x08c379a0 / 0x4e487b71 so we exercise the default branch.
+	revertHex := "0xdeadbeef"
+
+	handlers := txMockHandlers(common.HexToHash("0x2222"))
+	handlers["eth_estimateGas"] = func(_ []json.RawMessage) (json.RawMessage, error) {
+		return nil, &rpcMockDataError{msg: "execution reverted", dataHex: revertHex}
+	}
+
+	srv := mockRPC(t, handlers)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	err = client.SetMetadata(ctx, key, big.NewInt(42), "x402", []byte(`{"payment":"info"}`))
+	if err == nil {
+		t.Fatal("expected setMetadata revert error, got nil")
+	}
+	if !strings.Contains(err.Error(), "custom error 0xdeadbeef") {
+		t.Fatalf("error = %q, want custom error selector in message", err)
 	}
 }
 

--- a/internal/erc8004/revert.go
+++ b/internal/erc8004/revert.go
@@ -1,0 +1,137 @@
+package erc8004
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// decodeRevertReason inspects an error returned from a contract Transact (or
+// any underlying eth_estimateGas / eth_call) and returns a human-readable
+// revert reason where possible. Returns the empty string when the error
+// carries no revert data.
+//
+// It handles the three forms a Solidity contract revert can take:
+//   - revert("message")          → ABI-encoded Error(string) → "message"
+//   - panic(N)                   → ABI-encoded Panic(uint256) → "panic: <N>"
+//   - revert CustomError(...)    → 4-byte selector with no public ABI →
+//                                  "custom error 0x<selector>" (so an
+//                                  operator can grep the contract source)
+//
+// The whole point: when an ERC-8004 setMetadata reverts at gas-estimation
+// time, the Geth/Reth node returns the revert payload as the `data` field of
+// the JSON-RPC error envelope. go-ethereum exposes that via the
+// rpc.DataError interface; without decoding it we just see "execution
+// reverted" with no clue what the contract is rejecting on. With decoding,
+// the operator gets either the literal Solidity message or at least the
+// selector to look up in the contract source.
+func decodeRevertReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	type dataError interface{ ErrorData() any }
+	var de dataError
+	if !errors.As(err, &de) {
+		return ""
+	}
+	raw, ok := de.ErrorData().(string)
+	if !ok || raw == "" {
+		return ""
+	}
+
+	hexStr := strings.TrimPrefix(raw, "0x")
+	data, decodeErr := hex.DecodeString(hexStr)
+	if decodeErr != nil || len(data) < 4 {
+		return ""
+	}
+
+	selector := data[:4]
+	payload := data[4:]
+
+	switch fmt.Sprintf("0x%x", selector) {
+	case "0x08c379a0":
+		// Error(string) — the canonical Solidity revert("...") encoding.
+		stringT, _ := abi.NewType("string", "", nil)
+		args := abi.Arguments{{Type: stringT}}
+		decoded, derr := args.Unpack(payload)
+		if derr != nil || len(decoded) == 0 {
+			return ""
+		}
+		msg, _ := decoded[0].(string)
+		if msg == "" {
+			return ""
+		}
+		return msg
+	case "0x4e487b71":
+		// Panic(uint256) — assertions, division-by-zero, overflow checks, etc.
+		uintT, _ := abi.NewType("uint256", "", nil)
+		args := abi.Arguments{{Type: uintT}}
+		decoded, derr := args.Unpack(payload)
+		if derr != nil || len(decoded) == 0 {
+			return ""
+		}
+		code, _ := decoded[0].(*big.Int)
+		if code == nil {
+			return ""
+		}
+		return fmt.Sprintf("panic: %s (0x%x)", panicReason(code), code)
+	default:
+		// Custom error — we don't have the registry's full ABI for these,
+		// so surface the selector so a human can grep the contract source.
+		return fmt.Sprintf("custom error 0x%x", selector)
+	}
+}
+
+// panicReason maps the Solidity panic codes documented at
+// https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require
+// to their human-readable names. Unknown codes fall through to "unknown".
+func panicReason(code *big.Int) string {
+	if !code.IsUint64() {
+		return "unknown"
+	}
+	switch code.Uint64() {
+	case 0x00:
+		return "generic compiler-inserted panic"
+	case 0x01:
+		return "assert(false)"
+	case 0x11:
+		return "arithmetic overflow/underflow"
+	case 0x12:
+		return "division or modulo by zero"
+	case 0x21:
+		return "invalid enum conversion"
+	case 0x22:
+		return "incorrectly encoded storage byte array"
+	case 0x31:
+		return "pop on empty array"
+	case 0x32:
+		return "out-of-bounds array access"
+	case 0x41:
+		return "out-of-memory"
+	case 0x51:
+		return "uninitialized internal function call"
+	default:
+		return "unknown"
+	}
+}
+
+// wrapTransactError wraps an error from contract.Transact (or any inner
+// estimateGas / call) with a decoded revert reason when one is available,
+// keeping the original error chain intact for callers that errors.Is/As it.
+//
+// Calls that did not produce a revert (network errors, signing errors, etc.)
+// pass through unchanged so we do not pretend to know more than we do.
+func wrapTransactError(prefix string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if reason := decodeRevertReason(err); reason != "" {
+		return fmt.Errorf("%s: %w (revert: %s)", prefix, err, reason)
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
+}

--- a/internal/erc8004/revert_test.go
+++ b/internal/erc8004/revert_test.go
@@ -1,0 +1,71 @@
+package erc8004
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+type fakeDataErr struct {
+	msg  string
+	data string
+}
+
+func (e *fakeDataErr) Error() string  { return e.msg }
+func (e *fakeDataErr) ErrorData() any { return e.data }
+
+func TestDecodeRevertReason_ErrorString(t *testing.T) {
+	stringT, _ := abi.NewType("string", "", nil)
+	args := abi.Arguments{{Type: stringT}}
+	payload, err := args.Pack("not authorised")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := "0x08c379a0" + hex.EncodeToString(payload)
+
+	got := decodeRevertReason(&fakeDataErr{msg: "execution reverted", data: data})
+	if got != "not authorised" {
+		t.Errorf("decoded = %q, want %q", got, "not authorised")
+	}
+}
+
+func TestDecodeRevertReason_PanicCode(t *testing.T) {
+	uintT, _ := abi.NewType("uint256", "", nil)
+	args := abi.Arguments{{Type: uintT}}
+	payload, err := args.Pack(big.NewInt(0x11)) // arithmetic overflow/underflow
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := "0x4e487b71" + hex.EncodeToString(payload)
+
+	got := decodeRevertReason(&fakeDataErr{msg: "execution reverted", data: data})
+	if !strings.Contains(got, "arithmetic overflow/underflow") {
+		t.Errorf("decoded = %q, want substring %q", got, "arithmetic overflow/underflow")
+	}
+}
+
+func TestDecodeRevertReason_CustomErrorSelector(t *testing.T) {
+	got := decodeRevertReason(&fakeDataErr{msg: "execution reverted", data: "0xcafebabe1234"})
+	if got != "custom error 0xcafebabe" {
+		t.Errorf("decoded = %q, want %q", got, "custom error 0xcafebabe")
+	}
+}
+
+func TestDecodeRevertReason_NoData(t *testing.T) {
+	cases := []error{
+		nil,
+		errors.New("plain"),
+		&fakeDataErr{msg: "x", data: ""},
+		&fakeDataErr{msg: "x", data: "0x"},
+		&fakeDataErr{msg: "x", data: "0xnothex"},
+	}
+	for _, e := range cases {
+		if got := decodeRevertReason(e); got != "" {
+			t.Errorf("decoded(%v) = %q, want empty", e, got)
+		}
+	}
+}

--- a/internal/x402/config.go
+++ b/internal/x402/config.go
@@ -1,7 +1,9 @@
 package x402
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 
@@ -104,9 +106,22 @@ type RouteRule struct {
 }
 
 // LoadConfig reads and parses a pricing configuration YAML file.
+//
+// Missing-file is intentionally tolerated and returns a zero-valued config
+// with defaults applied (chain="base", facilitator=default). The verifier
+// is increasingly run with `--route-source=kube`, where the static
+// pricing.yaml is optional — Helm charts that don't ship one would
+// previously crashloop the pod on startup; now the in-cluster watcher gets
+// to populate routes from ServiceOffers and the file watcher quietly picks
+// up the file later if it appears. Genuinely unreadable files (permission
+// errors, IO failures) still surface as errors.
 func LoadConfig(path string) (*PricingConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("x402-verifier: pricing config %s not found, starting with defaults (routes will populate from --route-source)", path)
+			return defaultPricingConfig(), nil
+		}
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
 
@@ -129,6 +144,16 @@ func LoadConfig(path string) (*PricingConfig, error) {
 	}
 
 	return &cfg, nil
+}
+
+// defaultPricingConfig returns the zero-routes config used when no static
+// pricing.yaml is present. Callers must still expect routes to arrive from
+// whichever route source they configured (file watch, kube watcher, etc.).
+func defaultPricingConfig() *PricingConfig {
+	return &PricingConfig{
+		Chain:          "base",
+		FacilitatorURL: DefaultFacilitatorURL,
+	}
 }
 
 // ValidateFacilitatorURL checks that the facilitator URL uses HTTPS.

--- a/internal/x402/config_test.go
+++ b/internal/x402/config_test.go
@@ -106,10 +106,45 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_FileNotFound(t *testing.T) {
-	_, err := LoadConfig("/nonexistent/path/config.yaml")
-	if err == nil {
-		t.Fatal("expected error for missing file")
+// Missing-file is intentionally tolerated: when the verifier runs with
+// `--route-source=kube` and the chart doesn't ship a static pricing.yaml,
+// LoadConfig must return a usable defaulted config so the pod starts and
+// the kube watcher can populate routes. Previously this returned an error
+// and crashlooped the verifier (rc10 reproducer).
+func TestLoadConfig_FileNotFound_ReturnsDefaultsWithoutError(t *testing.T) {
+	cfg, err := LoadConfig("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("missing pricing.yaml must not error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("missing pricing.yaml must return a usable config, got nil")
+	}
+	if cfg.Chain != "base" {
+		t.Errorf("default chain = %q, want %q", cfg.Chain, "base")
+	}
+	if cfg.FacilitatorURL == "" {
+		t.Error("default FacilitatorURL must be set")
+	}
+	if len(cfg.Routes) != 0 {
+		t.Errorf("missing config must have no routes, got %d", len(cfg.Routes))
+	}
+}
+
+// Permission errors and other read failures must still surface — they
+// indicate a misconfigured deployment (e.g. wrong volume mount mode), not
+// "config not yet present".
+func TestLoadConfig_UnreadableFile_StillErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noread.yaml")
+	if err := os.WriteFile(path, []byte("chain: base\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	if os.Geteuid() == 0 {
+		t.Skip("root reads everything, can't test permission denial")
+	}
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for unreadable file")
 	}
 }
 


### PR DESCRIPTION
## Summary
                                        
  Verifier crashloop fix (the blocker)    
  - internal/x402/config.go: LoadConfig   
  now treats os.ErrNotExist as a soft     
  success — returns a defaulted         
  PricingConfig (chain base, default      
  facilitator, zero routes) and logs a    
  friendly explanation. Other read errors 
  (permission denied, IO failures) still  
  surface so genuinely broken deployments
  fail loudly. defaultPricingConfig()    
  helper introduced.                 
  - Two tests pinning the new contract:
  TestLoadConfig_FileNotFound_ReturnsDefau
  ltsWithoutError (the rc10 reproducer)   
  and TestLoadConfig_UnreadableFile_StillE
  rrors (permission-denied path still     
  rejects). Skips the latter under root.
  - End-to-end smoke: x402-verifier     
  --config /tmp/does-not-exist.yaml 
  --listen :18402 --watch=false boots     
  cleanly, logs the friendly message,
  /healthz → 200, /verify → 200 for an    
  unmatched URI. The new HTML 402 path is
  unblocked once the new image rolls.    
                                     
  setMetadata revert decoder (the partial 
  fix)                                    
  - internal/erc8004/revert.go: new
  decodeRevertReason(err) and             
  wrapTransactError(prefix, err). Decodes
  the three Solidity revert shapes the    
  node returns on the JSON-RPC data field:
    - Error(string) (selector 0x08c379a0) 
  → the literal Solidity message.        
    - Panic(uint256) (selector 0x4e487b71)
   → mapped to a human label via          
  panicReason() (overflow, div-by-zero,   
  OOB, etc.).                           
    - Any other 4-byte selector → surfaced
   as custom error 0x<selector> so an     
  operator can grep the contract source.  
  - internal/erc8004/client.go:         
  SetMetadata, SetMetadataWithOpts,       
  SetAgentURI now wrap their Transact     
  error with the decoder. The original
  error chain stays intact for            
  errors.Is/As.                         
  - internal/erc8004/revert_test.go: 4
  unit tests covering Error(string),  
  Panic(uint256), unknown selector, and   
  the no-data fast-paths.              
  - internal/erc8004/client_test.go:      
  extended the mock RPC to attach data on
  JSON-RPC error envelopes via a new      
  rpcMockDataError type. Two new    
  SetMetadata tests assert the decoded    
  reason / selector show up in the wrapped
   CLI error.                             
             
  What this means for the rc10 reproducer:
   next time someone runs obol sell       
  register twice in a row and hits the
  revert, the CLI message will contain    
  either the Solidity revert("…") text or
  custom error 0x<selector> — enough for
  engineering to grep the registry
  contract and identify the actual
  rejection condition (probably
  MetadataAlreadySet or a wallet-policy
  check, per the report). Doesn't fix the
  root cause, but turns the opaque error
  into something diagnosable in one rerun
  rather than a chain-trace expedition.