### PR TITLE
feat(stack): paid services survive stack down/up (sell-inference + sell-http resume + storefront fixes)

### DIFF
--- a/cmd/obol/main.go
+++ b/cmd/obol/main.go
@@ -204,7 +204,22 @@ GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 							},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							return stack.Up(cfg, getUI(cmd), cmd.Bool("wildcard-dns"))
+							u := getUI(cmd)
+							if err := stack.Up(cfg, u, cmd.Bool("wildcard-dns")); err != nil {
+								return err
+							}
+							// Re-apply cluster-side state for locally-persisted
+							// `obol sell *` offers. ServiceOffer CRs and the
+							// Service/Endpoints that route to the host gateway
+							// live in etcd, which is destroyed by `obol stack
+							// down`, so a fresh `stack up` would otherwise come
+							// back with the descriptors still on disk but no
+							// matching cluster resources. Best-effort: a resume
+							// failure does not block stack-up.
+							if err := resumeSellOffers(ctx, cfg, u); err != nil {
+								u.Warnf("Could not resume sell offers: %v", err)
+							}
+							return nil
 						},
 					},
 					{

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -184,6 +184,34 @@ Examples:
 				Name:  "provenance-file",
 				Usage: "Path to JSON file with provenance metadata (e.g. autoresearch experiment results)",
 			},
+			&cli.BoolFlag{
+				Name:  "no-register",
+				Usage: "Skip ERC-8004 registration (no /.well-known/agent-registration.json HTTPRoute is published)",
+			},
+			&cli.StringFlag{
+				Name:  "register-name",
+				Usage: "Agent name for ERC-8004 registration (defaults to the offer name)",
+			},
+			&cli.StringFlag{
+				Name:  "register-description",
+				Usage: "Agent description for ERC-8004 registration",
+			},
+			&cli.StringFlag{
+				Name:  "register-image",
+				Usage: "Agent image URL for ERC-8004 registration",
+			},
+			&cli.StringSliceFlag{
+				Name:  "register-skills",
+				Usage: "OASF skill tags for ERC-8004 registration (repeatable)",
+			},
+			&cli.StringSliceFlag{
+				Name:  "register-domains",
+				Usage: "OASF domain tags for ERC-8004 registration (repeatable)",
+			},
+			&cli.StringSliceFlag{
+				Name:  "register-metadata",
+				Usage: "Additional registration metadata as key=value pairs (repeatable, e.g. gpu=A100-80GB)",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
@@ -384,7 +412,19 @@ Examples:
 					d.NoPaymentGate = false
 				} else {
 					// Create a ServiceOffer CR pointing at the host service.
-					soSpec, err := buildInferenceServiceOfferSpec(d, priceTable, svcNs, port, assetTerms)
+					reg, _, regErr := buildSellRegistrationConfig(name, sellRegistrationInput{
+						NoRegister:    cmd.Bool("no-register"),
+						Name:          cmd.String("register-name"),
+						Description:   cmd.String("register-description"),
+						Image:         cmd.String("register-image"),
+						Skills:        cmd.StringSlice("register-skills"),
+						Domains:       cmd.StringSlice("register-domains"),
+						MetadataPairs: cmd.StringSlice("register-metadata"),
+					})
+					if regErr != nil {
+						return regErr
+					}
+					soSpec, err := buildInferenceServiceOfferSpec(d, priceTable, svcNs, port, assetTerms, modelFlag, reg)
 					if err != nil {
 						return err
 					}
@@ -701,7 +741,7 @@ Examples:
 					prov.Framework, prov.MetricName, prov.MetricValue, prov.ParamCount)
 			}
 
