### PR TITLE
feat(buy): support OBOL-priced sellers via --token on obol buy inference

### DIFF
--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -72,7 +72,7 @@ Examples:
 			},
 			&cli.StringFlag{
 				Name:     "budget",
-				Usage:    "Spending cap in the payment token (e.g. \"10\" for 10 USDC, or \"0.023\" for 0.023 OBOL). Converted to base units before passing to the agent.",
+				Usage:    "Spending cap in the payment token (e.g. \"10\" for 10 USDC, or \"5\" for 5 OBOL). Converted to base units before passing to the agent.",
 				Required: true,
 			},
 			&cli.StringFlag{

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -23,7 +23,6 @@ const (
 	hermesPython    = "/opt/hermes/.venv/bin/python3"
 	hermesBuyPyPath = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
 	defaultBuyName  = "default-paid"
-	usdcDecimals    = 6
 )
 
 func buyCommand(cfg *config.Config) *cli.Command {
@@ -57,7 +56,9 @@ Examples:
 	obol buy inference my-buy --seller https://seller.example/services/x \
 	                     --model qwen3.5:9b --expected-agent-id 42 --budget 1
 	obol buy inference --seller https://seller.example/services/x \
-	                     --model qwen3.5:9b --no-verify-identity --budget 1`,
+	                     --model qwen3.5:9b --no-verify-identity --budget 1
+	obol buy inference --seller https://inference.v1337.org/services/aeon \
+	                     --model aeon --no-verify-identity --budget 0.023 --token OBOL`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "seller",
@@ -71,8 +72,13 @@ Examples:
 			},
 			&cli.StringFlag{
 				Name:     "budget",
-				Usage:    "Spending cap in USDC (e.g. \"10\" for 10 USDC). Converted to micro-units before passing to the agent; current host-side preflight supports USDC-priced sellers only.",
+				Usage:    "Spending cap in the payment token (e.g. \"10\" for 10 USDC, or \"0.023\" for 0.023 OBOL). Converted to base units before passing to the agent.",
 				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "token",
+				Usage: fmt.Sprintf("Payment token to use (default \"USDC\"). Supported: %s. Must match the seller's priced asset.", strings.Join(x402verifier.SupportedTokens(), ", ")),
+				Value: "USDC",
 			},
 			&cli.IntFlag{
 				Name:  "expected-agent-id",
@@ -121,7 +127,8 @@ Examples:
 				return errors.New("--seller is empty and no DefaultBuySellerURL is configured")
 			}
 
-			budgetMicro, err := usdcToMicroUnits(cmd.String("budget"))
+			token := strings.ToUpper(strings.TrimSpace(cmd.String("token")))
+			budgetBase, err := budgetToBaseUnits(cmd.String("budget"), token)
 			if err != nil {
 				return err
 			}
@@ -131,7 +138,11 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("pricing pre-flight: %w", err)
 			}
