### PR TITLE
Add release description template

### DIFF
--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -103,6 +103,13 @@ QA LLM invariant:
 
 Read `references/remote-qa.md` before running SSH/tmux cleanup or live smoke remotely.
 
+## Release Notes
+
+- Use `.github/release-template.md` as the starting point for GitHub release descriptions.
+- The release workflow creates a draft with generated notes; replace the narrative body with the template and keep generated `What's Changed`, `New Contributors`, and `Full Changelog` sections at the bottom.
+- The v0.9.0 release is the style reference: banner, release theme, concise user-facing summary, install block, curated highlights, smaller wins, and generated changelog.
+- Never include private keys, seed phrases, passwords, hostnames, personal paths, or raw bearer tokens in release notes.
+
 ## Common Commands
 
 Local syntax/config:

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,117 @@
+<!--
+Release description template based on:
+https://github.com/ObolNetwork/obol-stack/releases/tag/v0.9.0
+
+Use this to rewrite the draft body created by .github/workflows/release.yml
+before publishing. Replace every bracketed placeholder, preserve the generated
+changelog sections at the bottom, and delete empty optional sections.
+-->
+
+[![Obol banner](https://obol.org/obolnetwork.png)](https://obol.org/obolnetwork.png)
+
+# [version] - [release theme]
+
+> Optional short quote, definition, or one-line context for the release theme.
+
+[One or two paragraphs describing the release in user terms. Name the headline
+capability, the user journey it unlocks, and the important networks, runtimes,
+or payment rails involved.]
+
+[Primary call to action. Example: "Get started with `obol [command]`." Include
+one public social/demo prompt only when the release is demo-worthy.]
+
+<p align="center">
+<img width="[width]" height="[height]" alt="[short screenshot description]" src="[github-user-attachment-url]" />
+</p>
+
+> [!NOTE]
+> Include faucet, testnet, migration, or compatibility notes that reduce first-run friction.
+
+> [!WARNING]
+> This software is early alpha, you could lose what you put in. Please use caution when it comes to non-testnet assets.
+
+## Install / Upgrade
+
+```bash
+# Install this release
+OBOL_RELEASE=[version] bash <(curl -s https://stack.obol.org)
+
+# Run the stack
+obol stack init && obol stack up
+
+# Try the headline workflow
+obol [headline command]
+
+# Optional agent/operator hand-off
+[copy-paste setup or prompt for the release's intended operator path]
+```
+
+---
+
+## Release Highlights
+
+### [headline feature] - [user outcome]
+
+[Explain the primary feature as a concrete workflow. Prefer exact commands,
+network names, payment tokens, and observable success states over internal
+implementation detail.]
+
+```bash
+[canonical command]
+```
+
+[One paragraph explaining why this is the canonical starting point and what users
+can build from it next.]
+
+### [payment, network, or settlement change]
+
+[Describe the money path carefully. Specify buyer and seller responsibilities,
+gas requirements, approval/permit behavior, settlement behavior, and supported
+networks.]
+
+### [runtime, agent, or developer-experience change]
+
+[Describe the runtime or operator experience. Include the smallest useful command
+set and call out alternate runtimes or compatibility expectations when relevant.]
+
+```bash
+[command 1]
+[command 2]
+[command 3]
+```
+
+### [ecosystem, plugin, or integration change]
+
+[Describe integrations users can install or connect to. Link to source
+repositories or docs.]
+
+---
+
+## Smaller wins
+
+- **[short feature name]** - [one-sentence user impact].
+- **[short feature name]** - [one-sentence user impact].
+- **[short feature name]** - [one-sentence user impact].
+
+## Breaking changes / Migration notes
+
+- [Delete this section if there are no breaking changes.]
+
+## Known issues
+
+- [Delete this section if there are no known release-impacting issues.]
+
+## What's Changed
+
+<!-- Keep or regenerate GitHub's generated PR list here. Curate the highlight
+sections above by hand; do not make users infer the release story from this list. -->
+
+* [generated PR entry]
+
+## New Contributors
+
+<!-- Keep GitHub's generated new-contributor section when present. Delete when empty. -->
+
+* [generated contributor entry]
+
+**Full Changelog**: https://github.com/ObolNetwork/obol-stack/compare/[previous-tag]...[version]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@
 #      - Uploads binaries and SHA256SUMS checksums
 #      - Generates release notes
 #
+#   Before publishing the draft release:
+#      - Rewrite the generated body using .github/release-template.md
+#      - Keep the generated "What's Changed", "New Contributors", and
+#        "Full Changelog" sections at the bottom
+#      - Do not include private keys, seed phrases, passwords, hostnames,
+#        personal paths, or raw bearer tokens
+#
 #   3. Binaries are available at:
 #      https://github.com/ObolNetwork/obol-stack/releases/download/v0.1.0/obol_linux_amd64
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Obol Stack: framework for AI agents to run decentralised infrastructure locally.
 - **Detailed architecture reference**: `@.claude/skills/obol-stack-dev/SKILL.md` (invoke with `/obol-stack-dev`)
 - **Review scope**: Avoid broad, vague review/delegation boundaries. State the exact files, invariants, and expected evidence before reviewing or spawning agents. Prefer concrete checks such as "controller cannot access signer/Secrets", "agent write RBAC is namespace-scoped", and "flow uses real obol CLI path" over generic "review architecture".
 - **Planning docs vs user docs**: Implementation plans, design notes, and feature retrospectives belong in `plans/` — they're useful to revisit when picking work back up later. Keep `docs/` for durable, user-facing documentation. Don't mix the two.
+- **Release descriptions**: Use `.github/release-template.md` for future GitHub releases. The release workflow creates a draft with generated notes; rewrite the narrative body from the template, keep generated `What's Changed`, `New Contributors`, and `Full Changelog` sections at the bottom, and never include private keys, seed phrases, passwords, hostnames, personal paths, or raw bearer tokens.
 
 ## Build, Test, Run
 


### PR DESCRIPTION
## Summary

- Add `.github/release-template.md` based on the v0.9.0 release description: https://github.com/ObolNetwork/obol-stack/releases/tag/v0.9.0
- Document how to use the template before publishing draft releases created by the release workflow.
- Point `obol-stack-dev` and `CLAUDE.md` at the template and repeat the no-secrets release-note constraint.

## Validation

- `git diff --cached --check` before commit
- Docs-only change; no Go tests required
