### PR TITLE
chore: harden secret leak prevention

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 0
 
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@44c470fca6cba13fce44de8a58376d9edcceee41 # v2.3.9
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@44c470fca6cba13fce44de8a58376d9edcceee41 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -18,7 +18,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar xz
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run gitleaks on PR diff
+        if: github.event_name == 'pull_request'
+        run: gitleaks detect --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" --verbose
+
+      - name: Run gitleaks on push
+        if: github.event_name == 'push'
+        run: gitleaks detect --log-opts "${{ github.event.before }}..${{ github.sha }}" --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ charts/*/Chart.lock
 
 # Build & logs
 *.log
+*.txt
+!**/templates/NOTES.txt
 logs/
 dist/
 build/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,30 @@ description = "Authorization header key=value pair with credential"
 regex = '''Authorization\s*[=:]\s*(?:Basic|Bearer)\s+\S+'''
 tags = ["auth", "credential"]
 
+[[rules]]
+id = "ethereum-private-key"
+description = "Ethereum/secp256k1 hex private key"
+regex = '''(?i)(?:private.?key|secret.?key|PRIVATE_KEY)\s*[=:]\s*(?:0x)?[0-9a-fA-F]{64}'''
+tags = ["key", "ethereum"]
+
+[[rules]]
+id = "charon-enr-private-key"
+description = "Charon ENR private key file content"
+regex = '''(?i)enr.?private.?key.*[0-9a-fA-F]{64}'''
+tags = ["key", "charon"]
+
+[[rules]]
+id = "jwt-hex-secret"
+description = "JWT hex secret (EL/CL auth)"
+regex = '''(?i)(?:jwt|engine).{0,20}(?:secret|hex|token)\s*[=:]\s*(?:0x)?[0-9a-fA-F]{64}'''
+tags = ["key", "jwt"]
+
+[[rules]]
+id = "bls-keystore-password"
+description = "BLS keystore password in plaintext"
+regex = '''(?i)(?:keystore|keystores|bls).{0,20}(?:password|pass|secret)\s*[=:]\s*\S{8,}'''
+tags = ["key", "validator"]
+
 [allowlist]
 description = "Global allowlist"
 regexTarget = "line"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,17 @@
 title = "obol-stack gitleaks config"
 
+[[rules]]
+id = "http-basic-auth-in-log"
+description = "HTTP Basic Auth credential in log output or config"
+regex = '''Basic\s+[A-Za-z0-9+/=]{8,}'''
+tags = ["auth", "credential"]
+
+[[rules]]
+id = "authorization-header-value"
+description = "Authorization header key=value pair with credential"
+regex = '''Authorization\s*[=:]\s*(?:Basic|Bearer)\s+\S+'''
+tags = ["auth", "credential"]
+
 [allowlist]
 description = "Global allowlist"
 regexTarget = "line"

--- a/justfile
+++ b/justfile
@@ -80,3 +80,14 @@ dev-frontend-reset:
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"
+
+# Install pre-commit hooks (run once after cloning)
+setup:
+    #!/usr/bin/env bash
+    set -e
+    if ! command -v pre-commit &>/dev/null; then
+        echo "⚠ pre-commit not found. Install: pip install pre-commit (or brew install pre-commit)"
+        exit 1
+    fi
+    pre-commit install
+    echo "✓ pre-commit hooks installed — gitleaks will run on every commit"


### PR DESCRIPTION
## Summary

- Add `*.txt` to `.gitignore` (with `!**/templates/NOTES.txt` exception for Helm charts) to prevent accidental commits of log/debug output files
- Add custom gitleaks rules for HTTP Basic Auth and `Authorization` header patterns commonly found in Charon log output
- Add gitleaks CI workflow (`gitleaks.yml`) to enforce secret scanning on PRs and pushes to `main`

## Context

Gitleaks was already configured in `.pre-commit-config.yaml` (good), but:
1. Pre-commit hooks only run if the developer has run `pre-commit install` locally
2. There was no CI-side enforcement — a developer who skips pre-commit or doesn't have it installed could still push secrets
3. `.gitignore` didn't block `.txt` files

This PR closes all three gaps.

## Test plan

- [ ] Verify `*.txt` files are ignored by git (except Helm NOTES.txt)
- [ ] Verify gitleaks CI workflow runs on PRs
- [ ] Verify custom rules catch `Authorization=Basic <base64>` patterns