### PR TITLE
feat(storefront): make service endpoint clickable

### DIFF
--- a/web/public-storefront/src/components/ServiceCard.tsx
+++ b/web/public-storefront/src/components/ServiceCard.tsx
@@ -55,9 +55,12 @@ export function ServiceCard({ service }: { service: Service }) {
         )}
         <div className="col-span-2">
           <span className="text-text-muted">Endpoint</span>
-          <p className="text-obol-green font-mono text-xs break-all">
+          <a
+            href={service.endpoint}
+            className="block text-obol-green font-mono text-xs break-all hover:underline"
+          >
             {service.endpoint}
-          </p>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Wraps the endpoint string on each `ServiceCard` in an anchor so visitors can click through to the published service URL instead of copy-pasting it. Pulled forward from the integration branch behind #452 where it didn't survive the squash merge.

## Test plan
- [x] `npx tsc --noEmit` — clean type check on the storefront with the changed component
- [x] `npm run dev` boots `next dev` cleanly on port 3344; `GET /` returns HTTP 200 with no build/compile-error overlay
- [x] Confirmed in the rendered HTML: no `<p …obol-green>` remains for the endpoint slot; `<a href=…obol-green>` is now present. Source has the required classNames (`block`, `text-obol-green`, `font-mono`, `text-xs`, `break-all`, `hover:underline`)