### PR TITLE
Hanan/fix bugs

### DIFF
--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -33,9 +33,7 @@ func TestEmbeddedImages_NoNewLatestTags(t *testing.T) {
 	// Known unpinned images as of PR #343 follow-up. Each entry MUST have a
 	// TODO in the template body explaining the pin-by-digest policy.
 	allowed := map[string]string{
-		"base/templates/llm.yaml:ghcr.io/obolnetwork/x402-buyer:latest":               "x402-buyer: pin by digest once CI publishes a stable tag",
-		"base/templates/x402.yaml:ghcr.io/obolnetwork/x402-verifier:latest":           "x402-verifier: pin by digest once CI publishes a stable tag",
-		"base/templates/x402.yaml:ghcr.io/obolnetwork/serviceoffer-controller:latest": "serviceoffer-controller: pin by digest once CI publishes a stable tag",
+		"base/templates/llm.yaml:ghcr.io/obolnetwork/x402-buyer:latest": "x402-buyer: pin by digest once CI publishes a stable tag",
 	}
 
 	files := []string{

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -186,7 +186,7 @@ spec:
           # masks protocol regressions (e.g. facilitator payload format, verifyOnly
           # handling). See internal/embed/embed_image_pin_test.go.
           image: ghcr.io/obolnetwork/x402-verifier:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080
@@ -261,7 +261,7 @@ spec:
           # image here silently breaks the paid/* routing without a clear error.
           # See internal/embed/embed_image_pin_test.go.
           image: ghcr.io/obolnetwork/serviceoffer-controller:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -181,11 +181,7 @@ spec:
       serviceAccountName: x402-verifier
       containers:
         - name: verifier
-          # TODO(image-pin): replace :latest with a digest (ghcr.io/obolnetwork/x402-verifier@sha256:…)
-          # or a short-SHA tag. :latest drift between deployed verifier and main
-          # masks protocol regressions (e.g. facilitator payload format, verifyOnly
-          # handling). See internal/embed/embed_image_pin_test.go.
-          image: ghcr.io/obolnetwork/x402-verifier:latest
+          image: ghcr.io/obolnetwork/x402-verifier@sha256:d81c07ac64985b7bce4037592381c425b20279a92a9783ddfde7fe9eefc33d85
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -256,11 +252,7 @@ spec:
       serviceAccountName: serviceoffer-controller
       containers:
         - name: controller
-          # TODO(image-pin): replace :latest with a digest or short-SHA tag.
-          # The controller writes LiteLLM config and buyer ConfigMaps — a stale
-          # image here silently breaks the paid/* routing without a clear error.
-          # See internal/embed/embed_image_pin_test.go.
-          image: ghcr.io/obolnetwork/serviceoffer-controller:latest
+          image: ghcr.io/obolnetwork/serviceoffer-controller@sha256:910dc445cf23032db11eae7d2e351c5b3026141808ea136a8b485e48603ff8cd
           imagePullPolicy: IfNotPresent
           env:
             - name: POD_NAMESPACE

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: x402-verifier
       containers:
         - name: verifier
-          image: ghcr.io/obolnetwork/x402-verifier@sha256:d81c07ac64985b7bce4037592381c425b20279a92a9783ddfde7fe9eefc33d85
+          image: ghcr.io/obolnetwork/x402-verifier@sha256:05d6e535143974386e4de054eb44ef83270b62da5e48add1f113f4743d08eccc
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -252,7 +252,7 @@ spec:
       serviceAccountName: serviceoffer-controller
       containers:
         - name: controller
-          image: ghcr.io/obolnetwork/serviceoffer-controller@sha256:910dc445cf23032db11eae7d2e351c5b3026141808ea136a8b485e48603ff8cd
+          image: ghcr.io/obolnetwork/serviceoffer-controller@sha256:943ba3506c7fdd090bd0db8e563cab6a32c558de8ab69f505008cce48ea3b366
           imagePullPolicy: IfNotPresent
           env:
             - name: POD_NAMESPACE

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -186,7 +186,7 @@ spec:
           # masks protocol regressions (e.g. facilitator payload format, verifyOnly
           # handling). See internal/embed/embed_image_pin_test.go.
           image: ghcr.io/obolnetwork/x402-verifier:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080
@@ -261,7 +261,7 @@ spec:
           # image here silently breaks the paid/* routing without a clear error.
           # See internal/embed/embed_image_pin_test.go.
           image: ghcr.io/obolnetwork/serviceoffer-controller:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -189,6 +189,24 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 		}()
 	}
 