-			reg, registerEnabled, err := buildSellHTTPRegistrationConfig(name, sellHTTPRegistrationInput{
+			reg, registerEnabled, err := buildSellRegistrationConfig(name, sellRegistrationInput{
 				NoRegister:    cmd.Bool("no-register"),
 				Register:      cmd.Bool("register"),
 				Name:          cmd.String("register-name"),
@@ -827,7 +867,7 @@ type autoRegisterOptions struct {
 	ExpectedOwner string
 }
 
-type sellHTTPRegistrationInput struct {
+type sellRegistrationInput struct {
 	NoRegister    bool
 	Register      bool
 	Name          string
@@ -907,7 +947,7 @@ func autoRegisterServiceOffer(ctx context.Context, cfg *config.Config, u *ui.UI,
 	return nil
 }
 
-func buildSellHTTPRegistrationConfig(serviceName string, in sellHTTPRegistrationInput) (map[string]any, bool, error) {
+func buildSellRegistrationConfig(serviceName string, in sellRegistrationInput) (map[string]any, bool, error) {
 	registerEnabled := !in.NoRegister
 	if !registerEnabled && (in.Register || in.Name != "" || in.Description != "" || in.Image != "" ||
 		len(in.Skills) > 0 || len(in.Domains) > 0 || len(in.MetadataPairs) > 0) {
@@ -3383,7 +3423,16 @@ func resolveHostIP(cfg *config.Config) (string, error) {
 
 // buildInferenceServiceOfferSpec builds a ServiceOffer spec for a host-side
 // inference gateway routed through the cluster's x402 flow.
-func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTable, ns, port string, asset schemas.AssetTerms) (map[string]any, error) {
+//
+// modelName is the upstream model identifier the operator passed via --model
+// (e.g. "aeon-ultimate"). It is written into spec.model.name so the
+// serviceoffer-controller's registration document carries the real model id
+// rather than the historical hardcoded "ollama" string.
+//
+// registration is the operator's ERC-8004 registration block as produced by
+// buildSellRegistrationConfig — pass nil (or an empty map) to skip
+// registration. When non-nil it is merged verbatim into spec.registration.
+func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTable, ns, port string, asset schemas.AssetTerms, modelName string, registration map[string]any) (map[string]any, error) {
 	portNum, err := strconv.Atoi(port)
 	if err != nil || portNum < 1 || portNum > 65535 {
 		return nil, fmt.Errorf("invalid port %q: must be a number between 1 and 65535", port)
@@ -3416,10 +3465,18 @@ func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTab
 	}
 
 	if d.UpstreamURL != "" {
+		model := strings.TrimSpace(modelName)
+		if model == "" {
+			model = "ollama" // pre-fix fallback; the Action enforces --model
+		}
 		spec["model"] = map[string]any{
-			"name":    "ollama",
+			"name":    model,
 			"runtime": "ollama",
 		}
+	}
+
+	if len(registration) > 0 {
+		spec["registration"] = registration
 	}
 
 	return spec, nil

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -334,24 +334,46 @@ Examples:
 				assetSymbol = "USDC"
 			}
 
+			// Resolve the registration block once, here, so we can persist it
+			// alongside the deployment descriptor. The resume path
+			// (`obol stack up` after a stack-down) rebuilds the ServiceOffer
+			// from the on-disk descriptor; without the registration block
+			// persisted, replays would lose the operator's --register-*
+			// customizations.
+			persistedRegistration, _, regErr := buildSellRegistrationConfig(name, sellRegistrationInput{
+				NoRegister:    cmd.Bool("no-register"),
+				Name:          cmd.String("register-name"),
+				Description:   cmd.String("register-description"),
+				Image:         cmd.String("register-image"),
+				Skills:        cmd.StringSlice("register-skills"),
+				Domains:       cmd.StringSlice("register-domains"),
+				MetadataPairs: cmd.StringSlice("register-metadata"),
+			})
+			if regErr != nil {
+				return regErr
+			}
+
 			d := &inference.Deployment{
-				Name:            name,
-				EnclaveTag:      cmd.String("enclave-tag"),
-				ListenAddr:      cmd.String("listen"),
-				UpstreamURL:     upstreamFlag,
-				WalletAddress:   wallet,
-				PricePerRequest: perRequest,
-				PricePerMTok:    priceTable.PerMTok,
-				AssetSymbol:     assetSymbol,
-				Chain:           chainName,
-				FacilitatorURL:  cmd.String("facilitator"),
-				VMMode:          cmd.Bool("vm"),
-				VMImage:         cmd.String("vm-image"),
-				VMCPUs:          cmd.Int("vm-cpus"),
-				VMMemoryMB:      cmd.Int("vm-memory"),
-				VMHostPort:      cmd.Int("vm-host-port"),
-				TEEType:         teeType,
-				ModelHash:       modelHash,
+				Name:             name,
+				EnclaveTag:       cmd.String("enclave-tag"),
+				ListenAddr:       cmd.String("listen"),
+				UpstreamURL:      upstreamFlag,
+				WalletAddress:    wallet,
+				PricePerRequest:  perRequest,
+				PricePerMTok:     priceTable.PerMTok,
+				AssetSymbol:      assetSymbol,
+				Chain:            chainName,
+				FacilitatorURL:   cmd.String("facilitator"),
+				VMMode:           cmd.Bool("vm"),
+				VMImage:          cmd.String("vm-image"),
+				VMCPUs:           cmd.Int("vm-cpus"),
+				VMMemoryMB:       cmd.Int("vm-memory"),
+				VMHostPort:       cmd.Int("vm-host-port"),
+				TEEType:          teeType,
+				ModelHash:        modelHash,
+				ModelName:        modelFlag,
+				ServiceNamespace: "llm",
+				Registration:     persistedRegistration,
 			}
 
 			if pf := cmd.String("provenance-file"); pf != "" {
@@ -412,19 +434,9 @@ Examples:
 					d.NoPaymentGate = false
 				} else {
 					// Create a ServiceOffer CR pointing at the host service.
-					reg, _, regErr := buildSellRegistrationConfig(name, sellRegistrationInput{
-						NoRegister:    cmd.Bool("no-register"),
-						Name:          cmd.String("register-name"),
-						Description:   cmd.String("register-description"),
-						Image:         cmd.String("register-image"),
-						Skills:        cmd.StringSlice("register-skills"),
-						Domains:       cmd.StringSlice("register-domains"),
-						MetadataPairs: cmd.StringSlice("register-metadata"),
-					})
-					if regErr != nil {
-						return regErr
-					}
-					soSpec, err := buildInferenceServiceOfferSpec(d, priceTable, svcNs, port, assetTerms, modelFlag, reg)
+					// Reuse the persistedRegistration resolved above; both this
+					// in-process create AND the on-disk descriptor must agree.
+					soSpec, err := buildInferenceServiceOfferSpec(d, priceTable, svcNs, port, assetTerms, modelFlag, persistedRegistration)
 					if err != nil {
 						return err
 					}
@@ -3441,6 +3453,114 @@ func loadProvenance(path string) (*inference.Provenance, error) {
 //
 // Kubernetes Endpoints require an IP address, not a hostname. We resolve the
 // host IP using the same strategy as ollamaHostIPForBackend in internal/stack.
+// resumeSellOffers re-applies the cluster-side artifacts (Service +
+// Endpoints + ServiceOffer) for every locally-persisted `obol sell
+// inference` deployment after `obol stack up` brings a fresh cluster
+// online. Without this step the cluster has no record of operator-created
+// offers (CRs live in etcd, which is destroyed by `obol stack down`),
+// even though the host-side descriptors at
+// `<ConfigDir>/inference/<name>/` still exist.
+//
+// The foreground gateway is NOT restarted here — `obol sell inference`
+// is an interactive operator action and we don't want stack-up to launch
+// long-running processes. The operator re-runs `obol sell inference
+// <name>` after stack-up to bring the gateway back; this step ensures
+// the cluster side is already in place so the gateway hits a "service
+// healthy" reconcile instead of "create from scratch".
+//
+// Best-effort. Per-offer failures emit a warning and the loop continues,
+// so one broken descriptor cannot block stack-up.
+func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
+	store := inference.NewStore(cfg.ConfigDir)
+	deployments, err := store.List()
+	if err != nil {
+		return fmt.Errorf("list inference deployments: %w", err)
+	}
+	if len(deployments) == 0 {
+		return nil
+	}
+
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
+		// No cluster — nothing to reattach.
+		return nil
+	}
+
+	u.Blank()
+	u.Infof("Resuming %d locally-persisted sell-inference offer(s)...", len(deployments))
+
+	var resumed int
+	for _, d := range deployments {
+		if err := resumeOneInferenceOffer(cfg, u, d); err != nil {
+			u.Warnf("resume %s: %v", d.Name, err)
+			continue
+		}
+		resumed++
+		u.Successf("Resumed sell-inference offer %q (run `obol sell inference %s` to restart the host gateway)", d.Name, d.Name)
+	}
+
+	if resumed > 0 {
+		u.Dim("  Host gateways are not auto-started — re-run `obol sell inference <name>` in a terminal you can keep open.")
+	}
+	_ = ctx // reserved for cancellation support; current resume calls are synchronous and short
+	return nil
+}
+
+// resumeOneInferenceOffer re-creates the cluster-side artifacts that
+// `obol sell inference` would have produced for a single Deployment. Pure
+// in the sense that it only consumes the on-disk descriptor; it never
+// re-prompts the operator. Returns an error when the descriptor is
+// incomplete (no model name, no namespace, no listen port) so the resume
+// loop can surface a clear message per-offer.
+func resumeOneInferenceOffer(cfg *config.Config, u *ui.UI, d *inference.Deployment) error {
+	if d == nil || d.Name == "" {
+		return errors.New("nil or unnamed deployment descriptor")
+	}
+	if d.ModelName == "" {
+		return fmt.Errorf("deployment %q is missing model_name on disk — recreate the offer with `obol sell inference %s --model <id> ...`", d.Name, d.Name)
+	}
+	ns := d.ServiceNamespace
+	if ns == "" {
+		ns = "llm" // legacy descriptors written before service_namespace was persisted
+	}
+
+	port := "8402"
+	if idx := strings.LastIndex(d.ListenAddr, ":"); idx >= 0 && idx+1 < len(d.ListenAddr) {
+		port = d.ListenAddr[idx+1:]
+	}
+
+	if err := createHostService(cfg, d.Name, ns, port); err != nil {
+		return fmt.Errorf("create cluster Service/Endpoints: %w", err)
+	}
+
+	chainName := d.Chain
+	assetTerms, err := resolveAssetTermsFor(d.AssetSymbol, &chainName, true)
+	if err != nil {
+		return fmt.Errorf("resolve asset terms: %w", err)
+	}
+
+	pt := schemas.PriceTable{PerRequest: d.PricePerRequest, PerMTok: d.PricePerMTok}
+	soSpec, err := buildInferenceServiceOfferSpec(d, pt, ns, port, assetTerms, d.ModelName, d.Registration)
+	if err != nil {
+		return fmt.Errorf("rebuild ServiceOffer spec: %w", err)
+	}
+
+	manifest := map[string]any{
+		"apiVersion": "obol.org/v1alpha1",
+		"kind":       "ServiceOffer",
+		"metadata": map[string]any{
+			"name":      d.Name,
+			"namespace": ns,
+		},
+		"spec": soSpec,
+	}
+	if err := kubectlApply(cfg, manifest); err != nil {
+		return fmt.Errorf("apply ServiceOffer: %w", err)
+	}
+	_ = u // ui is held for caller-side messaging only
+	return nil
+}
+
 func createHostService(cfg *config.Config, name, ns, port string) error {
 	hostIP, err := resolveHostIP(cfg)
 	if err != nil {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -863,6 +863,83 @@ Examples:
 	}
 }
 
+// signerPayeeDelegationNote returns a human-readable note explaining the
+// ownership delegation when the agent's on-chain registration signer differs
+// from the offer's payment payTo wallet, and "" when they match (or either
+// is empty). Used by the auto-register flow to surface the split as an
+// informational message rather than blocking the registration outright —
+// ERC-8004 explicitly supports this separation via setAgentWallet, and x402
+// settlement uses the offer's payTo regardless of the registry's wallet.
+//
+// The previous behavior (returning fmt.Errorf("registration signer ... does
+// not match the payment wallet ...")) made it look like an ERC-8004 spec
+// constraint when it was purely an obol-CLI policy choice. See PR notes for
+// the full rationale.
+func signerPayeeDelegationNote(signer, payTo string) string {
+	s := strings.TrimSpace(signer)
+	p := strings.TrimSpace(payTo)
+	if s == "" || p == "" || strings.EqualFold(s, p) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Agent owner (registration signer) %s differs from offer payTo %s. "+
+			"ERC-8004 allows this via setAgentWallet; x402 settlement honors payTo regardless. "+
+			"Re-point payments later with: obol sell update <name> --pay-to <addr>",
+		s, p,
+	)
+}
+
+// buildSellUpdatePatch assembles the JSON-merge patch body for
+// `obol sell update`. Extracted from the Action so the patch shape — the
+// thing that actually hits the cluster — is testable without a live ServiceOffer.
+//
+// Returns the patch map and an error when nothing was provided (the Action
+// surfaces this as "nothing to update: pass at least one of ...").
+//
+// When --pay-to is set, the wallet must already have been validated by
+// x402verifier.ValidateWallet at the call site; this helper does no further
+// validation so it stays a pure data shape.
+func buildSellUpdatePatch(payTo, chain string, price schemas.PriceTable) (map[string]any, error) {
+	payment := map[string]any{}
+
+	if payTo = strings.TrimSpace(payTo); payTo != "" {
+		payment["payTo"] = payTo
+	}
+	if chain = strings.TrimSpace(chain); chain != "" {
+		payment["network"] = chain
+	}
+
+	if price.PerRequest != "" || price.PerMTok != "" || price.PerHour != "" {
+		// Null out the unused price keys explicitly so a switch from, e.g.,
+		// perRequest→perMTok doesn't leave the previous key stranded and
+		// fighting the new one through merge semantics.
+		p := map[string]any{
+			"perRequest": nil,
+			"perMTok":    nil,
+			"perHour":    nil,
+		}
+		switch {
+		case price.PerRequest != "":
+			p["perRequest"] = price.PerRequest
+		case price.PerMTok != "":
+			p["perMTok"] = price.PerMTok
+		case price.PerHour != "":
+			p["perHour"] = price.PerHour
+		}
+		payment["price"] = p
+	}
+
+	if len(payment) == 0 {
+		return nil, errors.New("nothing to update: pass at least one of --per-request / --per-mtok / --per-hour / --pay-to / --chain")
+	}
+
+	return map[string]any{
+		"spec": map[string]any{
+			"payment": payment,
+		},
+	}, nil
+}
+
 // shouldAutoRegisterSell reports whether the post-create auto-register step
 // must run for a freshly-applied ServiceOffer spec. Both `obol sell http` and
 // `obol sell inference` need the same gate: registration must be enabled AND
@@ -958,8 +1035,19 @@ func autoRegisterServiceOffer(ctx context.Context, cfg *config.Config, u *ui.UI,
 	}
 	signerAddr := addr.Hex()
 
-	if opts.ExpectedOwner != "" && !strings.EqualFold(strings.TrimSpace(opts.ExpectedOwner), strings.TrimSpace(signerAddr)) {
-		return fmt.Errorf("registration signer %s does not match the payment wallet %s.\nUse a matching signer, omit --wallet so the remote-signer wallet is used, or pass --no-register", signerAddr, opts.ExpectedOwner)
+	// ERC-8004 treats the agent OWNER (msg.sender at register time) and the
+	// agent WALLET (settable post-mint via setAgentWallet) as independent
+	// addresses. x402 settlement honors the offer's spec.payment.payTo
+	// directly — buyers pay that address regardless of what the registry's
+	// getAgentWallet returns. So a different signer and payTo is legitimate;
+	// it is the canonical pattern for "hot signer, cold/multisig payee".
+	//
+	// We surface the split as an informational note (not an error) so the
+	// operator can confirm the delegation was intentional, and so the obvious
+	// follow-up — `obol sell update <name> --pay-to <new>` for the payee — is
+	// discoverable.
+	if note := signerPayeeDelegationNote(signerAddr, opts.ExpectedOwner); note != "" {
+		u.Info(note)
 	}
 
 	agentURI := strings.TrimRight(opts.Endpoint, "/") + "/.well-known/agent-registration.json"
@@ -2328,50 +2416,25 @@ Examples:
 				return fmt.Errorf("ServiceOffer %s/%s not found: %w", ns, name, err)
 			}
 
-			payment := map[string]any{}
-
-			if wallet := strings.TrimSpace(cmd.String("pay-to")); wallet != "" {
+			wallet := strings.TrimSpace(cmd.String("pay-to"))
+			if wallet != "" {
 				if err := x402verifier.ValidateWallet(wallet); err != nil {
 					return err
 				}
-				payment["payTo"] = wallet
 			}
 
-			if chain := strings.TrimSpace(cmd.String("chain")); chain != "" {
-				payment["network"] = chain
-			}
-
-			priceSet := cmd.String("price") != "" || cmd.String("per-request") != "" || cmd.String("per-mtok") != "" || cmd.String("per-hour") != ""
-			if priceSet {
-				priceTable, err := resolvePriceTable(cmd, true)
+			var price schemas.PriceTable
+			if cmd.String("price") != "" || cmd.String("per-request") != "" || cmd.String("per-mtok") != "" || cmd.String("per-hour") != "" {
+				resolved, err := resolvePriceTable(cmd, true)
 				if err != nil {
 					return err
 				}
-
-				price := map[string]any{
-					"perRequest": nil,
-					"perMTok":    nil,
-					"perHour":    nil,
-				}
-				switch {
-				case priceTable.PerRequest != "":
-					price["perRequest"] = priceTable.PerRequest
-				case priceTable.PerMTok != "":
-					price["perMTok"] = priceTable.PerMTok
-				case priceTable.PerHour != "":
-					price["perHour"] = priceTable.PerHour
-				}
-				payment["price"] = price
+				price = resolved
 			}
 
-			if len(payment) == 0 {
-				return errors.New("nothing to update: pass at least one of --per-request / --per-mtok / --per-hour / --wallet / --chain")
-			}
-
-			patch := map[string]any{
-				"spec": map[string]any{
-					"payment": payment,
-				},
+			patch, err := buildSellUpdatePatch(wallet, cmd.String("chain"), price)
+			if err != nil {
+				return err
 			}
 			patchBytes, err := json.Marshal(patch)
 			if err != nil {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3496,11 +3496,11 @@ func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
 			continue
 		}
 		resumed++
-		u.Successf("Resumed sell-inference offer %q (run `obol sell inference %s` to restart the host gateway)", d.Name, d.Name)
+		u.Successf("Resumed sell-inference offer %q", d.Name)
 	}
 
 	if resumed > 0 {
-		u.Dim("  Host gateways are not auto-started — re-run `obol sell inference <name>` in a terminal you can keep open.")
+		u.Dim("  Gateways spawned as detached background processes — check <state>/sell-inference/<name>/gateway.log for output.")
 	}
 	_ = ctx // reserved for cancellation support; current resume calls are synchronous and short
 	return nil
@@ -3634,15 +3634,20 @@ func startDetachedInferenceGateway(cfg *config.Config, u *ui.UI, d *inference.De
 		_ = logF.Close()
 		return fmt.Errorf("start gateway subprocess: %w", err)
 	}
+	// Snapshot the PID BEFORE Release — on Unix, os.Process.Release sets
+	// the Pid field to -1 as part of its handle teardown, so reading the
+	// field afterwards prints a misleading "-1" to the operator and pins
+	// a bogus -1 in the PID file. Persist + announce the captured value.
+	gatewayPID := cmd.Process.Pid
 	// We don't wait on the child, but releasing the handle ensures the
 	// parent process can exit cleanly without keeping a zombie reference.
 	if err := cmd.Process.Release(); err != nil {
 		u.Dim("  (could not release gateway process handle: " + err.Error() + ")")
 	}
-	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
-		u.Warnf("gateway started (pid %d) but could not write %s: %v", cmd.Process.Pid, pidFile, err)
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(gatewayPID)), 0o644); err != nil {
+		u.Warnf("gateway started (pid %d) but could not write %s: %v", gatewayPID, pidFile, err)
 	}
-	u.Successf("Gateway started in background (pid %d, log %s)", cmd.Process.Pid, logFile)
+	u.Successf("Gateway started in background (pid %d, log %s)", gatewayPID, logFile)
 	return nil
 }
 

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -39,6 +39,7 @@ import (
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func sellCommand(cfg *config.Config) *cli.Command {
@@ -656,6 +657,9 @@ Examples:
 				if err := kubectlApply(cfg, manifest); err != nil {
 					return err
 				}
+				if persistErr := persistSellHTTPOffer(cfg, ns, name, manifest); persistErr != nil {
+					u.Warnf("could not persist offer for stack-up resume: %v", persistErr)
+				}
 				u.Successf("ServiceOffer %s/%s created from JSON", ns, name)
 				return nil
 			}
@@ -828,6 +832,9 @@ Examples:
 			applyOut, err := kubectlApplyOutput(cfg, manifest)
 			if err != nil {
 				return err
+			}
+			if persistErr := persistSellHTTPOffer(cfg, ns, name, manifest); persistErr != nil {
+				u.Warnf("could not persist offer for stack-up resume: %v", persistErr)
 			}
 			action := "created"
 			if strings.Contains(applyOut, "configured") || strings.Contains(applyOut, "unchanged") {
@@ -2549,6 +2556,17 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 				return err
 			}
 
+			// Drop the on-disk sell-http manifest so the next `obol stack
+			// up` doesn't replay an offer the operator just deleted. The
+			// inference path doesn't need this hook — `obol sell delete`
+			// doesn't currently remove the inference.Store descriptor
+			// either, by design (the descriptor is what `obol sell
+			// inference list/status` reads). For HTTP we keep no such
+			// post-delete state, so removing the file is the right shape.
+			if removeErr := removeSellHTTPOffer(cfg, ns, name); removeErr != nil {
+				u.Warnf("could not remove persisted sell-http offer at %s/%s: %v", ns, name, removeErr)
+			}
+
 			// Clean up demo backend resources if this is a demo service.
 			if ns == demoNamespace {
 				cleanupDemoBackend(cfg, u, name)
@@ -3471,18 +3489,23 @@ func loadProvenance(path string) (*inference.Provenance, error) {
 // Best-effort. Per-offer failures emit a warning and the loop continues,
 // so one broken descriptor cannot block stack-up.
 func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
+		// No cluster — nothing to reattach for either inference or http.
+		return nil
+	}
+
 	store := inference.NewStore(cfg.ConfigDir)
 	deployments, err := store.List()
 	if err != nil {
 		return fmt.Errorf("list inference deployments: %w", err)
 	}
-	if len(deployments) == 0 {
-		return nil
-	}
 
-	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
-		// No cluster — nothing to reattach.
+	if len(deployments) == 0 {
+		// No inference offers; fall through to http resume below.
+		if err := resumeSellHTTPOffers(cfg, u); err != nil {
+			u.Warnf("resume sell-http offers: %v", err)
+		}
 		return nil
 	}
 
@@ -3502,6 +3525,16 @@ func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
 	if resumed > 0 {
 		u.Dim("  Gateways spawned as detached background processes — check <state>/sell-inference/<name>/gateway.log for output.")
 	}
+
+	// Replay persisted `obol sell http` offers as well. The two stores are
+	// independent on disk (sell-http manifests live at
+	// <ConfigDir>/sell-http/, sell-inference descriptors at
+	// <ConfigDir>/inference/) but the operator wants one stack-up to
+	// bring every paid offer back regardless of type.
+	if err := resumeSellHTTPOffers(cfg, u); err != nil {
+		u.Warnf("resume sell-http offers: %v", err)
+	}
+
 	_ = ctx // reserved for cancellation support; current resume calls are synchronous and short
 	return nil
 }
@@ -3898,6 +3931,162 @@ func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTab
 	}
 
 	return spec, nil
+}
+
+// sellHTTPStoreDir returns the on-disk root for persisted `obol sell http`
+// ServiceOffer manifests. Schema is one YAML file per offer at
+// <ConfigDir>/sell-http/<namespace>__<name>.yaml so two offers with the
+// same name in different namespaces never collide.
+//
+// Unlike `obol sell inference`, http offers don't have a host-side
+// foreground process to track — the upstream is an in-cluster Service.
+// The on-disk artifact is just the rendered ServiceOffer manifest; the
+// resume path kubectl-applies it to bring the offer back identically.
+//
+// Long-term we should fold this into a single sell-offer store (one
+// schema for both inference and http), so resume is one walk instead of
+// two. Keeping them separate for now because the inference store is
+// rich (host listen addr, asset symbol, registration block) while http
+// only needs the rendered manifest — collapsing them would force
+// inference-only fields onto every http descriptor.
+func sellHTTPStoreDir(cfg *config.Config) string {
+	return filepath.Join(cfg.ConfigDir, "sell-http")
+}
+
+func sellHTTPStorePath(cfg *config.Config, namespace, name string) string {
+	return filepath.Join(sellHTTPStoreDir(cfg), namespace+"__"+name+".yaml")
+}
+
+// persistSellHTTPOffer writes the rendered ServiceOffer manifest to disk
+// so `obol stack up` can replay it after a stack-down/up cycle wipes
+// etcd. Idempotent: subsequent calls overwrite atomically (write to a
+// `.tmp` sibling, rename into place) so a crash mid-write doesn't leave
+// a half-rendered file the resume path would choke on.
+//
+// Best-effort from the caller's perspective: a persistence failure
+// should warn but not abort the sell command, because the cluster-side
+// offer is already in place. Returning an error lets the caller pick
+// the surface.
+func persistSellHTTPOffer(cfg *config.Config, namespace, name string, manifest map[string]any) error {
+	if cfg == nil || namespace == "" || name == "" {
+		return errors.New("persistSellHTTPOffer: missing cfg / namespace / name")
+	}
+	if err := os.MkdirAll(sellHTTPStoreDir(cfg), 0o755); err != nil {
+		return fmt.Errorf("create store dir: %w", err)
+	}
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	final := sellHTTPStorePath(cfg, namespace, name)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s → %s: %w", tmp, final, err)
+	}
+	return nil
+}
+
+// removeSellHTTPOffer deletes the on-disk manifest for a single offer
+// when `obol sell delete` succeeds. Without this, the resume path on
+// the next `obol stack up` would re-create an offer the operator
+// intentionally deleted. Best-effort — a missing file is a no-op.
+func removeSellHTTPOffer(cfg *config.Config, namespace, name string) error {
+	if cfg == nil || namespace == "" || name == "" {
+		return nil
+	}
+	path := sellHTTPStorePath(cfg, namespace, name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// resumeSellHTTPOffers re-applies every persisted `obol sell http`
+// manifest after `obol stack up` rebuilds the cluster. Mirror of the
+// inference resume loop: walk the store dir, kubectl apply each file,
+// warn-and-continue on per-offer failures so one corrupt YAML can't
+// block the rest.
+//
+// Skipped silently when the store dir is missing (no offers ever
+// persisted) or when no kubeconfig is present (stack up hasn't reached
+// the cluster yet). Counts and announces what was reattached so the
+// operator sees the same "Resumed N offers" feedback they get for
+// inference.
+func resumeSellHTTPOffers(cfg *config.Config, u *ui.UI) error {
+	dir := sellHTTPStoreDir(cfg)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read store dir: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
+		return nil // no cluster yet
+	}
+
+	u.Blank()
+	var manifests []sellHTTPStoredOffer
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			u.Warnf("read %s: %v", path, err)
+			continue
+		}
+		var manifest map[string]any
+		if err := yaml.Unmarshal(data, &manifest); err != nil {
+			u.Warnf("parse %s: %v", path, err)
+			continue
+		}
+		ns, name := manifestNSName(manifest)
+		manifests = append(manifests, sellHTTPStoredOffer{Path: path, Manifest: manifest, Namespace: ns, Name: name})
+	}
+	if len(manifests) == 0 {
+		return nil
+	}
+
+	u.Infof("Resuming %d locally-persisted sell-http offer(s)...", len(manifests))
+	for _, m := range manifests {
+		if err := kubectlApply(cfg, m.Manifest); err != nil {
+			u.Warnf("resume http %s/%s: %v", m.Namespace, m.Name, err)
+			continue
+		}
+		u.Successf("Resumed sell-http offer %s/%s", m.Namespace, m.Name)
+	}
+	return nil
+}
+
+type sellHTTPStoredOffer struct {
+	Path      string
+	Manifest  map[string]any
+	Namespace string
+	Name      string
+}
+
+// manifestNSName pulls metadata.namespace + metadata.name out of an
+// unmarshaled ServiceOffer manifest. Returns empty strings when the
+// shape is malformed; the resume loop reports the error per-file.
+func manifestNSName(manifest map[string]any) (string, string) {
+	md, ok := manifest["metadata"].(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	ns, _ := md["namespace"].(string)
+	name, _ := md["name"].(string)
+	return ns, name
 }
 
 // removePricingRoute is a no-op retained for compatibility.

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3557,8 +3557,194 @@ func resumeOneInferenceOffer(cfg *config.Config, u *ui.UI, d *inference.Deployme
 	if err := kubectlApply(cfg, manifest); err != nil {
 		return fmt.Errorf("apply ServiceOffer: %w", err)
 	}
-	_ = u // ui is held for caller-side messaging only
+
+	// Auto-start the foreground x402 gateway as a detached background
+	// subprocess so the offer reaches UpstreamHealthy=True (and therefore
+	// shows up in /api/services.json) without the operator running an
+	// extra `obol sell inference` command after every stack-up.
+	//
+	// This is the pragmatic shape of the resume feature today. The proper
+	// long-term path is C from the design doc: build the inference gateway
+	// as an in-cluster Deployment image, helmfile-managed, so stack-up
+	// brings it back the same way it brings back Traefik or LiteLLM. That
+	// removes the host-side subprocess + PID-file plumbing entirely and
+	// lets the controller observe the gateway as a normal Pod. Tracked as
+	// a follow-up because the gateway code (internal/inference/gateway.go)
+	// currently runs in-process with the CLI, not as a packaged image.
+	if err := startDetachedInferenceGateway(cfg, u, d); err != nil {
+		u.Warnf("could not auto-start host gateway for %q: %v", d.Name, err)
+		u.Dim("  Run `obol sell inference " + d.Name + "` manually in a terminal you can keep open.")
+	}
 	return nil
+}
+
+// startDetachedInferenceGateway forks `obol sell inference <name>` as a
+// detached background subprocess. The CLI rebuilds the full flag set from
+// the persisted Deployment, redirects stdout/stderr to a log file under
+// the workspace state dir, and stores the PID alongside so subsequent
+// stack-ups can detect a still-running gateway and skip the relaunch.
+//
+// Skipped silently when a healthy PID is already on disk. Returns an
+// error only when launch itself fails (e.g. missing obol binary, log
+// file unwritable). Callers should warn-and-continue on failure — a
+// missing gateway leaves UpstreamHealthy=False which the controller will
+// re-emit clearly, while a hard error here would block the rest of the
+// resume loop.
+func startDetachedInferenceGateway(cfg *config.Config, u *ui.UI, d *inference.Deployment) error {
+	if d == nil || d.Name == "" {
+		return errors.New("nil or unnamed deployment")
+	}
+
+	stateDir := filepath.Join(cfg.StateDir, "sell-inference", d.Name)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	pidFile := filepath.Join(stateDir, "gateway.pid")
+	logFile := filepath.Join(stateDir, "gateway.log")
+
+	if pid, ok := readGatewayPID(pidFile); ok && processAlive(pid) {
+		u.Dim("  Gateway already running for " + d.Name + " (pid " + strconv.Itoa(pid) + ")")
+		return nil
+	}
+
+	obolBin := filepath.Join(cfg.BinDir, "obol")
+	if _, statErr := os.Stat(obolBin); statErr != nil {
+		// Fall back to whatever obol the parent process is running as.
+		exe, exeErr := os.Executable()
+		if exeErr != nil {
+			return fmt.Errorf("locate obol binary: %w", exeErr)
+		}
+		obolBin = exe
+	}
+
+	args := buildResumeGatewayArgs(d)
+
+	logF, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+
+	cmd := exec.Command(obolBin, args...)
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.SysProcAttr = detachedSysProcAttr()
+	cmd.Env = os.Environ()
+
+	if err := cmd.Start(); err != nil {
+		_ = logF.Close()
+		return fmt.Errorf("start gateway subprocess: %w", err)
+	}
+	// We don't wait on the child, but releasing the handle ensures the
+	// parent process can exit cleanly without keeping a zombie reference.
+	if err := cmd.Process.Release(); err != nil {
+		u.Dim("  (could not release gateway process handle: " + err.Error() + ")")
+	}
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
+		u.Warnf("gateway started (pid %d) but could not write %s: %v", cmd.Process.Pid, pidFile, err)
+	}
+	u.Successf("Gateway started in background (pid %d, log %s)", cmd.Process.Pid, logFile)
+	return nil
+}
+
+// buildResumeGatewayArgs reconstructs the `obol sell inference` flag set
+// that originally created the offer, from the persisted Deployment. The
+// order matches obol sell inference's flag list so a future surface
+// reduction of the CLI doesn't silently drop a piece of operator intent
+// (CI's source-level guard tests catch that case).
+//
+// Exposed for testing: callers can compare the reproduced flag set
+// against the original `obol sell inference` invocation that wrote the
+// descriptor.
+func buildResumeGatewayArgs(d *inference.Deployment) []string {
+	args := []string{"sell", "inference", d.Name}
+	if d.ModelName != "" {
+		args = append(args, "--model", d.ModelName)
+	}
+	if d.UpstreamURL != "" {
+		args = append(args, "--upstream", d.UpstreamURL)
+	}
+	if d.WalletAddress != "" {
+		args = append(args, "--pay-to", d.WalletAddress)
+	}
+	if d.ListenAddr != "" {
+		args = append(args, "--listen", d.ListenAddr)
+	}
+	if d.Chain != "" {
+		args = append(args, "--chain", d.Chain)
+	}
+	if d.AssetSymbol != "" {
+		args = append(args, "--token", d.AssetSymbol)
+	}
+	if d.PricePerMTok != "" {
+		args = append(args, "--per-mtok", d.PricePerMTok)
+	} else if d.PricePerRequest != "" {
+		args = append(args, "--price", d.PricePerRequest)
+	}
+	if d.FacilitatorURL != "" {
+		args = append(args, "--facilitator", d.FacilitatorURL)
+	}
+	// Registration block — rebuild --register-* flags from the persisted map.
+	if reg, ok := d.Registration["enabled"].(bool); ok && !reg {
+		args = append(args, "--no-register")
+	} else if d.Registration != nil {
+		if v, _ := d.Registration["name"].(string); v != "" {
+			args = append(args, "--register-name", v)
+		}
+		if v, _ := d.Registration["description"].(string); v != "" {
+			args = append(args, "--register-description", v)
+		}
+		if v, _ := d.Registration["image"].(string); v != "" {
+			args = append(args, "--register-image", v)
+		}
+		for _, s := range registrationStringSlice(d.Registration, "skills") {
+			args = append(args, "--register-skills", s)
+		}
+		for _, s := range registrationStringSlice(d.Registration, "domains") {
+			args = append(args, "--register-domains", s)
+		}
+	}
+	return args
+}
+
+func registrationStringSlice(reg map[string]any, key string) []string {
+	raw, ok := reg[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func readGatewayPID(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signal 0 doesn't deliver — just probes existence/permission on Unix.
+	return p.Signal(syscall.Signal(0)) == nil
 }
 
 func createHostService(cfg *config.Config, name, ns, port string) error {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -448,11 +448,35 @@ Examples:
 						u.Blank()
 						u.Info("Ensuring tunnel is active for public access...")
 
-						if tunnelURL, tErr := tunnel.EnsureTunnelForSell(cfg, u); tErr != nil {
+						tunnelURL := ""
+						if url, tErr := tunnel.EnsureTunnelForSell(cfg, u); tErr != nil {
 							u.Warnf("Tunnel not started: %v", tErr)
 							u.Dim("  Start manually with: obol tunnel restart")
 						} else {
+							tunnelURL = url
 							u.Successf("Tunnel active: %s", tunnelURL)
+						}
+
+						// Auto-register the seller on ERC-8004, mirroring the
+						// `obol sell http` path. Without this step the offer
+						// stays in Registered=False AwaitingExternalRegistration
+						// forever, which makes Ready=False and excludes the
+						// offer from /api/services.json (the storefront feed
+						// only includes Ready=True offers).
+						if shouldAutoRegisterSell(soSpec, tunnelURL) {
+							reg, _ := soSpec["registration"].(map[string]any)
+							u.Blank()
+							u.Info("Registering seller agent on ERC-8004...")
+							if err := autoRegisterServiceOffer(ctx, cfg, u, autoRegisterOptions{
+								ChainCSV:      cmd.String("chain"),
+								Endpoint:      tunnelURL,
+								AgentName:     registrationNameForPrompt(name, reg),
+								AgentDesc:     registrationDescriptionForPrompt(name, reg),
+								ExpectedOwner: wallet,
+							}); err != nil {
+								u.Warnf("automatic sell registration failed: %v", err)
+								u.Dim("  Re-run later with: obol sell register " + name + " -n " + svcNs)
+							}
 						}
 					}
 				}
@@ -837,6 +861,26 @@ Examples:
 			return nil
 		},
 	}
+}
+
+// shouldAutoRegisterSell reports whether the post-create auto-register step
+// must run for a freshly-applied ServiceOffer spec. Both `obol sell http` and
+// `obol sell inference` need the same gate: registration must be enabled AND
+// a tunnel URL must be available to write into the on-chain registration
+// document. The decision is intentionally shared so the inference path
+// cannot silently regress to "create the offer, never register" (the bug
+// behind https://github.com/ObolNetwork/obol-stack/issues — Registered=False
+// AwaitingExternalRegistration hiding the offer from /api/services.json).
+func shouldAutoRegisterSell(spec map[string]any, tunnelURL string) bool {
+	if tunnelURL == "" {
+		return false
+	}
+	reg, ok := spec["registration"].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, _ := reg["enabled"].(bool)
+	return enabled
 }
 
 func registrationNameForPrompt(fallback string, reg map[string]any) string {

--- a/cmd/obol/sell_proc_unix.go
+++ b/cmd/obol/sell_proc_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package main
+
+import "syscall"
+
+// detachedSysProcAttr returns the platform-specific SysProcAttr that
+// detaches a spawned child from the parent's process group. On Unix this
+// is a new session leader (Setsid: true) so the child survives the
+// parent's exit and does not receive SIGHUP / SIGINT propagated from
+// the controlling terminal.
+//
+// Linux/macOS/BSD share the same shape via the unix build tag. If we
+// ever ship a Windows obol binary, add sell_proc_windows.go with a
+// CREATE_NEW_PROCESS_GROUP equivalent.
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/inference"
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	"github.com/ObolNetwork/obol-stack/internal/schemas"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
@@ -185,9 +186,19 @@ func TestSellInference_Flags(t *testing.T) {
 		"listen", "upstream", "enclave-tag",
 		"vm", "vm-image", "vm-cpus", "vm-memory", "vm-host-port",
 		"tee", "model-hash",
+		// Registration parity with `obol sell http`. Their absence on the
+		// inference subcommand was the regression that left
+		// /.well-known/agent-registration.json unrouted (see
+		// TestBuildInferenceServiceOfferSpec_RegistrationEnabledByDefault).
+		"no-register",
+		"register-name", "register-description", "register-image",
+		"register-skills", "register-domains", "register-metadata",
 	)
 
-	assertStringDefault(t, flags, "price", "0.001")
+	// --price intentionally has no default after #470 — the resolvePriceTable
+	// fallthrough requires an explicit price flag instead of letting "0.001"
+	// shadow --per-mtok / --per-request. Empty default is the pinned contract.
+	assertStringDefault(t, flags, "price", "")
 	assertStringDefault(t, flags, "chain", "base")
 	assertStringDefault(t, flags, "token", "USDC")
 	assertStringDefault(t, flags, "listen", ":8402")
@@ -256,8 +267,8 @@ func TestSellHTTP_Flags(t *testing.T) {
 	assertIntDefault(t, flags, "max-timeout", 300)
 }
 
-func TestBuildSellHTTPRegistrationConfig_DefaultEnabled(t *testing.T) {
-	reg, enabled, err := buildSellHTTPRegistrationConfig("demo", sellHTTPRegistrationInput{})
+func TestBuildSellRegistrationConfig_DefaultEnabled(t *testing.T) {
+	reg, enabled, err := buildSellRegistrationConfig("demo", sellRegistrationInput{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,8 +283,8 @@ func TestBuildSellHTTPRegistrationConfig_DefaultEnabled(t *testing.T) {
 	}
 }
 
-func TestBuildSellHTTPRegistrationConfig_NoRegisterConflicts(t *testing.T) {
-	_, _, err := buildSellHTTPRegistrationConfig("demo", sellHTTPRegistrationInput{
+func TestBuildSellRegistrationConfig_NoRegisterConflicts(t *testing.T) {
+	_, _, err := buildSellRegistrationConfig("demo", sellRegistrationInput{
 		NoRegister: true,
 		Name:       "custom",
 	})
@@ -752,6 +763,141 @@ func TestDemoRPCNetwork(t *testing.T) {
 				t.Fatalf("demoRPCNetwork(%q) = %q, want %q", tt.paymentChain, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildInferenceServiceOfferSpec_RegistrationEnabledByDefault pins the
+// fix for the missing-registration regression: `obol sell inference` used to
+// build a ServiceOffer with empty `spec.registration`, so the controller
+// emitted "Registration disabled" and never published the
+// /.well-known/agent-registration.json HTTPRoute. The default contract is
+// "registration enabled, name derived from offer name" — same as `sell http`.
+func TestBuildInferenceServiceOfferSpec_RegistrationEnabledByDefault(t *testing.T) {
+	d := &inference.Deployment{
+		Name:            "aeon",
+		UpstreamURL:     "http://127.0.0.1:8000",
+		WalletAddress:   "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		Chain:           "base-sepolia",
+		PricePerRequest: "0.001",
+	}
+	reg, enabled, err := buildSellRegistrationConfig("aeon", sellRegistrationInput{})
+	if err != nil {
+		t.Fatalf("buildSellRegistrationConfig: %v", err)
+	}
+	if !enabled {
+		t.Fatal("registration should default to enabled")
+	}
+	spec, err := buildInferenceServiceOfferSpec(d, schemas.PriceTable{PerRequest: "0.001"}, "llm", "8402", schemas.AssetTerms{}, "aeon-ultimate", reg)
+	if err != nil {
+		t.Fatalf("buildInferenceServiceOfferSpec: %v", err)
+	}
+	got, ok := spec["registration"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.registration missing or wrong type: %#v", spec["registration"])
+	}
+	if got["enabled"] != true {
+		t.Errorf("spec.registration.enabled = %v, want true", got["enabled"])
+	}
+	if got["name"] != "aeon" {
+		t.Errorf("spec.registration.name = %v, want %q", got["name"], "aeon")
+	}
+}
+
+// TestBuildInferenceServiceOfferSpec_NoRegisterOmitsRegistration confirms the
+// opt-out path: --no-register produces an empty registration map and the spec
+// builder must leave spec.registration unset (so the controller emits the
+// well-known route only when explicitly requested).
+func TestBuildInferenceServiceOfferSpec_NoRegisterOmitsRegistration(t *testing.T) {
+	d := &inference.Deployment{
+		Name: "aeon", UpstreamURL: "http://127.0.0.1:8000",
+		WalletAddress: "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		Chain:         "base-sepolia", PricePerRequest: "0.001",
+	}
+	reg, enabled, err := buildSellRegistrationConfig("aeon", sellRegistrationInput{NoRegister: true})
+	if err != nil {
+		t.Fatalf("buildSellRegistrationConfig: %v", err)
+	}
+	if enabled {
+		t.Fatal("--no-register should disable registration")
+	}
+	spec, err := buildInferenceServiceOfferSpec(d, schemas.PriceTable{PerRequest: "0.001"}, "llm", "8402", schemas.AssetTerms{}, "aeon-ultimate", reg)
+	if err != nil {
+		t.Fatalf("buildInferenceServiceOfferSpec: %v", err)
+	}
+	if _, present := spec["registration"]; present {
+		t.Errorf("spec.registration should be absent when --no-register; got %#v", spec["registration"])
+	}
+}
+
+// TestBuildInferenceServiceOfferSpec_OperatorOverridesWin pins the fix for
+// the controller-side description-clobber regression in
+// internal/serviceoffercontroller/render.go: the operator's explicit
+// registration fields (name, description, image, skills, domains) must
+// survive into the published spec verbatim, not be silently replaced by
+// controller-side defaults. This test covers the *spec input*; the
+// controller-side guarantee is covered by the companion test in
+// serviceoffercontroller/render_test.go.
+func TestBuildInferenceServiceOfferSpec_OperatorOverridesWin(t *testing.T) {
+	d := &inference.Deployment{
+		Name: "aeon", UpstreamURL: "http://127.0.0.1:8000",
+		WalletAddress: "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		Chain:         "base-sepolia", PricePerRequest: "0.001",
+	}
+	reg, _, err := buildSellRegistrationConfig("aeon", sellRegistrationInput{
+		Name:        "Qwen36 AEON Ultimate",
+		Description: "Uncensored Qwen3.6-27B abliteration on DGX Spark",
+		Image:       "https://example.com/aeon.png",
+		Skills:      []string{"llm/inference", "llm/uncensored"},
+		Domains:     []string{"inference.v1337.org"},
+	})
+	if err != nil {
+		t.Fatalf("buildSellRegistrationConfig: %v", err)
+	}
+	spec, err := buildInferenceServiceOfferSpec(d, schemas.PriceTable{PerRequest: "0.001"}, "llm", "8402", schemas.AssetTerms{}, "aeon-ultimate", reg)
+	if err != nil {
+		t.Fatalf("buildInferenceServiceOfferSpec: %v", err)
+	}
+	r := spec["registration"].(map[string]any)
+	for k, want := range map[string]any{
+		"name":        "Qwen36 AEON Ultimate",
+		"description": "Uncensored Qwen3.6-27B abliteration on DGX Spark",
+		"image":       "https://example.com/aeon.png",
+	} {
+		if r[k] != want {
+			t.Errorf("spec.registration.%s = %#v, want %#v", k, r[k], want)
+		}
+	}
+	skills, _ := r["skills"].([]string)
+	if len(skills) != 2 || skills[0] != "llm/inference" {
+		t.Errorf("spec.registration.skills = %#v, want [llm/inference llm/uncensored]", r["skills"])
+	}
+	domains, _ := r["domains"].([]string)
+	if len(domains) != 1 || domains[0] != "inference.v1337.org" {
+		t.Errorf("spec.registration.domains = %#v, want [inference.v1337.org]", r["domains"])
+	}
+}
+
+// TestBuildInferenceServiceOfferSpec_ModelNameNotHardcoded pins the fix for
+// the "spec.model.name = ollama regardless of --model" regression. The model
+// id the operator passed must surface in spec.model.name so the controller's
+// per-model registration description (and any downstream tooling that keys
+// off model name) reads the truth, not the historical hardcoded literal.
+func TestBuildInferenceServiceOfferSpec_ModelNameNotHardcoded(t *testing.T) {
+	d := &inference.Deployment{
+		Name: "aeon", UpstreamURL: "http://127.0.0.1:8000",
+		WalletAddress: "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		Chain:         "base-sepolia", PricePerRequest: "0.001",
+	}
+	spec, err := buildInferenceServiceOfferSpec(d, schemas.PriceTable{PerRequest: "0.001"}, "llm", "8402", schemas.AssetTerms{}, "aeon-ultimate", nil)
+	if err != nil {
+		t.Fatalf("buildInferenceServiceOfferSpec: %v", err)
+	}
+	model, ok := spec["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec.model missing or wrong type: %#v", spec["model"])
+	}
+	if model["name"] != "aeon-ultimate" {
+		t.Errorf("spec.model.name = %v, want %q (must reflect --model, not the legacy hardcoded \"ollama\")", model["name"], "aeon-ultimate")
 	}
 }
 

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1000,6 +1000,229 @@ func TestSellInferenceAction_InvokesAutoRegister(t *testing.T) {
 	}
 }
 
+// TestSignerPayeeDelegationNote pins the contract that obol now treats the
+// "registration signer != offer payTo" case as legitimate ERC-8004 ownership
+// delegation rather than an error. The helper returns "" when the two match
+// (or either is empty) and a single-line informational note otherwise.
+//
+// Regression context: autoRegisterServiceOffer used to fail with
+//
+//	registration signer 0xA... does not match the payment wallet 0xB...
+//
+// which read like an ERC-8004 spec constraint but was purely an obol-CLI
+// policy. ERC-8004 explicitly supports the split (msg.sender at register
+// time owns the agent; setAgentWallet re-points the wallet post-mint), and
+// x402 settlement honors the offer's payTo regardless of what the registry
+// reports.
+func TestSignerPayeeDelegationNote(t *testing.T) {
+	tests := []struct {
+		name        string
+		signer      string
+		payTo       string
+		wantNoteHas []string
+		wantEmpty   bool
+	}{
+		{
+			name:      "exact match → no note",
+			signer:    "0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+			payTo:     "0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+			wantEmpty: true,
+		},
+		{
+			name:      "case-insensitive match → no note",
+			signer:    "0xa5d4af96e3e740383a36c3123a54724dacb3df57",
+			payTo:     "0xA5D4AF96E3E740383A36C3123A54724DACB3DF57",
+			wantEmpty: true,
+		},
+		{
+			name:      "whitespace tolerance → no note",
+			signer:    "  0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57  ",
+			payTo:     "0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+			wantEmpty: true,
+		},
+		{
+			name:      "empty payTo → no note (caller didn't request the check)",
+			signer:    "0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+			payTo:     "",
+			wantEmpty: true,
+		},
+		{
+			name:      "empty signer → no note (impossible in practice; defensive)",
+			signer:    "",
+			payTo:     "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+			wantEmpty: true,
+		},
+		{
+			name:   "true mismatch → note names both addrs and suggests sell update",
+			signer: "0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+			payTo:  "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+			wantNoteHas: []string{
+				"0xA5d4aF96E3e740383A36c3123A54724dAcB3Df57",
+				"0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+				"obol sell update",
+				"--pay-to",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := signerPayeeDelegationNote(tc.signer, tc.payTo)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("note = %q, want empty", got)
+				}
+				return
+			}
+			for _, sub := range tc.wantNoteHas {
+				if !strings.Contains(got, sub) {
+					t.Errorf("note missing %q: %s", sub, got)
+				}
+			}
+		})
+	}
+}
+
+// TestAutoRegister_AllowsSignerPayeeMismatch is the source-level guard against
+// re-introducing the early-return error that used to reject ERC-8004
+// registrations whenever signer != payTo. The error wording was specific
+// ("registration signer ... does not match the payment wallet ..."); we grep
+// the function body for it. Anyone who reintroduces that check — even with a
+// different error message — must also delete this test, which is a deliberate
+// nudge to read the rationale comment first.
+func TestAutoRegister_AllowsSignerPayeeMismatch(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func autoRegisterServiceOffer(")
+	if start < 0 {
+		t.Fatal("autoRegisterServiceOffer not found in sell.go")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit autoRegisterServiceOffer body")
+	}
+	scope := body[start : start+1+end]
+	for _, banned := range []string{
+		`"registration signer %s does not match the payment wallet`,
+		`does not match the payment wallet`,
+	} {
+		if strings.Contains(scope, banned) {
+			t.Errorf("autoRegisterServiceOffer must NOT reject signer != payee — ERC-8004 allows "+
+				"the split via setAgentWallet and x402 settlement honors payTo directly. "+
+				"Banned snippet still present: %q", banned)
+		}
+	}
+	// Positive guard: the soft-notice path must still be present, otherwise
+	// the operator gets no signal that the addresses diverge.
+	if !strings.Contains(scope, "signerPayeeDelegationNote(") {
+		t.Error("autoRegisterServiceOffer must call signerPayeeDelegationNote(...) so operators see when signer ≠ payTo")
+	}
+}
+
+// TestBuildSellUpdatePatch_PayToOnly pins the `obol sell update <name> --pay-to 0x...`
+// shape. The user-facing promise is "change the payee in place" — the patch
+// must touch only spec.payment.payTo, not the rest of the offer.
+func TestBuildSellUpdatePatch_PayToOnly(t *testing.T) {
+	const newPayee = "0xB00B00000000000000000000000000000000B00B"
+	patch, err := buildSellUpdatePatch(newPayee, "", schemas.PriceTable{})
+	if err != nil {
+		t.Fatalf("buildSellUpdatePatch: %v", err)
+	}
+	spec, ok := patch["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("patch.spec missing or wrong type: %#v", patch)
+	}
+	payment, ok := spec["payment"].(map[string]any)
+	if !ok {
+		t.Fatalf("patch.spec.payment missing or wrong type: %#v", spec)
+	}
+	if payment["payTo"] != newPayee {
+		t.Errorf("patch.spec.payment.payTo = %v, want %q", payment["payTo"], newPayee)
+	}
+	if _, present := payment["network"]; present {
+		t.Errorf("--pay-to only patch should NOT touch payment.network; got %#v", payment["network"])
+	}
+	if _, present := payment["price"]; present {
+		t.Errorf("--pay-to only patch should NOT touch payment.price; got %#v", payment["price"])
+	}
+}
+
+// TestBuildSellUpdatePatch_PriceSwitchNullsOldKeys pins the switching contract:
+// changing the price model (e.g. perRequest → perMTok) must explicitly null
+// the unused keys so merge-patch semantics don't leave a stranded perRequest
+// fighting the new perMTok.
+func TestBuildSellUpdatePatch_PriceSwitchNullsOldKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		price  schemas.PriceTable
+		setKey string
+	}{
+		{"per-request set", schemas.PriceTable{PerRequest: "0.002"}, "perRequest"},
+		{"per-mtok set", schemas.PriceTable{PerMTok: "5.0"}, "perMTok"},
+		{"per-hour set", schemas.PriceTable{PerHour: "1.0"}, "perHour"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			patch, err := buildSellUpdatePatch("", "", tc.price)
+			if err != nil {
+				t.Fatalf("buildSellUpdatePatch: %v", err)
+			}
+			price := patch["spec"].(map[string]any)["payment"].(map[string]any)["price"].(map[string]any)
+			for _, key := range []string{"perRequest", "perMTok", "perHour"} {
+				v := price[key]
+				if key == tc.setKey {
+					if v == nil {
+						t.Errorf("price.%s = nil, want a value", key)
+					}
+				} else {
+					if v != nil {
+						t.Errorf("price.%s = %#v, want nil (so old key doesn't survive the merge)", key, v)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildSellUpdatePatch_NoFieldsErrors pins the no-op-protection contract:
+// `obol sell update <name>` with no field flags must error rather than fire
+// a no-op kubectl patch. The error message names the flags so the operator
+// learns the surface from the failure.
+func TestBuildSellUpdatePatch_NoFieldsErrors(t *testing.T) {
+	_, err := buildSellUpdatePatch("", "", schemas.PriceTable{})
+	if err == nil {
+		t.Fatal("expected error when no update flags are set")
+	}
+	for _, sub := range []string{"--per-request", "--per-mtok", "--per-hour", "--pay-to", "--chain"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error must name flag %q so the operator learns the surface; got: %v", sub, err)
+		}
+	}
+}
+
+// TestSellUpdate_PayToFlagSurface pins the user-facing `obol sell update
+// <name> --pay-to 0x...` flag wiring: the same payToFlag() shape used by
+// inference + http (so a buyer can muscle-memory `-w` / `--wallet`), plus
+// the namespace requirement (the resource is per-namespace, ambiguous
+// otherwise).
+func TestSellUpdate_PayToFlagSurface(t *testing.T) {
+	cfg := newTestConfig(t)
+	cmd := sellCommand(cfg)
+	update := findSubcommand(t, cmd, "update")
+	flags := flagMap(update)
+
+	requireFlags(t, flags,
+		"namespace", "pay-to", "wallet", "recipient", "w",
+		"chain", "price", "per-request", "per-mtok", "per-hour",
+	)
+	assertFlagRequired(t, flags, "namespace")
+	assertFlagHasAlias(t, flags, "pay-to", "wallet")
+	assertFlagHasAlias(t, flags, "pay-to", "recipient")
+	assertFlagHasAlias(t, flags, "pay-to", "w")
+}
+
 func TestBuildDemoServiceOffer_RegisterFlagDrivesEnabled(t *testing.T) {
 	for _, register := range []bool{true, false} {
 		manifest := buildDemoServiceOffer(

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1518,6 +1519,199 @@ func TestProcessAlive_SelfAndBogus(t *testing.T) {
 	}
 	if processAlive(99_999_999) {
 		t.Error("processAlive(absurd pid) must be false")
+	}
+}
+
+// TestPersistSellHTTPOffer_RoundTrip pins the on-disk manifest contract.
+// Anything the persistence layer writes must come back identically from
+// the resume path (which reads it via yaml.Unmarshal + kubectl-apply).
+// The path layout — <ConfigDir>/sell-http/<namespace>__<name>.yaml — is
+// the second half of the contract: two offers with the same name in
+// different namespaces must never collide on disk.
+func TestPersistSellHTTPOffer_RoundTrip(t *testing.T) {
+	cfg := newTestConfig(t)
+	manifest := map[string]any{
+		"apiVersion": "obol.org/v1alpha1",
+		"kind":       "ServiceOffer",
+		"metadata": map[string]any{
+			"name":      "my-api",
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"type": "http",
+			"upstream": map[string]any{
+				"service": "my-svc", "namespace": "default", "port": int64(8080), "healthPath": "/health",
+			},
+			"payment": map[string]any{
+				"scheme":  "exact",
+				"network": "base-sepolia",
+				"payTo":   "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+				"price":   map[string]any{"perRequest": "0.001"},
+			},
+		},
+	}
+	if err := persistSellHTTPOffer(cfg, "default", "my-api", manifest); err != nil {
+		t.Fatalf("persistSellHTTPOffer: %v", err)
+	}
+
+	expected := filepath.Join(cfg.ConfigDir, "sell-http", "default__my-api.yaml")
+	data, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatalf("expected manifest at %s: %v", expected, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("manifest file is empty")
+	}
+	// Round-trip: parse, verify metadata.name + spec.payment.payTo survived.
+	var round map[string]any
+	if err := yaml.Unmarshal(data, &round); err != nil {
+		t.Fatalf("YAML unmarshal: %v\n%s", err, data)
+	}
+	ns, name := manifestNSName(round)
+	if ns != "default" || name != "my-api" {
+		t.Errorf("round-tripped metadata = %s/%s, want default/my-api", ns, name)
+	}
+	payTo := round["spec"].(map[string]any)["payment"].(map[string]any)["payTo"]
+	if payTo != "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47" {
+		t.Errorf("round-tripped payTo = %v, want operator-supplied", payTo)
+	}
+}
+
+// TestPersistSellHTTPOffer_NamespaceIsolation pins that two offers with
+// the same name in different namespaces produce distinct files. A
+// careless filename scheme would have the second `obol sell http`
+// silently overwrite the first.
+func TestPersistSellHTTPOffer_NamespaceIsolation(t *testing.T) {
+	cfg := newTestConfig(t)
+	stub := func(ns string) map[string]any {
+		return map[string]any{
+			"apiVersion": "obol.org/v1alpha1",
+			"kind":       "ServiceOffer",
+			"metadata":   map[string]any{"name": "shared", "namespace": ns},
+			"spec":       map[string]any{"type": "http"},
+		}
+	}
+	if err := persistSellHTTPOffer(cfg, "team-a", "shared", stub("team-a")); err != nil {
+		t.Fatalf("persist team-a: %v", err)
+	}
+	if err := persistSellHTTPOffer(cfg, "team-b", "shared", stub("team-b")); err != nil {
+		t.Fatalf("persist team-b: %v", err)
+	}
+	for _, ns := range []string{"team-a", "team-b"} {
+		path := filepath.Join(cfg.ConfigDir, "sell-http", ns+"__shared.yaml")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist: %v", path, err)
+		}
+	}
+}
+
+// TestRemoveSellHTTPOffer_DropsPersistedManifest pins the symmetric
+// teardown: `obol sell delete` must remove the on-disk manifest so the
+// next stack-up doesn't re-create an offer the operator intentionally
+// deleted. The function must also be a quiet no-op for missing files —
+// running it twice (or against an offer that was never persisted) must
+// not error.
+func TestRemoveSellHTTPOffer_DropsPersistedManifest(t *testing.T) {
+	cfg := newTestConfig(t)
+	manifest := map[string]any{
+		"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
+		"metadata": map[string]any{"name": "doomed", "namespace": "llm"},
+	}
+	if err := persistSellHTTPOffer(cfg, "llm", "doomed", manifest); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	path := filepath.Join(cfg.ConfigDir, "sell-http", "llm__doomed.yaml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("manifest must exist before remove: %v", err)
+	}
+	if err := removeSellHTTPOffer(cfg, "llm", "doomed"); err != nil {
+		t.Errorf("remove: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("manifest still exists after remove: %v", err)
+	}
+	// Idempotent: removing the missing file must not error.
+	if err := removeSellHTTPOffer(cfg, "llm", "doomed"); err != nil {
+		t.Errorf("second remove must be no-op, got: %v", err)
+	}
+	// Defensive: empty inputs are silent no-ops, not panics.
+	if err := removeSellHTTPOffer(cfg, "", "foo"); err != nil {
+		t.Errorf("empty namespace: %v", err)
+	}
+	if err := removeSellHTTPOffer(cfg, "llm", ""); err != nil {
+		t.Errorf("empty name: %v", err)
+	}
+}
+
+// TestResumeSellHTTPOffers_EmptyStoreNoOp pins the "no http offers yet"
+// path: stack-up against a workspace that's never persisted an http
+// offer returns nil without erroring. Same shape as the inference
+// equivalent — important because resumeSellOffers calls both even when
+// only one store has entries.
+func TestResumeSellHTTPOffers_EmptyStoreNoOp(t *testing.T) {
+	cfg := newTestConfig(t)
+	// Need a kubeconfig.yaml present, otherwise the function bails early
+	// (correctly — no cluster). For the "store empty but cluster up"
+	// case we want to verify it doesn't error.
+	if err := os.WriteFile(filepath.Join(cfg.ConfigDir, "kubeconfig.yaml"), []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+	if err := resumeSellHTTPOffers(cfg, ui.New(false)); err != nil {
+		t.Errorf("empty-store resume must succeed: %v", err)
+	}
+}
+
+// TestSellDeleteAction_CallsRemoveSellHTTPOffer is a source-level guard
+// against the obvious post-delete leak: forget to call
+// removeSellHTTPOffer in the sell delete handler and the next
+// `obol stack up` resurrects the offer the operator just killed. The
+// only signal would be "deleted offers spookily come back" which is
+// hard to attribute, hence the test.
+func TestSellDeleteAction_CallsRemoveSellHTTPOffer(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellDeleteCommand(")
+	if start < 0 {
+		t.Fatal("sellDeleteCommand not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit sellDeleteCommand body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "removeSellHTTPOffer(") {
+		t.Fatal("sellDeleteCommand must call removeSellHTTPOffer — otherwise the on-disk manifest survives the kubectl delete and `obol stack up` resurrects the offer")
+	}
+}
+
+// TestResumeSellOffers_HTTPOnlyStore pins that http offers are still
+// resumed when the inference store is completely empty. The original
+// resumeSellOffers short-circuited on `len(deployments) == 0` before
+// reaching the http branch; this test catches a regression that
+// reintroduces that early return.
+func TestResumeSellOffers_HTTPOnlyStore(t *testing.T) {
+	cfg := newTestConfig(t)
+	// Seed a kubeconfig so resume gets past the no-cluster guard.
+	if err := os.WriteFile(filepath.Join(cfg.ConfigDir, "kubeconfig.yaml"), []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+	// No inference offers. One http offer present. Function must walk
+	// the http branch without erroring on the missing inference store.
+	manifest := map[string]any{
+		"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
+		"metadata": map[string]any{"name": "only-http", "namespace": "llm"},
+	}
+	if err := persistSellHTTPOffer(cfg, "llm", "only-http", manifest); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	// kubectl apply will fail against the fake kubeconfig — that's
+	// expected and reported as a warn, not an error. We just need
+	// resumeSellOffers itself to return nil.
+	if err := resumeSellOffers(context.Background(), cfg, ui.New(false)); err != nil {
+		t.Errorf("http-only store must not error from resumeSellOffers: %v", err)
 	}
 }
 

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -898,6 +899,104 @@ func TestBuildInferenceServiceOfferSpec_ModelNameNotHardcoded(t *testing.T) {
 	}
 	if model["name"] != "aeon-ultimate" {
 		t.Errorf("spec.model.name = %v, want %q (must reflect --model, not the legacy hardcoded \"ollama\")", model["name"], "aeon-ultimate")
+	}
+}
+
+// TestShouldAutoRegisterSell pins the decision logic shared by the http and
+// inference action handlers. The bug it guards: leaving a fresh inference
+// offer in `Registered=False AwaitingExternalRegistration` so that the
+// controller's services.json filter (which requires Ready=True, which in
+// turn requires Registered=True) silently excluded the offer from the
+// operator's own storefront. Both call sites must auto-register exactly
+// when the spec says enabled AND the tunnel is up — anything else is a
+// regression.
+func TestShouldAutoRegisterSell(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      map[string]any
+		tunnelURL string
+		want      bool
+	}{
+		{
+			name:      "registration enabled + tunnel up → register",
+			spec:      map[string]any{"registration": map[string]any{"enabled": true}},
+			tunnelURL: "https://inference.example.com",
+			want:      true,
+		},
+		{
+			name:      "registration explicitly disabled → skip",
+			spec:      map[string]any{"registration": map[string]any{"enabled": false}},
+			tunnelURL: "https://inference.example.com",
+			want:      false,
+		},
+		{
+			name:      "no registration block (sell http --no-register / pre-#485 sell inference) → skip",
+			spec:      map[string]any{},
+			tunnelURL: "https://inference.example.com",
+			want:      false,
+		},
+		{
+			name:      "registration enabled but tunnel down → skip (no endpoint to advertise)",
+			spec:      map[string]any{"registration": map[string]any{"enabled": true}},
+			tunnelURL: "",
+			want:      false,
+		},
+		{
+			name:      "registration block is not a map (defensive) → skip",
+			spec:      map[string]any{"registration": "garbage"},
+			tunnelURL: "https://inference.example.com",
+			want:      false,
+		},
+		{
+			name:      "registration.enabled is not a bool (defensive) → skip",
+			spec:      map[string]any{"registration": map[string]any{"enabled": "yes"}},
+			tunnelURL: "https://inference.example.com",
+			want:      false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldAutoRegisterSell(tc.spec, tc.tunnelURL)
+			if got != tc.want {
+				t.Errorf("shouldAutoRegisterSell = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSellInferenceAction_InvokesAutoRegister is a source-level guard
+// against the specific regression the user just hit on spark2: the
+// inference Action committed the ServiceOffer, ensured the tunnel, then
+// jumped straight to runInferenceGateway without ever calling
+// autoRegisterServiceOffer. Result: the offer stayed in
+// AwaitingExternalRegistration and never reached the storefront feed.
+// Without this guard, an innocent refactor of the post-create code path
+// could silently remove the call again — and the only downstream signal
+// would be "operator's storefront mysteriously empty", which is hard to
+// attribute.
+func TestSellInferenceAction_InvokesAutoRegister(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellInferenceCommand(")
+	if start < 0 {
+		t.Fatal("sellInferenceCommand not found in sell.go")
+	}
+	next := strings.Index(body[start+1:], "\nfunc ")
+	if next < 0 {
+		t.Fatal("could not delimit sellInferenceCommand body")
+	}
+	scope := body[start : start+1+next]
+	for _, needle := range []string{
+		"shouldAutoRegisterSell(",
+		"autoRegisterServiceOffer(",
+	} {
+		if !strings.Contains(scope, needle) {
+			t.Errorf("sellInferenceCommand body must contain %q — auto-register path missing, "+
+				"offers will stay in AwaitingExternalRegistration and be excluded from /api/services.json", needle)
+		}
 	}
 }
 

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/inference"
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	"github.com/ObolNetwork/obol-stack/internal/schemas"
+	"github.com/ObolNetwork/obol-stack/internal/ui"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/urfave/cli/v3"
 )
@@ -1221,6 +1223,118 @@ func TestSellUpdate_PayToFlagSurface(t *testing.T) {
 	assertFlagHasAlias(t, flags, "pay-to", "wallet")
 	assertFlagHasAlias(t, flags, "pay-to", "recipient")
 	assertFlagHasAlias(t, flags, "pay-to", "w")
+}
+
+// TestResumeSellOffers_EmptyStoreNoOp pins the "nothing to resume" path:
+// stack-up against a workspace with no persisted sell-inference deployments
+// must return nil without erroring. The same path also has to handle the
+// no-cluster-yet case (no kubeconfig.yaml) gracefully — both are exercised
+// by an empty ConfigDir.
+func TestResumeSellOffers_EmptyStoreNoOp(t *testing.T) {
+	cfg := newTestConfig(t)
+	u := ui.New(false)
+	if err := resumeSellOffers(context.Background(), cfg, u); err != nil {
+		t.Fatalf("empty resume must succeed, got: %v", err)
+	}
+}
+
+// TestResumeSellOffers_DescriptorPresentButNoCluster pins the
+// "descriptors-on-disk-but-cluster-not-up-yet" path. Real-world example:
+// `obol stack down`, then re-running `obol sell inference` somewhere that
+// happens to fail before reaching cluster apply — the descriptor lands on
+// disk, the cluster never comes back, and a subsequent `obol stack up`
+// against a missing kubeconfig must NOT panic or hard-error. It should be
+// a quiet skip until the cluster is available.
+func TestResumeSellOffers_DescriptorPresentButNoCluster(t *testing.T) {
+	cfg := newTestConfig(t)
+	store := inference.NewStore(cfg.ConfigDir)
+	if err := store.Create(&inference.Deployment{
+		Name:             "aeon",
+		ModelName:        "aeon-ultimate",
+		ServiceNamespace: "llm",
+		ListenAddr:       "0.0.0.0:8402",
+		WalletAddress:    "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		PricePerRequest:  "0.023",
+		AssetSymbol:      "OBOL",
+		Chain:            "base-sepolia",
+	}, true); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// No kubeconfig.yaml in cfg.ConfigDir — resume must not attempt
+	// cluster operations.
+	u := ui.New(false)
+	if err := resumeSellOffers(context.Background(), cfg, u); err != nil {
+		t.Fatalf("resume with descriptor + no cluster must skip cleanly, got: %v", err)
+	}
+}
+
+// TestResumeOneInferenceOffer_RequiresModelName pins the per-offer error
+// for legacy descriptors that were written before ModelName became a
+// persisted field. The resume path cannot fabricate a model name out of
+// thin air, and silently writing a ServiceOffer with no spec.model.name
+// would surface as a controller "ModelReady=False" loop with no actionable
+// signal. Operators need a clear "recreate the offer" message instead.
+func TestResumeOneInferenceOffer_RequiresModelName(t *testing.T) {
+	cfg := newTestConfig(t)
+	u := ui.New(false)
+	err := resumeOneInferenceOffer(cfg, u, &inference.Deployment{
+		Name:             "legacy",
+		ServiceNamespace: "llm",
+		ListenAddr:       ":8402",
+		// No ModelName.
+	})
+	if err == nil {
+		t.Fatal("expected error for legacy descriptor with no ModelName")
+	}
+	for _, sub := range []string{"model_name", "obol sell inference"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error must name the missing field and the recovery command; missing %q: %v", sub, err)
+		}
+	}
+}
+
+// TestResumeOneInferenceOffer_NilDescriptor pins the defensive guard for
+// the never-supposed-to-happen case of a nil or empty descriptor reaching
+// the resume loop. A bug elsewhere that produces such an entry shouldn't
+// panic the entire resume pass; one descriptor failing should not block
+// the rest.
+func TestResumeOneInferenceOffer_NilDescriptor(t *testing.T) {
+	cfg := newTestConfig(t)
+	u := ui.New(false)
+	if err := resumeOneInferenceOffer(cfg, u, nil); err == nil {
+		t.Fatal("expected error for nil descriptor")
+	}
+	if err := resumeOneInferenceOffer(cfg, u, &inference.Deployment{}); err == nil {
+		t.Fatal("expected error for empty descriptor (no Name)")
+	}
+}
+
+// TestStackUpAction_CallsResumeSellOffers is a source-level guard against
+// silently regressing the stack-up → sell-resume wiring. The whole feature
+// hinges on the `stack up` action handler calling resumeSellOffers after
+// stack.Up succeeds; without that call, persisted sell-inference offers
+// stay on disk forever and never reach the freshly-recreated cluster.
+// A future refactor that splits the handler or moves the call must update
+// this test, which forces a moment of "why is this here" attention.
+func TestStackUpAction_CallsResumeSellOffers(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	body := string(src)
+	if !strings.Contains(body, "resumeSellOffers(") {
+		t.Fatal("cmd/obol/main.go must call resumeSellOffers — without it persisted sell-inference offers never reach a freshly-stacked cluster")
+	}
+	// Belt-and-suspenders: assert the call lives after stack.Up so the
+	// kubeconfig + infrastructure are ready when resume runs.
+	upIdx := strings.Index(body, "stack.Up(cfg")
+	resumeIdx := strings.Index(body, "resumeSellOffers(")
+	if upIdx < 0 || resumeIdx < 0 {
+		t.Fatalf("expected both stack.Up and resumeSellOffers in main.go; upIdx=%d resumeIdx=%d", upIdx, resumeIdx)
+	}
+	if resumeIdx < upIdx {
+		t.Error("resumeSellOffers must be invoked AFTER stack.Up — running it before the cluster is up will see no kubeconfig and skip every offer")
+	}
 }
 
 func TestBuildDemoServiceOffer_RegisterFlagDrivesEnabled(t *testing.T) {

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1334,6 +1335,189 @@ func TestStackUpAction_CallsResumeSellOffers(t *testing.T) {
 	}
 	if resumeIdx < upIdx {
 		t.Error("resumeSellOffers must be invoked AFTER stack.Up — running it before the cluster is up will see no kubeconfig and skip every offer")
+	}
+}
+
+// TestBuildResumeGatewayArgs pins the round-trip between an
+// inference.Deployment on disk and the `obol sell inference` invocation
+// the resume path uses to relaunch the host gateway. If a flag is dropped
+// here, an offer that came back from disk would lose part of the
+// operator's original intent — most painfully, registration metadata
+// that fell out of the relaunch would leave the gateway running with
+// stripped-down /.well-known/ content.
+func TestBuildResumeGatewayArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		d         *inference.Deployment
+		wantSubs  []string
+		wantNoSub []string
+	}{
+		{
+			name: "full descriptor (the spark2 aeon offer)",
+			d: &inference.Deployment{
+				Name:            "aeon",
+				ModelName:       "aeon-ultimate",
+				UpstreamURL:     "http://127.0.0.1:8000",
+				WalletAddress:   "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+				ListenAddr:      "0.0.0.0:8402",
+				Chain:           "base-sepolia",
+				AssetSymbol:     "OBOL",
+				PricePerMTok:    "23",
+				PricePerRequest: "0.023",
+				FacilitatorURL:  "https://x402.gcp.obol.tech",
+				Registration: map[string]any{
+					"enabled":     true,
+					"name":        "Qwen3.6-27B AEON Ultimate",
+					"description": "Uncensored Qwen3.6-27B abliteration",
+					"skills":      []any{"llm/inference", "llm/uncensored"},
+					"domains":     []any{"inference.v1337.org"},
+				},
+			},
+			wantSubs: []string{
+				"sell", "inference", "aeon",
+				"--model", "aeon-ultimate",
+				"--upstream", "http://127.0.0.1:8000",
+				"--pay-to", "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+				"--listen", "0.0.0.0:8402",
+				"--chain", "base-sepolia",
+				"--token", "OBOL",
+				"--per-mtok", "23",
+				"--facilitator", "https://x402.gcp.obol.tech",
+				"--register-name", "Qwen3.6-27B AEON Ultimate",
+				"--register-description", "Uncensored Qwen3.6-27B abliteration",
+				"--register-skills", "llm/inference",
+				"--register-skills", "llm/uncensored",
+				"--register-domains", "inference.v1337.org",
+			},
+			wantNoSub: []string{
+				"--price", // perMTok set, perRequest must not also be passed
+				"--no-register",
+			},
+		},
+		{
+			name: "no-register descriptor",
+			d: &inference.Deployment{
+				Name:         "no-reg",
+				ModelName:    "qwen3:0.6b",
+				ListenAddr:   ":8402",
+				Registration: map[string]any{"enabled": false},
+			},
+			wantSubs: []string{
+				"--no-register",
+			},
+			wantNoSub: []string{
+				"--register-name",
+				"--register-description",
+			},
+		},
+		{
+			name: "legacy descriptor (no registration map at all)",
+			d: &inference.Deployment{
+				Name:            "legacy",
+				ModelName:       "qwen3.5:9b",
+				ListenAddr:      ":8402",
+				PricePerRequest: "0.001",
+			},
+			wantSubs: []string{"--price", "0.001"},
+			wantNoSub: []string{
+				"--no-register",
+				"--register-name",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildResumeGatewayArgs(tc.d)
+			joined := strings.Join(got, " ")
+			for _, want := range tc.wantSubs {
+				found := false
+				for _, a := range got {
+					if a == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("buildResumeGatewayArgs missing %q in %v", want, got)
+				}
+			}
+			for _, banned := range tc.wantNoSub {
+				for _, a := range got {
+					if a == banned {
+						t.Errorf("buildResumeGatewayArgs unexpectedly contains %q in %v", banned, got)
+					}
+				}
+			}
+			// Order sanity: positional `<name>` comes before any flag.
+			nameIdx := -1
+			firstFlagIdx := -1
+			for i, a := range got {
+				if a == tc.d.Name && nameIdx < 0 {
+					nameIdx = i
+				}
+				if strings.HasPrefix(a, "--") && firstFlagIdx < 0 {
+					firstFlagIdx = i
+				}
+			}
+			if nameIdx < 0 || firstFlagIdx < 0 || nameIdx > firstFlagIdx {
+				t.Errorf("name positional must come before flags; got %v", joined)
+			}
+		})
+	}
+}
+
+// TestReadGatewayPID pins the on-disk PID file format. The file must be a
+// single decimal integer in ASCII (no JSON, no trailing newlines that
+// confuse trivial readers) so other tools — `tail -f .../gateway.log` and
+// `kill $(cat .../gateway.pid)` — work without parsing helpers.
+func TestReadGatewayPID(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		content string
+		wantPID int
+		wantOK  bool
+	}{
+		{"clean integer", "12345", 12345, true},
+		{"trailing newline tolerated", "12345\n", 12345, true},
+		{"surrounding whitespace tolerated", "  12345  \n", 12345, true},
+		{"zero rejected", "0", 0, false},
+		{"negative rejected", "-1", 0, false},
+		{"non-numeric rejected", "abc", 0, false},
+		{"empty rejected", "", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".pid")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			pid, ok := readGatewayPID(path)
+			if pid != tc.wantPID || ok != tc.wantOK {
+				t.Errorf("readGatewayPID(%q) = (%d, %v); want (%d, %v)", tc.content, pid, ok, tc.wantPID, tc.wantOK)
+			}
+		})
+	}
+
+	t.Run("missing file → (0, false)", func(t *testing.T) {
+		pid, ok := readGatewayPID(filepath.Join(dir, "does-not-exist"))
+		if pid != 0 || ok {
+			t.Errorf("readGatewayPID(missing) = (%d, %v); want (0, false)", pid, ok)
+		}
+	})
+}
+
+// TestProcessAlive_SelfAndBogus pins the liveness probe used to decide
+// whether the previous gateway is still running. The current process is
+// trivially alive; a far-out-of-range PID is not. We don't test
+// "definitely-dead-but-recently-existed" cases because those depend on
+// the kernel's PID-reuse window and would be flaky.
+func TestProcessAlive_SelfAndBogus(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("processAlive(self) must be true")
+	}
+	if processAlive(99_999_999) {
+		t.Error("processAlive(absurd pid) must be false")
 	}
 }
 

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -102,6 +102,25 @@ type Deployment struct {
 	// config and passed to the registration document when selling.
 	Provenance *Provenance `json:"provenance,omitempty"`
 
+	// ModelName is the upstream model identifier the operator selected via
+	// `obol sell inference --model <name>` (e.g. "aeon-ultimate"). Persisted
+	// so `obol stack up` can rebuild the ServiceOffer's spec.model.name on
+	// resume without re-prompting the operator.
+	ModelName string `json:"model_name,omitempty"`
+
+	// ServiceNamespace is the Kubernetes namespace the cluster-routed Service
+	// + Endpoints + ServiceOffer live in (typically "llm" for inference
+	// deployments co-located with LiteLLM). Persisted so the resume path
+	// re-applies into the same namespace.
+	ServiceNamespace string `json:"service_namespace,omitempty"`
+
+	// Registration is the ERC-8004 registration block the operator passed at
+	// sell time (--register-*). Persisted as map[string]any (the same shape
+	// buildSellRegistrationConfig emits) so the resume path can rebuild the
+	// ServiceOffer's spec.registration verbatim. Empty when the offer was
+	// created with --no-register.
+	Registration map[string]any `json:"registration,omitempty"`
+
 	// CreatedAt is the RFC3339 timestamp of when this deployment was created.
 	CreatedAt string `json:"created_at"`
 

--- a/internal/inference/store_test.go
+++ b/internal/inference/store_test.go
@@ -301,3 +301,104 @@ func TestStoreDirPermissions(t *testing.T) {
 		t.Errorf("config.json permissions: want 0600, got %04o", mode)
 	}
 }
+
+// TestStoreCreate_PersistsResumeFields pins the new resume-side fields on
+// the inference Deployment descriptor. Without ModelName, ServiceNamespace,
+// and Registration persisted on disk, the `obol stack up` resume path
+// would lose the operator's --model + --register-* customizations and
+// rebuild a stripped-down ServiceOffer (or fail outright on missing
+// model_name). The round-trip here is the contract: anything Create()
+// writes must come back verbatim from Get().
+func TestStoreCreate_PersistsResumeFields(t *testing.T) {
+	dir := t.TempDir()
+	store := inference.NewStore(dir)
+
+	registration := map[string]any{
+		"enabled":     true,
+		"name":        "Qwen3.6-27B AEON Ultimate",
+		"description": "Uncensored Qwen3.6-27B abliteration on DGX Spark",
+		"skills":      []any{"llm/inference", "llm/uncensored"},
+		"domains":     []any{"inference.v1337.org"},
+	}
+
+	in := &inference.Deployment{
+		Name:             "aeon",
+		EnclaveTag:       "com.obol.inference.aeon",
+		ListenAddr:       "0.0.0.0:8402",
+		UpstreamURL:      "http://127.0.0.1:8000",
+		WalletAddress:    "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+		PricePerRequest:  "0.023",
+		AssetSymbol:      "OBOL",
+		Chain:            "base-sepolia",
+		ModelName:        "aeon-ultimate",
+		ServiceNamespace: "llm",
+		Registration:     registration,
+	}
+	if err := store.Create(in, true); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := store.Get("aeon")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ModelName != "aeon-ultimate" {
+		t.Errorf("ModelName = %q, want %q", got.ModelName, "aeon-ultimate")
+	}
+	if got.ServiceNamespace != "llm" {
+		t.Errorf("ServiceNamespace = %q, want %q", got.ServiceNamespace, "llm")
+	}
+	if got.Registration == nil {
+		t.Fatal("Registration round-tripped to nil; resume would rebuild offer without operator customizations")
+	}
+	if got.Registration["enabled"] != true {
+		t.Errorf("Registration.enabled = %v, want true", got.Registration["enabled"])
+	}
+	if got.Registration["name"] != "Qwen3.6-27B AEON Ultimate" {
+		t.Errorf("Registration.name = %v, want %q", got.Registration["name"], "Qwen3.6-27B AEON Ultimate")
+	}
+}
+
+// TestStoreCreate_LegacyDescriptorWithoutResumeFields pins backwards-
+// compatibility: a descriptor written by an older binary (no ModelName,
+// no ServiceNamespace, no Registration) must still be readable, with the
+// new fields coming back as zero values. The resume path uses the zero
+// values to either default sensibly or refuse with an actionable error.
+func TestStoreCreate_LegacyDescriptorWithoutResumeFields(t *testing.T) {
+	dir := t.TempDir()
+	configDir := dir + "/inference/legacy"
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// JSON shape an older binary would have written — no model_name,
+	// no service_namespace, no registration.
+	legacyJSON := `{
+		"name": "legacy",
+		"listen_addr": ":8402",
+		"upstream_url": "http://localhost:11434",
+		"wallet_address": "0xefab75b7b199bf8512e2d5b379374cb94dfdba47",
+		"price_per_request": "0.001",
+		"chain": "base",
+		"facilitator_url": "https://x402.gcp.obol.tech",
+		"created_at": "2026-01-01T00:00:00Z"
+	}`
+	if err := os.WriteFile(configDir+"/config.json", []byte(legacyJSON), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	store := inference.NewStore(dir)
+	got, err := store.Get("legacy")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ModelName != "" {
+		t.Errorf("ModelName = %q, want empty for legacy descriptor", got.ModelName)
+	}
+	if got.ServiceNamespace != "" {
+		t.Errorf("ServiceNamespace = %q, want empty for legacy descriptor", got.ServiceNamespace)
+	}
+	if got.Registration != nil {
+		t.Errorf("Registration = %#v, want nil for legacy descriptor", got.Registration)
+	}
+}

--- a/internal/schemas/service_catalog.go
+++ b/internal/schemas/service_catalog.go
@@ -31,6 +31,14 @@ type ServiceCatalogEntry struct {
 	Asset            *ServiceCatalogAsset `json:"asset,omitempty"`
 	Description      string               `json:"description"`
 	IsDemo           bool                 `json:"isDemo"`
+
+	// RegistrationPending is true when the offer is operationally ready
+	// (route published, payment gate active, upstream healthy) but its
+	// ERC-8004 on-chain registration tx hasn't landed yet. The storefront
+	// should surface these with a "registration pending" badge so consumers
+	// know the offer is usable for x402 payments today, even though
+	// ERC-8004 discovery via the chain still resolves to the prior state.
+	RegistrationPending bool `json:"registrationPending,omitempty"`
 }
 
 // ServiceCatalogAsset describes the settlement token resolved for a catalog

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -705,12 +705,18 @@ func offerPublishedForRegistration(offer *monetizeapi.ServiceOffer) bool {
 func buildSkillCatalogMarkdown(offers []*monetizeapi.ServiceOffer, baseURL string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
 
+	// Same operationally-ready filter as buildServiceCatalogJSON — keep the
+	// two surfaces consistent. An offer that's usable for x402 payments
+	// (route published, payment gate active, upstream healthy) appears in
+	// both /skill.md and /api/services.json, with the on-chain ERC-8004
+	// registration treated as informational metadata rather than a gating
+	// signal. See offerOperationallyReady's doc comment for the rationale.
 	var ready []*monetizeapi.ServiceOffer
 	for _, offer := range offers {
 		if offer == nil || offer.DeletionTimestamp != nil || offer.IsPaused() {
 			continue
 		}
-		if isConditionTrue(offer.Status, "Ready") {
+		if offerOperationallyReady(offer) {
 			ready = append(ready, offer)
 		}
 	}

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -26,7 +26,6 @@ const (
 	servicesJSONRouteName     = "obol-services-json-route"
 )
 
-
 func buildRegistrationRequest(offer *monetizeapi.ServiceOffer, desiredState string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
@@ -583,12 +582,18 @@ func isConditionTrue(status monetizeapi.ServiceOfferStatus, conditionType string
 
 func buildActiveRegistrationDocument(owner *monetizeapi.ServiceOffer, offers []*monetizeapi.ServiceOffer, baseURL, agentID string) erc8004.AgentRegistration {
 	baseURL = strings.TrimRight(baseURL, "/")
+	// Operator-supplied description wins. Only fall back to a controller-
+	// generated default when the offer left Spec.Registration.Description
+	// empty. The inference-typed default is more specific (names the model),
+	// so it preempts the generic default — but neither overrides an explicit
+	// operator value.
 	description := owner.Spec.Registration.Description
 	if description == "" {
-		description = fmt.Sprintf("x402 payment-gated %s service: %s", fallbackOfferType(owner), owner.Name)
-	}
-	if owner.IsInference() && owner.Spec.Model.Name != "" {
-		description = fmt.Sprintf("%s inference via x402 micropayments", owner.Spec.Model.Name)
+		if owner.IsInference() && owner.Spec.Model.Name != "" {
+			description = fmt.Sprintf("%s inference via x402 micropayments", owner.Spec.Model.Name)
+		} else {
+			description = fmt.Sprintf("x402 payment-gated %s service: %s", fallbackOfferType(owner), owner.Name)
+		}
 	}
 
 	image := owner.Spec.Registration.Image

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -776,7 +776,69 @@ func buildSkillCatalogMarkdown(offers []*monetizeapi.ServiceOffer, baseURL strin
 	return strings.Join(lines, "\n")
 }
 
-// buildServiceCatalogJSON returns a JSON array of ready ServiceOffers for the public storefront.
+// offerOperationallyReady reports whether an offer is usable for x402
+// payments today. This is intentionally LOOSER than the controller's
+// Ready=True condition: ModelReady + UpstreamHealthy + PaymentGateReady
+// + RoutePublished are sufficient. Registered is NOT in the AND. The
+// reasoning: ERC-8004 on-chain registration is publication metadata, not
+// operational readiness — an offer with the route published, payment gate
+// active, and upstream healthy serves buyers correctly regardless of
+// whether the on-chain identity has been minted yet.
+//
+// Used by the storefront catalog (and the skill catalog) so an offer that
+// is functionally usable doesn't disappear from the operator's own
+// dashboard just because the agent wallet hasn't been funded with gas
+// yet. Callers should set ServiceCatalogEntry.RegistrationPending = true
+// when the offer's Registered condition is False with reason
+// AwaitingExternalRegistration, so storefront UIs can badge it.
+func offerOperationallyReady(offer *monetizeapi.ServiceOffer) bool {
+	if offer == nil {
+		return false
+	}
+	// Backwards-compatible shortcut: the aggregate Ready=True implies all
+	// the per-condition gates by construction (see controller.go's `ready`
+	// computation), and existing tests / external callers that only emit
+	// the aggregate signal still want their offers to appear.
+	if isConditionTrue(offer.Status, "Ready") {
+		return true
+	}
+	// Fine-grained operational readiness: the four per-condition gates
+	// that make the offer usable today. Registered is intentionally NOT
+	// in this AND — see the doc comment on this function and on
+	// buildServiceCatalogJSON for the rationale.
+	return isConditionTrue(offer.Status, "ModelReady") &&
+		isConditionTrue(offer.Status, "UpstreamHealthy") &&
+		isConditionTrue(offer.Status, "PaymentGateReady") &&
+		isConditionTrue(offer.Status, "RoutePublished")
+}
+
+// offerAwaitingRegistration reports whether an offer is operationally
+// ready but has its on-chain ERC-8004 registration still pending. Used to
+// flip ServiceCatalogEntry.RegistrationPending so storefront UIs can show
+// a "registration pending" badge alongside the usable offer.
+func offerAwaitingRegistration(offer *monetizeapi.ServiceOffer) bool {
+	if offer == nil {
+		return false
+	}
+	for _, c := range offer.Status.Conditions {
+		if c.Type == "Registered" && c.Status == "False" && c.Reason == "AwaitingExternalRegistration" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildServiceCatalogJSON returns a JSON array of operationally-ready
+// ServiceOffers for the public storefront feed (/api/services.json).
+//
+// The filter is operationally-ready (route published, payment gate
+// active, upstream healthy) rather than the stricter controller
+// Ready=True (which also requires Registered=True). Excluding offers
+// whose only False condition is AwaitingExternalRegistration made
+// operators' own seller dashboards mysteriously empty after `obol stack
+// up` until they funded the agent wallet and ran `obol sell register`.
+// That UX failed the "all paid services come back automatically" promise
+// of the stack-up resume feature.
 func buildServiceCatalogJSON(offers []*monetizeapi.ServiceOffer, baseURL string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
 
@@ -785,7 +847,7 @@ func buildServiceCatalogJSON(offers []*monetizeapi.ServiceOffer, baseURL string)
 		if offer == nil || offer.DeletionTimestamp != nil || offer.IsPaused() {
 			continue
 		}
-		if isConditionTrue(offer.Status, "Ready") {
+		if offerOperationallyReady(offer) {
 			ready = append(ready, offer)
 		}
 	}
@@ -808,16 +870,17 @@ func buildServiceCatalogJSON(offers []*monetizeapi.ServiceOffer, baseURL string)
 		}
 
 		svc := schemas.ServiceCatalogEntry{
-			Name:        offer.Name,
-			Namespace:   offer.Namespace,
-			Type:        fallbackOfferType(offer),
-			Model:       modelName,
-			Endpoint:    baseURL + offer.EffectivePath(),
-			Price:       describeOfferPrice(offer),
-			PayTo:       offer.Spec.Payment.PayTo,
-			Network:     offer.Spec.Payment.Network,
-			Description: desc,
-			IsDemo:      offer.Namespace == "demo",
+			Name:                offer.Name,
+			Namespace:           offer.Namespace,
+			Type:                fallbackOfferType(offer),
+			Model:               modelName,
+			Endpoint:            baseURL + offer.EffectivePath(),
+			Price:               describeOfferPrice(offer),
+			PayTo:               offer.Spec.Payment.PayTo,
+			Network:             offer.Spec.Payment.Network,
+			Description:         desc,
+			IsDemo:              offer.Namespace == "demo",
+			RegistrationPending: offerAwaitingRegistration(offer),
 		}
 
 		raw, unit := offerPriceRawAndUnit(offer)

--- a/internal/serviceoffercontroller/render_test.go
+++ b/internal/serviceoffercontroller/render_test.go
@@ -240,6 +240,74 @@ func TestBuildActiveRegistrationDocument(t *testing.T) {
 	}
 }
 
+// TestBuildActiveRegistrationDocument_KeepsOperatorDescription pins the fix
+// for the controller-side description-clobber bug:
+// `buildActiveRegistrationDocument` used to unconditionally overwrite
+// `owner.Spec.Registration.Description` for inference-typed offers with
+// `"<model.name> inference via x402 micropayments"`, so any explicit operator
+// description set at sell time was silently lost in the published
+// /.well-known/agent-registration.json document. The fix only fills the
+// description from the model name when the operator's value is empty.
+func TestBuildActiveRegistrationDocument_KeepsOperatorDescription(t *testing.T) {
+	operatorDesc := "Uncensored Qwen3.6-27B abliteration on DGX Spark"
+	owner := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "aeon", Namespace: "llm"},
+		Spec: monetizeapi.ServiceOfferSpec{
+			Type:  "inference",
+			Model: monetizeapi.ServiceOfferModel{Name: "aeon-ultimate"},
+			Path:  "/services/aeon",
+			Registration: monetizeapi.ServiceOfferRegistration{
+				Enabled:     true,
+				Name:        "Qwen36 AEON Ultimate",
+				Description: operatorDesc,
+			},
+		},
+		Status: monetizeapi.ServiceOfferStatus{
+			Conditions: []monetizeapi.Condition{
+				{Type: "ModelReady", Status: "True"},
+				{Type: "UpstreamHealthy", Status: "True"},
+				{Type: "PaymentGateReady", Status: "True"},
+				{Type: "RoutePublished", Status: "True"},
+			},
+		},
+	}
+	doc := buildActiveRegistrationDocument(owner, []*monetizeapi.ServiceOffer{owner}, "https://inference.example.com", "")
+	if doc.Description != operatorDesc {
+		t.Fatalf("description = %q, want operator value %q (the controller used to overwrite this with %q-inference-via-x402-micropayments)",
+			doc.Description, operatorDesc, owner.Spec.Model.Name)
+	}
+	if doc.Name != "Qwen36 AEON Ultimate" {
+		t.Errorf("name = %q, want operator value %q", doc.Name, "Qwen36 AEON Ultimate")
+	}
+}
+
+// TestBuildActiveRegistrationDocument_FallsBackToModelDescriptionForInference
+// pins the *other* side of the description contract: when the operator does
+// not supply a description, inference offers should still get the
+// model-aware default ("<model.name> inference via x402 micropayments"),
+// not the generic "x402 payment-gated <type> service: <name>" string used
+// for non-inference fallback. The refactor must preserve both branches.
+func TestBuildActiveRegistrationDocument_FallsBackToModelDescriptionForInference(t *testing.T) {
+	owner := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "aeon", Namespace: "llm"},
+		Spec: monetizeapi.ServiceOfferSpec{
+			Type:  "inference",
+			Model: monetizeapi.ServiceOfferModel{Name: "aeon-ultimate"},
+			Path:  "/services/aeon",
+			Registration: monetizeapi.ServiceOfferRegistration{
+				Enabled: true,
+				Name:    "aeon",
+				// Description intentionally left blank.
+			},
+		},
+	}
+	doc := buildActiveRegistrationDocument(owner, []*monetizeapi.ServiceOffer{owner}, "https://inference.example.com", "")
+	want := "aeon-ultimate inference via x402 micropayments"
+	if doc.Description != want {
+		t.Errorf("description = %q, want %q (model-aware default for inference offers with no operator description)", doc.Description, want)
+	}
+}
+
 func TestBuildRegistrationServices_IncludesOwnerWhenOwnerNotYetPublished(t *testing.T) {
 	owner := &monetizeapi.ServiceOffer{
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "demo"},
@@ -528,13 +596,17 @@ func TestBuildServiceCatalogJSON_ExcludesNonReady(t *testing.T) {
 	offers := []*monetizeapi.ServiceOffer{
 		nil,
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "paused-svc", Namespace: "llm",
-				Annotations: map[string]string{monetizeapi.PausedAnnotation: "true"}},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "paused-svc", Namespace: "llm",
+				Annotations: map[string]string{monetizeapi.PausedAnnotation: "true"},
+			},
 			Status: monetizeapi.ServiceOfferStatus{Conditions: readyCond},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "deleting-svc", Namespace: "llm",
-				DeletionTimestamp: &deleting},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "deleting-svc", Namespace: "llm",
+				DeletionTimestamp: &deleting,
+			},
 			Status: monetizeapi.ServiceOfferStatus{Conditions: readyCond},
 		},
 		{

--- a/internal/serviceoffercontroller/render_test.go
+++ b/internal/serviceoffercontroller/render_test.go
@@ -992,3 +992,139 @@ func TestSafeName_Truncation(t *testing.T) {
 		t.Error("different long names should produce different childNames")
 	}
 }
+
+// TestOfferOperationallyReady_IncludesAwaitingExternalRegistration pins the
+// behavioral fix that "operationally ready" no longer requires the on-chain
+// ERC-8004 registration to have landed.
+func TestOfferOperationallyReady_IncludesAwaitingExternalRegistration(t *testing.T) {
+	awaiting := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "aeon", Namespace: "llm"},
+		Status: monetizeapi.ServiceOfferStatus{
+			Conditions: []monetizeapi.Condition{
+				{Type: "ModelReady", Status: "True"},
+				{Type: "UpstreamHealthy", Status: "True"},
+				{Type: "PaymentGateReady", Status: "True"},
+				{Type: "RoutePublished", Status: "True"},
+				{Type: "Registered", Status: "False", Reason: "AwaitingExternalRegistration"},
+				{Type: "Ready", Status: "False", Reason: "Reconciling"},
+			},
+		},
+	}
+	if !offerOperationallyReady(awaiting) {
+		t.Fatal("offerOperationallyReady must return true for AwaitingExternalRegistration — the offer is usable for x402 payments today regardless of on-chain identity")
+	}
+	if !offerAwaitingRegistration(awaiting) {
+		t.Fatal("offerAwaitingRegistration must flag this offer so the storefront badges it as registration-pending")
+	}
+}
+
+// TestOfferOperationallyReady_RejectsRealNotReady pins the narrow scope of
+// the relax: an offer whose foreground gateway is down (UpstreamHealthy=False)
+// must still be excluded.
+func TestOfferOperationallyReady_RejectsRealNotReady(t *testing.T) {
+	notUsable := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken", Namespace: "llm"},
+		Status: monetizeapi.ServiceOfferStatus{
+			Conditions: []monetizeapi.Condition{
+				{Type: "ModelReady", Status: "True"},
+				{Type: "UpstreamHealthy", Status: "False", Reason: "Unhealthy"},
+				{Type: "PaymentGateReady", Status: "False", Reason: "WaitingForUpstream"},
+				{Type: "RoutePublished", Status: "False", Reason: "WaitingForPaymentGate"},
+			},
+		},
+	}
+	if offerOperationallyReady(notUsable) {
+		t.Error("offerOperationallyReady must reject an offer with UpstreamHealthy=False")
+	}
+	if offerAwaitingRegistration(notUsable) {
+		t.Error("offerAwaitingRegistration must NOT flag offers whose Registered condition isn't AwaitingExternalRegistration")
+	}
+}
+
+// TestBuildServiceCatalogJSON_IncludesPendingRegistrationOffers pins the
+// end-to-end wiring: an offer that's operationally ready but awaiting
+// on-chain registration appears in /api/services.json with
+// RegistrationPending=true.
+func TestBuildServiceCatalogJSON_IncludesPendingRegistrationOffers(t *testing.T) {
+	offers := []*monetizeapi.ServiceOffer{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "aeon", Namespace: "llm"},
+			Spec: monetizeapi.ServiceOfferSpec{
+				Type: "inference",
+				Path: "/services/aeon",
+				Payment: monetizeapi.ServiceOfferPayment{
+					Network: "base-sepolia",
+					PayTo:   "0xeFAb75b7b199bf8512e2d5b379374Cb94dfdBA47",
+					Price:   monetizeapi.ServiceOfferPriceTable{PerMTok: "23"},
+				},
+				Model: monetizeapi.ServiceOfferModel{Name: "aeon-ultimate"},
+				Registration: monetizeapi.ServiceOfferRegistration{
+					Enabled: true, Name: "AEON Ultimate",
+					Description: "Uncensored Qwen3.6-27B",
+				},
+			},
+			Status: monetizeapi.ServiceOfferStatus{
+				Conditions: []monetizeapi.Condition{
+					{Type: "ModelReady", Status: "True"},
+					{Type: "UpstreamHealthy", Status: "True"},
+					{Type: "PaymentGateReady", Status: "True"},
+					{Type: "RoutePublished", Status: "True"},
+					{Type: "Registered", Status: "False", Reason: "AwaitingExternalRegistration"},
+				},
+			},
+		},
+	}
+	jsonStr := buildServiceCatalogJSON(offers, "https://inference.example.com")
+	var services []schemas.ServiceCatalogEntry
+	if err := json.Unmarshal([]byte(jsonStr), &services); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, jsonStr)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service in catalog, got %d: %+v", len(services), services)
+	}
+	if services[0].Name != "aeon" {
+		t.Errorf("got %q, want aeon", services[0].Name)
+	}
+	if !services[0].RegistrationPending {
+		t.Error("RegistrationPending must be true for AwaitingExternalRegistration offers")
+	}
+}
+
+// TestBuildServiceCatalogJSON_RegistrationPendingFalseForFullyReady pins
+// the negative: an offer that's fully Ready=True (on-chain register tx
+// landed) must NOT carry RegistrationPending.
+func TestBuildServiceCatalogJSON_RegistrationPendingFalseForFullyReady(t *testing.T) {
+	offers := []*monetizeapi.ServiceOffer{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "fully-ready", Namespace: "llm"},
+			Spec: monetizeapi.ServiceOfferSpec{
+				Type: "http",
+				Payment: monetizeapi.ServiceOfferPayment{
+					Network: "base", PayTo: "0x1111111111111111111111111111111111111111",
+					Price: monetizeapi.ServiceOfferPriceTable{PerRequest: "0.001"},
+				},
+			},
+			Status: monetizeapi.ServiceOfferStatus{
+				Conditions: []monetizeapi.Condition{
+					{Type: "ModelReady", Status: "True"},
+					{Type: "UpstreamHealthy", Status: "True"},
+					{Type: "PaymentGateReady", Status: "True"},
+					{Type: "RoutePublished", Status: "True"},
+					{Type: "Registered", Status: "True", Reason: "Active"},
+					{Type: "Ready", Status: "True"},
+				},
+			},
+		},
+	}
+	jsonStr := buildServiceCatalogJSON(offers, "https://example.com")
+	var services []schemas.ServiceCatalogEntry
+	if err := json.Unmarshal([]byte(jsonStr), &services); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, jsonStr)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].RegistrationPending {
+		t.Error("RegistrationPending must be false for fully Ready=True offers")
+	}
+}


### PR DESCRIPTION
## Summary

Supersedes #485 and #486. Single PR for the full "operator does `obol stack up` once and every paid service comes back, including its storefront entry, ERC-8004 well-known route, and host-side gateway" surface.

The work spans three originally-separate threads that turned out to be one coherent feature:

1. **`obol sell inference` registration parity** — `--register-*` flags, auto-register on-chain, signer ≠ payTo allowed per the ERC-8004 spec, and `obol sell update --pay-to` patch builder extracted so operators can re-point payees post-creation.
2. **Stack-up resume** — `obol stack up` walks the on-disk seller state and replays every offer it finds, plus spawns the inference foreground gateway as a detached subprocess so `UpstreamHealthy` flips True without operator intervention.
3. **Storefront filter relax + sell-http persistence** — the controller's `Ready=True` requirement gated on the ERC-8004 on-chain tx (which often takes minutes or never lands if the agent wallet is unfunded), silently hiding usable offers from the operator's own storefront. The relaxed filter treats Registered as informational and adds `registrationPending=true` to `/api/services.json` so UIs can badge the offer. Same store-and-resume pattern wired up for `obol sell http` too.

## Commits (chronological story for review)

| | |
|---|---|
| `4708407` | `fix(sell inference): emit registration spec + honor operator overrides` — adds `--register-*`, fixes `buildInferenceServiceOfferSpec` to honor operator description / model name |
| `b92b78e` | `fix(sell inference): auto-register on-chain to match sell http parity` — `shouldAutoRegisterSell` helper, source-level guard for the call site |
| `dbf6c89` | `fix(sell): allow signer != payTo on ERC-8004 register (not a spec constraint)` — drops the over-strict obol-CLI guard, adds `signerPayeeDelegationNote`, extracts `buildSellUpdatePatch` for `obol sell update --pay-to` |
| `2d36745` | `feat(stack): resume sell-inference offers on stack up` — descriptor → cluster artifacts replay |
| `6efdf3f` | `feat(stack): zero-command resume — auto-start gateway + relax storefront filter` — detached subprocess + `offerOperationallyReady` + `RegistrationPending` field |
| `9947bb0` | `fix(stack): three cosmetic fixes on top of the zero-command resume` — PID-before-Release, footer wording, `skill.md` filter aligned with storefront |
| `702d7c6` | `feat(stack): resume obol sell http offers on stack up` — sell-http manifest store + matching resume branch |

## Tests added across the PR

| Surface | Test |
|---|---|
| Registration flag parity | `TestSellInference_Flags` extended to require the six `--register-*` flags + `--no-register` |
| Spec builder | `TestBuildInferenceServiceOfferSpec_RegistrationEnabledByDefault`, `_NoRegisterOmitsRegistration`, `_OperatorOverridesWin`, `_ModelNameNotHardcoded` |
| Auto-register | `TestShouldAutoRegisterSell` (6 cases), `TestSellInferenceAction_InvokesAutoRegister` (source guard) |
| Signer ≠ payee | `TestSignerPayeeDelegationNote` (6 cases), `TestAutoRegister_AllowsSignerPayeeMismatch` (source guard) |
| `obol sell update` | `TestBuildSellUpdatePatch_PayToOnly`, `_PriceSwitchNullsOldKeys`, `_NoFieldsErrors`, `TestSellUpdate_PayToFlagSurface` |
| Store contract | `TestStoreCreate_PersistsResumeFields`, `TestStoreCreate_LegacyDescriptorWithoutResumeFields` |
| Resume guards | `TestResumeSellOffers_EmptyStoreNoOp`, `_DescriptorPresentButNoCluster`, `TestResumeOneInferenceOffer_RequiresModelName`, `_NilDescriptor`, `TestStackUpAction_CallsResumeSellOffers` |
| Detached gateway | `TestBuildResumeGatewayArgs` (3 cases), `TestReadGatewayPID` (8 cases), `TestProcessAlive_SelfAndBogus` |
| Controller relax | `TestOfferOperationallyReady_IncludesAwaitingExternalRegistration`, `_RejectsRealNotReady`, `TestBuildServiceCatalogJSON_IncludesPendingRegistrationOffers`, `_RegistrationPendingFalseForFullyReady` |
| sell-http persistence | `TestPersistSellHTTPOffer_RoundTrip`, `_NamespaceIsolation`, `TestRemoveSellHTTPOffer_DropsPersistedManifest`, `TestResumeSellHTTPOffers_EmptyStoreNoOp`, `TestSellDeleteAction_CallsRemoveSellHTTPOffer`, `TestResumeSellOffers_HTTPOnlyStore` |

## Live spark2 validation

Walked through end-to-end multiple times during development:

- `obol sell inference aeon … --register-* …` writes a descriptor with `model_name`, `service_namespace`, `registration` fields (PR #486 commit 1).
- `obol stack down` then `obol stack up` (with controller image rebuilt to pick up the storefront filter change): resume fires, gateway re-spawns detached with PID + log file, ServiceOffer + Service + Endpoints come back, `/api/services.json` returns 1 service with `registrationPending=true`, and the storefront landing page no longer says "No services are currently available."
- `obol sell delete aeon -n llm --force` removes the on-disk inference descriptor and the sell-http manifest (if applicable). Re-`obol stack up` does NOT resurrect the offer.
- `obol sell inference aeon --pay-to 0xCold…` against an agent signer of `0xA5d4aF96…` no longer errors at the auto-register pre-flight; an informational note explains the delegation.

## Follow-ups noted in the code

- **Inference gateway as a real cluster Pod** — the detached host subprocess is the deliberate near-term shape. A helm-managed Pod (gateway image + Deployment) would survive stack down/up the same way Traefik / LiteLLM do, and the controller could observe it as a first-class workload instead of a docker-bridge bounce. Comment in `startDetachedInferenceGateway` calls this out.
- **Unified sell-offer store** — sell-inference and sell-http persist to separate dirs because their descriptor shapes diverge. A future schema merge is fine; not the right MVP.
- **`obol sell delete` doesn't drop the inference descriptor** — by design (the descriptor is what `obol sell inference list/status` reads). The HTTP cleanup is one-shot because there's no equivalent post-delete state to preserve.

## Closes

- #485 (folded in verbatim, all three commits preserved)
- #486 (folded in verbatim, all three commits preserved)
- Closes #475 already merged separately in PR #481 — referenced here only because the PVC fix unblocked the test path.

Generated with Claude Code