### PR TITLE
fix(sell inference): three bugs surfaced by OBOL-priced run on Linux Docker

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -103,12 +103,11 @@ Examples:
 			payToFlag("USDC recipient address"),
 			&cli.StringFlag{
 				Name:  "price",
-				Usage: "USDC price per request",
-				Value: "0.001",
+				Usage: "Per-request price (alias for --per-request; default 0.001 when no price flag is set)",
 			},
 			&cli.StringFlag{
 				Name:  "per-request",
-				Usage: "Per-request price in USDC (alias for --price)",
+				Usage: "Per-request price (alias for --price)",
 			},
 			&cli.StringFlag{
 				Name:  "per-mtok",
@@ -302,6 +301,11 @@ Examples:
 				return fmt.Errorf("invalid pricing: %w", err)
 			}
 
+			assetSymbol := strings.ToUpper(strings.TrimSpace(assetTerms.Symbol))
+			if assetSymbol == "" {
+				assetSymbol = "USDC"
+			}
+
 			d := &inference.Deployment{
 				Name:            name,
 				EnclaveTag:      cmd.String("enclave-tag"),
@@ -310,6 +314,7 @@ Examples:
 				WalletAddress:   wallet,
 				PricePerRequest: perRequest,
 				PricePerMTok:    priceTable.PerMTok,
+				AssetSymbol:     assetSymbol,
 				Chain:           chainName,
 				FacilitatorURL:  cmd.String("facilitator"),
 				VMMode:          cmd.Bool("vm"),
@@ -363,10 +368,13 @@ Examples:
 					port = listenAddr[idx+1:]
 				}
 
-				// Bind to loopback only — the cluster reaches us via the
-				// K8s Service+Endpoints bridge; there is no reason to expose
-				// the unpaid gateway on all interfaces.
-				d.ListenAddr = "127.0.0.1:" + port
+				// Bind on all interfaces — the in-cluster Endpoints object
+				// points at the host's docker-bridge IP (e.g. 172.17.0.1 on
+				// Linux), which the kernel only delivers to listeners bound
+				// to 0.0.0.0 or the bridge IP itself, not to 127.0.0.1.
+				// Loopback-only binding made the cluster see "connection
+				// refused" on the host-routed Service.
+				d.ListenAddr = "0.0.0.0:" + port
 
 				// Create a K8s Service + Endpoints pointing to the host.
 				svcNs := "llm" // co-locate with LiteLLM for simplicity
