### PR TITLE
fix(serviceoffer-controller): align remote-signer config with v0.3.0 image

### DIFF
--- a/internal/serviceoffercontroller/agent_wallet.go
+++ b/internal/serviceoffercontroller/agent_wallet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	"github.com/ObolNetwork/obol-stack/internal/openclaw"
@@ -17,11 +18,20 @@ import (
 // version synced with agentruntime.RemoteSignerChartVersion's notes
 // (chart 0.3.2 → image v0.3.0, the canonical recovery-id behaviour).
 const (
-	remoteSignerName        = "remote-signer"
-	remoteSignerPort        = 9000
-	remoteSignerImage       = "ghcr.io/obolnetwork/remote-signer:v0.3.0"
-	remoteSignerKeystoreDir = "/keystores"
+	remoteSignerName  = "remote-signer"
+	remoteSignerPort  = 9000
+	remoteSignerImage = "ghcr.io/obolnetwork/remote-signer:v0.3.0"
+	// Image hard-codes /data/keystores as the default and reads its
+	// config under the SIGNER__... env namespace; values picked to match
+	// the master agent's working config in hermes-obol-agent.
+	remoteSignerKeystoreDir = "/data/keystores"
 	remoteSignerSecretName  = "remote-signer-keystore"
+	// Fixed filename for the keystore inside the Secret + projected
+	// volume. The remote-signer reads the address from inside the V3
+	// keystore document, so the on-disk name is purely cosmetic — a
+	// stable name lets the volume `items` projection drop the password
+	// key cleanly without us having to thread the UUID through.
+	remoteSignerKeystoreKey = "keystore.json"
 )
 
 // ensureAgentWallet provisions a per-namespace remote-signer when the
@@ -69,6 +79,9 @@ func (c *Controller) ensureSignerKeystore(ctx context.Context, namespace string)
 	if err == nil {
 		annotations := existing.GetAnnotations()
 		if addr := annotations[signerKeystoreAddressAnnotation]; addr != "" {
+			if err := c.ensureCanonicalKeystoreKey(ctx, namespace, existing); err != nil {
+				return "", err
+			}
 			return addr, nil
 		}
 		// Secret exists but has no address — likely written by a
@@ -93,6 +106,43 @@ func (c *Controller) ensureSignerKeystore(ctx context.Context, namespace string)
 	return mat.Address, nil
 }
 
+func (c *Controller) ensureCanonicalKeystoreKey(ctx context.Context, namespace string, secret *unstructured.Unstructured) error {
+	data, _, err := unstructured.NestedStringMap(secret.Object, "data")
+	if err != nil {
+		return fmt.Errorf("read %s data: %w", remoteSignerSecretName, err)
+	}
+	if data[remoteSignerKeystoreKey] != "" {
+		return nil
+	}
+
+	var candidateKey, candidateValue string
+	for key, value := range data {
+		if key == "password" || !strings.HasSuffix(key, ".json") || value == "" {
+			continue
+		}
+		if candidateKey != "" {
+			return fmt.Errorf("secret %s/%s has multiple legacy keystore JSON data keys (%q and %q); refusing to choose one", namespace, remoteSignerSecretName, candidateKey, key)
+		}
+		candidateKey = key
+		candidateValue = value
+	}
+	if candidateKey == "" {
+		return fmt.Errorf("secret %s/%s has wallet annotation but no keystore JSON data", namespace, remoteSignerSecretName)
+	}
+
+	data[remoteSignerKeystoreKey] = candidateValue
+	if err := unstructured.SetNestedStringMap(secret.Object, data, "data"); err != nil {
+		return fmt.Errorf("set canonical keystore key: %w", err)
+	}
+	_, err = c.client.Resource(monetizeapi.SecretGVR).Namespace(namespace).Update(ctx, secret, metav1.UpdateOptions{
+		FieldManager: controllerFieldManager,
+	})
+	if err != nil {
+		return fmt.Errorf("update %s/%s with canonical keystore key: %w", namespace, remoteSignerSecretName, err)
+	}
+	return nil
+}
+
 func buildSignerKeystoreSecret(namespace string, mat *openclaw.KeystoreMaterial) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetUnstructuredContent(map[string]any{
@@ -111,11 +161,12 @@ func buildSignerKeystoreSecret(namespace string, mat *openclaw.KeystoreMaterial)
 		},
 		"type": "Opaque",
 		"data": map[string]any{
-			// V3 keystore filename matches its UUID by convention so
-			// remote-signer's directory walker resolves it consistently
-			// with the chart's flow.
-			mat.KeystoreUUID + ".json": base64.StdEncoding.EncodeToString(mat.KeystoreJSON),
-			"password":                 base64.StdEncoding.EncodeToString([]byte(mat.Password)),
+			// Fixed key name; the V3 document carries the UUID + address
+			// internally, and the volume's `items` projection only
+			// references this key (the password lives under a separate
+			// key, read via env, never mounted into the keystore dir).
+			remoteSignerKeystoreKey: base64.StdEncoding.EncodeToString(mat.KeystoreJSON),
+			"password":              base64.StdEncoding.EncodeToString([]byte(mat.Password)),
 		},
 	})
 	return u
