### PR TITLE
feat(buy): add `obol buy inference` host CLI

### DIFF
--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -20,10 +20,10 @@ import (
 // internal/hermes/hermes.go where the env is wired). We reference the
 // literal paths so we don't depend on shell expansion through `kubectl exec`.
 const (
-	hermesPython     = "/opt/hermes/.venv/bin/python3"
-	hermesBuyPyPath  = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
-	defaultBuyName   = "default-paid"
-	usdcDecimals     = 6
+	hermesPython    = "/opt/hermes/.venv/bin/python3"
+	hermesBuyPyPath = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
+	defaultBuyName  = "default-paid"
+	usdcDecimals    = 6
 )
 
 func buyCommand(cfg *config.Config) *cli.Command {
@@ -44,28 +44,34 @@ func buyInferenceCommand(cfg *config.Config) *cli.Command {
 		Description: `Pre-pays an x402-gated inference seller through the obol-agent's wallet.
 
 Identity is verified before signing: the seller's
-/.well-known/agent-registration.json must list an ERC-8004 agentId that
-matches --expected-agent-id (default: DefaultBuySellerAgentID). Use
+/.well-known/agent-registration.json must advertise the requested service
+endpoint and list an ERC-8004 agentId that matches --expected-agent-id on the
+same priced payment network that the seller advertises in its 402 response. Use
 --no-verify-identity to bypass during development.
 
+Today the baked default seller placeholders are not yet provisioned, so the
+practical path is to pass an explicit --seller, --model, and either
+--expected-agent-id or --no-verify-identity.
+
 Examples:
-  obol buy inference --budget 10                          # zero-arg, full default path
-  obol buy inference my-buy --budget 5 --model qwen3.5:9b
-  obol buy inference --seller https://seller.example/services/x \
-                     --expected-agent-id 42 --budget 1`,
+	obol buy inference my-buy --seller https://seller.example/services/x \
+	                     --model qwen3.5:9b --expected-agent-id 42 --budget 1
+	obol buy inference --seller https://seller.example/services/x \
+	                     --model qwen3.5:9b --no-verify-identity --budget 1`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "seller",
-				Usage: "Seller endpoint (defaults to the Obol-operated default seller)",
+				Usage: fmt.Sprintf("Seller endpoint (defaults to the Obol-operated %s demo seller placeholder)", x402verifier.DefaultBuySellerChain),
 				Value: x402verifier.DefaultBuySellerURL,
 			},
 			&cli.StringFlag{
-				Name:  "model",
-				Usage: "Remote model id to buy (e.g. qwen3.5:9b)",
+				Name:     "model",
+				Usage:    "Remote model id to buy (required until a default seller/model are provisioned, e.g. qwen3.5:9b)",
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "budget",
-				Usage:    "Spending cap in USDC (e.g. \"10\" for 10 USDC). Converted to micro-units before passing to the agent.",
+				Usage:    "Spending cap in USDC (e.g. \"10\" for 10 USDC). Converted to micro-units before passing to the agent; current host-side preflight supports USDC-priced sellers only.",
 				Required: true,
 			},
 			&cli.IntFlag{
@@ -96,7 +102,7 @@ Examples:
 			},
 			&cli.BoolFlag{
 				Name:  "force",
-				Usage: "Pass-through to buy.py: force re-creation of the PurchaseRequest",
+				Usage: "Pass-through to buy.py: replace an existing PurchaseRequest and bypass certain balance/overwrite safety checks",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -120,6 +126,15 @@ Examples:
 				return err
 			}
 
+			u.Infof("Probing seller pricing at %s …", seller)
+			pricing, err := buy.FetchSellerPricing(ctx, seller, cmd.String("model"))
+			if err != nil {
+				return fmt.Errorf("pricing pre-flight: %w", err)
+			}
+			if err := buy.ValidateBudgetAgainstPricing(budgetMicro, pricing); err != nil {
+				return err
+			}
+
 			if !cmd.Bool("no-verify-identity") {
 				expected := cmd.Int("expected-agent-id")
 				if expected == 0 {
@@ -130,7 +145,10 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("identity pre-flight: %w", err)
 				}
-				if err := buy.VerifyAgentID(reg, int64(expected)); err != nil {
+				if err := buy.VerifySellerEndpoint(reg, seller); err != nil {
+					return err
+				}
+				if err := buy.VerifyAgentIDForPricing(reg, int64(expected), pricing); err != nil {
 					return err
 				}
 				u.Infof("Identity OK: agentId=%d", expected)

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
+	"github.com/ObolNetwork/obol-stack/internal/buy"
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/validate"
+	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
+	"github.com/urfave/cli/v3"
+)
+
+// In-pod paths used by `obol buy inference`. Hermes always has python3 in
+// the venv and skills mounted at $OBOL_SKILLS_DIR (see
+// internal/hermes/hermes.go where the env is wired). We reference the
+// literal paths so we don't depend on shell expansion through `kubectl exec`.
+const (
+	hermesPython     = "/opt/hermes/.venv/bin/python3"
+	hermesBuyPyPath  = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
+	defaultBuyName   = "default-paid"
+	usdcDecimals     = 6
+)
+
+func buyCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "buy",
+		Usage: "Buy access to remote services via x402 micropayments",
+		Commands: []*cli.Command{
+			buyInferenceCommand(cfg),
+		},
+	}
+}
+
+func buyInferenceCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:      "inference",
+		Usage:     "Buy paid inference from an x402-gated seller via the obol-agent",
+		ArgsUsage: "[<name>]",
+		Description: `Pre-pays an x402-gated inference seller through the obol-agent's wallet.
+
+Identity is verified before signing: the seller's
+/.well-known/agent-registration.json must list an ERC-8004 agentId that
+matches --expected-agent-id (default: DefaultBuySellerAgentID). Use
+--no-verify-identity to bypass during development.
+
+Examples:
+  obol buy inference --budget 10                          # zero-arg, full default path
+  obol buy inference my-buy --budget 5 --model qwen3.5:9b
+  obol buy inference --seller https://seller.example/services/x \
+                     --expected-agent-id 42 --budget 1`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "seller",
+				Usage: "Seller endpoint (defaults to the Obol-operated default seller)",
+				Value: x402verifier.DefaultBuySellerURL,
+			},
+			&cli.StringFlag{
+				Name:  "model",
+				Usage: "Remote model id to buy (e.g. qwen3.5:9b)",
+			},
+			&cli.StringFlag{
+				Name:     "budget",
+				Usage:    "Spending cap in USDC (e.g. \"10\" for 10 USDC). Converted to micro-units before passing to the agent.",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:  "expected-agent-id",
+				Usage: "Expected ERC-8004 agentId of the seller (default: DefaultBuySellerAgentID)",
+				Value: int(x402verifier.DefaultBuySellerAgentID),
+			},
+			&cli.BoolFlag{
+				Name:  "no-verify-identity",
+				Usage: "Skip the ERC-8004 identity pre-flight (NOT recommended)",
+			},
+			&cli.BoolFlag{
+				Name:  "auto-refill",
+				Usage: "Enable agent-managed refill of the auth pool",
+			},
+			&cli.IntFlag{
+				Name:  "refill-threshold",
+				Usage: "Sign more auths when remaining drops below this (requires --auto-refill)",
+			},
+			&cli.IntFlag{
+				Name:  "refill-count",
+				Usage: "How many auths to sign each refill (requires --auto-refill)",
+			},
+			&cli.StringFlag{
+				Name:  "id",
+				Usage: "Obol agent instance id",
+				Value: agentruntime.DefaultInstanceID,
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Pass-through to buy.py: force re-creation of the PurchaseRequest",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u := getUI(cmd)
+
+			name := cmd.Args().First()
+			if name == "" {
+				name = defaultBuyName
+			}
+			if err := validate.Name(name); err != nil {
+				return err
+			}
+
+			seller := strings.TrimSpace(cmd.String("seller"))
+			if seller == "" {
+				return errors.New("--seller is empty and no DefaultBuySellerURL is configured")
+			}
+
+			budgetMicro, err := usdcToMicroUnits(cmd.String("budget"))
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Bool("no-verify-identity") {
+				expected := cmd.Int("expected-agent-id")
+				if expected == 0 {
+					return errors.New("expected-agent-id is 0 — set --expected-agent-id, configure DefaultBuySellerAgentID, or pass --no-verify-identity to bypass")
+				}
+				u.Infof("Verifying seller identity at %s …", seller)
+				reg, err := buy.FetchSellerRegistration(ctx, seller)
+				if err != nil {
+					return fmt.Errorf("identity pre-flight: %w", err)
+				}
+				if err := buy.VerifyAgentID(reg, int64(expected)); err != nil {
+					return err
+				}
+				u.Infof("Identity OK: agentId=%d", expected)
+			} else {
+				u.Warn("Skipping ERC-8004 identity check (--no-verify-identity).")
+			}
+
+			argv := buildBuyPyArgv(buyPyOptions{
+				Name:            name,
+				Seller:          seller,
+				Model:           cmd.String("model"),
+				BudgetMicro:     budgetMicro,
+				AutoRefill:      cmd.Bool("auto-refill"),
+				RefillThreshold: cmd.Int("refill-threshold"),
+				RefillCount:     cmd.Int("refill-count"),
+				Force:           cmd.Bool("force"),
+			})
+
+			u.Infof("Dispatching to obol-agent (instance=%s) …", cmd.String("id"))
+			return agentruntime.ExecInPod(cfg, agentruntime.Hermes, cmd.String("id"), argv)
+		},
+	}
+}
+
+// buyPyOptions captures everything needed to invoke `buy.py buy` inside the
+// agent pod. Kept as a flat struct so buildBuyPyArgv stays trivially testable.
+type buyPyOptions struct {
+	Name            string
+	Seller          string
+	Model           string
+	BudgetMicro     string
+	AutoRefill      bool
+	RefillThreshold int
+	RefillCount     int
+	Force           bool
+}
+
+// buildBuyPyArgv composes the argv for `python3 buy.py buy <name> ...`.
+func buildBuyPyArgv(opts buyPyOptions) []string {
+	argv := []string{
+		hermesPython, hermesBuyPyPath, "buy", opts.Name,
+		"--endpoint", opts.Seller,
+		"--budget", opts.BudgetMicro,
+	}
+	if m := strings.TrimSpace(opts.Model); m != "" {
+		argv = append(argv, "--model", m)
+	}
+	if opts.AutoRefill {
+		argv = append(argv, "--auto-refill")
+		if opts.RefillThreshold > 0 {
+			argv = append(argv, "--refill-threshold", fmt.Sprintf("%d", opts.RefillThreshold))
+		}
+		if opts.RefillCount > 0 {
+			argv = append(argv, "--refill-count", fmt.Sprintf("%d", opts.RefillCount))
+		}
+	}
+	if opts.Force {
+		argv = append(argv, "--force")
+	}
+	return argv
+}
+
+// usdcToMicroUnits parses a human USDC amount (e.g. "10", "0.5") and returns
+// the equivalent in 6-decimal micro-units as a base-10 integer string. The
+// result is passed verbatim to buy.py's --budget flag.
+//
+// Uses big.Rat so we don't lose precision on fractional amounts. Rejects
+// negatives and any value that isn't an integral number of micro-units
+// (e.g. "0.0000001" — finer than USDC's smallest denomination).
+func usdcToMicroUnits(amount string) (string, error) {
+	s := strings.TrimSpace(amount)
+	if s == "" {
+		return "", errors.New("--budget is empty")
+	}
+	r, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return "", fmt.Errorf("--budget %q is not a valid number", amount)
+	}
+	if r.Sign() <= 0 {
+		return "", fmt.Errorf("--budget %q must be positive", amount)
+	}
+
+	scale := new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(usdcDecimals), nil))
+	micro := new(big.Rat).Mul(r, scale)
+	if !micro.IsInt() {
+		return "", fmt.Errorf("--budget %q has more precision than USDC supports (%d decimals)", amount, usdcDecimals)
+	}
+	return micro.Num().String(), nil
+}

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestUSDCToMicroUnits(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr string
+	}{
+		{in: "1", want: "1000000"},
+		{in: "10", want: "10000000"},
+		{in: "0.001", want: "1000"},
+		{in: "0.000001", want: "1"},
+		{in: "  0.5  ", want: "500000"},
+		{in: "", wantErr: "empty"},
+		{in: "abc", wantErr: "valid number"},
+		{in: "0", wantErr: "positive"},
+		{in: "-1", wantErr: "positive"},
+		{in: "0.0000001", wantErr: "more precision"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := usdcToMicroUnits(tc.in)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("usdcToMicroUnits(%q) err = %v, want substring %q", tc.in, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("usdcToMicroUnits(%q) unexpected err: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("usdcToMicroUnits(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildBuyPyArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		opts buyPyOptions
+		want []string
+	}{
+		{
+			name: "minimal",
+			opts: buyPyOptions{
+				Name:        "default-paid",
+				Seller:      "https://demo.example/services/x",
+				BudgetMicro: "10000000",
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "default-paid",
+				"--endpoint", "https://demo.example/services/x",
+				"--budget", "10000000",
+			},
+		},
+		{
+			name: "all optional flags",
+			opts: buyPyOptions{
+				Name:            "demo",
+				Seller:          "https://s.example",
+				Model:           "qwen3.5:9b",
+				BudgetMicro:     "5000000",
+				AutoRefill:      true,
+				RefillThreshold: 3,
+				RefillCount:     7,
+				Force:           true,
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "5000000",
+				"--model", "qwen3.5:9b",
+				"--auto-refill",
+				"--refill-threshold", "3",
+				"--refill-count", "7",
+				"--force",
+			},
+		},
+		{
+			name: "auto-refill without explicit counts",
+			opts: buyPyOptions{
+				Name:        "demo",
+				Seller:      "https://s.example",
+				BudgetMicro: "1000000",
+				AutoRefill:  true,
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
+				"--auto-refill",
+			},
+		},
+		{
+			name: "auto-refill off does not emit refill flags",
+			opts: buyPyOptions{
+				Name:            "demo",
+				Seller:          "https://s.example",
+				BudgetMicro:     "1000000",
+				AutoRefill:      false,
+				RefillThreshold: 3,
+				RefillCount:     7,
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
+			},
+		},
+		{
+			name: "model whitespace trimmed",
+			opts: buyPyOptions{
+				Name:        "demo",
+				Seller:      "https://s.example",
+				Model:       "  qwen3.5:9b  ",
+				BudgetMicro: "1000000",
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
+				"--model", "qwen3.5:9b",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildBuyPyArgv(tc.opts)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("buildBuyPyArgv() = %#v\n want                  %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -89,6 +89,9 @@ COMMANDS:
      sell pricing     Manage service pricing
      sell register    Register on the ERC-8004 Agent Registry (multi-chain)
 
+   Buy Services (x402):
+     buy inference    Buy paid inference from an x402-gated seller via the obol-agent
+
    App Management:
      app install     Install a Helm chart as an application
      app list        List installed applications
@@ -283,6 +286,7 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 			hermesCommand(cfg),
 			openclawCommand(cfg),
 			sellCommand(cfg),
+			buyCommand(cfg),
 			modelCommand(cfg),
 			{
 				Name:  "app",

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -3,11 +3,13 @@
 #
 # Two independent obol stacks on the same machine. Alice registers her
 # inference service on the ERC-8004 Identity Registry (Base Sepolia).
-# Bob's Hermes agent discovers her by scanning the registry, buys inference
-# tokens via x402, and uses the paid/* sidecar route.
+# Bob's Hermes agent discovers her by scanning the registry. The buy step then
+# validates the host-side `obol buy inference` path by default. A legacy
+# in-agent `buy.py` prompt remains available only via an explicit
+# FLOW11_BUY_MODE=agent-prompt override.
 #
-# This is the most human-like integration test: every interaction with
-# Bob is through natural language prompts to his Hermes agent.
+# This exercises the live dual-stack Alice/Bob path while also covering the
+# host-side buy CLI on the same Base Sepolia flow.
 #
 # Requires:
 #   - .env with REMOTE_SIGNER_PRIVATE_KEY funded with Base Sepolia ETH for Alice
@@ -86,6 +88,18 @@ BOB_AGENT_RUNTIME="hermes"
 FLOW11_BUY_COUNT="${FLOW11_BUY_COUNT:-5}"
 FLOW11_PRICE_MICRO_USDC=1000
 FLOW11_REQUIRED_BOB_USDC=$((FLOW11_BUY_COUNT * FLOW11_PRICE_MICRO_USDC))
+FLOW11_BUY_MODE="${FLOW11_BUY_MODE:-host-cli}"
+FLOW11_BUY_BUDGET_USDC="$(python3 - "$FLOW11_REQUIRED_BOB_USDC" <<'PY'
+import sys
+
+micro = int(sys.argv[1])
+whole, frac = divmod(micro, 1_000_000)
+if frac:
+    print(f"{whole}.{frac:06d}".rstrip("0"))
+else:
+    print(str(whole))
+PY
+)"
 mkdir -p "$FLOW11_ARTIFACT_DIR"
 
 if [ -z "${OBOL_LLM_ENDPOINT:-}" ]; then
@@ -1216,34 +1230,71 @@ echo "${discover_content:0:500}"
 # versions (interim "let me check..." responses sometimes fall under threshold).
 pass "Agent discovery prompt issued (success will be confirmed by buy + PurchaseRequest CR)"
 
-step "Bob's agent: buy inference from Alice"
-buy_response=$(curl -sf --max-time 300 \
-    -X POST "http://localhost:${BOB_AGENT_PORT}/v1/chat/completions" \
-    -H "Authorization: Bearer $BOB_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d "{
-        \"model\": \"$BOB_AGENT_RUNTIME-agent\",
-        \"messages\": [{
-            \"role\": \"user\",
-            \"content\": \"Use the buy-x402 skill and your terminal tool. Run exactly once: ERPC_URL=http://erpc.erpc.svc.cluster.local/rpc ERPC_NETWORK=base-sepolia python3 $BOB_OBOL_SKILLS_DIR/buy-x402/scripts/buy.py buy alice-inference --endpoint $TUNNEL_URL/services/alice-inference/v1/chat/completions --model $OBOL_LLM_MODEL --count $FLOW11_BUY_COUNT\"
-        }],
-        \"max_tokens\": 4000,
-	        \"stream\": false
-	    }" 2>&1 || true)
-
-buy_content=$(extract_assistant_content "$buy_response" 2>/dev/null || true)
-# The agent's textual response is informational only; the purchase is confirmed
-# structurally by the next step's PurchaseRequest CR Ready=True poll. Natural-language
-# matching has been brittle across runtime versions (OpenClaw vs Hermes).
-echo "${buy_content:0:500}"
-if [ -z "$(printf '%s' "$buy_content" | tr -d '[:space:]')" ]; then
-    echo "  ! Agent returned no final assistant text; confirming purchase via PurchaseRequest CR"
-fi
-if printf '%s' "$buy_content" | agent_response_refused; then
-    fail "Agent refused to run buy.py: ${buy_content:0:500}"
+step "Bob: buy inference from Alice"
+buy_mode="$FLOW11_BUY_MODE"
+case "$buy_mode" in
+    host-cli|agent-prompt) ;;
+    *)
+        fail "Unsupported FLOW11_BUY_MODE=$buy_mode (expected host-cli or agent-prompt)"
+        cleanup_pid "$PF_AGENT"
+        rm -f "$PF_AGENT_LOG"
+        emit_metrics; exit 1
+        ;;
+esac
+if [ "$buy_mode" = "host-cli" ] && [ "$BOB_AGENT_RUNTIME" != "hermes" ]; then
+    fail "FLOW11_BUY_MODE=host-cli requires the Hermes runtime, got runtime=$BOB_AGENT_RUNTIME. Re-run with FLOW11_BUY_MODE=agent-prompt only if you intentionally want legacy coverage."
+    cleanup_pid "$PF_AGENT"
+    rm -f "$PF_AGENT_LOG"
     emit_metrics; exit 1
 fi
-pass "Agent buy prompt issued (success will be confirmed by PurchaseRequest CR)"
+
+if [ "$buy_mode" = "host-cli" ]; then
+    if buy_output=$(bob buy inference alice-inference \
+        --seller "$TUNNEL_URL/services/alice-inference/v1/chat/completions" \
+        --model "$OBOL_LLM_MODEL" \
+        --budget "$FLOW11_BUY_BUDGET_USDC" \
+        --expected-agent-id "$AGENT_ID" 2>&1); then
+        buy_ec=0
+    else
+        buy_ec=$?
+    fi
+    echo "${buy_output:0:500}"
+    if [ "$buy_ec" -ne 0 ]; then
+        fail "Host buy CLI failed — ${buy_output:0:500}"
+        cleanup_pid "$PF_AGENT"
+        rm -f "$PF_AGENT_LOG"
+        emit_metrics; exit 1
+    fi
+    pass "Host buy CLI succeeded (PurchaseRequest CR will confirm auth provisioning)"
+else
+    buy_response=$(curl -sf --max-time 300 \
+        -X POST "http://localhost:${BOB_AGENT_PORT}/v1/chat/completions" \
+        -H "Authorization: Bearer $BOB_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"$BOB_AGENT_RUNTIME-agent\",
+            \"messages\": [{
+                \"role\": \"user\",
+                \"content\": \"Use the buy-x402 skill and your terminal tool. Run exactly once: ERPC_URL=http://erpc.erpc.svc.cluster.local/rpc ERPC_NETWORK=base-sepolia python3 $BOB_OBOL_SKILLS_DIR/buy-x402/scripts/buy.py buy alice-inference --endpoint $TUNNEL_URL/services/alice-inference/v1/chat/completions --model $OBOL_LLM_MODEL --count $FLOW11_BUY_COUNT\"
+            }],
+            \"max_tokens\": 4000,
+	            \"stream\": false
+	        }" 2>&1 || true)
+
+    buy_content=$(extract_assistant_content "$buy_response" 2>/dev/null || true)
+    # The agent's textual response is informational only; the purchase is confirmed
+    # structurally by the next step's PurchaseRequest CR Ready=True poll. Natural-language
+    # matching has been brittle across runtime versions (OpenClaw vs Hermes).
+    echo "${buy_content:0:500}"
+    if [ -z "$(printf '%s' "$buy_content" | tr -d '[:space:]')" ]; then
+        echo "  ! Agent returned no final assistant text; confirming purchase via PurchaseRequest CR"
+    fi
+    if printf '%s' "$buy_content" | agent_response_refused; then
+        fail "Agent refused to run buy.py: ${buy_content:0:500}"
+        emit_metrics; exit 1
+    fi
+    pass "Agent buy prompt issued (success will be confirmed by PurchaseRequest CR)"
+fi
 
 poll_step_grep "Bob: PurchaseRequest Ready" "True" 24 5 purchase_request_status
 pr_status=$(purchase_request_status)

--- a/internal/agentruntime/exec.go
+++ b/internal/agentruntime/exec.go
@@ -1,0 +1,74 @@
+package agentruntime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// BuildExecArgs returns the kubectl argv for `kubectl exec` into the agent
+// pod identified by (runtime, id), running argv inside it. Pure / testable —
+// no side effects. argv is the full in-pod command vector; argv[0] is the
+// binary (e.g. "python3" or a runtime CLI path), argv[1:] its args.
+//
+// withTTY toggles the `-t` flag; callers usually pass stdinIsTerminal().
+func BuildExecArgs(runtime Runtime, id string, argv []string, withTTY bool) []string {
+	svc := Describe(runtime).ServiceName
+	out := []string{"exec", "-i"}
+	if withTTY {
+		out = append(out, "-t")
+	}
+	out = append(out,
+		"-c", svc,
+		"-n", Namespace(runtime, id),
+		"deploy/"+svc,
+		"--",
+	)
+	return append(out, argv...)
+}
+
+// ExecInPod runs argv inside the agent pod identified by (runtime, id) using
+// the bundled kubectl binary. Stdin/stdout/stderr are wired to the host TTY.
+//
+// On non-zero exit from the in-pod command, ExecInPod calls os.Exit with the
+// same status to preserve exit codes for shell scripting. A nil return means
+// the command exited 0.
+func ExecInPod(cfg *config.Config, runtime Runtime, id string, argv []string) error {
+	if len(argv) == 0 {
+		return errors.New("ExecInPod: argv is empty")
+	}
+
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return errors.New("cluster not running. Run 'obol stack up' first")
+	}
+
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+
+	cmd := exec.Command(kubectlBinary, BuildExecArgs(runtime, id, argv, stdinIsTerminal())...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(status.ExitStatus())
+			}
+		}
+		return fmt.Errorf("kubectl exec into %s/%s: %w", Namespace(runtime, id), Describe(runtime).ServiceName, err)
+	}
+	return nil
+}
+
+func stdinIsTerminal() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/agentruntime/exec_test.go
+++ b/internal/agentruntime/exec_test.go
@@ -1,0 +1,100 @@
+package agentruntime
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+func TestBuildExecArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime Runtime
+		id      string
+		argv    []string
+		withTTY bool
+		want    []string
+	}{
+		{
+			name:    "hermes default instance, no TTY",
+			runtime: Hermes,
+			id:      DefaultInstanceID,
+			argv:    []string{"/opt/hermes/.venv/bin/hermes", "skills", "audit"},
+			withTTY: false,
+			want: []string{
+				"exec", "-i",
+				"-c", "hermes",
+				"-n", "hermes-obol-agent",
+				"deploy/hermes",
+				"--",
+				"/opt/hermes/.venv/bin/hermes", "skills", "audit",
+			},
+		},
+		{
+			name:    "hermes default instance, with TTY",
+			runtime: Hermes,
+			id:      DefaultInstanceID,
+			argv:    []string{"/opt/hermes/.venv/bin/python3", "/data/.hermes/obol-skills/buy-x402/scripts/buy.py", "buy", "demo", "--budget", "1000000"},
+			withTTY: true,
+			want: []string{
+				"exec", "-i", "-t",
+				"-c", "hermes",
+				"-n", "hermes-obol-agent",
+				"deploy/hermes",
+				"--",
+				"/opt/hermes/.venv/bin/python3",
+				"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
+				"buy", "demo",
+				"--budget", "1000000",
+			},
+		},
+		{
+			name:    "openclaw alternate runtime, no TTY",
+			runtime: OpenClaw,
+			id:      "research",
+			argv:    []string{"node", "openclaw.mjs", "skills", "list"},
+			withTTY: false,
+			want: []string{
+				"exec", "-i",
+				"-c", "openclaw",
+				"-n", "openclaw-research",
+				"deploy/openclaw",
+				"--",
+				"node", "openclaw.mjs", "skills", "list",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildExecArgs(tc.runtime, tc.id, tc.argv, tc.withTTY)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("BuildExecArgs() = %#v\n want                 %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecInPod_EmptyArgvRejected(t *testing.T) {
+	cfg := &config.Config{ConfigDir: t.TempDir(), BinDir: t.TempDir()}
+	err := ExecInPod(cfg, Hermes, DefaultInstanceID, nil)
+	if err == nil || err.Error() != "ExecInPod: argv is empty" {
+		t.Fatalf("ExecInPod(nil argv) err = %v, want \"ExecInPod: argv is empty\"", err)
+	}
+}
+
+func TestExecInPod_ClusterDownErrorMessage(t *testing.T) {
+	// Empty ConfigDir means kubeconfig.yaml does not exist → human-readable error,
+	// not a kubectl crash. Lets `obol buy inference` produce a usable message
+	// when the cluster isn't running.
+	cfg := &config.Config{ConfigDir: t.TempDir(), BinDir: t.TempDir()}
+	err := ExecInPod(cfg, Hermes, DefaultInstanceID, []string{"true"})
+	if err == nil {
+		t.Fatal("expected error when kubeconfig missing, got nil")
+	}
+	if got := err.Error(); got != "cluster not running. Run 'obol stack up' first" {
+		t.Fatalf("err = %q, want cluster-down message", got)
+	}
+}

--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -1,0 +1,114 @@
+// Package buy contains host-side helpers for `obol buy` commands.
+//
+// Today this is just the ERC-8004 identity pre-flight that
+// `obol buy inference` runs before signing any payment authorizations.
+// Signing, PurchaseRequest creation, facilitator interaction, and refill
+// bookkeeping all live inside the agent pod's buy.py — see
+// internal/embed/skills/buy-x402/scripts/buy.py.
+package buy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+)
+
+// wellKnownPath is the canonical ERC-8004 registration document path.
+const wellKnownPath = "/.well-known/agent-registration.json"
+
+// registrationFetchTimeout caps the .well-known GET. The pre-flight should
+// not block a buy for more than a few seconds; on timeout the user can
+// re-run with --no-verify-identity.
+const registrationFetchTimeout = 5 * time.Second
+
+// FetchSellerRegistration fetches and parses the seller's ERC-8004
+// registration document. sellerURL may be either the seller's base URL
+// (e.g. "https://demo-seller.obol.tech") or a service URL (e.g.
+// ".../services/foo"); the path component is replaced with the
+// well-known path so callers can pass either shape.
+func FetchSellerRegistration(ctx context.Context, sellerURL string) (*erc8004.AgentRegistration, error) {
+	wellKnown, err := wellKnownURL(sellerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, registrationFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build registration request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", wellKnown, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: HTTP %d", wellKnown, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read registration body: %w", err)
+	}
+
+	var reg erc8004.AgentRegistration
+	if err := json.Unmarshal(body, &reg); err != nil {
+		return nil, fmt.Errorf("parse registration JSON: %w", err)
+	}
+	return &reg, nil
+}
+
+// VerifyAgentID returns nil iff at least one of reg.Registrations matches
+// the expected ERC-8004 tokenId. The seller may publish multiple
+// registrations (one per chain); a match on any of them is sufficient.
+func VerifyAgentID(reg *erc8004.AgentRegistration, expected int64) error {
+	if reg == nil {
+		return errors.New("nil registration")
+	}
+	if expected == 0 {
+		return errors.New("expected agentId is 0; default seller is not yet provisioned — pass --seller and --no-verify-identity to bypass, or set DefaultBuySellerAgentID")
+	}
+	if len(reg.Registrations) == 0 {
+		return errors.New("registration document has no on-chain registrations")
+	}
+	for _, r := range reg.Registrations {
+		if r.AgentID == expected {
+			return nil
+		}
+	}
+
+	got := make([]string, 0, len(reg.Registrations))
+	for _, r := range reg.Registrations {
+		got = append(got, fmt.Sprintf("%d@%s", r.AgentID, r.AgentRegistry))
+	}
+	return fmt.Errorf("seller agentId mismatch: expected %d, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, strings.Join(got, ", "))
+}
+
+// wellKnownURL replaces the path of sellerURL with the .well-known path,
+// preserving scheme and host. Any query string is dropped.
+func wellKnownURL(sellerURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(sellerURL))
+	if err != nil {
+		return "", fmt.Errorf("parse seller URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("seller URL must include scheme and host: %q", sellerURL)
+	}
+	u.Path = wellKnownPath
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}

--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -1,33 +1,69 @@
 // Package buy contains host-side helpers for `obol buy` commands.
 //
-// Today this is just the ERC-8004 identity pre-flight that
-// `obol buy inference` runs before signing any payment authorizations.
+// Today this is primarily pre-flight logic for `obol buy inference`:
+//   - probe the seller's 402 pricing response
+//   - verify the seller's ERC-8004 registration document against the priced chain
+//   - reject budgets that would exceed the advertised one-request price floor
+//
 // Signing, PurchaseRequest creation, facilitator interaction, and refill
 // bookkeeping all live inside the agent pod's buy.py — see
 // internal/embed/skills/buy-x402/scripts/buy.py.
 package buy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+	internalx402 "github.com/ObolNetwork/obol-stack/internal/x402"
 )
 
-// wellKnownPath is the canonical ERC-8004 registration document path.
-const wellKnownPath = "/.well-known/agent-registration.json"
+const (
+	// wellKnownPath is the canonical ERC-8004 registration document path.
+	wellKnownPath = "/.well-known/agent-registration.json"
 
-// registrationFetchTimeout caps the .well-known GET. The pre-flight should
-// not block a buy for more than a few seconds; on timeout the user can
-// re-run with --no-verify-identity.
-const registrationFetchTimeout = 5 * time.Second
+	// registrationFetchTimeout caps the .well-known GET. The pre-flight should
+	// not block a buy for more than a few seconds; on timeout the user can
+	// re-run with --no-verify-identity.
+	registrationFetchTimeout = 5 * time.Second
+
+	// pricingProbeTimeout caps the host-side 402 probe. buy.py will probe again
+	// in-pod, but the host pre-flight should fail fast when the seller URL is
+	// free, malformed, or otherwise not x402-gated.
+	pricingProbeTimeout = 15 * time.Second
+)
+
+// PricingResponse is the subset of the seller's x402 402 body that the host
+// pre-flight needs before dispatching into buy.py.
+type PricingResponse struct {
+	X402Version int             `json:"x402Version"`
+	Accepts     []PaymentOption `json:"accepts"`
+}
+
+// PaymentOption is one entry from the seller's x402 accepts array.
+type PaymentOption struct {
+	PayTo             string `json:"payTo"`
+	Network           string `json:"network"`
+	Asset             string `json:"asset"`
+	Amount            string `json:"amount"`
+	MaxAmountRequired string `json:"maxAmountRequired"`
+}
+
+func (p PaymentOption) requiredAmount() string {
+	if strings.TrimSpace(p.Amount) != "" {
+		return strings.TrimSpace(p.Amount)
+	}
+	return strings.TrimSpace(p.MaxAmountRequired)
+}
 
 // FetchSellerRegistration fetches and parses the seller's ERC-8004
 // registration document. sellerURL may be either the seller's base URL
@@ -71,10 +107,168 @@ func FetchSellerRegistration(ctx context.Context, sellerURL string) (*erc8004.Ag
 	return &reg, nil
 }
 
-// VerifyAgentID returns nil iff at least one of reg.Registrations matches
-// the expected ERC-8004 tokenId. The seller may publish multiple
-// registrations (one per chain); a match on any of them is sufficient.
+// FetchSellerPricing probes the seller's chat-completions endpoint and returns
+// the parsed x402 402 body. sellerURL may be either the service root
+// (`.../services/foo`) or the final chat-completions URL.
+func FetchSellerPricing(ctx context.Context, sellerURL, model string) (*PricingResponse, error) {
+	pricingURL, err := pricingURL(sellerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"model": strings.TrimSpace(model),
+		"messages": []map[string]string{{
+			"role":    "user",
+			"content": "ping",
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal pricing probe: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, pricingProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pricingURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build pricing probe: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("probe %s: %w", pricingURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read pricing body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		preview := strings.TrimSpace(string(body))
+		if preview == "" {
+			return nil, fmt.Errorf("probe %s: expected HTTP 402, got HTTP %d", pricingURL, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("probe %s: expected HTTP 402, got HTTP %d: %s", pricingURL, resp.StatusCode, preview)
+	}
+
+	var pricing PricingResponse
+	if err := json.Unmarshal(body, &pricing); err != nil {
+		return nil, fmt.Errorf("parse pricing JSON: %w", err)
+	}
+	if _, err := firstPaymentOption(&pricing); err != nil {
+		return nil, err
+	}
+	return &pricing, nil
+}
+
+// VerifyAgentID returns nil iff at least one of reg.Registrations matches the
+// expected ERC-8004 tokenId. The seller may publish multiple registrations
+// (one per chain); a match on any of them is sufficient.
 func VerifyAgentID(reg *erc8004.AgentRegistration, expected int64) error {
+	return verifyAgentID(reg, expected, "")
+}
+
+// VerifyAgentIDOnRegistry requires the expected agentId to appear on the
+// specific CAIP-10 registry identifier resolved from the seller's priced
+// payment network.
+func VerifyAgentIDOnRegistry(reg *erc8004.AgentRegistration, expected int64, expectedRegistry string) error {
+	return verifyAgentID(reg, expected, expectedRegistry)
+}
+
+// VerifyAgentIDForPricing pins the ERC-8004 identity check to the seller's
+// priced network so a matching tokenId on an unrelated registry does not pass.
+func VerifyAgentIDForPricing(reg *erc8004.AgentRegistration, expected int64, pricing *PricingResponse) error {
+	payment, err := firstPaymentOption(pricing)
+	if err != nil {
+		return err
+	}
+	registry, err := registryForPaymentNetwork(payment.Network)
+	if err != nil {
+		return fmt.Errorf("resolve agent registry for payment network %q: %w", payment.Network, err)
+	}
+	return VerifyAgentIDOnRegistry(reg, expected, registry)
+}
+
+// VerifySellerEndpoint ensures the requested seller URL is one of the service
+// endpoints advertised in the seller's ERC-8004 registration document.
+func VerifySellerEndpoint(reg *erc8004.AgentRegistration, sellerURL string) error {
+	if reg == nil {
+		return errors.New("nil registration")
+	}
+	want, err := normalizedEndpointIdentity(sellerURL)
+	if err != nil {
+		return err
+	}
+
+	advertised := make([]string, 0, len(reg.Services))
+	for _, svc := range reg.Services {
+		endpoint := strings.TrimSpace(svc.Endpoint)
+		if endpoint == "" {
+			continue
+		}
+		advertised = append(advertised, endpoint)
+		have, err := normalizedEndpointIdentity(endpoint)
+		if err != nil {
+			continue
+		}
+		if have == want {
+			return nil
+		}
+	}
+
+	if len(advertised) == 0 {
+		return errors.New("registration document has no service endpoints")
+	}
+	return fmt.Errorf("seller endpoint mismatch: requested %s, registration advertises [%s]", want, strings.Join(advertised, ", "))
+}
+
+// ValidateBudgetAgainstPricing rejects budgets smaller than one request price.
+// buy.py currently rounds `budget // price` up to at least one auth; the host
+// CLI advertises --budget as a spending cap, so we fail early instead of
+// silently overspending the requested cap.
+func ValidateBudgetAgainstPricing(budgetMicro string, pricing *PricingResponse) error {
+	payment, err := firstPaymentOption(pricing)
+	if err != nil {
+		return err
+	}
+
+	networkName, err := canonicalPaymentNetworkName(payment.Network)
+	if err != nil {
+		return fmt.Errorf("resolve payment network %q: %w", payment.Network, err)
+	}
+	canonicalUSDC, ok := internalx402.ResolveToken("USDC", networkName)
+	if !ok {
+		return fmt.Errorf("host-side --budget currently supports only USDC-priced sellers; no canonical USDC metadata is configured for %s", payment.Network)
+	}
+	if asset := strings.TrimSpace(payment.Asset); asset != "" && !strings.EqualFold(asset, canonicalUSDC.Address) {
+		return fmt.Errorf("host-side --budget currently supports only USDC-priced sellers; seller requires asset %s on %s", asset, payment.Network)
+	}
+
+	budget, ok := new(big.Int).SetString(strings.TrimSpace(budgetMicro), 10)
+	if !ok || budget.Sign() <= 0 {
+		return fmt.Errorf("invalid budget micro-units %q", budgetMicro)
+	}
+
+	priceRaw := payment.requiredAmount()
+	if priceRaw == "" {
+		return errors.New("pricing response missing amount/maxAmountRequired")
+	}
+	price, ok := new(big.Int).SetString(priceRaw, 10)
+	if !ok || price.Sign() <= 0 {
+		return fmt.Errorf("pricing response has invalid amount %q", priceRaw)
+	}
+	if budget.Cmp(price) < 0 {
+		return fmt.Errorf("--budget %s is smaller than one request price %s on %s; raise the budget or buy.py will round up to one auth and exceed the requested cap", budget.String(), price.String(), payment.Network)
+	}
+	return nil
+}
+
+func verifyAgentID(reg *erc8004.AgentRegistration, expected int64, expectedRegistry string) error {
 	if reg == nil {
 		return errors.New("nil registration")
 	}
@@ -85,7 +279,10 @@ func VerifyAgentID(reg *erc8004.AgentRegistration, expected int64) error {
 		return errors.New("registration document has no on-chain registrations")
 	}
 	for _, r := range reg.Registrations {
-		if r.AgentID == expected {
+		if r.AgentID != expected {
+			continue
+		}
+		if expectedRegistry == "" || strings.EqualFold(strings.TrimSpace(r.AgentRegistry), strings.TrimSpace(expectedRegistry)) {
 			return nil
 		}
 	}
@@ -94,7 +291,60 @@ func VerifyAgentID(reg *erc8004.AgentRegistration, expected int64) error {
 	for _, r := range reg.Registrations {
 		got = append(got, fmt.Sprintf("%d@%s", r.AgentID, r.AgentRegistry))
 	}
-	return fmt.Errorf("seller agentId mismatch: expected %d, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, strings.Join(got, ", "))
+	if expectedRegistry == "" {
+		return fmt.Errorf("seller agentId mismatch: expected %d, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, strings.Join(got, ", "))
+	}
+	return fmt.Errorf("seller registration mismatch: expected agentId %d on %s, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, expectedRegistry, strings.Join(got, ", "))
+}
+
+func firstPaymentOption(pricing *PricingResponse) (*PaymentOption, error) {
+	if pricing == nil {
+		return nil, errors.New("nil pricing response")
+	}
+	if len(pricing.Accepts) == 0 {
+		return nil, errors.New("pricing response has no payment options")
+	}
+	return &pricing.Accepts[0], nil
+}
+
+func registryForPaymentNetwork(network string) (string, error) {
+	networkName, err := canonicalPaymentNetworkName(network)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := erc8004.ResolveNetwork(networkName)
+	if err != nil {
+		return "", err
+	}
+	return cfg.CAIP10Registry(), nil
+}
+
+func canonicalPaymentNetworkName(network string) (string, error) {
+	net := strings.TrimSpace(network)
+	if net == "" {
+		return "", errors.New("empty payment network")
+	}
+	if strings.HasPrefix(net, "eip155:") {
+		parts := strings.Split(net, ":")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("unsupported CAIP-2 payment network %q", network)
+		}
+		switch parts[1] {
+		case "1":
+			return erc8004.Ethereum.Name, nil
+		case "8453":
+			return erc8004.Base.Name, nil
+		case "84532":
+			return erc8004.BaseSepolia.Name, nil
+		default:
+			return "", fmt.Errorf("unsupported EIP-155 chain id %q", parts[1])
+		}
+	}
+	cfg, err := erc8004.ResolveNetwork(net)
+	if err != nil {
+		return "", err
+	}
+	return cfg.Name, nil
 }
 
 // wellKnownURL replaces the path of sellerURL with the .well-known path,
@@ -108,6 +358,47 @@ func wellKnownURL(sellerURL string) (string, error) {
 		return "", fmt.Errorf("seller URL must include scheme and host: %q", sellerURL)
 	}
 	u.Path = wellKnownPath
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func pricingURL(sellerURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(sellerURL))
+	if err != nil {
+		return "", fmt.Errorf("parse seller URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("seller URL must include scheme and host: %q", sellerURL)
+	}
+	path := strings.TrimRight(u.Path, "/")
+	for _, suffix := range []string{"/v1/chat/completions", "/chat/completions"} {
+		if strings.HasSuffix(path, suffix) {
+			path = strings.TrimSuffix(path, suffix)
+			break
+		}
+	}
+	if path == "" {
+		u.Path = "/v1/chat/completions"
+	} else {
+		u.Path = path + "/v1/chat/completions"
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func normalizedEndpointIdentity(raw string) (string, error) {
+	normalized, err := pricingURL(raw)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String(), nil

--- a/internal/buy/discover_test.go
+++ b/internal/buy/discover_test.go
@@ -1,0 +1,151 @@
+package buy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+)
+
+func TestWellKnownURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"base URL", "https://demo.example", "https://demo.example/.well-known/agent-registration.json"},
+		{"service path stripped", "https://demo.example/services/foo", "https://demo.example/.well-known/agent-registration.json"},
+		{"trailing slash", "https://demo.example/", "https://demo.example/.well-known/agent-registration.json"},
+		{"query dropped", "https://demo.example/services/foo?x=1", "https://demo.example/.well-known/agent-registration.json"},
+		{"trim spaces", "  https://demo.example  ", "https://demo.example/.well-known/agent-registration.json"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := wellKnownURL(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("wellKnownURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWellKnownURL_Invalid(t *testing.T) {
+	tests := []string{"", "not-a-url", "/relative/only"}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			if _, err := wellKnownURL(in); err == nil {
+				t.Fatalf("wellKnownURL(%q) returned nil err, want error", in)
+			}
+		})
+	}
+}
+
+func TestVerifyAgentID(t *testing.T) {
+	multi := &erc8004.AgentRegistration{
+		Registrations: []erc8004.OnChainReg{
+			{AgentID: 41, AgentRegistry: "eip155:1:0xabc"},
+			{AgentID: 42, AgentRegistry: "eip155:84532:0xdef"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		reg         *erc8004.AgentRegistration
+		expected    int64
+		wantErrSubs string
+	}{
+		{name: "match first", reg: multi, expected: 41},
+		{name: "match second", reg: multi, expected: 42},
+		{name: "mismatch", reg: multi, expected: 99, wantErrSubs: "expected 99"},
+		{name: "empty registrations", reg: &erc8004.AgentRegistration{}, expected: 42, wantErrSubs: "no on-chain registrations"},
+		{name: "expected zero", reg: multi, expected: 0, wantErrSubs: "expected agentId is 0"},
+		{name: "nil registration", reg: nil, expected: 42, wantErrSubs: "nil registration"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := VerifyAgentID(tc.reg, tc.expected)
+			if tc.wantErrSubs == "" {
+				if err != nil {
+					t.Fatalf("VerifyAgentID() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrSubs) {
+				t.Fatalf("VerifyAgentID() err = %v, want substring %q", err, tc.wantErrSubs)
+			}
+		})
+	}
+}
+
+func TestFetchSellerRegistration_Success(t *testing.T) {
+	body := `{
+		"type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+		"name": "demo",
+		"description": "demo seller",
+		"image": "https://demo.example/logo.png",
+		"services": [{"name": "OASF"}],
+		"x402Support": true,
+		"active": true,
+		"registrations": [{"agentId": 42, "agentRegistry": "eip155:84532:0xabc"}]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wellKnownPath {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	reg, err := FetchSellerRegistration(context.Background(), srv.URL+"/services/foo")
+	if err != nil {
+		t.Fatalf("FetchSellerRegistration: %v", err)
+	}
+	if got := reg.Registrations[0].AgentID; got != 42 {
+		t.Fatalf("agentId = %d, want 42", got)
+	}
+}
+
+func TestFetchSellerRegistration_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := FetchSellerRegistration(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("FetchSellerRegistration(404) err = %v, want 404 error", err)
+	}
+}
+
+func TestFetchSellerRegistration_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := FetchSellerRegistration(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "parse registration JSON") {
+		t.Fatalf("FetchSellerRegistration(bad json) err = %v, want parse error", err)
+	}
+}
+
+func TestFetchSellerRegistration_InvalidURL(t *testing.T) {
+	_, err := FetchSellerRegistration(context.Background(), "not-a-url")
+	if err == nil || !strings.Contains(err.Error(), "scheme and host") {
+		t.Fatalf("FetchSellerRegistration(invalid url) err = %v, want scheme/host error", err)
+	}
+}

--- a/internal/buy/discover_test.go
+++ b/internal/buy/discover_test.go
@@ -48,6 +48,37 @@ func TestWellKnownURL_Invalid(t *testing.T) {
 	}
 }
 
+func TestPricingURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"service root", "https://demo.example/services/foo", "https://demo.example/services/foo/v1/chat/completions"},
+		{"already full path", "https://demo.example/services/foo/v1/chat/completions", "https://demo.example/services/foo/v1/chat/completions"},
+		{"chat path normalized to v1", "https://demo.example/services/foo/chat/completions", "https://demo.example/services/foo/v1/chat/completions"},
+		{"host root", "https://demo.example", "https://demo.example/v1/chat/completions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := pricingURL(tc.in)
+			if err != nil {
+				t.Fatalf("pricingURL(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("pricingURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPricingURL_Invalid(t *testing.T) {
+	if _, err := pricingURL("not-a-url"); err == nil {
+		t.Fatal("pricingURL(invalid) returned nil err, want error")
+	}
+}
+
 func TestVerifyAgentID(t *testing.T) {
 	multi := &erc8004.AgentRegistration{
 		Registrations: []erc8004.OnChainReg{
@@ -84,6 +115,75 @@ func TestVerifyAgentID(t *testing.T) {
 				t.Fatalf("VerifyAgentID() err = %v, want substring %q", err, tc.wantErrSubs)
 			}
 		})
+	}
+}
+
+func TestVerifyAgentIDOnRegistry(t *testing.T) {
+	reg := &erc8004.AgentRegistration{
+		Registrations: []erc8004.OnChainReg{
+			{AgentID: 42, AgentRegistry: erc8004.Base.CAIP10Registry()},
+			{AgentID: 42, AgentRegistry: erc8004.BaseSepolia.CAIP10Registry()},
+		},
+	}
+
+	if err := VerifyAgentIDOnRegistry(reg, 42, erc8004.BaseSepolia.CAIP10Registry()); err != nil {
+		t.Fatalf("VerifyAgentIDOnRegistry(match) = %v, want nil", err)
+	}
+	if err := VerifyAgentIDOnRegistry(reg, 42, erc8004.Ethereum.CAIP10Registry()); err == nil || !strings.Contains(err.Error(), erc8004.Ethereum.CAIP10Registry()) {
+		t.Fatalf("VerifyAgentIDOnRegistry(mismatch) err = %v, want registry mismatch", err)
+	}
+}
+
+func TestVerifyAgentIDForPricing(t *testing.T) {
+	reg := &erc8004.AgentRegistration{
+		Registrations: []erc8004.OnChainReg{{AgentID: 42, AgentRegistry: erc8004.BaseSepolia.CAIP10Registry()}},
+	}
+	pricing := &PricingResponse{Accepts: []PaymentOption{{Network: "base-sepolia", Amount: "1000"}}}
+	if err := VerifyAgentIDForPricing(reg, 42, pricing); err != nil {
+		t.Fatalf("VerifyAgentIDForPricing(match) = %v, want nil", err)
+	}
+	pricing.Accepts[0].Network = "base"
+	if err := VerifyAgentIDForPricing(reg, 42, pricing); err == nil || !strings.Contains(err.Error(), erc8004.Base.CAIP10Registry()) {
+		t.Fatalf("VerifyAgentIDForPricing(mismatch) err = %v, want base registry mismatch", err)
+	}
+}
+
+func TestVerifySellerEndpoint(t *testing.T) {
+	reg := &erc8004.AgentRegistration{
+		Services: []erc8004.ServiceDef{
+			{Name: "inference", Endpoint: "https://seller.example/services/alice-inference"},
+			{Name: "OASF"},
+		},
+	}
+	if err := VerifySellerEndpoint(reg, "https://seller.example/services/alice-inference/v1/chat/completions"); err != nil {
+		t.Fatalf("VerifySellerEndpoint(match) = %v, want nil", err)
+	}
+	if err := VerifySellerEndpoint(reg, "https://seller.example/services/other/v1/chat/completions"); err == nil || !strings.Contains(err.Error(), "seller endpoint mismatch") {
+		t.Fatalf("VerifySellerEndpoint(mismatch) err = %v, want endpoint mismatch", err)
+	}
+}
+
+func TestValidateBudgetAgainstPricing(t *testing.T) {
+	pricing := &PricingResponse{Accepts: []PaymentOption{{Network: "base-sepolia", Amount: "1000"}}}
+	if err := ValidateBudgetAgainstPricing("1000", pricing); err != nil {
+		t.Fatalf("ValidateBudgetAgainstPricing(equal) = %v, want nil", err)
+	}
+	if err := ValidateBudgetAgainstPricing("2500", pricing); err != nil {
+		t.Fatalf("ValidateBudgetAgainstPricing(greater) = %v, want nil", err)
+	}
+	if err := ValidateBudgetAgainstPricing("999", pricing); err == nil || !strings.Contains(err.Error(), "smaller than one request price 1000") {
+		t.Fatalf("ValidateBudgetAgainstPricing(too small) err = %v, want floor error", err)
+	}
+}
+
+func TestValidateBudgetAgainstPricing_NonUSDCPricingRejected(t *testing.T) {
+	pricing := &PricingResponse{Accepts: []PaymentOption{{
+		Network: "base-sepolia",
+		Asset:   "0x0a09371a8b011d5110656ceBCc70603e53FD2c78",
+		Amount:  "1000000000000000000",
+	}}}
+	if err := ValidateBudgetAgainstPricing("2000000", pricing); err == nil || !strings.Contains(err.Error(), "currently supports only USDC-priced sellers") {
+		t.Fatalf("ValidateBudgetAgainstPricing(non-usdc) err = %v, want explicit non-USDC rejection", err)
 	}
 }
 
@@ -147,5 +247,55 @@ func TestFetchSellerRegistration_InvalidURL(t *testing.T) {
 	_, err := FetchSellerRegistration(context.Background(), "not-a-url")
 	if err == nil || !strings.Contains(err.Error(), "scheme and host") {
 		t.Fatalf("FetchSellerRegistration(invalid url) err = %v, want scheme/host error", err)
+	}
+}
+
+func TestFetchSellerPricing_Success(t *testing.T) {
+	const wantPath = "/services/demo/v1/chat/completions"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Fatalf("path = %s, want %s", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"x402Version":2,"accepts":[{"payTo":"0xabc","network":"base-sepolia","amount":"1000"}]}`))
+	}))
+	defer srv.Close()
+
+	pricing, err := FetchSellerPricing(context.Background(), srv.URL+"/services/demo", "gemma4-fast")
+	if err != nil {
+		t.Fatalf("FetchSellerPricing: %v", err)
+	}
+	if got := pricing.Accepts[0].Network; got != "base-sepolia" {
+		t.Fatalf("network = %q, want base-sepolia", got)
+	}
+}
+
+func TestFetchSellerPricing_Non402(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	_, err := FetchSellerPricing(context.Background(), srv.URL+"/services/demo", "gemma4-fast")
+	if err == nil || !strings.Contains(err.Error(), "expected HTTP 402") {
+		t.Fatalf("FetchSellerPricing(non402) err = %v, want 402 error", err)
+	}
+}
+
+func TestFetchSellerPricing_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{oops`))
+	}))
+	defer srv.Close()
+
+	_, err := FetchSellerPricing(context.Background(), srv.URL+"/services/demo", "gemma4-fast")
+	if err == nil || !strings.Contains(err.Error(), "parse pricing JSON") {
+		t.Fatalf("FetchSellerPricing(bad json) err = %v, want parse error", err)
 	}
 }

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
 	"github.com/ObolNetwork/obol-stack/internal/config"
@@ -574,50 +573,21 @@ func containsID(ids []string, id string) bool {
 }
 
 func cliViaKubectlExec(cfg *config.Config, id string, args []string) error {
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return errors.New("cluster not running. Run 'obol stack up' first")
-	}
-
-	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
-	namespace := agentruntime.Namespace(agentruntime.Hermes, id)
-	cmd := exec.Command(kubectlBinary, hermesExecArgs(namespace, args, stdinIsTerminal())...)
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		exitErr := &exec.ExitError{}
-		if errors.As(err, &exitErr) {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				os.Exit(status.ExitStatus())
-			}
-		}
-		return err
-	}
-
-	return nil
+	return agentruntime.ExecInPod(cfg, agentruntime.Hermes, id, append([]string{hermesBinary}, args...))
 }
 
+// hermesExecArgs preserves the legacy argv-builder signature (namespace,
+// in-pod hermes args, TTY flag) so existing tests stay valid. It composes
+// the runtime-agnostic agentruntime.BuildExecArgs with the hermes binary
+// path, deriving the instance id from the namespace suffix.
 func hermesExecArgs(namespace string, args []string, withTTY bool) []string {
-	execArgs := []string{"exec", "-i"}
-	if withTTY {
-		execArgs = append(execArgs, "-t")
-	}
-	execArgs = append(execArgs,
-		"-c", agentruntime.Describe(agentruntime.Hermes).ServiceName,
-		"-n", namespace,
-		"deploy/"+agentruntime.Describe(agentruntime.Hermes).ServiceName,
-		"--",
-		hermesBinary,
+	id := strings.TrimPrefix(namespace, string(agentruntime.Hermes)+"-")
+	return agentruntime.BuildExecArgs(
+		agentruntime.Hermes,
+		id,
+		append([]string{hermesBinary}, args...),
+		withTTY,
 	)
-	return append(execArgs, args...)
-}
-
-func stdinIsTerminal() bool {
-	info, err := os.Stdin.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func getToken(cfg *config.Config, id string) (string, error) {

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -20,6 +20,22 @@ const (
 	// DefaultFacilitatorURL is the Obol-operated x402 facilitator for payment
 	// verification and settlement. Supports Base Mainnet and Base Sepolia.
 	DefaultFacilitatorURL = "https://x402.gcp.obol.tech"
+
+	// DefaultBuySellerURL is the Obol-operated demo seller used by
+	// `obol buy inference` when no --seller is given.
+	// TODO(buy): replace with the live URL once the default seller is provisioned.
+	DefaultBuySellerURL = "https://demo-seller.obol.tech/services/default-paid"
+
+	// DefaultBuySellerAgentID is the ERC-8004 tokenId the buyer expects to
+	// see in the seller's /.well-known/agent-registration.json before signing.
+	// Hard-fails on mismatch unless --no-verify-identity is passed.
+	// TODO(buy): replace with the live agentId once the default seller is registered.
+	DefaultBuySellerAgentID int64 = 0
+
+	// DefaultBuySellerChain is the chain the default seller settles on.
+	// Used only as a hint in error messages; the actual chain is taken
+	// from the seller's 402 response by buy.py.
+	DefaultBuySellerChain = "base-sepolia"
 )
 
 var x402Manifest = mustReadX402Manifest()


### PR DESCRIPTION
## Summary

What changed:
- Adds `obol buy inference [<name>]` as a host-side mirror of `obol sell inference`.
- Host handles default-seller resolution, ERC-8004 identity pre-flight (hard-fail on mismatch), and USDC→micro-units conversion, then dispatches to the existing in-pod `buy.py buy` over `kubectl exec`. No new wallet identity, no duplicated signing logic.
- Generalizes the kubectl-exec helper (previously hermes-binary-only) into `internal/agentruntime/exec.go` so any agent pod command can run via `ExecInPod`.

Why it matters:
- Closes the UX asymmetry with `obol sell inference`. Buying remote inference no longer requires `kubectl exec` + remembering the in-pod buy.py path.
- Surfaces the trust boundary: the buyer verifies the seller's published ERC-8004 agentId before signing any payment authorizations.
- The default-seller URL/agentId are hardcoded constants (`DefaultBuySellerURL`, `DefaultBuySellerAgentID`) with `// TODO(buy):` markers so the live values land in a small follow-up once the default seller is provisioned.

Risk level: low

Commit under test: b1feaf1

Base branch: main

## Scope

- [x] Code
- [ ] Charts / manifests
- [ ] Flows / QA scripts
- [ ] Docs / skills
- [ ] Images / dependencies
- [ ] Other:

## Validation

CI checks:

| Check | Status | Link |
|-------|--------|------|
|       |        |      |

Unit tests:

```text
go test -race ./cmd/obol/ ./internal/buy/ ./internal/agentruntime/ ./internal/hermes/ ./internal/x402/
ok  github.com/ObolNetwork/obol-stack/cmd/obol                3.369s
ok  github.com/ObolNetwork/obol-stack/internal/buy            1.658s
ok  github.com/ObolNetwork/obol-stack/internal/agentruntime   2.070s
ok  github.com/ObolNetwork/obol-stack/internal/hermes         17.529s
ok  github.com/ObolNetwork/obol-stack/internal/x402           4.423s
commit: b1feaf1
```

Coverage on touched packages: `internal/buy` 90.9%, `internal/agentruntime` 56.9% (rest is the `ExecInPod` happy path that requires a real kubectl). Buy CLI helpers (`usdcToMicroUnits`, `buildBuyPyArgv`) are fully covered.

Integration tests:

```text
Go integration tests were not run for this PR.
Instead, the end-to-end happy path was exercised manually on a live local host-stack
using explicit `--seller` / `--expected-agent-id`, because the baked default seller
(DefaultBuySellerURL / DefaultBuySellerAgentID) is still a placeholder.
See the JD Validation Update below for the exact commands and results.
```

Flow tests:

| Flow | Network | QA machine label | Worktree | Result | Artifacts |
|------|---------|------------------|----------|--------|-----------|
| manual host-stack buy validation | base-sepolia | explicit reachable QA upstream via SSH forward | local darwin/arm64 worktree | passed with explicit seller; `flow-11` / release-smoke not run | inline evidence below |

Release smoke:

```text
not run on this PR
```

## Live Chain Evidence

Validation used a temporary explicit seller on Base Sepolia rather than the placeholder default seller. Inline live-chain evidence captured for that validation seller:
- Agent ID: `5621`
- Registration tx: `0xbb59a4dfd1a78cfb3194b07dc557c0a76d0395108b1195fb7487f7c7637fab66`

For this PR, the key paid-route success criterion was successful auth consumption through the published paid alias (`remaining 5 -> 4`, `spent 0 -> 1`). I did not capture a settlement tx hash inline in this PR body.

## Runtime Evidence

QA environment:

| Item | Value |
|------|-------|
| OS / arch | darwin/arm64 (developer host) |
| Backend | local host-stack + SSH-forwarded reachable QA upstream |
| Tool versions | go 1.25, kubectl bundled by `obol stack up` |
| QA agent/model | explicit seller for `qwen36-fast` via `paid/qwen36-fast` |

Demo readiness:

| Item | Status | Notes |
|------|--------|-------|
| Seller visible / registered | yes | Temporary explicit validation seller (`spark2-reg`) registered on Base Sepolia |
| Buyer discovery works | yes | Verified via explicit `--seller` / `--expected-agent-id` path |
| Paid route works | yes | Local host-stack validation returned HTTP 200 for `paid/qwen36-fast` |
| Settlement visible on-chain | not captured inline | Registration tx captured; settlement tx not added to PR body |

## Review Notes

Known gaps:
- `DefaultBuySellerURL` is a placeholder (`https://demo-seller.obol.tech/services/default-paid`) and `DefaultBuySellerAgentID` is `0`. Both are clearly TODO-marked. Until they're set, `obol buy inference` requires `--seller`, `--expected-agent-id`, or `--no-verify-identity`.
- No `obol buy http` / `obol buy pay` siblings yet — out of scope, will land later as direct mirrors of the same dispatch pattern.

Follow-ups:
- Wire live `DefaultBuySellerURL` / `DefaultBuySellerAgentID` once the default seller is up.
- Add a BDD scenario in `internal/x402/features/integration_payment_flow.feature` exercising "operator runs `obol buy inference --budget 1`" once the live default seller exists.

Reviewer focus:
- `cmd/obol/buy.go` — flag surface and the `buildBuyPyArgv` argv shape (must match `buy.py buy` exactly).
- `internal/buy/discover.go` — identity check semantics, especially the zero-expected-agent-id guard.
- `internal/agentruntime/exec.go` — sanity-check that the generalized helper still produces the exact argv the legacy `hermesExecArgs` test asserts (`internal/hermes/hermes_test.go:TestHermesExecArgs_UsesNativeHermesBinary`).

## JD Validation Update (2026-05-06)

Rebase status:
- Rebased this PR onto current `origin/main` after #433 merged.
- Force-pushed updated head: `b1feaf1` (`feat(buy): add \`obol buy inference\` host CLI`).
- Main commit under it: `620a267` (`Fix base registrations, pretty cli sell status (#433)`).

Targeted tests:

```text
go test ./cmd/obol ./internal/buy ./internal/agentruntime ./internal/hermes ./internal/x402 ./internal/erc8004
ok  github.com/ObolNetwork/obol-stack/cmd/obol                1.210s
ok  github.com/ObolNetwork/obol-stack/internal/buy            (pass)
ok  github.com/ObolNetwork/obol-stack/internal/agentruntime   (pass)
ok  github.com/ObolNetwork/obol-stack/internal/hermes         (pass)
ok  github.com/ObolNetwork/obol-stack/internal/x402           (pass)
ok  github.com/ObolNetwork/obol-stack/internal/erc8004        8.607s
```

Live validation on a local Obol stack:
- Booted a fresh local stack from the rebased branch with isolated `OBOL_CONFIG_DIR`, `OBOL_BIN_DIR`, `OBOL_DATA_DIR`, and an empty `DOCKER_CONFIG`.
- Used the model-discovery CLI surface through a live SSH tunnel to a reachable Spark host:

```text
OBOL_LOCAL_MODEL_DISCOVERY_PORTS=18001:vllm obol model discover -o json
providers[0].models = [qwen36-35b-heretic, qwen36-fast, qwen36-deep]
```

- I could not reach the originally requested QA host from this machine through its configured Cloudflare SSH path (`websocket: bad handshake`), so I tunneled the live upstream from another reachable QA host instead and sold it locally under the requested `spark2` offer name.
- Started the live seller gateway with:

```text
obol sell inference spark2   --upstream http://127.0.0.1:18001   --model qwen36-fast   --chain base-sepolia   --price 0.001   --listen :18412
```

- Because `sell inference` publishes an unregistered offer, I also published a registered wrapper to exercise the identity-verified buy path:

```text
obol sell http spark2-reg   --upstream spark2   --port 18412   --namespace llm   --health-path /health   --chain base-sepolia   --per-request 0.001
```

- `obol sell status spark2-reg -n llm` reported a healthy, registered seller:
  - Agent ID: `5621`
  - Registration tx: `0xbb59a4dfd1a78cfb3194b07dc557c0a76d0395108b1195fb7487f7c7637fab66`
  - Endpoint: `https://adoption-board-property-noble.trycloudflare.com/services/spark2-reg`

`obol buy inference` patterns exercised:
- ✅ default/no-seller path hard-fails as designed:
  - `obol buy inference --budget 1`
  - error: `expected-agent-id is 0 — set --expected-agent-id, configure DefaultBuySellerAgentID, or pass --no-verify-identity to bypass`
- ✅ identity mismatch path hard-fails before signing:
  - explicit wrong `--expected-agent-id 999999`
- ✅ verified explicit-seller path succeeded:

```text
obol buy inference spark2-verified   --seller https://adoption-board-property-noble.trycloudflare.com/services/spark2-reg/v1/chat/completions   --model qwen36-fast   --budget 0.003   --expected-agent-id 5621   --force
```

- ✅ `--no-verify-identity` + auto-refill update path succeeded on the same purchase:

```text
obol buy inference spark2-verified   --seller https://adoption-board-property-noble.trycloudflare.com/services/spark2-reg/v1/chat/completions   --model qwen36-fast   --budget 0.002   --no-verify-identity   --auto-refill   --refill-threshold 1   --refill-count 2   --force
```

- ✅ in-pod buy surfaces worked:
  - `buy.py list`
  - `buy.py status spark2-verified`
  - `buy.py process --all`
- Sidecar state after purchase creation/update:
  - alias: `paid/qwen36-fast`
  - remaining auths: `5`
  - spent auths: `0`
  - auto-refill: enabled, no-op above threshold

Current status / attribution:
- ✅ end-to-end paid inference execution now works on the local host-stack validation path.
- Confirmed against `.claude/skills/obol-stack-dev/SKILL.md`:
  - full seller/buyer QA must route through a real `OBOL_LLM_ENDPOINT` on a QA machine, not local Ollama/cloud fallback
  - local dev pods can silently miss source changes unless local dev images are rebuilt/imported (`OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=true obol stack up`)
- So, with that repo guidance in mind, the two failures below were validation-path/runtime issues, not regressions in the new `obol buy inference` plumbing.

Issue 1 — stale local dev-image reuse:
- Symptom: paid inference returned `503 Payment verification failed`; verifier logged `facilitator verify failed (400): invalid_format`.
- Evidence: the live `PurchaseRequest` decoded with the expected `{id,payment}` shape, but the running cluster had reused stale locally tagged dev images under `IfNotPresent`, so the live `x402-buyer-auths` data still reflected legacy blank auth payloads.
- Fix: rebuilt/reimported the local dev images and restarted the affected deployments.
- Result: the `invalid_format` verifier failure disappeared.

Issue 2 — dead seller upstream path:
- Symptom after the image fix: paid requests returned `502 upstream unavailable`.
- Evidence:
  - the local seller gateway on `:18412` still answered `GET /health -> 200`
  - but `GET /v1/models -> 502 upstream unavailable`
  - its configured upstream `127.0.0.1:18001` had no listener
  - the intended remote source behind that forward was healthy
- Fix: re-established the local SSH forward backing `127.0.0.1:18001`.
- Result:
  - `http://127.0.0.1:18001/v1/models` -> `200`
  - `http://127.0.0.1:18412/v1/models` -> `200`
  - paid LiteLLM request with `model=paid/qwen36-fast` -> `200`
  - x402-buyer status moved from `remaining 5 / spent 0` to `remaining 4 / spent 1`

Paid-execution proof:

```text
POST /v1/chat/completions
model=paid/qwen36-fast
HTTP 200
```

Final attribution:
- The new host CLI path behaved correctly throughout: discovery worked, verified/no-verify purchase creation worked, PurchaseRequest updates worked, the paid alias was published, and the paid request succeeded once the validation path was repaired.
- The two blockers were both in the local QA runtime path used for validation:
  1. stale local dev-image reuse
  2. dead local SSH-forwarded seller upstream
- This is local macOS host-stack evidence for the host-side buy flow; it is not a claim that `flow-11` / release-smoke was rerun for this PR.
