### PR TITLE
chore(images): digest-pin verifier, controller, litellm, cloudflared

### DIFF
--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -136,3 +136,135 @@ func TestEmbeddedImages_NoNewLatestTags(t *testing.T) {
 			strings.Join(stale, "\n  "))
 	}
 }
+
+// TestEmbeddedImages_NamedImagesAreDigestPinned guards the @sha256: discipline
+// for the cluster-side container images that ship as part of the embedded
+// infrastructure. Tag-only refs (e.g. `:b13254e`) are vulnerable to mutable-tag
+// rewrites — the class of supply-chain bug CLAUDE.md pitfall #12 documented
+// after a real local-cluster incident.
+//
+// Adding a new image to this list MUST be accompanied by an `@sha256:<digest>`
+// suffix on the `image:` line (or, for Helm value files, on the `tag:` field
+// such that the rendered manifest produces `<repo>:<tag>@sha256:<digest>`).
+//
+// To regenerate a digest:
+//
+//	docker buildx imagetools inspect <repo>:<tag> --format '{{ .Manifest.Digest }}'
+func TestEmbeddedImages_NamedImagesAreDigestPinned(t *testing.T) {
+	cases := []struct {
+		file string
+		// repo is the substring used to locate the relevant line. The match
+		// is line-scoped — the line must also contain @sha256: to pass.
+		repo string
+	}{
+		// internal/embed/infrastructure/base/templates/x402.yaml
+		{file: "base/templates/x402.yaml", repo: "ghcr.io/obolnetwork/x402-verifier"},
+		{file: "base/templates/x402.yaml", repo: "ghcr.io/obolnetwork/serviceoffer-controller"},
+		// internal/embed/infrastructure/base/templates/llm.yaml
+		{file: "base/templates/llm.yaml", repo: "ghcr.io/obolnetwork/litellm"},
+		{file: "base/templates/llm.yaml", repo: "ghcr.io/obolnetwork/x402-buyer"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.repo, func(t *testing.T) {
+			data, err := ReadInfrastructureFile(tc.file)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+
+			var (
+				found     bool
+				offenders []string
+			)
+
+			scanner := bufio.NewScanner(bytes.NewReader(data))
+			scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+			lineNum := 0
+			for scanner.Scan() {
+				lineNum++
+				line := scanner.Text()
+
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "#") {
+					continue
+				}
+				// Must look like a Kubernetes container `image:` field, not a
+				// random doc-comment or env var.
+				if !strings.Contains(trimmed, "image:") {
+					continue
+				}
+				if !strings.Contains(line, tc.repo) {
+					continue
+				}
+
+				found = true
+				if !strings.Contains(line, "@sha256:") {
+					offenders = append(offenders,
+						fmt.Sprintf("%s:%d → %q lacks @sha256: digest pin", tc.file, lineNum, strings.TrimSpace(line)))
+				}
+			}
+
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("scan %s: %v", tc.file, err)
+			}
+
+			if !found {
+				t.Fatalf("no image: line containing %q found in %s — has the image been renamed or moved? "+
+					"Update this test alongside the manifest change.", tc.repo, tc.file)
+			}
+
+			if len(offenders) > 0 {
+				t.Fatalf("digest-pin discipline broken in %s:\n  %s\n\n"+
+					"Pin the image as `<repo>:<tag>@sha256:<digest>`. Resolve with:\n"+
+					"  docker buildx imagetools inspect %s:<tag> --format '{{ .Manifest.Digest }}'",
+					tc.file, strings.Join(offenders, "\n  "), tc.repo)
+			}
+		})
+	}
+}
+
+// TestEmbeddedImages_CloudflaredHelmTagIsDigestPinned covers the cloudflared
+// chart, which uses the Helm idiom `image.repository` + `image.tag` rather
+// than a literal `image:` line. The chart template renders
+// `<repository>:<tag>`; embedding `@sha256:<digest>` inside `.tag` produces
+// a valid digest-pinned ref at render time and preserves the same
+// mutable-tag protection.
+func TestEmbeddedImages_CloudflaredHelmTagIsDigestPinned(t *testing.T) {
+	data, err := ReadInfrastructureFile("cloudflared/values.yaml")
+	if err != nil {
+		t.Fatalf("read cloudflared/values.yaml: %v", err)
+	}
+
+	var tagLine string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "tag:") {
+			tagLine = line
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan cloudflared/values.yaml: %v", err)
+	}
+
+	if tagLine == "" {
+		t.Fatal("no `tag:` field found in cloudflared/values.yaml — chart layout changed; update this test.")
+	}
+
+	if !strings.Contains(tagLine, "@sha256:") {
+		t.Fatalf("cloudflared image tag is not digest-pinned: %q\n\n"+
+			"Pin it as `tag: \"<tag>@sha256:<digest>\"`. Resolve with:\n"+
+			"  docker buildx imagetools inspect cloudflare/cloudflared:<tag> --format '{{ .Manifest.Digest }}'",
+			strings.TrimSpace(tagLine))
+	}
+}