@@ -165,9 +216,17 @@ func remoteSignerManifests(agent *monetizeapi.Agent) []*unstructured.Unstructure
 							"ports": []any{
 								map[string]any{"name": "http", "containerPort": int64(remoteSignerPort)},
 							},
+							// Env names match the upstream remote-signer image's
+							// SIGNER__<SECTION>__<KEY> hierarchy. Mirrors the
+							// master agent's config in hermes-obol-agent.
 							"env": []any{
+								map[string]any{"name": "SIGNER__SERVER__HOST", "value": "0.0.0.0"},
+								map[string]any{"name": "SIGNER__SERVER__PORT", "value": fmt.Sprintf("%d", remoteSignerPort)},
+								map[string]any{"name": "SIGNER__KEYSTORE__DIR", "value": remoteSignerKeystoreDir},
+								map[string]any{"name": "SIGNER__LOGGING__FORMAT", "value": "json"},
+								map[string]any{"name": "SIGNER__LOGGING__LEVEL", "value": "info"},
 								map[string]any{
-									"name": "KEYSTORE_PASSWORD",
+									"name": "SIGNER__KEYSTORE__PASSWORD",
 									"valueFrom": map[string]any{
 										"secretKeyRef": map[string]any{
 											"name": remoteSignerSecretName,
@@ -175,15 +234,14 @@ func remoteSignerManifests(agent *monetizeapi.Agent) []*unstructured.Unstructure
 										},
 									},
 								},
-								map[string]any{"name": "KEYSTORE_PATH", "value": remoteSignerKeystoreDir},
 							},
 							"readinessProbe": map[string]any{
-								"httpGet":             map[string]any{"path": "/health", "port": int64(remoteSignerPort)},
+								"httpGet":             map[string]any{"path": "/healthz", "port": int64(remoteSignerPort)},
 								"initialDelaySeconds": int64(2),
 								"periodSeconds":       int64(5),
 							},
 							"livenessProbe": map[string]any{
-								"httpGet":             map[string]any{"path": "/health", "port": int64(remoteSignerPort)},
+								"httpGet":             map[string]any{"path": "/healthz", "port": int64(remoteSignerPort)},
 								"initialDelaySeconds": int64(10),
 								"periodSeconds":       int64(15),
 							},
@@ -201,14 +259,15 @@ func remoteSignerManifests(agent *monetizeapi.Agent) []*unstructured.Unstructure
 							"name": "keystore",
 							"secret": map[string]any{
 								"secretName": remoteSignerSecretName,
-								// Mount only the keystore JSON (and not
-								// the password) into the directory — the
-								// password is wired through env, not file.
+								// Mount only the keystore JSON. The password
+								// lives in the same Secret under a separate
+								// key but is read via env, not file —
+								// projecting it would create a non-keystore
+								// file in /data/keystores and trigger the
+								// signer's "skipping keystore" warnings.
 								"items": []any{
-									map[string]any{"key": "password", "path": ".password.skip"},
+									map[string]any{"key": remoteSignerKeystoreKey, "path": remoteSignerKeystoreKey},
 								},
-								// Default-mode override irrelevant: fsGroup
-								// + readOnly on volumeMount cover access.
 							},
 						},
 					},
@@ -216,11 +275,6 @@ func remoteSignerManifests(agent *monetizeapi.Agent) []*unstructured.Unstructure
 			},
 		},
 	})
