### PR TITLE
fix(serviceoffer-controller): preserve operator-supplied description on inference offers

### DIFF
--- a/internal/serviceoffercontroller/identity_render.go
+++ b/internal/serviceoffercontroller/identity_render.go
@@ -80,12 +80,19 @@ func identityDocumentMetadata(identity *monetizeapi.AgentIdentity, offers []*mon
 	}
 	owner := selectRegistrationOwner(offers)
 	name := defaultString(owner.Spec.Registration.Name, owner.Name)
+	// Operator-supplied description wins. Only fall back to a controller-
+	// generated default when the offer left Spec.Registration.Description
+	// empty. The inference-typed default is more specific (names the model),
+	// so it preempts the generic default — but neither overrides an explicit
+	// operator value. Mirrors the same precedence in render.go's
+	// buildActiveRegistrationDocument.
 	description := owner.Spec.Registration.Description
 	if description == "" {
-		description = fmt.Sprintf("x402 payment-gated %s service: %s", fallbackOfferType(owner), owner.Name)
-	}
-	if owner.IsInference() && owner.Spec.Model.Name != "" {
-		description = fmt.Sprintf("%s inference via x402 micropayments", owner.Spec.Model.Name)
+		if owner.IsInference() && owner.Spec.Model.Name != "" {
+			description = fmt.Sprintf("%s inference via x402 micropayments", owner.Spec.Model.Name)
+		} else {
+			description = fmt.Sprintf("x402 payment-gated %s service: %s", fallbackOfferType(owner), owner.Name)
+		}
 	}
 	image := owner.Spec.Registration.Image
 	if image == "" {

--- a/internal/serviceoffercontroller/identity_render_test.go
+++ b/internal/serviceoffercontroller/identity_render_test.go
@@ -191,3 +191,60 @@ func TestSeedIdentityFromOffers_NoAgentIDReturnsNil(t *testing.T) {
 		t.Errorf("seed = %+v, want nil when no offer has agentId", seed)
 	}
 }
+
+// TestBuildIdentityRegistrationDocument_DescriptionPrecedence pins the
+// operator > inference-default > generic-default ordering. Regression test
+// for the case where an explicit spec.registration.description on an
+// inference ServiceOffer was being overwritten by the auto-generated
+// "<model> inference via x402 micropayments" string.
+func TestBuildIdentityRegistrationDocument_DescriptionPrecedence(t *testing.T) {
+	id := defaultIdentity("1")
+
+	cases := []struct {
+		name    string
+		mutate  func(*monetizeapi.ServiceOffer)
+		wantDoc string
+	}{
+		{
+			name: "operator description wins on inference offer",
+			mutate: func(o *monetizeapi.ServiceOffer) {
+				o.Spec.Type = "inference"
+				o.Spec.Model.Name = "aeon-ultimate"
+				o.Spec.Registration.Description = "Uncensored Qwen3.6-27B abliteration on NVIDIA GB10"
+			},
+			wantDoc: "Uncensored Qwen3.6-27B abliteration on NVIDIA GB10",
+		},
+		{
+			name: "inference fallback fires when description empty",
+			mutate: func(o *monetizeapi.ServiceOffer) {
+				o.Spec.Type = "inference"
+				o.Spec.Model.Name = "aeon-ultimate"
+				o.Spec.Registration.Description = ""
+			},
+			wantDoc: "aeon-ultimate inference via x402 micropayments",
+		},
+		{
+			name: "generic fallback when no description and not inference",
+			mutate: func(o *monetizeapi.ServiceOffer) {
+				o.Spec.Type = "http"
+				o.Spec.Registration.Description = ""
+			},
+			wantDoc: "x402 payment-gated http service: svc-a",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			offer := readyOffer("svc-a")
+			tc.mutate(offer)
+			doc := BuildIdentityRegistrationDocument(IdentityRegistrationView{
+				Identity: id,
+				Offers:   []*monetizeapi.ServiceOffer{offer},
+				BaseURL:  "https://example.tunnel.test",
+			})
+			if doc.Description != tc.wantDoc {
+				t.Errorf("Description = %q, want %q", doc.Description, tc.wantDoc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`identityDocumentMetadata` in `identity_render.go` unconditionally overwrites the registration document description with `"<model> inference via x402 micropayments"` whenever the offer is inference-typed with a model name — even when the operator explicitly set `spec.registration.description` on the ServiceOffer.

This regressed `/.well-known/agent-registration.json` on inference offers introduced by PR #489.

## Repro

After upgrading `spark2` (`inference.v1337.org`) to current `main`, the AEON ServiceOffer's description:

```yaml
spec:
  registration:
    description: "Uncensored Qwen3.6-27B abliteration on NVIDIA GB10"
  model:
    name: aeon-ultimate
  type: inference
```

…was replaced in the rendered registration document by the auto-generated string:

```json
"description": "aeon-ultimate inference via x402 micropayments"
```

## Waterfall

```
ServiceOffer.spec.registration.description    →  "Uncensored Qwen3.6-27B abliteration on NVIDIA GB10"
                                               ↓
identityDocumentMetadata reads it correctly   →  description = "Uncensored Qwen3.6-27B..."
                                               ↓
empty-check skipped (description is set)      →  ok
                                               ↓
inference-typed branch fires unconditionally  →  description = "aeon-ultimate inference via x402 micropayments"   ← bug
                                               ↓
/.well-known/agent-registration.json          →  wrong
```

## Fix

Wrap the inference-typed default in the same `if description == ""` check as the generic default. This matches the precedence already in place in `render.go`'s `buildActiveRegistrationDocument`: operator value wins; otherwise prefer the more specific inference default; otherwise the generic one.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/ ./cmd/obol/ -count=1` passes locally
- [x] New table test `TestBuildIdentityRegistrationDocument_DescriptionPrecedence` covers all three branches (operator wins / inference default / generic default)
- [ ] Re-roll controller on `spark2`, hit `https://inference.v1337.org/.well-known/agent-registration.json`, confirm `description` is back to operator-supplied value