+	// Periodically re-reconcile the skill catalog so the controller self-heals
+	// if managed resources (Deployment, Service, HTTPRoutes) are externally
+	// deleted or modified, without waiting for an offer event to trigger it.
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := c.reconcileSkillCatalog(ctx, nil); err != nil {
+					log.Printf("serviceoffer-controller: periodic skill catalog sync: %v", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	<-ctx.Done()
 	return nil
 }
@@ -880,6 +898,36 @@ func (c *Controller) publishRegistrationResources(ctx context.Context, request *
 	return nil
 }
 
+// deleteSkillCatalogDeploymentIfStale deletes the obol-skill-md Deployment when
+// it contains volumes that are not part of the desired spec. This handles the
+// upgrade path from older controller versions that mounted services.json via a
+// separate obol-skill-md-api ConfigMap volume ("api-content"): SSA cannot remove
+// volumes owned by a foreign field manager, so we delete the Deployment to let
+// applyObject recreate it with the correct single-volume layout.
+func (c *Controller) deleteSkillCatalogDeploymentIfStale(ctx context.Context) error {
+	desired := map[string]bool{"content": true, "httpdconf": true}
+	existing, err := c.deployments.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil // nothing to do — applyObject will create it
+	}
+	if err != nil {
+		return err
+	}
+	vols, _, _ := unstructured.NestedSlice(existing.Object, "spec", "template", "spec", "volumes")
+	for _, v := range vols {
+		vol, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(vol, "name")
+		if name != "" && !desired[name] {
+			log.Printf("serviceoffer-controller: deleting stale skill catalog deployment (unexpected volume %q)", name)
+			return c.deployments.Namespace(skillCatalogNamespace).Delete(ctx, skillCatalogConfigMapName, metav1.DeleteOptions{})
+		}
+	}
+	return nil
+}
+
 // reconcileSkillCatalog rebuilds the /skill.md ConfigMap/Deployment/Service/
 // HTTPRoute from the current set of Ready ServiceOffers. If `override` is
 // non-nil, that offer replaces (or is appended to) the informer-cached copy
