### PR TITLE
chore: bump frontend to v0.1.23 and hermes-agent to v2026.5.7

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -44,7 +44,7 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.21-rc1"
+  tag: "v0.1.23"
 
 service:
   type: ClusterIP

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -33,7 +33,7 @@ const (
 	// renovate: datasource=helm depName=raw registryUrl=https://bedag.github.io/helm-charts/
 	rawChartVersion = "2.0.2"
 
-	defaultImage = "nousresearch/hermes-agent:v2026.4.30"
+	defaultImage = "nousresearch/hermes-agent:v2026.5.7"
 	// Use the upstream image venv instead of cloning Hermes into the PVC on
 	// every cold start. The init container below validates the required extras
 	// are present so image regressions fail before the gateway starts.

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -23,7 +23,7 @@ const (
 	hermesAPISecret    = "hermes-api-server"
 	hermesDataPVC      = "hermes-data"
 	hermesAPIPath      = "/health"
-	defaultHermesImage = "nousresearch/hermes-agent:v2026.4.30"
+	defaultHermesImage = "nousresearch/hermes-agent:v2026.5.7"
 )
 
 // agentLabels returns the standard label set we attach to every primitive

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.19 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.23 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
## Summary
Aligns `main` with two image versions that were intended to land via the integration branch behind #452 but did not survive the squash merges.

- `obolnetwork/obol-stack-front-end`: `v0.1.21-rc1` → `v0.1.23` (off the rc, latest stable release)
- `nousresearch/hermes-agent`: `v2026.4.30` → `v2026.5.7` (referenced from both `internal/hermes/hermes.go` and `internal/serviceoffercontroller/agent_render.go`)
- `justfile` `dev-frontend-reset` target: `v0.1.19` → `v0.1.23` to match the deployed image

## Test plan
- [x] `docker manifest inspect` confirms both tags are published
- [x] `go build ./...` clean
- [x] `go test ./internal/hermes/... ./internal/serviceoffercontroller/...` passes
- [ ] Smoke `obol stack up` and confirm frontend renders + hermes agent pod reaches Ready