### PR TITLE
fix(stack): preload runtime images via k3s crictl

### DIFF
--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -1175,11 +1175,10 @@ func image() string {
 }
 
 // ImageRef returns the upstream Hermes container image ref. Used by
-// stack.devPreloadImages so `obol stack up` pulls the image to the host
-// docker daemon and imports it into the k3d cluster's containerd cache —
-// otherwise the cluster's first Hermes pod stalls waiting for the
-// registry mirror to serve a cold pull, which has caused flow-14 step 32
-// timeouts in the past.
+// stack.devPreloadImages so `obol stack up` preloads the image through the
+// k3s node's CRI before the first Hermes pod starts — otherwise the first pod
+// stalls waiting for the registry mirror to serve a cold pull, which has
+// caused flow-14 step 32 timeouts in the past.
 func ImageRef() string {
 	return image()
 }

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -991,8 +991,9 @@ func importImageWithCache(k3dBinary, clusterName, tag, serverCID string, cache *
 // built and already loaded into the running cluster (the common case after
 // our reuse/cache fixes), we emit a single "  ✓ Local dev images ready"
 // summary line so the surrounding spinner-flanked output stays clean. Only
-// real work — actual `docker build`, `docker pull`, and tarball imports —
-// gets per-image lines, and those go through the UI for consistent styling.
+// real work — actual `docker build`, runtime image preloads, and tarball
+// imports — gets per-image lines, and those go through the UI for consistent
+// styling.
 func buildAndImportLocalImages(cfg *config.Config, u *ui.UI) {
 	start := time.Now()
 
@@ -1066,24 +1067,8 @@ func buildAndImportLocalImages(cfg *config.Config, u *ui.UI) {
 	for _, ref := range devPreloadImages() {
 		total++
 
-		if shouldForceRebuild(ref) || !dockerImageAvailableLocally(ref) {
-			if u != nil {
-				u.Infof("Pulling %s", ref)
-			}
-			pullCmd := exec.Command("docker", "pull", ref)
-			pullCmd.Stdout = os.Stdout
-			pullCmd.Stderr = os.Stderr
-			if err := pullCmd.Run(); err != nil {
-				if u != nil {
-					u.Warnf("Failed to pull %s: %v", ref, err)
-				}
-				continue
-			}
+		if preloadRuntimeImageIntoCluster(clusterName, ref, u) {
 			pulled++
-		}
-
-		if importImageWithCache(k3dBinary, clusterName, ref, serverCID, &cache, u) {
-			imported++
 		}
 	}
 
@@ -1116,6 +1101,42 @@ func importImageToCluster(k3dBinary, clusterName, tag string) error {
 	importCmd.Stderr = os.Stderr
 
 	return importCmd.Run()
+}
+
+// preloadRuntimeImageIntoCluster pulls a public upstream runtime image into the
+// k3s node's CRI store. These images are multi-arch OCI indexes; importing them
+// through `k3d image import` can make Docker Desktop save an index whose sibling
+// platform manifests are absent from the local content store, which then shows
+// up as noisy `content digest ... not found` errors during node import.
+func preloadRuntimeImageIntoCluster(clusterName, ref string, u *ui.UI) bool {
+	if u != nil {
+		u.Infof("Preloading %s into cluster %s", ref, clusterName)
+	}
+	if err := pullRuntimeImageWithCrictl(clusterName, ref, false); err == nil {
+		return true
+	} else {
+		primaryErr := err
+		if err := pullRuntimeImageWithCrictl(clusterName, ref, true); err == nil {
+			return true
+		} else if u != nil {
+			u.Warnf("Failed to preload %s into k3d via crictl: %v; fallback failed: %v", ref, primaryErr, err)
+		}
+	}
+	return false
+}
+
+func pullRuntimeImageWithCrictl(clusterName, ref string, useK3sCrictl bool) error {
+	args := []string{"exec", "k3d-" + clusterName + "-server-0"}
+	if useK3sCrictl {
+		args = append(args, "k3s", "crictl", "pull", ref)
+	} else {
+		args = append(args, "crictl", "pull", ref)
+	}
+	pullCmd := exec.Command("docker", args...)
+	pullCmd.Stdout = os.Stdout
+	pullCmd.Stderr = os.Stderr
+
+	return pullCmd.Run()
 }
 
 // findProjectRoot walks up from the current directory to find go.mod.

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -972,6 +972,126 @@ func TestBuildAndImportLocalImages_SkipsK3dImportWhenCacheIsValid(t *testing.T) 
 	}
 }
 
+func TestBuildAndImportLocalImages_PreloadsRuntimeImagesViaCrictl(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "config")
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	for _, d := range []string{cfgDir, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, stackIDFile), []byte("test-stack"), 0o600); err != nil {
+		t.Fatalf("write stack id: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"inspect\" ] && [ \"${2:-}\" = \"--format\" ]; then\n" +
+		"  printf 'k3d-server-cid-fake\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"exec\" ]; then exit 0; fi\n" +
+		"if [ \"${1:-}\" = \"image\" ] && [ \"${2:-}\" = \"inspect\" ]; then exit 1; fi\n" +
+		"if [ \"${1:-}\" = \"pull\" ]; then exit 97; fi\n" +
+		"exit 0\n"
+	k3dScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'k3d %s\\n' \"$*\" >> \"" + logPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "k3d"), []byte(k3dScript), 0o755); err != nil {
+		t.Fatalf("write k3d stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+	t.Setenv("OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES", "")
+
+	buildAndImportLocalImages(&config.Config{ConfigDir: cfgDir, BinDir: binDir}, ui.NewWithOptions(false, true))
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"docker exec k3d-obol-stack-test-stack-server-0 crictl pull ghcr.io/obolnetwork/openclaw:",
+		"docker exec k3d-obol-stack-test-stack-server-0 crictl pull nousresearch/hermes-agent:",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("expected runtime preload via node crictl command %q, log:\n%s", want, log)
+		}
+	}
+	for _, unwanted := range []string{
+		"docker pull ghcr.io/obolnetwork/openclaw",
+		"docker pull nousresearch/hermes-agent",
+		"k3d image import ghcr.io/obolnetwork/openclaw",
+		"k3d image import nousresearch/hermes-agent",
+	} {
+		if strings.Contains(log, unwanted) {
+			t.Fatalf("runtime preload should not use host docker pull or k3d image import (%q), log:\n%s", unwanted, log)
+		}
+	}
+}
+
+func TestPreloadRuntimeImage_FallsBackToK3sCrictl(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	logPath := filepath.Join(root, "commands.log")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	dockerScript := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf 'docker %s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"if [ \"${1:-}\" = \"exec\" ] && [ \"${2:-}\" = \"k3d-obol-stack-test-stack-server-0\" ] && [ \"${3:-}\" = \"crictl\" ]; then\n" +
+		"  exit 42\n" +
+		"fi\n" +
+		"if [ \"${1:-}\" = \"exec\" ] && [ \"${2:-}\" = \"k3d-obol-stack-test-stack-server-0\" ] && [ \"${3:-}\" = \"k3s\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+
+	if ok := preloadRuntimeImageIntoCluster("obol-stack-test-stack", "example.com/runtime:tag", ui.NewWithOptions(false, true)); !ok {
+		t.Fatal("expected k3s crictl fallback to succeed")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"docker exec k3d-obol-stack-test-stack-server-0 crictl pull example.com/runtime:tag",
+		"docker exec k3d-obol-stack-test-stack-server-0 k3s crictl pull example.com/runtime:tag",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("expected command %q, log:\n%s", want, log)
+		}
+	}
+}
+
 // newCaptureUI returns a UI that writes stdout and stderr into the returned
 // buffers. Warn → stderr, Dim/Blank/Info → stdout.
 func newCaptureUI() (*ui.UI, *bytes.Buffer, *bytes.Buffer) {
@@ -985,7 +1105,7 @@ func TestWarnIfNoChatModel_EmitsWarnWhenNoModels(t *testing.T) {
 	u, stdout, stderr := newCaptureUI()
 	warnIfNoChatModel(nil, u)
 
-	if !strings.Contains(stderr.String(), "No chat-capable LLM detected") {
+	if !strings.Contains(stderr.String(), "No chat-capable model detected") {
 		t.Fatalf("expected warn on stderr, got: %q", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "ollama pull") {
@@ -1013,7 +1133,7 @@ func TestWarnIfNoChatModel_SilentWhenConcretePaidModelPresent(t *testing.T) {
 	u, _, stderr := newCaptureUI()
 	warnIfNoChatModel([]string{"paid/aeon"}, u)
 
-	if strings.Contains(stderr.String(), "No chat-capable LLM detected") {
+	if strings.Contains(stderr.String(), "No chat-capable model detected") {
 		t.Fatalf("concrete paid/aeon should suppress warn, got: %q", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the noisy k3d image import failure seen during dev `obol stack up` for public multi-arch runtime images such as OpenClaw and Hermes.

Instead of host `docker pull` + `k3d image import`, upstream runtime preloads now run inside the k3d server node with `crictl pull`, with a `k3s crictl pull` fallback. Locally built Obol dev images still use the existing cached `k3d image import` path.

## Root Cause

`k3d image import` saves/imports the public multi-arch OCI index. On Docker Desktop/containerd-store setups, the saved tar can reference sibling platform manifests that are not present in the local content store. The node-side import then logs errors like `content digest sha256:... not found`; in the observed case, the missing digest was the linux/amd64 child manifest while the host was using linux/arm64 content.

## Changes

- Preload `devPreloadImages()` through `docker exec k3d-<cluster>-server-0 crictl pull <ref>`.
- Fallback to `docker exec ... k3s crictl pull <ref>` when standalone `crictl` is unavailable or fails.
- Keep cached `k3d image import` for locally built images only.
- Update the Hermes preload comment to describe the new CRI path.
- Add tests covering the new runtime preload path and fallback.
- Update stale stack test expectations for the existing "No chat-capable model detected" warning string so the package gate passes.

## Validation

- `go test ./internal/stack -count=1`
- Reproduced that the current stack is healthy after the original warning: all pods Running.
- Built and deployed the frontend marketplace tip with `just dev-frontend` using `OBOL_DEVELOPMENT=true`; rollout is live on `localhost:54103/obol-stack-front-end:dev@sha256:8b3f232e9ea19461cab9a4e5da2ef2c2a6fc2ffaf609c1003ef247b5672075f5`.
