### PR TITLE
fix(serviceoffer-controller): harden agent reconciliation and storefront

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -288,10 +288,14 @@ spec:
           resources:
             requests:
               cpu: 25m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 250m
-              memory: 256Mi
+              # Bumped from 256Mi after adding the Agent informer + agent
+              # reconciler — the additional shared cache + workqueue + the
+              # in-controller keystore generation pushed steady-state past
+              # 256Mi and triggered OOMKilled restart loops.
+              memory: 512Mi
 
 ---
 apiVersion: v1

--- a/internal/serviceoffercontroller/agent.go
+++ b/internal/serviceoffercontroller/agent.go
@@ -50,6 +50,40 @@ func (c *Controller) enqueueAgent(obj any) {
 	c.agentQueue.Add(key)
 }
 
+// enqueueOffersFromAgent re-queues every ServiceOffer whose
+// spec.agent.ref points at the given Agent. Without this, an Agent
+// status change (e.g. status.pinnedModel after the user edits the
+// Agent's spec.model) would not propagate into the offer's
+// status.agentResolution — the offer reconciler only runs when the
+// offer itself changes. Mirrors enqueueOfferFromRegistration.
+func (c *Controller) enqueueOffersFromAgent(obj any) {
+	u := asUnstructured(obj)
+	if u == nil {
+		return
+	}
+	agentNS := u.GetNamespace()
+	agentName := u.GetName()
+	for _, item := range c.offerInformer.GetStore().List() {
+		ou := asUnstructured(item)
+		if ou == nil {
+			continue
+		}
+		offer, err := decodeServiceOffer(ou)
+		if err != nil {
+			log.Printf("serviceoffer-controller: decode offer for agent fan-out: %v", err)
+			continue
+		}
+		if !offer.IsAgent() {
+			continue
+		}
+		ref := offer.Spec.Agent.Ref
+		if ref.Name != agentName || ref.Namespace != agentNS {
+			continue
+		}
+		c.offerQueue.Add(offer.Namespace + "/" + offer.Name)
+	}
+}
+
 func (c *Controller) processNextAgent(ctx context.Context) bool {
 	key, shutdown := c.agentQueue.Get()
 	if shutdown {
@@ -384,6 +418,16 @@ func (c *Controller) applyAgentObject(ctx context.Context, resource dynamic.Reso
 		return err
 	}
 
+	// Some kinds we only ever create — never reshape after the fact.
+	// Namespaces are the canonical example: the host CLI creates the
+	// namespace before applying the Agent CR (since the CR is namespaced
+	// and can't land otherwise), and the controller's RBAC intentionally
+	// only grants `create`, not `update`, to keep the blast radius small.
+	// Treat existence as success for these and move on.
+	if isCreateOnlyKind(desired.GetKind()) {
+		return nil
+	}
+
 	// Preserve resourceVersion + uid so Update doesn't 409. Spec/data is
 	// rewritten in full from `desired`; that's the controller's contract.
 	desired.SetResourceVersion(existing.GetResourceVersion())
@@ -395,6 +439,21 @@ func (c *Controller) applyAgentObject(ctx context.Context, resource dynamic.Reso
 		FieldManager: controllerFieldManager,
 	})
 	return err
+}
+
+// isCreateOnlyKind returns true for kinds that the controller refuses to
+// Update on subsequent reconciles. Either the Update would require
+// broader RBAC than we want (Namespace), or the resource has immutable
+// spec fields that reject any wholesale Update (PVC's
+// `spec is immutable after creation`). Mutable kinds (ConfigMap, Secret
+// data, Deployment, Service ports, ServiceAccount) keep going through
+// the normal Update path so reconciles still pick up rendered changes.
+func isCreateOnlyKind(kind string) bool {
+	switch kind {
+	case "Namespace", "PersistentVolumeClaim":
+		return true
+	}
+	return false
 }
 
 // resourceFor maps an unstructured.Unstructured to the dynamic resource

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -228,6 +228,14 @@ func agentPodSpec(agent *monetizeapi.Agent) map[string]any {
 		map[string]any{"name": "API_SERVER_MODEL_NAME", "value": agent.EffectiveModel()},
 		map[string]any{"name": "AGENT_NAMESPACE", "value": agent.Namespace},
 		map[string]any{"name": "OBOL_SKILLS_DIR", "value": "/data/.hermes/obol-skills"},
+		// CRD agents expose only the API (gated by API_SERVER_KEY and reached
+		// only through the in-cluster Traefik route + x402 ForwardAuth). No
+		// Telegram/Discord/dashboard platforms are wired, so Hermes' user
+		// gateway has nothing to actually gate — "allow all" silences its
+		// startup warning without opening any real surface. If platform
+		// integrations are ever added, swap this for explicit per-platform
+		// allowlists.
+		map[string]any{"name": "GATEWAY_ALLOW_ALL_USERS", "value": "true"},
 	}
 	if agent.Status.WalletAddress != "" {
 		containerEnv = append(containerEnv, map[string]any{

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -157,9 +157,18 @@ func New(cfg *rest.Config) (*Controller, error) {
 		DeleteFunc: controller.enqueuePurchase,
 	})
 	agentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.enqueueAgent,
-		UpdateFunc: func(_, newObj any) { controller.enqueueAgent(newObj) },
-		DeleteFunc: controller.enqueueAgent,
+		AddFunc: func(obj any) {
+			controller.enqueueAgent(obj)
+			controller.enqueueOffersFromAgent(obj)
+		},
+		UpdateFunc: func(_, newObj any) {
+			controller.enqueueAgent(newObj)
+			controller.enqueueOffersFromAgent(newObj)
+		},
+		DeleteFunc: func(obj any) {
+			controller.enqueueAgent(obj)
+			controller.enqueueOffersFromAgent(obj)
+		},
 	})
 	configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueDiscoveryRefresh,

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -794,11 +794,19 @@ func buildServiceCatalogJSON(offers []*monetizeapi.ServiceOffer, baseURL string)
 		if desc == "" {
 			desc = fmt.Sprintf("x402 payment-gated %s service", fallbackOfferType(offer))
 		}
