### PR TITLE
chore(frontend): bump frontend image to v0.1.21-rc1

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -44,7 +44,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.20"
+  tag: "v0.1.21-rc1"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

What changed:
- Bumps the embedded `obol-frontend` image tag in `internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl` from `v0.1.20` to `v0.1.21-rc1`.
- Aligns `obol-stack` with the pending frontend release-candidate PR ObolNetwork/obol-stack-front-end#294.

Why it matters:
- The frontend `main` branch currently has a broken `Build, Push and Deploy` workflow on the merged faucet UI change path.
- The follow-up frontend PR fixes that image build and prepares the next release candidate tag.
- This stack PR makes the default deployed frontend image ready to consume that release candidate once it is published.

Risk level: low

Commit under test:
- `79ad1e5fda9e5d852389a321e750bc99fd1fa0ee`

Base branch:
- `main`

## Scope

- [ ] Code
- [x] Charts / manifests
- [ ] Flows / QA scripts
- [ ] Docs / skills
- [x] Images / dependencies
- [ ] Other:

## Validation

CI checks:

| Check | Status | Link |
|-------|--------|------|
| PR CI | pending | GitHub Actions after PR creation |

Unit tests:

```text
Not run locally — config-only image tag change in internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl.
```

Integration tests:

```text
Not run locally — no Go/chart logic changed beyond the frontend image tag reference.
```

Flow tests:

| Flow | Network | QA machine label | Worktree | Result | Artifacts |
|------|---------|------------------|----------|--------|-----------|
| N/A | N/A | N/A | N/A | Not run | Config-only change |

Release smoke:

```text
Not run locally — this PR only repoints the default frontend image tag and depends on publishing obol-stack-front-end:v0.1.21-rc1.
```

## Live Chain Evidence

Do not include private keys, seed phrases, passwords, hostnames, personal paths, or raw bearer tokens.

Network:
- N/A

RPC/provider:
- N/A

Facilitator:
- N/A

Contracts and tokens:

| Name | Address | Version / notes |
|------|---------|-----------------|
| N/A | N/A | Image-tag-only change |

Wallet roles:

| Role | Address | Source |
|------|---------|--------|
| Alice / seller / register | N/A | N/A |
| Bob / buyer / payer | N/A | N/A |
| Facilitator / receiver | N/A | N/A |

Balances:

| Token | Address | Before | After | Expected delta | Actual delta |
|-------|---------|--------|-------|----------------|--------------|
| N/A | N/A | N/A | N/A | N/A | N/A |

Transaction receipts:

| Purpose | Tx hash | From | To | Amount / event | Status |
|---------|---------|------|----|----------------|--------|
| N/A | N/A | N/A | N/A | N/A | N/A |

## Runtime Evidence

QA environment:

| Item | Value |
|------|-------|
| OS / arch | macOS / arm64 |
| Backend | local git worktree only |
| Tool versions | `git`, `gh` |
| QA agent/model | Hermes / gpt-5.4 |

Images:

| Component | Image | Tag / digest | Source |
|-----------|-------|--------------|--------|
| Frontend | `obolnetwork/obol-stack-front-end` | `v0.1.21-rc1` | Pending publish from ObolNetwork/obol-stack-front-end#294 |

Kubernetes / stack:

| Item | Value |
|------|-------|
| Stack IDs | N/A |
| Namespaces | N/A |
| Pod readiness | N/A |
| Cleanup result | N/A |

Model and routing:

| Item | Value |
|------|-------|
| Agent/model used | N/A |
| LiteLLM route | N/A |
| Paid endpoint status | N/A |
| Auth token source | N/A |

Artifacts and logs:

| Artifact | Location / link | Notes |
|----------|-----------------|-------|
| Frontend release-candidate dependency | ObolNetwork/obol-stack-front-end#294 | Publishes the image this PR points to |

Demo readiness:

| Item | Status | Notes |
|------|--------|-------|
| Seller visible / registered | N/A | No commerce-path change |
| Buyer discovery works | N/A | No commerce-path change |
| Paid route works | N/A | No commerce-path change |
| Settlement visible on-chain | N/A | No commerce-path change |

## Review Notes

Known gaps:
- Do not merge/deploy this before the frontend image for `v0.1.21-rc1` has been published.

Follow-ups:
- After ObolNetwork/obol-stack-front-end#294 merges, create/publish the `v0.1.21-rc1` frontend release tag and then land this stack PR.

Reviewer focus:
- Confirm the frontend tag bump is the only stack-side change.
- Confirm the dependency on ObolNetwork/obol-stack-front-end#294 is clearly captured.
