### PR TITLE
fix(buy): clearer hint when seller didn't publish on-chain identity

### DIFF
--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -276,7 +276,10 @@ func verifyAgentID(reg *erc8004.AgentRegistration, expected int64, expectedRegis
 		return errors.New("expected agentId is 0; default seller is not yet provisioned — pass --seller and --no-verify-identity to bypass, or set DefaultBuySellerAgentID")
 	}
 	if len(reg.Registrations) == 0 {
-		return errors.New("registration document has no on-chain registrations")
+		return errors.New("seller didn't publish on-chain identity: agent-registration.json has no `registrations[]` field.\n" +
+			"This usually means: (a) the seller didn't run `obol sell register` on-chain, or\n" +
+			"(b) the seller is on an older obol-stack version that pre-dates the AgentIdentity CRD.\n" +
+			"Re-run with --no-verify-identity to buy without identity verification, or contact the seller to publish their agentId.")
 	}
 	for _, r := range reg.Registrations {
 		if r.AgentID != expected {

--- a/internal/buy/discover_test.go
+++ b/internal/buy/discover_test.go
@@ -96,7 +96,7 @@ func TestVerifyAgentID(t *testing.T) {
 		{name: "match first", reg: multi, expected: 41},
 		{name: "match second", reg: multi, expected: 42},
 		{name: "mismatch", reg: multi, expected: 99, wantErrSubs: "expected 99"},
-		{name: "empty registrations", reg: &erc8004.AgentRegistration{}, expected: 42, wantErrSubs: "no on-chain registrations"},
+		{name: "empty registrations", reg: &erc8004.AgentRegistration{}, expected: 42, wantErrSubs: "no `registrations[]` field"},
 		{name: "expected zero", reg: multi, expected: 0, wantErrSubs: "expected agentId is 0"},
 		{name: "nil registration", reg: nil, expected: 42, wantErrSubs: "nil registration"},
 	}
@@ -145,6 +145,25 @@ func TestVerifyAgentIDForPricing(t *testing.T) {
 	pricing.Accepts[0].Network = "base"
 	if err := VerifyAgentIDForPricing(reg, 42, pricing); err == nil || !strings.Contains(err.Error(), erc8004.Base.CAIP10Registry()) {
 		t.Fatalf("VerifyAgentIDForPricing(mismatch) err = %v, want base registry mismatch", err)
+	}
+}
+
+func TestVerifyAgentIDForPricing_EmptyRegistrations(t *testing.T) {
+	// Seller returned a valid registration document but with no registrations[]
+	// (e.g. they never ran `obol sell register`, or are on an older stack version).
+	// The error must explain the situation and hint at --no-verify-identity.
+	reg := &erc8004.AgentRegistration{}
+	pricing := &PricingResponse{Accepts: []PaymentOption{{Network: "base-sepolia", Amount: "1000"}}}
+
+	err := VerifyAgentIDForPricing(reg, 42, pricing)
+	if err == nil {
+		t.Fatal("VerifyAgentIDForPricing(empty regs) = nil, want error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"no `registrations[]` field", "--no-verify-identity"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing expected substring %q", msg, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- When `agent-registration.json` parses successfully but has an empty `registrations[]`, the error now explains *why* it failed and surfaces `--no-verify-identity` as the opt-out — instead of the opaque `"registration document has no on-chain registrations"` message users saw before.
- UX-only change: no security model modifications, no auto-bypass, `--no-verify-identity` remains the explicit opt-out.

## Why

On the v1337 live demo (`inference.v1337.org`), `obol buy inference v1337-aeon --seller https://inference.v1337.org/services/aeon` hard-failed because v1337's `/.well-known/agent-registration.json` has no `registrations[]` field — the seller never ran `obol sell register`. The previous error gave no hint that `--no-verify-identity` exists, forcing users to dig through help text.

This is categorised as a UX gap, not a security bug. The buyer flow's refuse-by-default identity check is correct and unchanged.

## Behavior change

**Before:**
```
identity pre-flight: registration document has no on-chain registrations
```

**After:**
```
identity pre-flight: seller didn't publish on-chain identity: agent-registration.json has no `registrations[]` field.
This usually means: (a) the seller didn't run `obol sell register` on-chain, or
(b) the seller is on an older obol-stack version that pre-dates the AgentIdentity CRD.
Re-run with --no-verify-identity to buy without identity verification, or contact the seller to publish their agentId.
```

## Test plan
- [x] Updated existing `"empty registrations"` table row in `TestVerifyAgentID` to match new substring (`no \`registrations[]\` field`).
- [x] Added `TestVerifyAgentIDForPricing_EmptyRegistrations`: seller returns valid JSON with `registrations: []`; asserts error contains both `no \`registrations[]\` field` and `--no-verify-identity`.
- [x] Existing passing cases (valid `registrations[{agentId, agentRegistry}]`) unchanged — `TestVerifyAgentIDForPricing` still green.
- [x] `go test ./cmd/obol/ ./internal/buy/ ./internal/erc8004/ -count=1` — all pass.
- [x] `go build ./...` — clean.

## Risks
None — message-only change in a single code path. No security impact. The opt-out flag and its semantics are untouched.