### PR TITLE
test(sell): align TestSellInference_Flags with --price default removal

### DIFF
--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -187,7 +187,7 @@ func TestSellInference_Flags(t *testing.T) {
 		"tee", "model-hash",
 	)
 
-	assertStringDefault(t, flags, "price", "0.001")
+	assertStringDefault(t, flags, "price", "")
 	assertStringDefault(t, flags, "chain", "base")
 	assertStringDefault(t, flags, "token", "USDC")
 	assertStringDefault(t, flags, "listen", ":8402")


### PR DESCRIPTION
## Summary

Follow-up to #470 — that PR removed the hardcoded \`"0.001"\` default from the \`--price\` flag so \`--per-mtok\` / \`--per-request\` can take effect when \`--price\` is not passed. The flag-defaults table test still asserted the old default and now breaks on main.

Update \`TestSellInference_Flags\` to expect empty string, matching the post-#470 behavior.

## Test plan

- [x] \`go test ./cmd/obol -run TestSellInference_Flags\` green
- [x] \`go test ./cmd/obol ./internal/x402 ./internal/inference ./internal/tunnel ./internal/serviceoffercontroller\` all green