### PR TITLE
fix: lower Base Sepolia OBOL faucet default amount

### DIFF
--- a/contracts/fork-obol/README.md
+++ b/contracts/fork-obol/README.md
@@ -12,7 +12,7 @@ smokes.
 
 The faucet intentionally does not mint. Deployers should mint test OBOL to a funded holder, transfer a bounded allocation into the faucet, and top it up as needed.
 
-The Foundry profile pins `solc_version = "0.8.35"` (latest `solc` on npm when this PR was updated).
+The Foundry profile pins `solc_version = "0.8.24"` to match the deployed Base Sepolia token/faucet bytecode that was verified via Sourcify.
 
 ## Example deploy flow
 

--- a/contracts/fork-obol/foundry.toml
+++ b/contracts/fork-obol/foundry.toml
@@ -2,4 +2,4 @@
 src = "src"
 out = "out"
 libs = []
-solc_version = "0.8.35"
+solc_version = "0.8.24"

--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -40,7 +40,7 @@ image:
     - name: BASE_SEPOLIA_OBOL_FAUCET_ADDRESS
       value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_ADDRESS" | default "0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076" | quote }}
     - name: BASE_SEPOLIA_OBOL_FAUCET_AMOUNT
-      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_AMOUNT" | default "100 OBOL" | quote }}
+      value: {{ env "BASE_SEPOLIA_OBOL_FAUCET_AMOUNT" | default "5 OBOL" | quote }}
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Lowers the default Base Sepolia OBOL faucet display/config amount from `100 OBOL` to `5 OBOL` in the stack frontend values.
- Keeps runtime env override support unchanged.
- Aligns `contracts/fork-obol` Foundry/docs to `solc 0.8.24`, matching the deployed Base Sepolia token/faucet bytecode verified via Sourcify.

## Context
- PR #447 merged the deployed Base Sepolia OBOL token/faucet addresses and initially kept the faucet amount at `100 OBOL`.
- The live owner wallet has now updated the faucet on-chain to `5 OBOL` per claim with the existing `86400` second cooldown.
- This PR aligns the stack runtime default and the fork-obol deployment docs with the current deployed state.

## Live deployed state
- Token: `0x0a09371a8b011d5110656ceBCc70603e53FD2c78`
- Faucet: `0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076`
- On-chain claim amount: `5 OBOL`
- Cooldown: `86400` seconds
- Owner after transfer:
  - token: `0x1Adf1208feB12A2D785e842d35C09132850F1231`
  - faucet: `0x1Adf1208feB12A2D785e842d35C09132850F1231`
- Faucet balance after the claim-terms update: `50,000 OBOL`
- Claim-terms update tx: `0x559eb0b368323382a555ca72633e2e1ff9359aef4be54ba6d0fc414ccaf91d39`

## Runtime env default

```bash
BASE_SEPOLIA_OBOL_TOKEN_ADDRESS=0x0a09371a8b011d5110656ceBCc70603e53FD2c78
BASE_SEPOLIA_OBOL_FAUCET_ADDRESS=0x0c8Ec594d067d1D850deba7BAa05d4052Ab97076
BASE_SEPOLIA_OBOL_FAUCET_AMOUNT="5 OBOL"
```

Related: #406

## Validation
- Follow-up local validation for the compiler/doc alignment change in this PR:
  - `git diff --check`
  - `forge build`
- GitHub checks rerun on the updated branch push.
