### PR TITLE
fix(sell): accept --yes / -y as aliases for --force on sell delete

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -2316,8 +2316,8 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:    "force",
-				Aliases: []string{"f"},
-				Usage:   "Skip confirmation",
+				Aliases: []string{"f", "y", "yes"},
+				Usage:   "Skip confirmation (aliases: -f, -y, --yes)",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {


### PR DESCRIPTION
## Summary

`obol sell delete <name> -n <ns>` only accepted `--force` / `-f` to skip the confirmation prompt. The conventional non-interactive flags `--yes` and `-y` were rejected outright:

```
$ obol sell delete aeon -n llm --yes
Incorrect Usage: flag provided but not defined: -yes
✗ flag provided but not defined: -yes
```

This blocks scripted teardowns and surprises operators muscle-memoried on `-y`. Surfaced on spark2 today while tearing down an offer between two flow runs.

Fix: add `y`, `yes` as aliases on the existing `--force` BoolFlag. Same runtime path, just more accepted surface.

## Scope

Intentionally narrow to `sell delete` because that is what surfaced. Several other places also gate destructive commands on `--force` without `-y`:

- `obol stack purge -f`
- `obol agent delete --force`
- `obol app delete --force`
- `obol network remove --force`

A consistency pass across all of them is a reasonable follow-up; I left it out here to keep the PR scoped to a single confirmed regression.

## Test plan

- [x] `obol sell delete --help` now lists `--force, -f, -y, --yes`.
- [x] `go build ./...` clean.
- [x] Manual: `obol sell delete aeon -n llm --yes` and `-y` both run without the "flag not defined" error.

Full report (PR template) added as the first comment.