### PR TITLE
fix(x402-metrics): align Prometheus retention with recording-rule windows; rename mis-named lifetime rule

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
+++ b/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
@@ -47,10 +47,11 @@ spec:
               increase(obol_x402_verifier_charged_requests_total[7d])
             )
 
-        # Lifetime charged-request count per offer (sum across replicas
-        # + chains). Used in the My Listings "today · X earned" header
-        # text and the Browse catalog usage badge.
-        - record: x402:revenue:lifetime_by_offer
+        # Sum of currently-running verifier replicas' counters — resets
+        # on rollout; for true lifetime, query against a long-retention
+        # store or use `sum_over_time(...[Nd])`. Used in the My Listings
+        # "today · X earned" header text and the Browse catalog usage badge.
+        - record: x402:revenue:total_by_offer_current
           expr: |
             sum by (offer_namespace, offer_name) (
               obol_x402_verifier_charged_requests_total

--- a/internal/embed/infrastructure/values/monitoring.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/monitoring.yaml.gotmpl
@@ -11,7 +11,7 @@ prometheus:
       matchLabels:
         release: monitoring
     podMonitorNamespaceSelector: {}
-    retention: 6h
+    retention: 8d
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Why

`27e1ac5` (this PR's parent) added recording rules over `[24h]` and `[7d]`. The Prometheus retention was 6h. `increase(x[24h])` over a 6h TSDB silently returns 6h extrapolated as 24h — the frontend reads it and shows the wrong number with no warning.

Same commit's `x402:revenue:lifetime_by_offer` rule is `sum(counter)`, not `sum(increase[lifetime])` — it resets on every replica restart, so "lifetime" is a misnomer.

## Before
```
   recording rule expressions      |   actual TSDB retention
   ---------------------------------------------------------
   increase(x[24h])                |   <- reads last 6h only
   increase(x[7d])                 |   <- reads last 6h only
   sum(charged_requests_total)     |   <- survives, but resets
                                   |     on every verifier restart

   Frontend "24h revenue" / "7d earnings" / "lifetime" cells all wrong
```

## After
```
   recording rule expressions      |   actual TSDB retention
   ---------------------------------------------------------
   increase(x[24h])                |   <- 8d window, valid
   increase(x[7d])                 |   <- 8d window, valid
   sum(charged_requests_total)     |   <- renamed to
   -> total_by_offer_current       |     `total_by_offer_current`
                                   |     with doc-comment that says
                                   |     "this resets on rollout"

   Cells match reality. Naming matches semantics.
```

## What changed
- `monitoring.yaml.gotmpl`: `retention: 6h -> 8d` (= 7d max window + 1d safety)
- `x402-prometheus-rules.yaml`: rename rule + add explanatory comment

## Disk impact
~32x increase in Prometheus disk footprint (proportional to retention). Local-only kube-prometheus-stack PVC currently has no size cap (inherits storageClass default). Watch for PVC-full on next `obol stack up` and add a cap if it bites.

## Frontend consumer
`obol-stack-front-end/src/lib/services/prometheus.ts` (lines 49, 61) references `x402:revenue:lifetime_by_offer` in a doc comment + OR-fallback expression for the lifetime-earnings query. Architecture-review notes flagged the OR fallback added in #330 was unused on the consumer side anyway, so this rename has zero immediate UI impact. A follow-up small PR on the frontend repo should update the name + comment to `x402:revenue:total_by_offer_current`. Not modified in this PR (separate repo).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/embed/... ./internal/x402/...` green
- [ ] On next stack up: PromQL `x402:revenue:7d_by_offer_chain` should return non-extrapolated values

## Stacks on
PR #513. Rebase onto main after #513 merges.