### PR TITLE
fix(flows): use ERE alternation in run_step_grep / poll_step_grep patterns

### DIFF
--- a/flows/flow-01-prerequisites.sh
+++ b/flows/flow-01-prerequisites.sh
@@ -9,7 +9,7 @@ run_step "Docker daemon running" docker info
 # LLM endpoint must be serving. Full QA uses an OpenAI-compatible
 # vLLM/llama.cpp endpoint; local development can still use Ollama.
 if [ -n "${OBOL_LLM_ENDPOINT:-}" ]; then
-    run_step_grep "OpenAI-compatible LLM endpoint serving models" "data\\|id" \
+    run_step_grep "OpenAI-compatible LLM endpoint serving models" "data|id" \
         curl -sf "${OBOL_LLM_ENDPOINT%/}/models"
 else
     run_step_grep "Ollama serving models" "models" curl -sf http://localhost:11434/api/tags

--- a/flows/flow-02-stack-init-up.sh
+++ b/flows/flow-02-stack-init-up.sh
@@ -61,12 +61,12 @@ poll_step "Frontend at $INGRESS_URL/" 60 5 \
 # §6: obol network list shows available networks (getting-started §6)
 # Tests the network management CLI without deploying any Ethereum clients.
 run_step_grep "obol network list shows available networks" \
-    "ethereum\|aztec\|Available" \
+    "Local Nodes|Remote RPCs|mainnet|chain=" \
     "$OBOL" network list
 
 # §6: obol network status shows eRPC gateway health (getting-started §Managing Networks)
 run_step_grep "obol network status shows eRPC upstreams" \
-    "Running\|upstream\|chain" \
+    "eRPC|Pod|Upstream|Running" \
     "$OBOL" network status
 
 # §6/§1.6: eRPC /rpc JSON lists base-sepolia among available chains + all states OK

--- a/flows/flow-05-network.sh
+++ b/flows/flow-05-network.sh
@@ -8,16 +8,16 @@ refresh_obol_ingress_env
 INGRESS_URL="${OBOL_INGRESS_URL%/}"
 
 # List available networks (local nodes + remote RPCs)
-run_step_grep "network list" "ethereum\|Remote\|Local" "$OBOL" network list
+run_step_grep "network list" "Remote RPCs|Local Nodes|mainnet|chain=" "$OBOL" network list
 
 # eRPC gateway health via obol network status
-run_step_grep "eRPC gateway status" "eRPC\|Pod\|Upstream" "$OBOL" network status
+run_step_grep "eRPC gateway status" "eRPC|Pod|Upstream|Running" "$OBOL" network status
 
 # Add a public RPC for base-sepolia (documented user path for RPC access)
 run_step "network add base-sepolia RPC" "$OBOL" network add base-sepolia --count 1
 
 # Verify it appears in list
-run_step_grep "base-sepolia in network list" "base-sepolia\|84532" "$OBOL" network list
+run_step_grep "base-sepolia in network list" "base-sepolia|84532" "$OBOL" network list
 
 # eRPC is accessible at /rpc/evm/<chainId> — base-sepolia is chain 84532
 step "eRPC base-sepolia via Traefik (/rpc/evm/84532)"

--- a/flows/flow-06-sell-setup.sh
+++ b/flows/flow-06-sell-setup.sh
@@ -151,7 +151,7 @@ fi
 sleep 2
 
 run_step_grep "sell http flow-qwen" \
-    "ServiceOffer.*created\|ServiceOffer.*updated\|agent will reconcile" \
+    "ServiceOffer.*created|ServiceOffer.*updated|agent will reconcile" \
     "$OBOL" sell http flow-qwen \
     --wallet "$SELLER_WALLET" \
     --chain "$CHAIN" \

--- a/flows/flow-10-anvil-facilitator.sh
+++ b/flows/flow-10-anvil-facilitator.sh
@@ -240,7 +240,7 @@ run_step_grep "Facilitator /supported" "eip155" \
 CLUSTER_FACILITATOR_HOST=$(cluster_facilitator_host)
 CLUSTER_FACILITATOR_URL="http://${CLUSTER_FACILITATOR_HOST}:$FACILITATOR_PORT"
 run_step_grep "sell pricing with local facilitator" \
-    "configured.*facilitator\|x402 configured" \
+    "configured.*facilitator|x402 configured|x402-pricing configured" \
     "$OBOL" sell pricing \
     --wallet "$SELLER_WALLET" \
     --chain "$CHAIN" \


### PR DESCRIPTION
## Summary

`lib.sh`'s `run_step_grep` and `poll_step_grep` helpers both use `grep -qE` (extended regex) — the comment in the helper explicitly says callers may use ERE quantifiers. But several callsites passed BRE alternation (`\|`), which in ERE is a literal backslash-pipe and never matches.

The spark1 smoke run surfaced this as cascading "pattern not found" FAILs in flow-01 / flow-02 / flow-05 / flow-06 / flow-10, even though the expected substrings were present in the CLI output.

## What's changed

Convert all 8 BRE call sites to ERE `|`. Also widen the patterns where the CLI output has drifted since they were written:

- `obol network list` now prints `Local Nodes:` / `Remote RPCs:` / `mainnet … chain=…` instead of network shortnames; the old `ethereum|aztec` pattern would never have matched the current output even with correct ERE syntax.
- `obol network status` now prints `eRPC Gateway Status` / `Pod:` / upstream rows; added `Running` for completeness.
- flow-10 facilitator-pricing check now also accepts the `configmap/x402-pricing configured` line that `obol sell pricing` actually emits.

## Test plan

- [x] `bash -n` clean on all 5 modified flow files
- [x] Confirmed zero remaining BRE `\|` patterns sent to ERE helpers (`grep -rn ... | grep -E 'run_step_grep|poll_step_grep'` returns nothing)
- [ ] Re-run release-smoke on spark1 to confirm the cascading flow-01/02/05/06/10 pattern-FAILs are gone