-			if err := buy.ValidateBudgetAgainstPricing(budgetMicro, pricing); err != nil {
+
+			if err := buy.ValidateTokenAgainstPricing(token, pricing); err != nil {
+				return err
+			}
+			if err := buy.ValidateBudgetAgainstPricing(budgetBase, pricing); err != nil {
 				return err
 			}
 
@@ -160,7 +171,7 @@ Examples:
 				Name:            name,
 				Seller:          seller,
 				Model:           cmd.String("model"),
-				BudgetMicro:     budgetMicro,
+				BudgetMicro:     budgetBase,
 				AutoRefill:      cmd.Bool("auto-refill"),
 				RefillThreshold: cmd.Int("refill-threshold"),
 				RefillCount:     cmd.Int("refill-count"),
@@ -211,14 +222,15 @@ func buildBuyPyArgv(opts buyPyOptions) []string {
 	return argv
 }
 
-// usdcToMicroUnits parses a human USDC amount (e.g. "10", "0.5") and returns
-// the equivalent in 6-decimal micro-units as a base-10 integer string. The
-// result is passed verbatim to buy.py's --budget flag.
+// budgetToBaseUnits parses a human-readable token amount (e.g. "10" for 10
+// USDC, "0.023" for 0.023 OBOL) and returns the equivalent in atomic base
+// units as a base-10 integer string. The token name is matched against the
+// x402 token registry to determine the correct decimal precision.
 //
 // Uses big.Rat so we don't lose precision on fractional amounts. Rejects
-// negatives and any value that isn't an integral number of micro-units
-// (e.g. "0.0000001" — finer than USDC's smallest denomination).
-func usdcToMicroUnits(amount string) (string, error) {
+// negatives and any value that isn't an integral number of base units (i.e.
+// finer than the token's smallest denomination).
+func budgetToBaseUnits(amount, token string) (string, error) {
 	s := strings.TrimSpace(amount)
 	if s == "" {
 		return "", errors.New("--budget is empty")
@@ -231,10 +243,25 @@ func usdcToMicroUnits(amount string) (string, error) {
 		return "", fmt.Errorf("--budget %q must be positive", amount)
 	}
 
-	scale := new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(usdcDecimals), nil))
-	micro := new(big.Rat).Mul(r, scale)
-	if !micro.IsInt() {
-		return "", fmt.Errorf("--budget %q has more precision than USDC supports (%d decimals)", amount, usdcDecimals)
+	tok := strings.ToUpper(strings.TrimSpace(token))
+	if tok == "" {
+		tok = "USDC"
 	}
-	return micro.Num().String(), nil
+
+	// Look up decimals from any chain the token is registered on — the decimal
+	// count is the same across all chains for a given token symbol.
+	chains := x402verifier.ChainsForToken(tok)
+	if len(chains) == 0 {
+		supported := strings.Join(x402verifier.SupportedTokens(), ", ")
+		return "", fmt.Errorf("--token %q is not a known payment token; supported tokens: %s", token, supported)
+	}
+	entry, _ := x402verifier.ResolveToken(tok, chains[0])
+	decimals := entry.Decimals
+
+	scale := new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil))
+	base := new(big.Rat).Mul(r, scale)
+	if !base.IsInt() {
+		return "", fmt.Errorf("--budget %q has more precision than %s supports (%d decimals)", amount, tok, decimals)
+	}
+	return base.Num().String(), nil
 }

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -4,40 +4,55 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/buy"
 )
 
