### PR TITLE
fix(prometheus-rules): use increase() for the per-offer revenue rule

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
+++ b/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
@@ -47,14 +47,33 @@ spec:
               increase(obol_x402_verifier_charged_requests_total[7d])
             )
 
-        # Sum of currently-running verifier replicas' counters — resets
-        # on rollout; for true lifetime, query against a long-retention
-        # store or use `sum_over_time(...[Nd])`. Used in the My Listings
-        # "today · X earned" header text and the Browse catalog usage badge.
-        - record: x402:revenue:total_by_offer_current
+        # 7d charged-request count per offer (chain-agnostic). Used in the
+        # My Listings "7d · X earned" header text and the Browse catalog
+        # usage badge.
+        #
+        # Why `increase()` and not `sum(counter)`:
+        #   Prometheus counters are per-process by design — they reset to
+        #   zero on every pod restart (rollout, OOM, eviction, node
+        #   reschedule). A naive `sum by (...) (counter)` query therefore
+        #   drops to zero whenever the verifier restarts, producing a
+        #   misleading "0 requests" reading on offers with real on-chain
+        #   traffic. `increase()` performs reset detection at query time
+        #   across the samples the TSDB holds, accounting for the wraps.
+        #
+        # Why `[7d]` and not `[8d]` (matching retention):
+        #   The TSDB is the canonical persistence layer. `increase()`
+        #   needs samples on both sides of the window edge to do reset
+        #   detection at the left edge; a 7d window inside 8d retention
+        #   gives a 1-day headroom so the rule keeps working at exactly
+        #   the moment data ages out, instead of silently producing
+        #   NaN/undercounts at the boundary.
+        #
+        # Canonical reference: Robust Perception, "avoiding the counter-
+        # reset undercount".
+        - record: x402:revenue:7d_by_offer
           expr: |
             sum by (offer_namespace, offer_name) (
-              obol_x402_verifier_charged_requests_total
+              increase(obol_x402_verifier_charged_requests_total[7d])
             )
 
         # Settlement rate (verified / attempted) over the last hour, per


### PR DESCRIPTION
## Summary

The recording rule `x402:revenue:total_by_offer_current` used a naive `sum(counter)` expression, which is wrong for any metric where the counter can reset across pod restarts. Prometheus counters are **per-process by design** — they reset to zero on every pod restart (rollout, OOM, eviction, node reschedule). A `sum by (...) (counter)` query therefore drops to zero whenever the verifier restarts, producing a misleading "0 requests" reading on offers with real on-chain traffic.

This PR fixes the rule to use `increase()`, which performs reset detection at query time across the samples held in the TSDB.

### Before

```yaml
- record: x402:revenue:total_by_offer_current
  expr: |
    sum by (offer_namespace, offer_name) (
      obol_x402_verifier_charged_requests_total
    )
```

### After

```yaml
- record: x402:revenue:7d_by_offer
  expr: |
    sum by (offer_namespace, offer_name) (
      increase(obol_x402_verifier_charged_requests_total[7d])
    )
```

### Why `increase([7d])` not `[8d]`

The TSDB is the canonical persistence layer (retention 8d). `increase()` needs samples on both sides of the window edge to do reset detection at the **left** edge of the window. A 7d window inside 8d retention gives a 1-day headroom so the rule keeps working at exactly the moment data ages out, instead of silently producing NaN/undercounts at the boundary.

### Why the rename

The old names (`total_by_offer_current`, `lifetime_by_offer`) were aspirational against a finite retention window. The new name (`7d_by_offer`) matches what the expression actually returns and makes the bounded nature of the value explicit at the call site.

Canonical reference: [Robust Perception "avoiding the counter-reset undercount"](https://www.robustperception.io/avoiding-the-counter-reset-undercount/).

### Provenance

Found by the 14-PR integration test (`plans/integration-test-results-final-20260524.md`). The OBOL parity smoke surfaced it more visibly when a verifier restart produced a "0 req·24h" UI display on a row with real on-chain traffic.

Stacks on #527 (Helm-escape fix for the same file). Frontend consumer PR follows.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/embed/... ./internal/x402/...` green
- [ ] Verify the recording rule lands in Prometheus after `obol stack up` and returns a per-offer 7d count for a verifier that's been restarted at least once
- [ ] Frontend follow-up PR points at the renamed rule