### PR TITLE
fix(x402): verifier replicas: 2 → 1 to keep metric GC correct

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -200,7 +200,11 @@ metadata:
   labels:
     app: x402-verifier
 spec:
-  replicas: 2
+  # Single replica — verifier holds per-pod metric registries and per-pod
+  # informer caches; multiple replicas produce metric series drift across
+  # ServiceMonitor scrape rotations and the pruneSeriesNotIn GC (metrics.go)
+  # becomes inconsistent. Single-node k3d gains no HA from 2 replicas.
+  replicas: 1
   selector:
     matchLabels:
       app: x402-verifier
@@ -320,18 +324,6 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: x402-verifier
-  namespace: x402
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: x402-verifier
 
 ---
 # ServiceMonitor for x402-verifier — scrapes the stable Service endpoint


### PR DESCRIPTION
## Why

`0fbb99a` (this PR's parent) shipped `pruneSeriesNotIn` to GC verifier metric series when offers are deleted. The GC is per-pod (each pod runs its own informer + its own registry). With `replicas: 2` + ServiceMonitor scraping Endpoints (round-robin), Prometheus sees inconsistent series — deleted offers come back every other scrape.

## Before
```
                 ServiceMonitor scrape (round-robin Endpoints)
                            │
                    ┌───────┴───────┐
                    ▼               ▼
              verifier-pod-A   verifier-pod-B
              metric registry  metric registry
              GC ran on        GC ran on
              Reload event ✓   Reload event ?
                    │               │
                    ▼               ▼
              clean series     stale series for
              for deleted X    deleted offer X
                            │
                    Prometheus sees flip-flop
                    → alerts fire/silence on dead labels
                    → dashboards show resurrected offers
```

## After
```
              ServiceMonitor scrape → only verifier-pod-A
                            │
                            ▼
                      single registry
                      single GC source
                            │
                            ▼
                   deterministic series state
                   alerts trustworthy
                   dashboards consistent
```

## What changed
- `x402.yaml` verifier Deployment: `replicas: 2 → 1`
- Removed verifier PDB (was `minAvailable: 1` at `replicas: 1` — blocks voluntary drains on the only pod, useless on single-node k3d)
- Added explanatory comment so this isn't re-bumped without thought

## Future HA path
If/when this stack runs multi-node and wants 2+ verifier replicas, the correct pattern is `ServiceMonitor → PodMonitor` (each pod scraped with a `pod` label) + recording rules using `sum without(pod)`. Not now; correctness > theoretical HA on a single-node k3d.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/x402/...` green
- [ ] Manual on next stack up: scrape `/metrics` from the verifier, delete a ServiceOffer, scrape again — series should disappear and STAY disappeared

## Stacks on
PR #513 (introduces `pruneSeriesNotIn`). Will rebase onto main after #513 merges.