@@ -2802,6 +2810,7 @@ func runInferenceGateway(u *ui.UI, d *inference.Deployment, chain x402verifier.C
 		UpstreamURL:     d.UpstreamURL,
 		WalletAddress:   d.WalletAddress,
 		PricePerRequest: d.PricePerRequest,
+		AssetSymbol:     d.AssetSymbol,
 		Chain:           chain,
 		FacilitatorURL:  d.FacilitatorURL,
 		EnclaveTag:      d.EnclaveTag,

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -30,8 +30,15 @@ type GatewayConfig struct {
 	// WalletAddress is the USDC recipient address for payments.
 	WalletAddress string
 
-	// PricePerRequest is the USDC amount charged per inference request (e.g., "0.001").
+	// PricePerRequest is the amount charged per inference request, denominated
+	// in AssetSymbol units (e.g., "0.001" with AssetSymbol="USDC", or "0.023"
+	// with AssetSymbol="OBOL"). Atomic-unit conversion happens at the x402
+	// middleware boundary using the token's decimals.
 	PricePerRequest string
+
+	// AssetSymbol is the token symbol charged per request (default "USDC").
+	// Used for human-readable log output and price summaries.
+	AssetSymbol string
 
 	// Chain is the x402 chain configuration (e.g., x402pkg.ChainBaseMainnet).
 	Chain x402pkg.ChainInfo
@@ -108,6 +115,16 @@ type Gateway struct {
 	server    *http.Server
 	container *ContainerManager // non-nil when VMMode is active
 	seKey     enclave.Key       // non-nil when TEE or SE mode is active
+}
+
+// formatPriceLogLine renders the human-readable per-request price string used
+// in the gateway's startup log. An empty symbol defaults to "USDC" so legacy
+// callers that don't set AssetSymbol keep their previous output.
+func formatPriceLogLine(price, symbol string) string {
+	if symbol == "" {
+		symbol = "USDC"
+	}
+	return fmt.Sprintf("%s %s/request", price, symbol)
 }
 
 // NewGateway creates a new inference gateway with the given configuration.
@@ -354,7 +371,7 @@ func (g *Gateway) Start() error {
 	log.Printf("x402 inference gateway listening on %s", g.config.ListenAddr)
 	log.Printf("  upstream:    %s", upstreamURL)
 	log.Printf("  wallet:      %s", g.config.WalletAddress)
-	log.Printf("  price:       %s USDC/request", g.config.PricePerRequest)
+	log.Printf("  price:       %s", formatPriceLogLine(g.config.PricePerRequest, g.config.AssetSymbol))
 	log.Printf("  chain:       %s", g.config.Chain.NetworkID)
 	log.Printf("  facilitator: %s", g.config.FacilitatorURL)
 

--- a/internal/inference/gateway_test.go
+++ b/internal/inference/gateway_test.go
@@ -653,3 +653,53 @@ func TestGateway_ServicePrefixedPath_PreservesQuery(t *testing.T) {
 		t.Errorf("expected 402 after prefix normalisation with query, got %d", resp.StatusCode)
 	}
 }
+
+func TestFormatPriceLogLine(t *testing.T) {
+	tests := []struct {
+		name   string
+		price  string
+		symbol string
+		want   string
+	}{
+		{"empty symbol defaults to USDC", "0.001", "", "0.001 USDC/request"},
+		{"explicit USDC", "0.001", "USDC", "0.001 USDC/request"},
+		{"OBOL", "0.023", "OBOL", "0.023 OBOL/request"},
+		{"lowercase passed through", "0.5", "obol", "0.5 obol/request"},
+		{"empty price stays empty", "", "OBOL", " OBOL/request"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatPriceLogLine(tc.price, tc.symbol)
+			if got != tc.want {
+				t.Errorf("formatPriceLogLine(%q, %q) = %q; want %q", tc.price, tc.symbol, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewGateway_PreservesAssetSymbol(t *testing.T) {
+	tests := []struct {
+		name   string
+		symbol string
+		want   string
+	}{
+		{"explicit OBOL", "OBOL", "OBOL"},
+		{"explicit USDC", "USDC", "USDC"},
+		{"empty kept as empty (default applied at log site)", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gw, err := NewGateway(GatewayConfig{
+				UpstreamURL:   "http://localhost:11434",
+				WalletAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+				AssetSymbol:   tc.symbol,
+			})
+			if err != nil {
+				t.Fatalf("NewGateway: %v", err)
+			}
+			if gw.config.AssetSymbol != tc.want {
+				t.Errorf("gw.config.AssetSymbol = %q; want %q", gw.config.AssetSymbol, tc.want)
+			}
+		})
+	}
+}

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -43,8 +43,13 @@ type Deployment struct {
 	// WalletAddress is the USDC payment recipient.
 	WalletAddress string `json:"wallet_address"`
 
-	// PricePerRequest is the USDC price per inference call (default "0.001").
+	// PricePerRequest is the per-inference price denominated in AssetSymbol
+	// units (default "0.001" USDC).
 	PricePerRequest string `json:"price_per_request"`
+
+	// AssetSymbol is the token symbol charged per request (default "USDC").
+	// Used for human-readable log output and to label persisted state.
+	AssetSymbol string `json:"asset_symbol,omitempty"`
 
 	// PricePerMTok is the original per-million-token price when request pricing
 	// was derived from the temporary phase-1 approximation.


### PR DESCRIPTION
## Summary

Three independent regressions in `obol sell inference`, all of which only become visible in sequence on a Linux k3d host running with `--token OBOL --chain base-sepolia` (testnet OBOL just became registry-resident in #452).

1. **`--price` hardcoded default overrides every other price flag.**
   `resolvePriceTable` checks `cmd.String("price")` first; with `Value: "0.001"` baked into the flag, that's never empty, so `--per-mtok` and `--per-request` are silently ignored. ServiceOffer ends up with `price.perRequest: "0.001"` and no `perMTok` no matter what the operator passed.

2. **Cluster-mode listener was forced to `127.0.0.1`.** When `clusterAvailable`, the CLI rewrote `d.ListenAddr` to `"127.0.0.1:" + port`. The k8s Endpoints object created next door points at the host's docker-bridge IP (e.g. `172.17.0.1`) — the Linux kernel delivers those connections only to listeners on `0.0.0.0` or the bridge IP, **not** to `127.0.0.1`. End result on spark2: `UpstreamHealthy=False — dial tcp 10.43.x.x:8402: connection refused`. macOS Docker tolerated this because of how `host.docker.internal` is wired.

3. **Gateway log hardcoded `USDC/request`.** With `--token OBOL` the startup banner read `0.023 USDC/request`, which is just wrong reporting. Plumb `AssetSymbol` through `inference.Deployment` → `inference.GatewayConfig` and render via a small pure helper.

## Why these are bundled

You only see #2 once #1 is fixed (the offer otherwise pegs `perRequest: "0.001"` and you debug pricing instead of routing). You only see #3 once #2 is fixed and you watch the gateway actually start. They were all visible in a single broken session on spark2 and are all one-line conceptual fixes in the same code path; splitting risks an awkward partial state on main.

## Before / after on Linux k3d

```
# before
$ obol sell inference aeon --per-mtok 23 --token OBOL --chain base-sepolia ...
serviceoffer.obol.org/aeon created
...
2026/05/12 13:45:01 x402 inference gateway listening on 127.0.0.1:8402
2026/05/12 13:45:01   price:       0.001 USDC/request
...
UpstreamHealthy=False — dial tcp 10.43.237.1:8402: connection refused
```

```
# after
$ obol sell inference aeon --per-mtok 23 --token OBOL --chain base-sepolia ...
serviceoffer.obol.org/aeon created
2026/05/12 14:00:44 x402 inference gateway listening on 0.0.0.0:8402
2026/05/12 14:00:44   price:       0.023 OBOL/request
...
Ready=True Reconciled: Offer reconciled successfully
```

Public 402 quote from `https://<tunnel>/services/aeon/v1/models` returns the right `amount: 23000000000000000` wei (23 OBOL/Mtok at 1k tok approx) with `asset` the Base Sepolia OBOL contract and `network: eip155:84532`.

## Test plan

- [x] `go test ./internal/inference -count=1` — new `TestFormatPriceLogLine` (table-driven over USDC/OBOL/lowercase/empty) and `TestNewGateway_PreservesAssetSymbol` pass alongside the existing gateway suite.
- [x] `go build ./...` clean.
- [x] End-to-end on spark2 (k3d on Linux ARM64) — ServiceOffer reaches `Ready=True` with `price.perMTok: "23"` and `payment.asset.symbol: OBOL`, public 402 quote returns the right amount on Base Sepolia.

## Follow-ups (not in this PR)

- `obol tunnel setup` doesn't pass `--overwrite-dns` to cloudflared, so re-running the wizard against a hostname with an existing CNAME silently fails on the route-DNS step. Filing separately.
- `obol sell delete` requires `--force` but rejects `--yes` / `-y` for unattended use. Cosmetic; separate PR.

Generated with Claude Code