### PR TITLE
security(frontend): digest-pin obol-stack-front-end v0.1.23

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -44,7 +44,10 @@ image:
 
   repository: obolnetwork/obol-stack-front-end
   pullPolicy: IfNotPresent
-  tag: "v0.1.23"
+  # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
+  # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
+  # review. Multi-arch index digest for v0.1.23 (linux/amd64 + linux/arm64).
+  tag: "v0.1.23@sha256:950b887e1cbaca9f928ff7b449b5602ed9777b629b4ee1b9c4c91fac2d74c2f2"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

- Pins the frontend image by sha256 digest in addition to the `v0.1.23` tag.
- New value: `obolnetwork/obol-stack-front-end:v0.1.23@sha256:950b887e1cbaca9f928ff7b449b5602ed9777b629b4ee1b9c4c91fac2d74c2f2`
- Eliminates the mutable-tag attack surface flagged as a non-blocking follow-up by the supply-chain review of `v0.10.0-rc2`.

## Why

A floating tag (`v0.1.23`) could be re-pushed in the upstream registry, and the cluster would silently pick up the new content on the next image pull. Digest pinning makes the cluster's image content cryptographically reproducible. The tag is kept for human readability; the digest is authoritative for the runtime.

Multi-arch index digest covers `linux/amd64` and `linux/arm64`. Verified locally with `helm template obol/obol-app@0.1.1` — the resulting `image:` field is a legal OCI reference (`name:tag@digest`).

## Test plan

- [ ] Lint and Test Charts CI green
- [ ] CodeQL CI green
- [ ] After merge, `obol stack up` should pull `obolnetwork/obol-stack-front-end@sha256:950b...` on first reconcile and the pod should become Ready
- [ ] Roll into the next RC (likely `v0.10.0-rc3`)

## Not self-merging

Per `feedback_main_merge_gates.md` (in Claude memory): "never merge to main without flows-green AND a second human reviewer." Leaving merge to a maintainer.