-	// Patch the volume to also project the keystore JSON. The fixed
-	// `items` list above only references `password`; we want the keystore
-	// JSON file too. Using a projected items list lets us pick filenames
-	// without parsing Secret keys at apply time.
-	patchSignerVolumeWithKeystoreJSON(deployment)
 
 	service := &unstructured.Unstructured{}
 	service.SetUnstructuredContent(map[string]any{
@@ -249,37 +303,4 @@ func remoteSignerManifests(agent *monetizeapi.Agent) []*unstructured.Unstructure
 	})
 
 	return []*unstructured.Unstructured{deployment, service}
-}
-
-// patchSignerVolumeWithKeystoreJSON drops the no-op .password.skip stub
-// produced inline above and projects every Secret key as a file under
-// /keystores. Done after the Deployment is fully constructed so the
-// inline literal stays readable; a build-time-only post-step rather than
-// branching the construction logic is the smaller change.
-func patchSignerVolumeWithKeystoreJSON(deployment *unstructured.Unstructured) {
-	volumes, _, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "volumes")
-	if err != nil {
-		return
-	}
-	for i, raw := range volumes {
-		v, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if v["name"] != "keystore" {
-			continue
-		}
-		secretMap, _ := v["secret"].(map[string]any)
-		if secretMap == nil {
-			continue
-		}
-		// Drop items so the Secret volume mounts every key as a file at
-		// /keystores/<key>. The remote-signer's keystore-dir scan picks
-		// up the .json file; "password" is a non-JSON sibling that the
-		// scanner ignores.
-		delete(secretMap, "items")
-		v["secret"] = secretMap
-		volumes[i] = v
-	}
-	_ = unstructured.SetNestedSlice(deployment.Object, volumes, "spec", "template", "spec", "volumes")
 }

