### PR TITLE
chore(frontend): bump obol-stack-front-end v0.1.24 → v0.1.25-rc1 (digest-pinned)

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.24 (linux/amd64 + linux/arm64).
-  tag: "v0.1.24@sha256:d5abd6aebddcabf7b7fccd2f5e922cb6067c90dca808b306bd46db71b0010206"
+  # review. Multi-arch index digest for v0.1.25-rc1 (linux/amd64 + linux/arm64).
+  tag: "v0.1.25-rc1@sha256:e7b38ca43771c29475d6831dbee53adb5d2685137ecb7d5878c82e4ecebee92a"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

Promotes the frontend image pin to **v0.1.25-rc1**, which combines 10 Dependabot dependency bumps (see frontend integration PR [#322](https://github.com/ObolNetwork/obol-stack-front-end/pull/322), all 8 CI checks green).

## Image identity

- Repository: `obolnetwork/obol-stack-front-end`
- Tag (informational): `v0.1.25-rc1`
- Multi-arch index digest (authoritative): `sha256:e7b38ca43771c29475d6831dbee53adb5d2685137ecb7d5878c82e4ecebee92a`
- linux/amd64: `sha256:2d39e666dd7f807e4a6b56e7f7f509cd96b8427fcabe413bbd9000da55f2cf55`
- linux/arm64: `sha256:6afb996dd6c21e68d714f4aa1ef0c51b2a4553e24d72629529e053e611d889b3`

Frontend release: https://github.com/ObolNetwork/obol-stack-front-end/releases/tag/v0.1.25-rc1

## Bumps included via frontend PR #322

| Package | From → To | Frontend PR |
|---|---|---|
| `@typescript-eslint/eslint-plugin` (dev) | 8.59.1 → 8.59.2 | #312 |
| `@tanstack/react-query` | 5.100.9 → 5.100.10 | #313 |
| `@playwright/test` (dev) | 1.59.1 → 1.60.0 | #314 |
| `thread-stream` | 4.0.0 → 4.2.0 | #315 |
| `@copilotkit/runtime` | 1.56.3 → 1.57.1 | #316 |
| `@types/node` (dev) | 25.6.2 → 25.9.0 | #317 |
| `viem` | 2.48.11 → 2.49.3 | #318 |
| `lint-staged` (dev) | 16.4.0 → 17.0.5 | #319 |
| `react-dom` | 19.2.5 → 19.2.6 | #320 |
| `dompurify` | 3.4.2 → 3.4.5 | #321 |

## Why digest pin

The tag is informational; the `@sha256:…` is authoritative. This eliminates the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain review. The multi-arch index covers both `linux/amd64` and `linux/arm64`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/embed/...` pass
- [ ] CI: lint-test + CodeQL (actions, go, javascript-typescript, python)
- [ ] flows-green before merge (maintainer gate)
- [ ] Second human reviewer approval before merge (maintainer gate)

This PR is a single-file frontend pin bump; no behavioural changes to the Go side. Merge gate (flows-green + reviewer) is enforced per project policy.