-func TestUSDCToMicroUnits(t *testing.T) {
+func TestBudgetToBaseUnits(t *testing.T) {
 	tests := []struct {
-		in      string
+		amount  string
+		token   string
 		want    string
 		wantErr string
 	}{
-		{in: "1", want: "1000000"},
-		{in: "10", want: "10000000"},
-		{in: "0.001", want: "1000"},
-		{in: "0.000001", want: "1"},
-		{in: "  0.5  ", want: "500000"},
-		{in: "", wantErr: "empty"},
-		{in: "abc", wantErr: "valid number"},
-		{in: "0", wantErr: "positive"},
-		{in: "-1", wantErr: "positive"},
-		{in: "0.0000001", wantErr: "more precision"},
+		// USDC — 6 decimals
+		{amount: "0.5", token: "USDC", want: "500000"},
+		{amount: "1", token: "USDC", want: "1000000"},
+		{amount: "10", token: "USDC", want: "10000000"},
+		{amount: "0.001", token: "USDC", want: "1000"},
+		{amount: "0.000001", token: "USDC", want: "1"},
+		{amount: "  0.5  ", token: "USDC", want: "500000"},
+		// OBOL — 18 decimals
+		{amount: "0.023", token: "OBOL", want: "23000000000000000"},
+		{amount: "1", token: "OBOL", want: "1000000000000000000"},
+		{amount: "0.000000000000000001", token: "OBOL", want: "1"},
+		// lower-case token name normalised
+		{amount: "0.023", token: "obol", want: "23000000000000000"},
+		// Error cases
+		{amount: "", token: "USDC", wantErr: "empty"},
+		{amount: "abc", token: "USDC", wantErr: "valid number"},
+		{amount: "0", token: "USDC", wantErr: "positive"},
+		{amount: "-1", token: "USDC", wantErr: "positive"},
+		{amount: "0.0000001", token: "USDC", wantErr: "more precision"},
+		{amount: "0.0000000000000000001", token: "OBOL", wantErr: "more precision"},
+		{amount: "1", token: "SHITCOIN", wantErr: "not a known payment token"},
 	}
 	for _, tc := range tests {
-		t.Run(tc.in, func(t *testing.T) {
+		name := tc.token + "/" + tc.amount
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got, err := usdcToMicroUnits(tc.in)
+			got, err := budgetToBaseUnits(tc.amount, tc.token)
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("usdcToMicroUnits(%q) err = %v, want substring %q", tc.in, err, tc.wantErr)
+					t.Fatalf("budgetToBaseUnits(%q, %q) err = %v, want substring %q", tc.amount, tc.token, err, tc.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("usdcToMicroUnits(%q) unexpected err: %v", tc.in, err)
+				t.Fatalf("budgetToBaseUnits(%q, %q) unexpected err: %v", tc.amount, tc.token, err)
 			}
 			if got != tc.want {
-				t.Fatalf("usdcToMicroUnits(%q) = %q, want %q", tc.in, got, tc.want)
+				t.Fatalf("budgetToBaseUnits(%q, %q) = %q, want %q", tc.amount, tc.token, got, tc.want)
 			}
 		})
 	}
@@ -139,6 +154,85 @@ func TestBuildBuyPyArgv(t *testing.T) {
 			got := buildBuyPyArgv(tc.opts)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("buildBuyPyArgv() = %#v\n want                  %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateTokenAgainstPricing exercises the token-mismatch check using
+// synthetic PricingResponse values without any network calls.
+func TestValidateTokenAgainstPricing(t *testing.T) {
+	const (
+		usdcAddrBaseSepolia = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+		obolAddrBaseSepolia = "0x0a09371a8b011d5110656ceBCc70603e53FD2c78"
+		networkBaseSepolia  = "eip155:84532"
+	)
+
+	mkPricing := func(network, asset string) *buy.PricingResponse {
+		return &buy.PricingResponse{
+			X402Version: 1,
+			Accepts: []buy.PaymentOption{{
+				Network: network,
+				Asset:   asset,
+				Amount:  "23000000000000000",
+			}},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		token   string
+		pricing *buy.PricingResponse
+		wantErr string
+	}{
+		{
+			name:    "USDC matches USDC seller",
+			token:   "USDC",
+			pricing: mkPricing(networkBaseSepolia, usdcAddrBaseSepolia),
+		},
+		{
+			name:    "OBOL matches OBOL seller",
+			token:   "OBOL",
+			pricing: mkPricing(networkBaseSepolia, obolAddrBaseSepolia),
+		},
+		{
+			name:    "USDC vs OBOL seller — names both sides",
+			token:   "USDC",
+			pricing: mkPricing(networkBaseSepolia, obolAddrBaseSepolia),
+			wantErr: "--token USDC selected, but seller requires asset",
+		},
+		{
+			name:    "USDC vs OBOL seller — suggests --token OBOL",
+			token:   "USDC",
+			pricing: mkPricing(networkBaseSepolia, obolAddrBaseSepolia),
+			wantErr: "retry with --token OBOL",
+		},
+		{
+			name:    "OBOL vs USDC seller — suggests --token USDC",
+			token:   "OBOL",
+			pricing: mkPricing(networkBaseSepolia, usdcAddrBaseSepolia),
+			wantErr: "retry with --token USDC",
+		},
+		{
+			name:    "unknown token name",
+			token:   "SHITCOIN",
+			pricing: mkPricing(networkBaseSepolia, obolAddrBaseSepolia),
+			wantErr: "not available on network",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := buy.ValidateTokenAgainstPricing(tc.token, tc.pricing)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateTokenAgainstPricing(%q) unexpected err: %v", tc.token, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateTokenAgainstPricing(%q) err = %v, want substring %q", tc.token, err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -227,11 +227,14 @@ func VerifySellerEndpoint(reg *erc8004.AgentRegistration, sellerURL string) erro
 	return fmt.Errorf("seller endpoint mismatch: requested %s, registration advertises [%s]", want, strings.Join(advertised, ", "))
 }
 
-// ValidateBudgetAgainstPricing rejects budgets smaller than one request price.
-// buy.py currently rounds `budget // price` up to at least one auth; the host
-// CLI advertises --budget as a spending cap, so we fail early instead of
-// silently overspending the requested cap.
-func ValidateBudgetAgainstPricing(budgetMicro string, pricing *PricingResponse) error {
+// ValidateTokenAgainstPricing checks that the requested --token matches the
+// seller's priced asset. When there is a mismatch it returns a structured
+// error that names both the requested token and the seller's required asset,
+// and suggests the correct --token value when the asset address is known.
+//
+// Call this before ValidateBudgetAgainstPricing so the caller sees a clear
+// token-mismatch error instead of a confusing budget-validation failure.
+func ValidateTokenAgainstPricing(token string, pricing *PricingResponse) error {
 	payment, err := firstPaymentOption(pricing)
 	if err != nil {
 		return err
@@ -241,17 +244,67 @@ func ValidateBudgetAgainstPricing(budgetMicro string, pricing *PricingResponse) 
 	if err != nil {
 		return fmt.Errorf("resolve payment network %q: %w", payment.Network, err)
 	}
-	canonicalUSDC, ok := internalx402.ResolveToken("USDC", networkName)
+
+	tok := strings.ToUpper(strings.TrimSpace(token))
+	requested, ok := internalx402.ResolveToken(tok, networkName)
 	if !ok {
-		return fmt.Errorf("host-side --budget currently supports only USDC-priced sellers; no canonical USDC metadata is configured for %s", payment.Network)
-	}
-	if asset := strings.TrimSpace(payment.Asset); asset != "" && !strings.EqualFold(asset, canonicalUSDC.Address) {
-		return fmt.Errorf("host-side --budget currently supports only USDC-priced sellers; seller requires asset %s on %s", asset, payment.Network)
+		supported := strings.Join(internalx402.TokensOnChain(networkName), ", ")
+		return fmt.Errorf("--token %s is not available on network %s; tokens available on this network: %s", tok, payment.Network, supported)
 	}
 
-	budget, ok := new(big.Int).SetString(strings.TrimSpace(budgetMicro), 10)
+	sellerAsset := strings.TrimSpace(payment.Asset)
+	if sellerAsset != "" && !strings.EqualFold(sellerAsset, requested.Address) {
+		// Find which registered token matches the seller's asset address.
+		suggestion := ""
+		for _, sym := range internalx402.SupportedTokens() {
+			if sym == tok {
+				continue
+			}
+			if entry, ok2 := internalx402.ResolveToken(sym, networkName); ok2 {
+				if strings.EqualFold(entry.Address, sellerAsset) {
+					suggestion = "; retry with --token " + sym
+					break
+				}
+			}
+		}
+		return fmt.Errorf("--token %s selected, but seller requires asset %s (%s) on %s%s",
+			tok, sellerAsset, tokenSymbolForAsset(sellerAsset, networkName), payment.Network, suggestion)
+	}
+	return nil
+}
+
+// tokenSymbolForAsset returns the symbol of the registered token whose address
+// matches assetAddr on chainName, or a shortened address when no match is found.
+func tokenSymbolForAsset(assetAddr, chainName string) string {
+	for _, sym := range internalx402.SupportedTokens() {
+		if entry, ok := internalx402.ResolveToken(sym, chainName); ok {
+			if strings.EqualFold(entry.Address, assetAddr) {
+				return sym
+			}
+		}
+	}
+	if len(assetAddr) > 10 {
+		return assetAddr[:6] + "…" + assetAddr[len(assetAddr)-4:]
+	}
+	return assetAddr
+}
+
+// ValidateBudgetAgainstPricing rejects budgets smaller than one request price.
+// buy.py currently rounds `budget // price` up to at least one auth; the host
+// CLI advertises --budget as a spending cap, so we fail early instead of
+// silently overspending the requested cap.
+//
+// Call ValidateTokenAgainstPricing first; this function assumes the token has
+// already been validated against the seller's priced asset.
+func ValidateBudgetAgainstPricing(budgetBase string, pricing *PricingResponse) error {
+	payment, err := firstPaymentOption(pricing)
+	if err != nil {
+		return err
+	}
+
+	budget, ok := new(big.Int).SetString(strings.TrimSpace(budgetBase), 10)
 	if !ok || budget.Sign() <= 0 {
-		return fmt.Errorf("invalid budget micro-units %q", budgetMicro)
+		return fmt.Errorf("invalid budget base-units %q", budgetBase)
 	}
 
 	priceRaw := payment.requiredAmount()

--- a/internal/buy/discover_test.go
+++ b/internal/buy/discover_test.go
@@ -195,14 +195,66 @@ func TestValidateBudgetAgainstPricing(t *testing.T) {
 	}
 }
 
-func TestValidateBudgetAgainstPricing_NonUSDCPricingRejected(t *testing.T) {
+func TestValidateBudgetAgainstPricing_OBOLPricingAccepted(t *testing.T) {
+	// ValidateBudgetAgainstPricing is now token-agnostic; the token-mismatch
+	// check moved to ValidateTokenAgainstPricing. A budget that covers at least
+	// one OBOL request must pass when called after a successful token check.
 	pricing := &PricingResponse{Accepts: []PaymentOption{{
 		Network: "base-sepolia",
 		Asset:   "0x0a09371a8b011d5110656ceBCc70603e53FD2c78",
-		Amount:  "1000000000000000000",
+		Amount:  "23000000000000000", // 0.023 OBOL in base units
 	}}}
-	if err := ValidateBudgetAgainstPricing("2000000", pricing); err == nil || !strings.Contains(err.Error(), "currently supports only USDC-priced sellers") {
-		t.Fatalf("ValidateBudgetAgainstPricing(non-usdc) err = %v, want explicit non-USDC rejection", err)
+	// Budget equal to one request price — must pass.
+	if err := ValidateBudgetAgainstPricing("23000000000000000", pricing); err != nil {
+		t.Fatalf("ValidateBudgetAgainstPricing(OBOL equal) = %v, want nil", err)
+	}
+	// Budget smaller than one request price — must fail with floor error.
+	if err := ValidateBudgetAgainstPricing("1000000", pricing); err == nil || !strings.Contains(err.Error(), "smaller than one request price") {
+		t.Fatalf("ValidateBudgetAgainstPricing(OBOL too small) err = %v, want floor error", err)
+	}
+}
+
+func TestValidateTokenAgainstPricing(t *testing.T) {
+	const (
+		usdcAddr = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+		obolAddr = "0x0a09371a8b011d5110656ceBCc70603e53FD2c78"
+		network  = "eip155:84532"
+	)
+
+	mkPricing := func(asset string) *PricingResponse {
+		return &PricingResponse{Accepts: []PaymentOption{{
+			Network: network, Asset: asset, Amount: "23000000000000000",
+		}}}
+	}
+
+	tests := []struct {
+		name    string
+		token   string
+		pricing *PricingResponse
+		wantErr string
+	}{
+		{name: "USDC matches USDC seller", token: "USDC", pricing: mkPricing(usdcAddr)},
+		{name: "OBOL matches OBOL seller", token: "OBOL", pricing: mkPricing(obolAddr)},
+		{name: "USDC vs OBOL seller — names both sides", token: "USDC", pricing: mkPricing(obolAddr), wantErr: "--token USDC selected, but seller requires asset"},
+		{name: "USDC vs OBOL seller — suggests OBOL", token: "USDC", pricing: mkPricing(obolAddr), wantErr: "retry with --token OBOL"},
+		{name: "OBOL vs USDC seller — suggests USDC", token: "OBOL", pricing: mkPricing(usdcAddr), wantErr: "retry with --token USDC"},
+		{name: "unknown token", token: "SHITCOIN", pricing: mkPricing(obolAddr), wantErr: "not available on network"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTokenAgainstPricing(tc.token, tc.pricing)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateTokenAgainstPricing(%q) = %v, want nil", tc.token, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateTokenAgainstPricing(%q) err = %v, want substring %q", tc.token, err, tc.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `--token [USDC|OBOL]` flag to `obol buy inference` (default `USDC` — fully back-compatible with existing buyers).
- Generalise `usdcToMicroUnits` into `budgetToBaseUnits(amount, token)` that reads decimal precision from the token registry in `internal/x402/tokens.go` (6 for USDC, 18 for OBOL).
- Add `buy.ValidateTokenAgainstPricing`: checks `--token` against the seller's `accepts[0].asset` before budget validation, returning a structured error that names both sides and suggests the correct `--token` when a match is found (e.g. `retry with --token OBOL`).

## Why

**Release-blocker.** The live external seller at `https://inference.v1337.org/services/aeon` is priced in OBOL (0.023 OBOL on Base Sepolia). Running `obol buy inference` against it failed immediately with:

```
✗ host-side --budget currently supports only USDC-priced sellers; seller requires asset 0x0a09371a8b011d5110656ceBCc70603e53FD2c78 on eip155:84532
```

`buy.py` inside the agent pod was already token-aware via Permit2. Only the host-side CLI wrapper needed updating. Refer to Bug F in `plans/v1337-demo-passes-20260515.md`.

## Test plan

Unit tests added (all passing — `go test ./cmd/obol/ ./internal/x402/ ./internal/buy/ -count=1`):

- `TestBudgetToBaseUnits`: USDC 6-decimal (0.5 → 500000), OBOL 18-decimal (0.023 → 23000000000000000), lower-case token normalised, negative → error, sub-base-unit precision → error, unknown token name → error with supported-tokens list.
- `TestValidateTokenAgainstPricing` (in `cmd/obol`): USDC matches USDC seller ✓, OBOL matches OBOL seller ✓, USDC vs OBOL mismatch → names both sides + suggests `--token OBOL`, OBOL vs USDC mismatch → suggests `--token USDC`, unknown token → actionable error.
- `TestValidateTokenAgainstPricing` (in `internal/buy`): same cases as internal white-box tests.
- `TestValidateBudgetAgainstPricing_OBOLPricingAccepted`: replaces the now-invalid `NonUSDCPricingRejected` test; confirms budget floor check works for OBOL amounts.

Manual test against v1337 (requires agent wallet funded with Base Sepolia OBOL):

```bash
obol buy inference v1337-aeon \
  --seller https://inference.v1337.org/services/aeon \
  --model aeon \
  --budget 0.023 \
  --token OBOL \
  --no-verify-identity
# Expect: PurchaseRequest Ready=True, sidecar /status shows remaining > 0
```

## Risks

- **Back-compat**: default `--token USDC` means existing scripts without `--token` continue to work identically.
- **Scope**: host-side wrapper only; `buy.py` unchanged (it was already token-aware).
- **Token registry**: any future token added to `internal/x402/tokens.go` is automatically supported with no further CLI changes.