### PR TITLE
fix(litellm): forgetting api keys on restart

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -96,9 +96,12 @@ metadata:
 data: {}
 
 ---
-# Secret for LiteLLM master key and cloud provider API keys.
-# Master key is unique per cluster ({{CLUSTER_ID}} resolved at init).
-# Provider keys start empty; patched via `obol model setup`.
+# Secret for LiteLLM master key. Provider API keys (ANTHROPIC_API_KEY,
+# OPENAI_API_KEY, ...) are patched in by `obol model setup` and the
+# autoConfigureLLM hook on first up. We deliberately do NOT declare empty
+# placeholders here — re-applying this manifest on every `obol stack up`
+# would overwrite any keys the user has set, leaving `obol model status`
+# in the misleading state of `enabled: true, api_key: false`.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -107,8 +110,6 @@ metadata:
 type: Opaque
 stringData:
   LITELLM_MASTER_KEY: "sk-obol-{{CLUSTER_ID}}"
-  ANTHROPIC_API_KEY: ""
-  OPENAI_API_KEY: ""
 
 ---
 apiVersion: apps/v1

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -630,9 +630,15 @@ func autoDetectCloudProvider(cfg *config.Config, u *ui.UI) string {
 		return ""
 	}
 
-	// Already configured — skip.
-	if model.HasProviderConfigured(cfg, provider) {
-		return ""
+	// Skip only when both the model entry AND the API key are present.
+	// A re-up that lost the Secret's API key (or any drift between
+	// ConfigMap and Secret) heals here by re-patching from the env var,
+	// instead of leaving `obol model status` reporting
+	// `enabled: true, api_key: false` as it did before this check.
+	if statuses, err := model.GetProviderStatus(cfg); err == nil {
+		if st, ok := statuses[provider]; ok && st.Enabled && st.HasAPIKey {
+			return ""
+		}
 	}
 
 	// Resolve API key: try primary + alt env vars, then .env in dev mode.

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -496,6 +496,20 @@ func TestLLMTemplate_IncludesPaidRouteAndBuyerSidecar(t *testing.T) {
 	if strings.Contains(out, "custom_provider_map") {
 		t.Fatalf("llm template should not require a custom provider:\n%s", out)
 	}
+
+	// Regression guard: provider API keys must not be pre-declared as
+	// empty placeholders in the bootstrap Secret. If they are, every
+	// `obol stack up` re-applies the manifest and overwrites whatever
+	// `obol model setup` (or autoConfigureLLM) patched in, leaving the
+	// user with `obol model status` reporting `enabled: true, api_key: false`.
+	for _, forbidden := range []string{
+		`ANTHROPIC_API_KEY: ""`,
+		`OPENAI_API_KEY: ""`,
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("llm template must not pre-declare empty provider API keys (found %q) — these get clobbered on every `obol stack up`", forbidden)
+		}
+	}
 }
 
 func TestMergeLiteLLMConfigPreservesChartDefaultsAndPreviousModels(t *testing.T) {


### PR DESCRIPTION
## Summary
﻿                                                              
  (1) Stop clobbering provider keys on every up —              
  internal/embed/infrastructure/base/templates/llm.yaml: the   
  litellm-secrets Secret no longer pre-declares                
  ANTHROPIC_API_KEY: "" / OPENAI_API_KEY: "". The bootstrap    
  only owns LITELLM_MASTER_KEY. envFrom: secretRef doesn't     
  require those keys to exist; LiteLLM just won't see them     
  until obol model setup (or auto-config) patches them in.     
  Added a regression test in stack_test.go so a future
  copy-paste can't reintroduce the empty placeholders.

  (3) Self-heal in auto-config — autoDetectCloudProvider       
  (internal/stack/stack.go:633-642): replaced the
  ConfigMap-only HasProviderConfigured check with              
  GetProviderStatus, and skip only when the provider is both
  Enabled (ConfigMap entry) and has HasAPIKey (Secret value
  present). If the entry exists but the key is missing —
  exactly your symptom — auto-config falls through and
  re-patches from the env var. So even if drift recurs from
  some other path, the next obol stack up heals it instead of
  leaving you in the misleading enabled: true, api_key: false
  state.

  Transitional caveat for users on the upgrade path: kubectl's 
  three-way merge will, on the first up after this change, see
  that ANTHROPIC_API_KEY was previously a managed empty field  
  and remove it — wiping any key currently set. Fix (3) makes
  that self-heal automatically (provided ANTHROPIC_API_KEY /
  CLAUDE_CODE_OAUTH_TOKEN is in the shell env at up-time), so
  the user-visible impact should be nil. After that one up, the
   field stops being managed and persists forever.

  go build ./... and go test ./internal/stack/...              
  ./internal/model/... ./cmd/obol/ all pass.