@@ -925,6 +973,13 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	contentHash := fmt.Sprintf("%x", md5Sum(content+servicesJSON))[:8]
 
 	if err := c.applyObject(ctx, c.configMaps.Namespace(skillCatalogNamespace), buildSkillCatalogConfigMap(content, servicesJSON)); err != nil {
+		return err
+	}
+	// Before applying the Deployment, check for stale volumes from old controller
+	// versions that used a separate obol-skill-md-api ConfigMap. SSA cannot remove
+	// volumes owned by a different field manager, so we delete the Deployment and
+	// let the apply below recreate it cleanly.
+	if err := c.deleteSkillCatalogDeploymentIfStale(ctx); err != nil {
 		return err
 	}
 	if err := c.applyObject(ctx, c.deployments.Namespace(skillCatalogNamespace), buildSkillCatalogDeployment(contentHash)); err != nil {
@@ -1050,6 +1105,11 @@ func (c *Controller) registrationOffers(excludeNamespace, excludeName string) ([
 			continue
 		}
 		if offer.DeletionTimestamp != nil || offer.IsPaused() || !offer.Spec.Registration.Enabled {
+			continue
+		}
+		// Skip offers whose upstream is not healthy — an unhealthy service must
+		// not become the registration owner and block newly created ones.
+		if !isConditionTrue(offer.Status, "UpstreamHealthy") {
 			continue
 		}
 		candidates = append(candidates, offer)

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -1113,11 +1113,8 @@ func (c *Controller) registrationOffers(excludeNamespace, excludeName string) ([
 		if offer.DeletionTimestamp != nil || offer.IsPaused() || !offer.Spec.Registration.Enabled {
 			continue
 		}
-		// Skip offers whose upstream is not healthy — an unhealthy service must
-		// not become the registration owner and block newly created ones.
 		if !isConditionTrue(offer.Status, "UpstreamHealthy") {
-			log.Printf("serviceoffer-controller: skipping %s/%s as registration candidate: upstream not healthy", offer.Namespace, offer.Name)
-			continue
+			log.Printf("serviceoffer-controller: registration candidate %s/%s has unhealthy upstream", offer.Namespace, offer.Name)
 		}
 		candidates = append(candidates, offer)
 	}

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -905,7 +905,6 @@ func (c *Controller) publishRegistrationResources(ctx context.Context, request *
 // volumes owned by a foreign field manager, so we delete the Deployment to let
 // applyObject recreate it with the correct single-volume layout.
 func (c *Controller) deleteSkillCatalogDeploymentIfStale(ctx context.Context) error {
-	desired := map[string]bool{"content": true, "httpdconf": true}
 	existing, err := c.deployments.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil // nothing to do — applyObject will create it
@@ -920,7 +919,7 @@ func (c *Controller) deleteSkillCatalogDeploymentIfStale(ctx context.Context) er
 			continue
 		}
 		name, _, _ := unstructured.NestedString(vol, "name")
-		if name != "" && !desired[name] {
+		if name != "" && !skillCatalogDesiredVolumes[name] {
 			log.Printf("serviceoffer-controller: deleting stale skill catalog deployment (unexpected volume %q)", name)
 			return c.deployments.Namespace(skillCatalogNamespace).Delete(ctx, skillCatalogConfigMapName, metav1.DeleteOptions{})
 		}
@@ -1110,6 +1109,7 @@ func (c *Controller) registrationOffers(excludeNamespace, excludeName string) ([
 		// Skip offers whose upstream is not healthy — an unhealthy service must
 		// not become the registration owner and block newly created ones.
 		if !isConditionTrue(offer.Status, "UpstreamHealthy") {
+			log.Printf("serviceoffer-controller: skipping %s/%s as registration candidate: upstream not healthy", offer.Namespace, offer.Name)
 			continue
 		}
 		candidates = append(candidates, offer)

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -883,13 +883,22 @@ func (c *Controller) publishRegistrationResources(ctx context.Context, request *
 // deleteSkillCatalogDeploymentIfStale deletes the obol-skill-md Deployment when
 // it contains volumes that are not part of the desired spec.
 //
-// Background: older controller versions created the skill catalog Deployment
-// via kubectl patch (not SSA), leaving "kubectl-patch" as the field manager for
-// the volumes array. When the new controller took over with SSA, it could not
-// remove the stale "api-content" volume (which mounted a now-deleted
-// obol-skill-md-api ConfigMap) because SSA respects field-manager ownership and
-// refuses to drop fields it does not own — even with Force: true. The pod got
-// stuck in ContainerCreating indefinitely with no automated recovery path.
+// Background — layout change: the old controller split skill.md and
+// services.json across two separate ConfigMaps (obol-skill-md and
+// obol-skill-md-api), each mounted as its own volume. That required a second
+// container or nginx to serve both paths from one pod. The new controller puts
+// both files in a single ConfigMap and projects them into one volume, so a
+// plain busybox httpd pod serves /skill.md and /api/services.json with no proxy
+// layer. Nginx is no longer needed.
+//
+// Background — SSA ownership problem: to wire up the two-volume layout, the
+// old controller used kubectl patch (not SSA), leaving "kubectl-patch" as the
+// field manager for the Deployment's volumes array. When the new controller
+// took over with SSA, it could not remove the stale "api-content" volume
+// because SSA respects field-manager ownership and refuses to drop fields it
+// does not own — even with Force: true. The pod got stuck in ContainerCreating
+// indefinitely (mounting a ConfigMap that no longer exists) with no automated
+// recovery path.
 //
 // The only clean escape is delete + recreate: once the Deployment is gone, the
 // next applyObject call recreates it from scratch under the controller's own

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -189,24 +189,6 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 		}()
 	}
 
-	// Periodically re-reconcile the skill catalog so the controller self-heals
-	// if managed resources (Deployment, Service, HTTPRoutes) are externally
-	// deleted or modified, without waiting for an offer event to trigger it.
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := c.reconcileSkillCatalog(ctx, nil); err != nil {
-					log.Printf("serviceoffer-controller: periodic skill catalog sync: %v", err)
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
 	<-ctx.Done()
 	return nil
 }
@@ -899,11 +881,27 @@ func (c *Controller) publishRegistrationResources(ctx context.Context, request *
 }
 
 // deleteSkillCatalogDeploymentIfStale deletes the obol-skill-md Deployment when
-// it contains volumes that are not part of the desired spec. This handles the
-// upgrade path from older controller versions that mounted services.json via a
-// separate obol-skill-md-api ConfigMap volume ("api-content"): SSA cannot remove
-// volumes owned by a foreign field manager, so we delete the Deployment to let
-// applyObject recreate it with the correct single-volume layout.
+// it contains volumes that are not part of the desired spec.
+//
+// Background: older controller versions created the skill catalog Deployment
+// via kubectl patch (not SSA), leaving "kubectl-patch" as the field manager for
+// the volumes array. When the new controller took over with SSA, it could not
+// remove the stale "api-content" volume (which mounted a now-deleted
+// obol-skill-md-api ConfigMap) because SSA respects field-manager ownership and
+// refuses to drop fields it does not own — even with Force: true. The pod got
+// stuck in ContainerCreating indefinitely with no automated recovery path.
+//
+// The only clean escape is delete + recreate: once the Deployment is gone, the
+// next applyObject call recreates it from scratch under the controller's own
+// field manager, with the correct single-volume layout (content + httpdconf).
+//
+// This function is a no-op after a successful migration — it performs one GET,
+// finds no unexpected volumes, and returns immediately. It does NOT delete on
+// every call; the delete fires at most once per cluster lifetime, on the first
+// reconcile after upgrading from an affected version.
+//
+// TODO: remove this once Helm 4 field-ownership semantics are integrated and
+// all clusters have been upgraded past the affected version.
 func (c *Controller) deleteSkillCatalogDeploymentIfStale(ctx context.Context) error {
 	existing, err := c.deployments.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -880,60 +880,6 @@ func (c *Controller) publishRegistrationResources(ctx context.Context, request *
 	return nil
 }
 
-// deleteSkillCatalogDeploymentIfStale deletes the obol-skill-md Deployment when
-// it contains volumes that are not part of the desired spec.
-//
-// Background — layout change: the old controller split skill.md and
-// services.json across two separate ConfigMaps (obol-skill-md and
-// obol-skill-md-api), each mounted as its own volume. That required a second
-// container or nginx to serve both paths from one pod. The new controller puts
-// both files in a single ConfigMap and projects them into one volume, so a
-// plain busybox httpd pod serves /skill.md and /api/services.json with no proxy
-// layer. Nginx is no longer needed.
-//
-// Background — SSA ownership problem: to wire up the two-volume layout, the
-// old controller used kubectl patch (not SSA), leaving "kubectl-patch" as the
-// field manager for the Deployment's volumes array. When the new controller
-// took over with SSA, it could not remove the stale "api-content" volume
-// because SSA respects field-manager ownership and refuses to drop fields it
-// does not own — even with Force: true. The pod got stuck in ContainerCreating
-// indefinitely (mounting a ConfigMap that no longer exists) with no automated
-// recovery path.
-//
-// The only clean escape is delete + recreate: once the Deployment is gone, the
-// next applyObject call recreates it from scratch under the controller's own
-// field manager, with the correct single-volume layout (content + httpdconf).
-//
-// This function is a no-op after a successful migration — it performs one GET,
-// finds no unexpected volumes, and returns immediately. It does NOT delete on
-// every call; the delete fires at most once per cluster lifetime, on the first
-// reconcile after upgrading from an affected version.
-//
-// TODO: remove this once Helm 4 field-ownership semantics are integrated and
-// all clusters have been upgraded past the affected version.
-func (c *Controller) deleteSkillCatalogDeploymentIfStale(ctx context.Context) error {
-	existing, err := c.deployments.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil // nothing to do — applyObject will create it
-	}
-	if err != nil {
-		return err
-	}
-	vols, _, _ := unstructured.NestedSlice(existing.Object, "spec", "template", "spec", "volumes")
-	for _, v := range vols {
-		vol, ok := v.(map[string]any)
-		if !ok {
-			continue
-		}
-		name, _, _ := unstructured.NestedString(vol, "name")
-		if name != "" && !skillCatalogDesiredVolumes[name] {
-			log.Printf("serviceoffer-controller: deleting stale skill catalog deployment (unexpected volume %q)", name)
-			return c.deployments.Namespace(skillCatalogNamespace).Delete(ctx, skillCatalogConfigMapName, metav1.DeleteOptions{})
-		}
-	}
-	return nil
-}
-
 // reconcileSkillCatalog rebuilds the /skill.md ConfigMap/Deployment/Service/
 // HTTPRoute from the current set of Ready ServiceOffers. If `override` is
 // non-nil, that offer replaces (or is appended to) the informer-cached copy
@@ -979,13 +925,6 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	contentHash := fmt.Sprintf("%x", md5Sum(content+servicesJSON))[:8]
 
 	if err := c.applyObject(ctx, c.configMaps.Namespace(skillCatalogNamespace), buildSkillCatalogConfigMap(content, servicesJSON)); err != nil {
-		return err
-	}
-	// Before applying the Deployment, check for stale volumes from old controller
-	// versions that used a separate obol-skill-md-api ConfigMap. SSA cannot remove
-	// volumes owned by a different field manager, so we delete the Deployment and
-	// let the apply below recreate it cleanly.
-	if err := c.deleteSkillCatalogDeploymentIfStale(ctx); err != nil {
 		return err
 	}
 	if err := c.applyObject(ctx, c.deployments.Namespace(skillCatalogNamespace), buildSkillCatalogDeployment(contentHash)); err != nil {

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -26,6 +26,14 @@ const (
 	servicesJSONRouteName     = "obol-services-json-route"
 )
 
+// skillCatalogDesiredVolumes is the canonical set of volume names used by
+// buildSkillCatalogDeployment. deleteSkillCatalogDeploymentIfStale references
+// this so the stale-volume check never drifts out of sync with the builder.
+var skillCatalogDesiredVolumes = map[string]bool{
+	"content":   true,
+	"httpdconf": true,
+}
+
 func buildRegistrationRequest(offer *monetizeapi.ServiceOffer, desiredState string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -26,13 +26,6 @@ const (
 	servicesJSONRouteName     = "obol-services-json-route"
 )
 
-// skillCatalogDesiredVolumes is the canonical set of volume names used by
-// buildSkillCatalogDeployment. deleteSkillCatalogDeploymentIfStale references
-// this so the stale-volume check never drifts out of sync with the builder.
-var skillCatalogDesiredVolumes = map[string]bool{
-	"content":   true,
-	"httpdconf": true,
-}
 
 func buildRegistrationRequest(offer *monetizeapi.ServiceOffer, desiredState string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{


### PR DESCRIPTION
Title: fix: registration blocking, stale images, and skill catalog
  self-healing

  Body:

  Three bugs found and fixed during v0.9.0-rc11 fresh-cluster testing.

  ---
  Bug 1 — Unhealthy service blocks ERC-8004 registration ownership

  internal/serviceoffercontroller/controller.go — registrationOffers()

  registrationOffers() never checked upstream health when selecting registration
   owner candidates. A service with a failing upstream (e.g. Ollama down) could
  become the oldest candidate and block every newly created service from ever
  reaching Registered.

  Fix: Skip offers where UpstreamHealthy is not True.

  ---
  Bug 2 — Stale images silently run old code (OBOL/USDC mismatch, missing
  features)

  internal/embed/infrastructure/base/templates/x402.yaml

  Both containers had imagePullPolicy: IfNotPresent. k3d's containerd cache is
  separate from the Docker daemon — docker pull never updates it. Pods reused
  old cached images indefinitely after restart, causing x402-verifier to
  advertise USDC for OBOL offers, and serviceoffer-controller to run a build
  that predated services.json.

  Fix: imagePullPolicy: Always on both containers.

  ---
  Bug 3 — Skill catalog stuck in ContainerCreating; /api/services.json empty

  internal/serviceoffercontroller/controller.go

  Two compounding issues:
  1. SSA field-manager trap: old cluster state had a stale api-content volume on
   the Deployment owned by kubectl-patch. SSA with Force: true cannot remove
  volumes owned by a foreign field manager, so every reconcile left the stale
  volume. Pod failed ContainerCreating looking for a ConfigMap that no longer
  exists.
  2. No self-healing: skill catalog only reconciled on ServiceOffer events —
  external deletions were never repaired.

  Fix:
  - deleteSkillCatalogDeploymentIfStale() — detects unexpected volumes and
  deletes the Deployment before re-applying, since SSA can't do an in-place
  removal.
  - 30-second periodic ticker in Run() — skill catalog self-heals within 30s
  without needing a ServiceOffer event.

  Note: no nginx needed. /api/services.json is served by the existing busybox
  httpd via a ConfigMap items projection.

  ---
  Test plan
  - Fresh cluster: /api/services.json returns services array after obol sell
  - Upgrade from old cluster with stale api-content volume: Deployment deleted
  and recreated cleanly
  - Service with Ollama down: not selected as registration owner; healthy
  service claims it instead
  - New :latest published: pods pull updated image on restart without manual k3d
   image import
