### PR TITLE
fix(tunnel): detect cloudflared zone-mismatch routing and fail loudly

### DIFF
--- a/internal/tunnel/login.go
+++ b/internal/tunnel/login.go
@@ -117,6 +117,9 @@ func Login(cfg *config.Config, u *ui.UI, opts LoginOptions) error {
 		}
 		return fmt.Errorf("cloudflared tunnel route dns failed: %w\n%s%s", err, strings.TrimSpace(string(routeOut)), hint)
 	}
+	if err := verifyRoutedHostname(string(routeOut), hostname); err != nil {
+		return err
+	}
 
 	if err := applyLocalManagedK8sResources(cfg, u, kubeconfigPath, hostname, tunnelID, cert, cred); err != nil {
 		return err
@@ -201,6 +204,52 @@ func parseFirstUUID(s string) (string, error) {
 	}
 
 	return "", errors.New("uuid not found")
+}
+
+// routedHostnameRegexps matches the two log shapes cloudflared emits on a
+// successful `tunnel route dns` invocation:
+//
+//	... INF Added CNAME <hostname> which will route to this tunnel tunnelID=<UUID>
+//	... INF <hostname> is already configured to route to your tunnel tunnelID=<UUID>
+var routedHostnameRegexps = []*regexp.Regexp{
+	regexp.MustCompile(`Added CNAME\s+(\S+)\s+which will route to this tunnel`),
+	regexp.MustCompile(`(\S+)\s+is already configured to route to your tunnel`),
+}
+
+// verifyRoutedHostname parses cloudflared's combined stdout/stderr from
+// `tunnel route dns` and returns an error when the hostname it actually routed
+// differs from the requested hostname. This catches the silent zone-fallback
+// failure mode where ~/.cloudflared/cert.pem is scoped to a Cloudflare account
+// that does not own the requested zone, and cloudflared appends its default
+// zone to the request (e.g. requested "inference.v1337.org" → routed
+// "inference.v1337.org.humanresearch.ai").
+//
+// If neither known log pattern is found, the parser returns nil so a benign
+// upstream log-format change does not break the happy path.
+func verifyRoutedHostname(routedOutput, requestedHostname string) error {
+	want := strings.TrimSpace(requestedHostname)
+	if want == "" {
+		return nil
+	}
+
+	for _, re := range routedHostnameRegexps {
+		m := re.FindStringSubmatch(routedOutput)
+		if len(m) < 2 {
+			continue
+		}
+
+		got := strings.TrimSpace(m[1])
+		if strings.EqualFold(got, want) {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"cloudflared routed DNS to %q, not %q. Your ~/.cloudflared/cert.pem is scoped to a Cloudflare account that does not own the zone for %q. Move or delete the cert and re-run `obol tunnel login` to authorize a fresh cert against the correct account.",
+			got, want, want,
+		)
+	}
+
+	return nil
 }
 
 func applyLocalManagedK8sResources(cfg *config.Config, u *ui.UI, kubeconfigPath, hostname, tunnelID string, certPEM, credJSON []byte) error {

--- a/internal/tunnel/login_test.go
+++ b/internal/tunnel/login_test.go
@@ -2,6 +2,7 @@ package tunnel
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +35,81 @@ func TestRouteDNSArgs(t *testing.T) {
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("routeDNSArgs(%q, %q, %v) = %v; want %v",
 					tc.tunnelName, tc.hostname, tc.overwrite, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyRoutedHostname(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		requested   string
+		wantErr     bool
+		wantInError []string
+	}{
+		{
+			name:      "added CNAME success line with matching hostname",
+			output:    "2026-05-12T10:00:00Z INF Added CNAME inference.example.com which will route to this tunnel tunnelID=f37ef341-1234-5678-9abc-def012345678",
+			requested: "inference.example.com",
+			wantErr:   false,
+		},
+		{
+			name:      "already-configured line with matching hostname",
+			output:    "2026-05-12T10:00:00Z INF inference.example.com is already configured to route to your tunnel tunnelID=f37ef341-1234-5678-9abc-def012345678",
+			requested: "inference.example.com",
+			wantErr:   false,
+		},
+		{
+			name:        "added CNAME line with mismatched FQDN (zone fallback)",
+			output:      "2026-05-12T10:00:00Z INF Added CNAME inference.want.com.other.com which will route to this tunnel tunnelID=f37ef341-1234-5678-9abc-def012345678",
+			requested:   "inference.want.com",
+			wantErr:     true,
+			wantInError: []string{"inference.want.com", "inference.want.com.other.com"},
+		},
+		{
+			name:        "already-configured line with mismatched FQDN (zone fallback)",
+			output:      "2026-05-12T10:00:00Z INF inference.v1337.org.humanresearch.ai is already configured to route to your tunnel tunnelID=f37ef341-1234-5678-9abc-def012345678",
+			requested:   "inference.v1337.org",
+			wantErr:     true,
+			wantInError: []string{"inference.v1337.org", "inference.v1337.org.humanresearch.ai"},
+		},
+		{
+			name:      "empty output is treated as no signal",
+			output:    "",
+			requested: "inference.example.com",
+			wantErr:   false,
+		},
+		{
+			name:      "mixed-case hostname tolerated",
+			output:    "2026-05-12T10:00:00Z INF Added CNAME X.Want.com which will route to this tunnel tunnelID=f37ef341-1234-5678-9abc-def012345678",
+			requested: "x.want.com",
+			wantErr:   false,
+		},
+		{
+			name:      "unknown log shape continues without error",
+			output:    "2026-05-12T10:00:00Z INF Some new log shape we have never seen before",
+			requested: "inference.example.com",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyRoutedHostname(tt.output, tt.requested)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("verifyRoutedHostname(...) = nil, want error")
+				}
+				for _, want := range tt.wantInError {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not contain %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("verifyRoutedHostname(...) = %v, want nil", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `obol tunnel login` now parses cloudflared's `tunnel route dns` output and fails loudly if the routed hostname does not match the requested one (case-insensitive). Catches the silent zone-fallback failure mode where `~/.cloudflared/cert.pem` is scoped to a Cloudflare account that does not own the zone for the requested hostname — cloudflared appends its default zone (e.g. `inference.v1337.org` → `inference.v1337.org.example.com`) and exits 0.
- Helper `verifyRoutedHostname` is a pure function on the cloudflared output string; no Cloudflare API calls (locally-managed mode has no API token). Unknown log shapes are treated as "no signal" so an upstream log-format change cannot break the happy path.
- New table-driven `TestVerifyRoutedHostname` covers both success log shapes, both mismatch shapes, empty output, mixed-case tolerance, and unknown-shape pass-through.

## Test plan

- [x] `go test ./internal/tunnel -count=1 -run 'TestVerifyRoutedHostname|TestRouteDNSArgs'` (7 subtests pass)
- [x] `go build ./...`
- [ ] Manual: re-run `obol tunnel login --hostname inference.v1337.org` on a host whose `~/.cloudflared/cert.pem` is scoped to a different zone — expect a clear error pointing at cert.pem, no helm/manifest apply
- [ ] Manual: happy-path `obol tunnel login` against a correctly-scoped cert.pem still succeeds end-to-end