### PR TITLE
chore(frontend): bump obol-stack-front-end v0.1.23 → v0.1.24 (digest-pinned)

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.23 (linux/amd64 + linux/arm64).
-  tag: "v0.1.23@sha256:950b887e1cbaca9f928ff7b449b5602ed9777b629b4ee1b9c4c91fac2d74c2f2"
+  # review. Multi-arch index digest for v0.1.24 (linux/amd64 + linux/arm64).
+  tag: "v0.1.24@sha256:d5abd6aebddcabf7b7fccd2f5e922cb6067c90dca808b306bd46db71b0010206"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

Bumps the frontend image pin from `v0.1.23` (tag-only) to **stable `v0.1.24`** with multi-arch digest:

```
obolnetwork/obol-stack-front-end:v0.1.24@sha256:d5abd6aebddcabf7b7fccd2f5e922cb6067c90dca808b306bd46db71b0010206
```

Single commit; combines the version bump with the supply-chain hardening that was previously staged in #468 (digest-pin at v0.1.23). #468 closed as superseded.

## What v0.1.24 contains (frontend-side)

Cumulative since `v0.1.23`:

- 12 Dependabot dep bumps integrated via [frontend #310](https://github.com/ObolNetwork/obol-stack-front-end/pull/310):
  - Runtime: `next` 16.2.4→16.2.6, `react` 19.2.5→19.2.6, `@rainbow-me/rainbowkit` 2.2.10→2.2.11, `@copilotkit/{react-core,react-ui}` 1.56.3→1.57.1
  - Dev: `@typescript-eslint/{parser 8.59.2,eslint-plugin 8.59.1}`, `@next/eslint-plugin-next 16.2.6`, `eslint-config-next 16.2.6`, `@types/node 25.6.2`
  - Infra: Dockerfile base `node:22-alpine` → `node:26-alpine`; `actions/setup-node` 6.3.0 → 6.4.0
- [frontend #292](https://github.com/ObolNetwork/obol-stack-front-end/pull/292) `feat(dashboard): storefront link + AgentRegistrationCard`

Frontend release sequence: `v0.1.24-rc1` (dep bumps only) → `v0.1.24-rc2` (+ #292) → **`v0.1.24`** (stable, same code as rc2, freshly-built Docker image).

## Supply-chain review (frontend-side): GREEN

Audited via security subagent on both #310 (dep diff) and #292 (feature diff):
- All workflow `uses:` SHA-pinned (verified `actions/setup-node@v6.4.0` SHA matches the public tag)
- **Zero net-new transitive packages** (4 chevrotain sub-deps consolidated, no additions)
- All target versions ≥4 days old on npm (no race-to-hijack window)
- No new install scripts; pre-existing ignored-build-script set unchanged
- Peer-deps verified: Next 16.2 / React 19.2 / RainbowKit 2.2.11 / CopilotKit 1.57.1
- `node:26-alpine` multi-arch OCI index verified on Docker Hub
- PR #292: UI-only feature; new `/api/agents/registration` route consumes operator-controlled `tunnelURL` from in-cluster `obol-stack-config` ConfigMap (no SSRF/user-input surface); no `dangerouslySetInnerHTML`; consistent with existing `/api/agents/*` auth patterns

Multi-arch digest `sha256:d5abd6…010206` is the OCI image index covering `linux/amd64` + `linux/arm64`. Note: this is a different digest than `v0.1.24-rc2` (`sha256:cdcc8c…2ba4c`) because the Docker images were rebuilt for the `v0.1.24` tag — same git SHA, different binary digests (typical for non-reproducible Docker builds).

## Why digest-pin

Mutable tag pins allow a registry-credential compromise to silently swap image contents under the same `v0.1.24` tag on the next pull. The `name:tag@digest` format renders to a valid OCI reference via the `obol-app` chart's `obol-app.image` helper; the digest is authoritative at pull time, the tag stays for human readability.

## Test plan
- [ ] `lint-test` CI green
- [ ] CodeQL (actions / go / javascript-typescript / python) green
- [ ] After merge: `obol stack up` pulls the new digest and frontend pod becomes Ready
- [ ] Roll into the next `obol-stack` RC at maintainer discretion

## Not self-merging

Per `feedback_main_merge_gates.md`: requires flows-green (flow-11 + flow-14 receipts) AND a second human reviewer. Maintainer hand-off.