--- a/internal/serviceoffercontroller/agent_wallet_test.go
+++ b/internal/serviceoffercontroller/agent_wallet_test.go
@@ -43,21 +43,24 @@ func TestEnsureAgentWallet_FreshKeystore(t *testing.T) {
 	if decoded, err := base64.StdEncoding.DecodeString(pwd); err != nil || len(decoded) == 0 {
 		t.Errorf("password not valid base64 / empty: %v", err)
 	}
-	hasKeystore := false
+	keystoreValue, ok := dataMap[remoteSignerKeystoreKey]
+	if !ok || keystoreValue == "" {
+		t.Fatalf("Secret missing canonical %q key", remoteSignerKeystoreKey)
+	}
+	decodedKeystore, err := base64.StdEncoding.DecodeString(keystoreValue)
+	if err != nil {
+		t.Fatalf("%s not valid base64: %v", remoteSignerKeystoreKey, err)
+	}
+	if !strings.Contains(string(decodedKeystore), "\"crypto\"") {
+		t.Fatalf("%s does not look like a V3 keystore JSON", remoteSignerKeystoreKey)
+	}
 	for k, v := range dataMap {
 		if k == "password" {
 			continue
 		}
-		if !strings.HasSuffix(k, ".json") {
-			continue
+		if k != remoteSignerKeystoreKey && strings.HasSuffix(k, ".json") && v != "" {
+			t.Errorf("unexpected extra keystore JSON key %q in fresh Secret", k)
 		}
-		if decoded, err := base64.StdEncoding.DecodeString(v); err == nil && strings.Contains(string(decoded), "\"crypto\"") {
-			hasKeystore = true
-			break
-		}
-	}
-	if !hasKeystore {
-		t.Error("Secret missing V3 keystore JSON")
 	}
 
 	// Deployment + Service got applied alongside.
@@ -89,6 +92,206 @@ func TestEnsureAgentWallet_ReusesExistingKeystore(t *testing.T) {
 	}
 	if address != "0x1111111111111111111111111111111111111111" {
 		t.Errorf("address = %q, want pre-seeded value", address)
+	}
+	secret := getRemoteSignerSecret(t, c, "agent-quant")
+	dataMap := remoteSignerSecretData(t, secret)
+	wantData := remoteSignerSecretData(t, preSeeded)
+	if dataMap[remoteSignerKeystoreKey] != wantData[remoteSignerKeystoreKey] {
+		t.Error("canonical keystore data changed during reuse")
+	}
+	if dataMap["password"] != wantData["password"] {
+		t.Error("keystore password changed during reuse")
+	}
+
+	address, err = c.ensureAgentWallet(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("ensureAgentWallet second pass: %v", err)
+	}
+	if address != "0x1111111111111111111111111111111111111111" {
+		t.Errorf("second address = %q, want pre-seeded value", address)
+	}
+	dataMap = remoteSignerSecretData(t, getRemoteSignerSecret(t, c, "agent-quant"))
+	if dataMap[remoteSignerKeystoreKey] != wantData[remoteSignerKeystoreKey] {
+		t.Error("canonical keystore data changed during second reuse")
+	}
+	if dataMap["password"] != wantData["password"] {
+		t.Error("keystore password changed during second reuse")
+	}
+}
+
+func TestEnsureAgentWallet_MigratesLegacyKeystoreKey(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	legacySecret := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{}}`),
+		Password:     "preseed",
+	})
+	dataMap, found, err := unstructured.NestedStringMap(legacySecret.Object, "data")
+	if err != nil {
+		t.Fatalf("read generated secret data: %v", err)
+	}
+	if !found || dataMap[remoteSignerKeystoreKey] == "" {
+		t.Fatalf("generated secret missing %q data: %v", remoteSignerKeystoreKey, dataMap)
+	}
+	dataMap["existing-uuid.json"] = dataMap[remoteSignerKeystoreKey]
+	delete(dataMap, remoteSignerKeystoreKey)
+	if err := unstructured.SetNestedStringMap(legacySecret.Object, dataMap, "data"); err != nil {
+		t.Fatalf("set legacy data: %v", err)
+	}
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), legacySecret)
+
+	address, err := c.ensureAgentWallet(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("ensureAgentWallet: %v", err)
+	}
+	if address != "0x1111111111111111111111111111111111111111" {
+		t.Errorf("address = %q, want pre-seeded value", address)
+	}
+
+	secret, err := c.client.Resource(monetizeapi.SecretGVR).Namespace("agent-quant").Get(context.Background(), remoteSignerSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	migrated, found, err := unstructured.NestedStringMap(secret.Object, "data")
+	if err != nil {
+		t.Fatalf("read migrated secret data: %v", err)
+	}
+	if !found {
+		t.Fatal("migrated secret has no data")
+	}
+	if migrated[remoteSignerKeystoreKey] == "" {
+		t.Fatalf("legacy keystore secret was not migrated to %q: keys=%v", remoteSignerKeystoreKey, migrated)
+	}
+	if migrated[remoteSignerKeystoreKey] != migrated["existing-uuid.json"] {
+		t.Errorf("migrated keystore data differs from legacy key")
+	}
+	if migrated["password"] != dataMap["password"] {
+		t.Error("migrated secret password changed")
+	}
+}
+
+func TestEnsureAgentWallet_RejectsAmbiguousLegacyKeystoreKeys(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	legacySecret := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{"id":"first"}}`),
+		Password:     "preseed",
+	})
+	dataMap := remoteSignerSecretData(t, legacySecret)
+	dataMap["existing-uuid.json"] = dataMap[remoteSignerKeystoreKey]
+	dataMap["other-uuid.json"] = base64.StdEncoding.EncodeToString([]byte(`{"crypto":{"id":"second"}}`))
+	delete(dataMap, remoteSignerKeystoreKey)
+	if err := unstructured.SetNestedStringMap(legacySecret.Object, dataMap, "data"); err != nil {
+		t.Fatalf("set ambiguous legacy data: %v", err)
+	}
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), legacySecret)
+
+	_, err := c.ensureAgentWallet(context.Background(), agent)
+	if err == nil {
+		t.Fatal("expected ambiguous legacy keystore error")
+	}
+	if !strings.Contains(err.Error(), "multiple legacy keystore JSON data keys") {
+		t.Fatalf("error = %v, want ambiguous legacy keystore message", err)
+	}
+	secret := getRemoteSignerSecret(t, c, "agent-quant")
+	after := remoteSignerSecretData(t, secret)
+	if after[remoteSignerKeystoreKey] != "" {
+		t.Fatal("ambiguous legacy secret should not get a canonical keystore key")
+	}
+	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
+		t.Fatal("remote-signer deployment should not be applied after ambiguous keystore error")
+	}
+}
+
+func TestEnsureAgentWallet_RejectsExistingSecretWithoutAddressAnnotation(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	orphaned := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{}}`),
+		Password:     "preseed",
+	})
+	orphaned.SetAnnotations(nil)
+	wantData := remoteSignerSecretData(t, orphaned)
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), orphaned)
+
+	_, err := c.ensureAgentWallet(context.Background(), agent)
+	if err == nil {
+		t.Fatal("expected error for existing keystore Secret without address annotation")
+	}
+	if !strings.Contains(err.Error(), "exists without obol.org/wallet-address annotation") {
+		t.Fatalf("error = %v, want missing address annotation message", err)
+	}
+	after := remoteSignerSecretData(t, getRemoteSignerSecret(t, c, "agent-quant"))
+	if after[remoteSignerKeystoreKey] != wantData[remoteSignerKeystoreKey] {
+		t.Error("orphaned keystore data changed despite missing annotation")
+	}
+	if after["password"] != wantData["password"] {
+		t.Error("orphaned keystore password changed despite missing annotation")
+	}
+	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
+		t.Fatal("remote-signer deployment should not be applied after missing annotation error")
+	}
+}
+
+func TestEnsureAgentWallet_RejectsAnnotatedSecretWithoutKeystoreJSON(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	broken := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{}}`),
+		Password:     "preseed",
+	})
+	dataMap := remoteSignerSecretData(t, broken)
+	delete(dataMap, remoteSignerKeystoreKey)
+	if err := unstructured.SetNestedStringMap(broken.Object, dataMap, "data"); err != nil {
+		t.Fatalf("set broken data: %v", err)
+	}
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), broken)
+
+	_, err := c.ensureAgentWallet(context.Background(), agent)
+	if err == nil {
+		t.Fatal("expected missing keystore JSON error")
+	}
+	if !strings.Contains(err.Error(), "has wallet annotation but no keystore JSON data") {
+		t.Fatalf("error = %v, want missing keystore JSON message", err)
+	}
+	after := remoteSignerSecretData(t, getRemoteSignerSecret(t, c, "agent-quant"))
+	if after[remoteSignerKeystoreKey] != "" {
+		t.Fatal("broken secret should not get an empty canonical keystore key")
+	}
+	if after["password"] != dataMap["password"] {
+		t.Error("broken secret password changed despite migration failure")
+	}
+	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
+		t.Fatal("remote-signer deployment should not be applied after missing keystore JSON error")
+	}
+}
+
+func TestEnsureAgentWallet_RejectsMalformedSecretData(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	malformed := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{}}`),
+		Password:     "preseed",
+	})
+	malformed.Object["data"] = map[string]any{
+		"password": float64(123),
+	}
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), malformed)
+
+	_, err := c.ensureAgentWallet(context.Background(), agent)
+	if err == nil {
+		t.Fatal("expected malformed Secret data error")
+	}
+	if !strings.Contains(err.Error(), "read remote-signer-keystore data") {
+		t.Fatalf("error = %v, want malformed Secret data message", err)
+	}
+	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
+		t.Fatal("remote-signer deployment should not be applied after malformed Secret data error")
 	}
 }
 
@@ -134,6 +337,114 @@ func TestReconcileAgent_WithWallet_PopulatesAddressAndReady(t *testing.T) {
 	}
 }
 
+func TestReconcileAgent_WithExistingWallet_DoesNotRotateKeyMaterial(t *testing.T) {
+	agent := agentWithWallet(t, "quant-wallet", "agent-quant-wallet", true)
+	preSeeded := buildSignerKeystoreSecret("agent-quant-wallet", &openclaw.KeystoreMaterial{
+		Address:      "0x1111111111111111111111111111111111111111",
+		KeystoreUUID: "existing-uuid",
+		KeystoreJSON: []byte(`{"crypto":{"ciphertext":"preserved"}}`),
+		Password:     "preseed",
+	})
+	wantData := remoteSignerSecretData(t, preSeeded)
+	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), preSeeded)
+
+	if err := c.reconcileAgent(context.Background(), "agent-quant-wallet/quant-wallet"); err != nil {
+		t.Fatalf("reconcileAgent (finalizer): %v", err)
+	}
+	if err := c.reconcileAgent(context.Background(), "agent-quant-wallet/quant-wallet"); err != nil {
+		t.Fatalf("reconcileAgent (provisioning): %v", err)
+	}
+	if err := c.reconcileAgent(context.Background(), "agent-quant-wallet/quant-wallet"); err != nil {
+		t.Fatalf("reconcileAgent (idempotent): %v", err)
+	}
+
+	got := getAgent(t, c, "agent-quant-wallet", "quant-wallet")
+	if got.Status.WalletAddress != "0x1111111111111111111111111111111111111111" {
+		t.Errorf("walletAddress = %q, want existing keystore address", got.Status.WalletAddress)
+	}
+	after := remoteSignerSecretData(t, getRemoteSignerSecret(t, c, "agent-quant-wallet"))
+	if after[remoteSignerKeystoreKey] != wantData[remoteSignerKeystoreKey] {
+		t.Error("existing keystore data changed across reconcile lifecycle")
+	}
+	if after["password"] != wantData["password"] {
+		t.Error("existing keystore password changed across reconcile lifecycle")
+	}
+}
+
+func TestRemoteSignerManifests_ProjectOnlyCanonicalKeystoreAndUsePasswordEnv(t *testing.T) {
+	agent := agentWithWallet(t, "quant", "agent-quant", true)
+	manifests := remoteSignerManifests(agent)
+	deployment := manifests[0]
+
+	volumes, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "volumes")
+	if err != nil || !found {
+		t.Fatalf("deployment volumes not found: found=%v err=%v", found, err)
+	}
+	var keystoreVolume map[string]any
+	for _, volume := range volumes {
+		v, ok := volume.(map[string]any)
+		if ok && v["name"] == "keystore" {
+			keystoreVolume = v
+			break
+		}
+	}
+	if keystoreVolume == nil {
+		t.Fatal("keystore volume not found")
+	}
+	secret, ok := keystoreVolume["secret"].(map[string]any)
+	if !ok {
+		t.Fatalf("keystore volume secret = %#v", keystoreVolume["secret"])
+	}
+	items, ok := secret["items"].([]any)
+	if !ok {
+		t.Fatalf("keystore volume items = %#v", secret["items"])
+	}
+	if len(items) != 1 {
+		t.Fatalf("keystore volume items = %d, want 1", len(items))
+	}
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("keystore item = %#v", items[0])
+	}
+	if item["key"] != remoteSignerKeystoreKey || item["path"] != remoteSignerKeystoreKey {
+		t.Fatalf("keystore projection = %#v, want key/path %q", item, remoteSignerKeystoreKey)
+	}
+
+	containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found || len(containers) != 1 {
+		t.Fatalf("deployment containers not found: len=%d found=%v err=%v", len(containers), found, err)
+	}
+	container, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("container = %#v", containers[0])
+	}
+	env, ok := container["env"].([]any)
+	if !ok {
+		t.Fatalf("container env = %#v", container["env"])
+	}
+	passwordEnv := false
+	for _, entry := range env {
+		e, ok := entry.(map[string]any)
+		if !ok || e["name"] != "SIGNER__KEYSTORE__PASSWORD" {
+			continue
+		}
+		valueFrom, ok := e["valueFrom"].(map[string]any)
+		if !ok {
+			t.Fatalf("password env valueFrom = %#v", e["valueFrom"])
+		}
+		secretKeyRef, ok := valueFrom["secretKeyRef"].(map[string]any)
+		if !ok {
+			t.Fatalf("password env secretKeyRef = %#v", valueFrom["secretKeyRef"])
+		}
+		if secretKeyRef["name"] == remoteSignerSecretName && secretKeyRef["key"] == "password" {
+			passwordEnv = true
+		}
+	}
+	if !passwordEnv {
+		t.Fatal("password must be supplied from the Secret password key via env")
+	}
+}
+
 // agentWithWallet builds an Agent CR for the wallet tests with a model
 // set so we don't trip the ModelUnpinned guard before reaching the
 // wallet path.
@@ -149,4 +460,29 @@ func agentWithWallet(t *testing.T, name, namespace string, create bool) *monetiz
 			Wallet:  monetizeapi.AgentWallet{Create: create},
 		},
 	}
+}
+
+func getRemoteSignerSecret(t *testing.T, c *Controller, namespace string) *unstructured.Unstructured {
+	t.Helper()
+	secret, err := c.client.Resource(monetizeapi.SecretGVR).Namespace(namespace).Get(context.Background(), remoteSignerSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get remote-signer Secret: %v", err)
+	}
+	return secret
+}
+
+func remoteSignerSecretData(t *testing.T, secret *unstructured.Unstructured) map[string]string {
+	t.Helper()
+	dataMap, found, err := unstructured.NestedStringMap(secret.Object, "data")
+	if err != nil {
+		t.Fatalf("read remote-signer Secret data: %v", err)
+	}
+	if !found {
+		t.Fatal("remote-signer Secret has no data")
+	}
+	out := make(map[string]string, len(dataMap))
+	for key, value := range dataMap {
+		out[key] = value
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
The `serviceoffer-controller` on `main` currently speaks the wrong contract to the deployed `ghcr.io/obolnetwork/remote-signer:v0.3.0` image. Any Agent CR with `wallet.create=true` has a signer pod that fails to start or fails its probes, blocking the agent from reaching Ready.

### Local verification against the published image

I pulled `ghcr.io/obolnetwork/remote-signer:v0.3.0` and ran it with both env schemes plus probed both health paths. Results:

| Test | Result |
|------|--------|
| Image default volume (from `docker inspect`) | `/data/keystores` — **not** `/keystores` |
| Run with main's env (`KEYSTORE_PASSWORD`, `KEYSTORE_PATH`) | Exits immediately: `Error: NoPassword` |
| Run with branch's env (`SIGNER__KEYSTORE__PASSWORD`, `SIGNER__KEYSTORE__DIR`) | Runs healthy for 5+ minutes |
| `GET /health` on a running signer | HTTP 404 |
| `GET /healthz` on a running signer | HTTP 200 `{"status":"ok"}` |

So every one of main's three signer-related constants is wrong against the deployed image.

## Fix

Pulls forward the integration branch's S6 work (originally on `integration/pr450-pr451-cloudflare-obol`, dropped by the squash merges):

- **Keystore dir** moved to `/data/keystores` (image default).
- **Keystore filename** pinned to `keystore.json` so the Secret's `items` projection no longer needs to thread the V3 UUID through. The V3 document carries the address internally, so the on-disk name is cosmetic.
- **Migration helper** `ensureCanonicalKeystoreKey`: on reconcile of an existing Secret with the wallet annotation, if data is keyed under the old UUID-named JSON field, rewrite it as `keystore.json` in place. Refuses ambiguous Secrets that already have multiple legacy JSON keys (operator must intervene).
- **Env scheme** switched to upstream's `SIGNER__SECTION__KEY` hierarchy: `SIGNER__SERVER__HOST`, `SIGNER__SERVER__PORT`, `SIGNER__KEYSTORE__DIR`, `SIGNER__KEYSTORE__PASSWORD`, `SIGNER__LOGGING__FORMAT`, `SIGNER__LOGGING__LEVEL`. Matches the master agent's known-good config in `hermes-obol-agent`.
- **Probe paths** switched from `/health` to `/healthz`.

## Tests
Adds 8 unit tests in `agent_wallet_test.go` covering:
- Fresh keystore creation populates the Secret with annotation + canonical key
- Reuse of an existing keystore Secret with the canonical key (no-op)
- Migration from legacy UUID-named key → `keystore.json`
- Rejection of ambiguous Secrets with multiple legacy JSON keys
- Rejection of secrets missing the address annotation or JSON
- Rejection of malformed Secret data
- The wallet-disabled no-op path
- The rendered Deployment shape (single `keystore.json` projected, password read via env, never mounted into the keystore dir)

## Test plan
- [x] `go test ./internal/serviceoffercontroller/...` — all green
- [x] `docker run ghcr.io/obolnetwork/remote-signer:v0.3.0` with the new env scheme — runs healthy, `/healthz` returns 200
- [ ] On a fresh cluster: `kubectl apply` an Agent CR with `wallet.create: true` and confirm the remote-signer pod reaches Ready 1/1 without restarts
- [ ] On a cluster that previously had a working old-format Secret (UUID-named key): confirm the migration helper rewrites it to `keystore.json` on next reconcile without rotating key material