### PR TITLE
fix(sell): allow concrete paid/<model> as default agent chat model

### DIFF
--- a/cmd/obol/sell_agent.go
+++ b/cmd/obol/sell_agent.go
@@ -427,9 +427,14 @@ func runAgentBackedDemo(
 
 // resolveDefaultAgentModel picks a model to pin onto a fresh Agent CR.
 // Walks the cluster's LiteLLM model_list (the same source `obol model
-// list` reads), drops the meta `paid/*` route, and returns the top
-// entry. The list is already in the operator's preferred order via
-// `obol model prefer`, so "first non-paid" is a meaningful default.
+// list` reads), drops the wildcard `paid/*` meta route, and returns the
+// top entry. The list is already in the operator's preferred order via
+// `obol model prefer`, so "first usable" is a meaningful default.
+//
+// Concrete entries like `paid/aeon` ARE valid: they route through the
+// x402-buyer sidecar to a purchased remote model. Only the literal
+// `paid/*` wildcard is skipped — that is a LiteLLM routing namespace
+// entry, not a model the agent can call by name.
 //
 // Returns an error if the cluster has no usable models — the caller
 // turns this into a clear "configure a model first" message rather than
@@ -439,10 +444,19 @@ func resolveDefaultAgentModel(cfg *config.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return pickAgentDefault(configured)
+}
+
+// pickAgentDefault is the pure filter-and-pick logic for resolveDefaultAgentModel,
+// extracted so it can be unit-tested without a live cluster.
+func pickAgentDefault(configured []string) (string, error) {
 	for _, name := range configured {
-		// Skip the paid/* meta route — it's a buyer-side namespace, not
-		// a model the agent can actually run inference on.
-		if strings.HasPrefix(name, "paid/") {
+		// Skip only the literal `paid/*` wildcard meta route — that entry is
+		// a LiteLLM routing namespace, not a concrete model the agent can call.
+		// Concrete purchased entries like `paid/aeon` are valid and should be
+		// returned when they're at the head of the rank (e.g. after
+		// `obol model prefer paid/aeon`).
+		if name == "paid/*" {
 			continue
 		}
 		return name, nil

--- a/cmd/obol/sell_agent_test.go
+++ b/cmd/obol/sell_agent_test.go
@@ -68,6 +68,59 @@ func TestDecodeAgentJSON_RejectsGarbage(t *testing.T) {
 	}
 }
 
+func TestPickAgentDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured []string
+		wantModel  string
+		wantErr    bool
+	}{
+		{
+			name:       "concrete paid entry at head wins",
+			configured: []string{"paid/aeon", "qwen36-deep", "paid/*"},
+			wantModel:  "paid/aeon",
+		},
+		{
+			name:       "wildcard skipped, falls through to unpaid",
+			configured: []string{"paid/*", "qwen36-deep"},
+			wantModel:  "qwen36-deep",
+		},
+		{
+			name:       "wildcard-only list is an error",
+			configured: []string{"paid/*"},
+			wantErr:    true,
+		},
+		{
+			name:       "concrete paid entry is the only entry",
+			configured: []string{"paid/aeon"},
+			wantModel:  "paid/aeon",
+		},
+		{
+			name:       "empty list is an error",
+			configured: []string{},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pickAgentDefault(tt.configured)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got model %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantModel {
+				t.Errorf("pickAgentDefault = %q, want %q", got, tt.wantModel)
+			}
+		})
+	}
+}
+
 func TestSellAgentCommand_FlagShape(t *testing.T) {
 	cfg := newTestConfig(t)
 	cmd := sellCommand(cfg)


### PR DESCRIPTION
## Summary

- `resolveDefaultAgentModel` was skipping ALL `paid/`-prefixed entries via `strings.HasPrefix`; only the literal `paid/*` wildcard (a LiteLLM routing namespace entry) should be filtered out
- Extracts a pure `pickAgentDefault([]string)` helper and adds 5 table-driven unit tests covering the key cases

## Why

After `obol buy inference v1337-aeon --model aeon && obol model prefer paid/aeon`, running `obol sell demo quant` would pin the agent to the **second-rank** model because all `paid/*`-prefixed entries were being skipped. The wildcard `paid/*` and a concrete `paid/aeon` are different LiteLLM concepts: the wildcard is a routing namespace (not callable), while concrete purchased entries route through the x402-buyer sidecar and are fully valid chat models. This fix makes "agent uses my preferred model" work without a `--chat-model` flag.

## Test plan

- [x] `TestPickAgentDefault` — 5 cases: concrete-paid-at-head wins, wildcard-skipped-fallthrough, wildcard-only error, concrete-paid-only, empty-list error
- [ ] Manual: `obol buy inference <name> --model <id>` → `obol model prefer paid/<id>` → `obol sell demo quant` → `kubectl get agent quant -n agent-quant -o jsonpath='{.spec.model}'` should return `paid/<id>`