+		// type=agent offers leave spec.model empty by design (the model
+		// lives on the linked Agent). Fall back to the controller's
+		// resolved view so the storefront can display it.
+		modelName := offer.Spec.Model.Name
+		if modelName == "" && offer.Status.AgentResolution != nil {
+			modelName = offer.Status.AgentResolution.Model
+		}
+
 		svc := schemas.ServiceCatalogEntry{
 			Name:        offer.Name,
 			Namespace:   offer.Namespace,
 			Type:        fallbackOfferType(offer),
-			Model:       offer.Spec.Model.Name,
+			Model:       modelName,
 			Endpoint:    baseURL + offer.EffectivePath(),
 			Price:       describeOfferPrice(offer),
 			PayTo:       offer.Spec.Payment.PayTo,


### PR DESCRIPTION
## Summary
Pulls forward five small correctness fixes that were carried on the integration branch behind #452 but did not survive the squash merges.

- **S1 — Agent → ServiceOffer fan-out** (`controller.go`, `agent.go`). Re-queue every ServiceOffer whose `spec.agent.ref` points at an Agent when the Agent changes. Without this, an Agent status edit (e.g. `status.pinnedModel` after the user edits `spec.model`) never propagates into the offer's `status.agentResolution` because the offer reconciler only runs when the offer itself changes.
- **S2 — Create-only kinds** (`agent.go`). `applyAgentObject` returns success for `Namespace` and `PersistentVolumeClaim` instead of trying to `Update`. PVCs reject wholesale Update with `spec is immutable after creation`, and the controller's RBAC only grants `create` on Namespaces. Mutable kinds (ConfigMap, Secret data, Deployment, Service ports, ServiceAccount) keep going through the normal Update path so reconciles still pick up rendered changes.
- **S3 — Agent-offer model fallback** (`render.go`). `type=agent` offers leave `spec.model` empty by design (the model lives on the linked Agent). Fall back to `status.agentResolution.Model` so the storefront catalog can display it.
- **S4 — Memory bump** (`x402.yaml`). Bump the serviceoffer-controller Deployment request from 64Mi → 128Mi and limit from 256Mi → 512Mi. The Agent informer + agent reconciler + in-controller keystore generation pushed steady-state past 256Mi after #453 and triggered OOMKilled restart loops.
- **S5 — `GATEWAY_ALLOW_ALL_USERS=true`** (`agent_render.go`). CRD agents expose only the API (gated by `API_SERVER_KEY` + ForwardAuth); no Telegram/Discord/dashboard platforms are wired. The flag silences Hermes' user-gateway startup warning without opening any real surface.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/serviceoffercontroller/...` — all green, including the existing storefront catalog tests
- [ ] On a live cluster: edit an Agent's `spec.model` and confirm the linked offer's `status.agentResolution.Model` updates without manually poking the offer
- [ ] On a live cluster: delete + re-apply an Agent and confirm the controller does not error on PVC update attempts
- [ ] On a live cluster: confirm serviceoffer-controller pod has no `OOMKilled` restarts after seeding several Agents