### PR TITLE
feat: wire Base Sepolia OBOL faucet env

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -33,6 +33,15 @@ image:
     - name: OLLAMA_URL
       value: "http://ollama.llm.svc.cluster.local:11434"
 
+    # Base Sepolia OBOL test faucet runtime config. The frontend exposes these
+    # through /api/config/base-sepolia-obol once the token/faucet are deployed.
+    - name: BASE_SEPOLIA_OBOL_TOKEN_ADDRESS
+      value: {{ env "BASE_SEPOLIA_OBOL_TOKEN_ADDRESS" | default "" | quote }}
+    - name: BASE_SEPOLIA_OBOL_FAUCET_ADDRESS
+      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_ADDRESS" | default "" | quote }}
+    - name: BASE_SEPOLIA_OBOL_FAUCET_AMOUNT
+      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_AMOUNT" | default "100 OBOL" | quote }}
+
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
   tag: "v0.1.20"

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -36,9 +36,9 @@ image:
     # Base Sepolia OBOL test faucet runtime config. The frontend exposes these
     # through /api/config/base-sepolia-obol once the token/faucet are deployed.
     - name: BASE_SEPOLIA_OBOL_TOKEN_ADDRESS
-      value: {{ env "BASE_SEPOLIA_OBOL_TOKEN_ADDRESS" | default "" | quote }}
+      value: {{ env "BASE_SEPOLIA_OBOL_TOKEN_ADDRESS" | default "0x0a09371a8b011d5110656ceBCc70603e53FD2c78" | quote }}
     - name: BASE_SEPOLIA_OBOL_FAUCET_ADDRESS
-      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_ADDRESS" | default "" | quote }}
+      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_ADDRESS" | default "0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076" | quote }}
     - name: BASE_SEPOLIA_OBOL_FAUCET_AMOUNT
       value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_AMOUNT" | default "100 OBOL" | quote }}
 


### PR DESCRIPTION
## Summary
- Wires Base Sepolia OBOL faucet runtime env vars into the deployed frontend Helm values.
- Sets the chart defaults to the now-deployed Base Sepolia OBOL token/faucet addresses while preserving env override support.
- Keeps `BASE_SEPOLIA_OBOL_FAUCET_AMOUNT` overrideable while defaulting to `100 OBOL`.

## Coordination
- Follows contract PR #443, which merged the Base Sepolia OBOL token/faucet contracts into `main`.
- Coordinates with frontend PR ObolNetwork/obol-stack-front-end#293, which reads these env vars through `/api/config/base-sepolia-obol`.
- Post-deploy ownership for both contracts was transferred from Alice to `0x1Adf1208feB12A2D785e842d35C09132850F1231`.

## Deployed Base Sepolia contracts
- Token: `0x0a09371a8b011d5110656ceBCc70603e53FD2c78`
- Faucet: `0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076`
- Faucet amount: `100 OBOL`
- Faucet cooldown: `86400` seconds
- Owner after transfer:
  - token: `0x1Adf1208feB12A2D785e842d35C09132850F1231`
  - faucet: `0x1Adf1208feB12A2D785e842d35C09132850F1231`

Funding / seeding after deploy:
- Faucet seeded with `50,000 OBOL`
- Owner wallet funded with `50,000 OBOL`
- Owner wallet funded with `0.01 ETH` on Base Sepolia for admin gas

Deployment txs:
- Token deploy: `0x3f74e95281fdadb88e85749d4cbdadc3db62cea646b22a78d521a13d99c967db`
- Faucet deploy: `0x361a4573070a398cad73437beb4fcd6caca2dda5e79521b025e30dbd1b9ba90a`
- Faucet seed: `0xa3f15bb2b253c5b38785271e13b3235f8895417bf282f7cf552f0303f8cc85c9`
- Owner OBOL funding: `0x386401dd07c71bf49f620cf03ec96c79006b785f1c3fcaca47fe604777e97aba`
- Owner ETH funding: `0x521e0738bb34df61283e169afe063918d18d2cdee106b943c33f2839ccb4c6b6`
- Token ownership transfer: `0x12eb79972f92883d4ca29b255cb7a6c43bf690930d4a3d3c1e977c9400a0c82d`
- Faucet ownership transfer: `0xe03a7e951b6912bf86f03ae8f07318ccca9edef6da9b313583e7c998df0976e9`

Runtime env vars:

```bash
BASE_SEPOLIA_OBOL_TOKEN_ADDRESS=0x0a09371a8b011d5110656ceBCc70603e53FD2c78
BASE_SEPOLIA_OBOL_FAUCET_ADDRESS=0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076
BASE_SEPOLIA_OBOL_FAUCET_AMOUNT="100 OBOL"
```

Related: #406

## Validation
- `git diff --check`
- `go test ./cmd/obol ./internal/x402`
