### PR TITLE
fix(flow-02): poll node-ready + eRPC /rpc instead of one-shot

### DIFF
--- a/flows/flow-02-stack-init-up.sh
+++ b/flows/flow-02-stack-init-up.sh
@@ -25,8 +25,11 @@ else
     fail "Stack config missing: stack-id=${STACK_ID:-empty}, kubeconfig=$([ -f "$OBOL_CONFIG_DIR/kubeconfig.yaml" ] && echo 'present' || echo 'MISSING')"
 fi
 
-# §2: Verify the cluster — wait for all pods to be Running/Completed
-run_step_grep "Nodes ready" "Ready" "$OBOL" kubectl get nodes
+# §2: Verify the cluster — wait for all pods to be Running/Completed.
+# `obol stack up` returns once the k3s API responds, but the node may take
+# another few seconds to register in `kubectl get nodes`. Poll briefly to
+# absorb that race instead of one-shotting.
+poll_step_grep "Nodes ready" " Ready " 12 5 "$OBOL" kubectl get nodes
 # Verify the k3s cluster version matches the documented version (CLAUDE.md: v1.35.1-k3s1)
 step "k3s server version is v1.35.1+k3s1"
 kube_ver=$("$OBOL" kubectl version 2>&1) || true
@@ -69,20 +72,26 @@ run_step_grep "obol network status shows eRPC upstreams" \
     "Running\|upstream\|chain" \
     "$OBOL" network status
 
-# §6/§1.6: eRPC /rpc JSON lists base-sepolia among available chains + all states OK
+# §6/§1.6: eRPC /rpc JSON lists base-sepolia among available chains + all states OK.
+# Poll briefly because eRPC's HTTP listener is up before its upstream pool has
+# fully resolved every alias; one-shotting this races with cold-start init.
 step "eRPC /rpc lists base-sepolia (required for x402 payment chain)"
-erpc_json=$($CURL_OBOL -sf --max-time 5 "$INGRESS_URL/rpc" 2>&1) || true
-if echo "$erpc_json" | python3 -c "
+erpc_json=""
+for i in $(seq 1 12); do
+    erpc_json=$($CURL_OBOL -sf --max-time 5 "$INGRESS_URL/rpc" 2>&1) || true
+    if echo "$erpc_json" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 aliases = [r.get('alias','') for r in d.get('rpc',[])]
 assert 'base-sepolia' in aliases, f'base-sepolia not in {aliases}'
 print(f'eRPC chains: {aliases}')
-" 2>&1; then
-    pass "eRPC lists base-sepolia chain for x402 payments"
-else
-    fail "eRPC /rpc missing base-sepolia — ${erpc_json:0:100}"
-fi
+" 2>/dev/null; then
+        pass "eRPC lists base-sepolia chain for x402 payments (attempt $i)"
+        break
+    fi
+    [ "$i" -eq 12 ] && fail "eRPC /rpc missing base-sepolia after 60s — ${erpc_json:0:100}"
+    sleep 5
+done
 
 step "eRPC all configured chains are in OK state"
 if echo "$erpc_json" | python3 -c "


### PR DESCRIPTION
## Summary

Two cold-start races surfaced on spark1's smoke run:

1. **Node registration race.** \`obol stack up\` returns once the k3s API responds, but the k3d node can take another few seconds to appear in `kubectl get nodes`. The old `run_step_grep "Nodes ready" "Ready" kubectl get nodes` raced that window and FAILed on "No resources found". Switched to `poll_step_grep` with 12×5s ceiling. Also tightened the pattern to ` Ready ` (surrounding spaces) so the word "NotReady" in the status column does not satisfy the match.
2. **eRPC upstream-pool warmup race.** eRPC's HTTP listener becomes reachable before its upstream pool has fully resolved every alias. A one-shot GET `/rpc` moments after pods report Running often returns a partial list missing `base-sepolia`, which then cascades into the chains-OK and JSON-RPC checks. Poll the first eRPC assertion until base-sepolia appears (or 60s elapses); the subsequent assertions then have a stable list to reason about.

## Test plan

- [x] `bash -n flows/flow-02-stack-init-up.sh` clean
- [ ] Re-run release-smoke on spark1; expect flow-02 steps 5, 11, 12, 14, 15 to no longer race the cluster bring-up