--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -148,7 +148,7 @@ spec:
           # No Postgres required — /model/new and /model/delete work via
           # in-memory router + config.yaml persistence.
           # Source: https://github.com/ObolNetwork/litellm
-          image: ghcr.io/obolnetwork/litellm:sha-c16b156
+          image: ghcr.io/obolnetwork/litellm:sha-c16b156@sha256:9f112b51ac5a57d73cdd54103fb98d24eabaddd8689a9a285884dca6456dc86e
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -212,7 +212,7 @@ spec:
       serviceAccountName: x402-verifier
       containers:
         - name: verifier
-          image: ghcr.io/obolnetwork/x402-verifier:b13254e
+          image: ghcr.io/obolnetwork/x402-verifier:b13254e@sha256:a8a7aa0ca4c35b0ddf6983fa6e3e5f8a3f64e44d8e506ebfd55e39de2bc0342d
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -283,7 +283,7 @@ spec:
       serviceAccountName: serviceoffer-controller
       containers:
         - name: controller
-          image: ghcr.io/obolnetwork/serviceoffer-controller:b13254e
+          image: ghcr.io/obolnetwork/serviceoffer-controller:b13254e@sha256:f83bd7e55bdc5d87edb49c04e7fd9257097364e2d43e769c19dfd7c8b47d07af
           imagePullPolicy: IfNotPresent
           env:
             - name: POD_NAMESPACE

--- a/internal/embed/infrastructure/cloudflared/values.yaml
+++ b/internal/embed/infrastructure/cloudflared/values.yaml
@@ -5,7 +5,7 @@ transport:
 
 image:
   repository: cloudflare/cloudflared
-  tag: "2026.3.0"
+  tag: "2026.3.0@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0"
 
 metrics:
   address: "0.0.0.0:2000"


### PR DESCRIPTION
## Why

Only `x402-buyer` and the frontend image carried `@sha256:` digest pins. Tag-only refs are vulnerable to mutable-tag rewrites — exactly the class CLAUDE.md pitfall #12 codified after a real local-cluster incident. Extending digest discipline to the other four images closes the gap.

## Before
```
              ┌─────────────────────┐
              │  ghcr.io registry   │
              └──────────┬──────────┘
                         │ tag-only refs (mutable)
       ┌─────────────────┼──────────────────┐
       ▼                 ▼                  ▼
   x402-verifier   serviceoffer-      litellm
   :b13254e        controller:b13254e :sha-c16b156
       │                 │                  │
       │  tag rewrite at registry → new digest │
       ▼                 ▼                  ▼
   silently pulls compromised image on any new node
```

## After
```
              ┌─────────────────────┐
              │  ghcr.io registry   │
              └──────────┬──────────┘
                         │ tag@sha256 (immutable)
       ┌─────────────────┼──────────────────┐
       ▼                 ▼                  ▼
   x402-verifier   serviceoffer-      litellm
   :b13254e        controller:b13254e :sha-c16b156
   @sha256:…       @sha256:…          @sha256:…
                         │
                         ▼
   tag rewrite → digest mismatch → image pull fails loud
```

## What's pinned
- `ghcr.io/obolnetwork/x402-verifier:b13254e@sha256:a8a7aa0c…0342d`
- `ghcr.io/obolnetwork/serviceoffer-controller:b13254e@sha256:f83bd7e5…07af`
- `ghcr.io/obolnetwork/litellm:sha-c16b156@sha256:9f112b51…c86e`
- `cloudflare/cloudflared:2026.3.0@sha256:6b599ca3…31b0`

(`x402-buyer` and `obol-stack-front-end` already digest-pinned — no change.)

Digests resolved via `docker buildx imagetools inspect <ref> --format '{{ .Manifest.Digest }}'`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/embed/... ./internal/defaults/... ./internal/x402/...` green
- [x] Regression test added (`TestEmbeddedImages_NamedImagesAreDigestPinned`, `TestEmbeddedImages_CloudflaredHelmTagIsDigestPinned`) asserting `@sha256:` on every named image
- [x] Dev-mode rewrite invariant (combo-form regex from CLAUDE.md pitfall #12) verified intact — `TestCopyInfrastructure_DevModeRewritesDigestPins` and `TestX402Manifest_DevModeRewritesPins` both pass against the new combo-form pins

## Companion to
Architecture review surfaced this as the simplest open security item in PRs #513 / #330 follow-up.