### PR TITLE
fix(x402): scope token-availability error to the requested chain

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3158,9 +3158,35 @@ func resolveAssetTermsFor(tokenName string, chainName *string, chainExplicit boo
 	// Registry lookup.
 	entry, ok := x402verifier.ResolveToken(tokenName, *chainName)
 	if !ok {
+		onChain := x402verifier.TokensOnChain(*chainName)
+		forToken := x402verifier.ChainsForToken(tokenName)
+		var hint string
+		switch {
+		case len(forToken) > 0 && len(onChain) > 0:
+			hint = fmt.Sprintf(
+				"; tokens on %s: %s; %s is registered on: %s",
+				*chainName, strings.Join(onChain, ", "),
+				tokenName, strings.Join(forToken, ", "),
+			)
+		case len(forToken) > 0:
+			hint = fmt.Sprintf(
+				"; no tokens registered on %s; %s is registered on: %s",
+				*chainName, tokenName, strings.Join(forToken, ", "),
+			)
+		case len(onChain) > 0:
+			hint = fmt.Sprintf(
+				"; tokens on %s: %s; %s is not registered on any chain",
+				*chainName, strings.Join(onChain, ", "), tokenName,
+			)
+		default:
+			hint = fmt.Sprintf(
+				"; no tokens registered on %s and %s is not registered on any chain",
+				*chainName, tokenName,
+			)
+		}
 		return schemas.AssetTerms{}, fmt.Errorf(
-			"--token %s is not available on chain %s (supported tokens: %s)",
-			tokenName, *chainName, strings.Join(x402verifier.SupportedTokens(), ", "),
+			"--token %s is not available on chain %s%s",
+			tokenName, *chainName, hint,
 		)
 	}
 

--- a/internal/x402/tokens.go
+++ b/internal/x402/tokens.go
@@ -108,3 +108,33 @@ func TokenSupportedOnChain(tokenName, chainName string) bool {
 	_, ok := ResolveToken(tokenName, chainName)
 	return ok
 }
+
+// TokensOnChain returns a sorted slice of token symbols registered for the
+// given chain. Returns an empty slice when no tokens are registered for that
+// chain (or the chain is unknown).
+func TokensOnChain(chainName string) []string {
+	canonical := normalizeChainAlias(chainName)
+	tokens := make([]string, 0, len(tokenRegistry))
+	for name, chains := range tokenRegistry {
+		if _, ok := chains[canonical]; ok {
+			tokens = append(tokens, name)
+		}
+	}
+	sort.Strings(tokens)
+	return tokens
+}
+
+// ChainsForToken returns a sorted slice of canonical chain names on which the
+// given token is registered. Returns an empty slice for unknown tokens.
+func ChainsForToken(tokenName string) []string {
+	chains, ok := tokenRegistry[strings.ToUpper(strings.TrimSpace(tokenName))]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(chains))
+	for name := range chains {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/x402/tokens_test.go
+++ b/internal/x402/tokens_test.go
@@ -173,6 +173,72 @@ func TestSupportedTokens(t *testing.T) {
 	}
 }
 
+func TestTokensOnChain(t *testing.T) {
+	tests := []struct {
+		chain string
+		want  []string
+	}{
+		{"base", []string{"USDC"}},
+		{"base-mainnet", []string{"USDC"}},
+		{"base-sepolia", []string{"OBOL", "USDC"}},
+		{"ethereum", []string{"OBOL", "USDC"}},
+		{"mainnet", []string{"OBOL", "USDC"}},
+		{"polygon", []string{"USDC"}},
+		{"unknown-chain", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.chain, func(t *testing.T) {
+			got := TokensOnChain(tc.chain)
+			if len(got) != len(tc.want) {
+				t.Fatalf("TokensOnChain(%q) = %v, want %v", tc.chain, got, tc.want)
+			}
+			for i, want := range tc.want {
+				if got[i] != want {
+					t.Errorf("TokensOnChain(%q)[%d] = %q, want %q", tc.chain, i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestChainsForToken(t *testing.T) {
+	usdc := ChainsForToken("USDC")
+	if len(usdc) < 4 {
+		t.Errorf("ChainsForToken(USDC) returned %d chains, want >= 4: %v", len(usdc), usdc)
+	}
+	contains := func(slice []string, want string) bool {
+		for _, s := range slice {
+			if s == want {
+				return true
+			}
+		}
+		return false
+	}
+	for _, want := range []string{"base", "base-sepolia", "ethereum"} {
+		if !contains(usdc, want) {
+			t.Errorf("ChainsForToken(USDC) missing %q: %v", want, usdc)
+		}
+	}
+
+	obol := ChainsForToken("OBOL")
+	if len(obol) != 2 {
+		t.Fatalf("ChainsForToken(OBOL) = %v, want exactly [base-sepolia ethereum]", obol)
+	}
+	for _, want := range []string{"base-sepolia", "ethereum"} {
+		if !contains(obol, want) {
+			t.Errorf("ChainsForToken(OBOL) missing %q: %v", want, obol)
+		}
+	}
+
+	if got := ChainsForToken("obol"); len(got) != 2 {
+		t.Errorf("ChainsForToken(obol) lowercase = %v, want 2 chains", got)
+	}
+
+	if got := ChainsForToken("WETH"); got != nil {
+		t.Errorf("ChainsForToken(WETH) = %v, want nil", got)
+	}
+}
+
 func TestTokenSupportedOnChain(t *testing.T) {
 	if !TokenSupportedOnChain("USDC", "base") {
 		t.Error("USDC should be supported on base")


### PR DESCRIPTION
## Summary

- `--token X is not available on chain Y (supported tokens: …)` returned the **global** token list, not the **chain-scoped** one — so operators saw OBOL listed as "supported" while the lookup had just rejected `OBOL` on `base-sepolia`/`base`.
- Add `TokensOnChain(chain)` and `ChainsForToken(token)` helpers in `internal/x402/tokens.go`.
- Rewrite `resolveAssetTermsFor`'s error message to use both — now it tells you what's *actually* on the requested chain and where the token you asked for *is* registered.

## How this surfaced

While wiring `obol sell inference … --token OBOL --chain base-sepolia` on spark2 against the v0.9.0 binary:

```
$ obol sell inference aeon … --token OBOL --chain base-sepolia
✗ --token OBOL is not available on chain base-sepolia (supported tokens: OBOL, USDC)
```

The OBOL Base Sepolia registry entry only landed in #452 (post-v0.9.0). That's fine — but the error message confidently claimed OBOL was supported, sending the operator off-trail. (The PR doesn't backport the registry entry; it's already on `main`.)

## Before / after

Before:
```
--token OBOL is not available on chain base (supported tokens: OBOL, USDC)
```

After:
```
--token OBOL is not available on chain base; tokens on base: USDC; OBOL is registered on: base-sepolia, ethereum
```

Other branches handle "no tokens on this chain at all" and "this token isn't anywhere" without losing the chain context.

## Test plan

- [x] `go test ./internal/x402 -count=1` — new `TestTokensOnChain` and `TestChainsForToken` plus existing token tests pass.
- [x] `go build ./...` clean.
- [x] Repro on spark2: `obol sell inference … --token OBOL --chain base` (mainnet, OBOL not registered there) now shows the chain-scoped hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)