### PR TITLE
fix(prometheus-rules): use epsilon floor not 1.0 to avoid under-reporting low-traffic alerts

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
+++ b/internal/embed/infrastructure/base/templates/x402-prometheus-rules.yaml
@@ -105,6 +105,15 @@ spec:
 
         # Settlement rate (verified / attempted) over the last hour, per
         # (offer, chain). Useful for the dashboard + the alert below.
+        #
+        # The `clamp_min(..., 1e-9)` is a division-by-zero guard, not a
+        # traffic floor. An earlier revision used `clamp_min(..., 1)`,
+        # which floored the denominator at 1 req/s and silently
+        # distorted the ratio on low-traffic offers (e.g. verified=
+        # 0.001/s ÷ floored_denominator=1 ≈ 0 instead of the real
+        # 0.001/0.002 = 0.5). Epsilon keeps the answer accurate at any
+        # non-zero traffic level while still avoiding a NaN when no
+        # samples exist in the window.
         - record: x402:settlement_rate:1h_by_offer_chain
           expr: |
             sum by (offer_namespace, offer_name, chain) (
@@ -119,7 +128,7 @@ spec:
                 +
                 rate(obol_x402_verifier_payment_failed_total[1h])
               ),
-              1
+              1e-9
             )
 
     - name: x402.alerting
@@ -128,6 +137,14 @@ spec:
         # route that's actually receiving traffic. Typical cause:
         # facilitator unreachable, chain pruning, or seller's CA bundle
         # missing (CLAUDE.md pitfall #8).
+        #
+        # The `clamp_min(..., 1e-9)` here is a div-by-zero guard only.
+        # A prior `clamp_min(..., 1)` floored the denominator at 1 req/s,
+        # which under-reports the failure ratio on light-traffic
+        # endpoints (failed=0.001/s ÷ floored_denominator=1 = 0.001
+        # instead of the true 0.001/0.002 = 0.5) and prevented the
+        # alert from ever firing at sub-1 req/s. Epsilon avoids NaN
+        # without distorting the ratio.
         - alert: X402PaymentFailureRateHigh
           expr: |
             (
@@ -141,7 +158,7 @@ spec:
                   +
                   rate(obol_x402_verifier_payment_verified_total[1h])
                 ),
-                1
+                1e-9
               )
             ) > 0.10
           for: 10m


### PR DESCRIPTION
## Summary

- Replace `clamp_min(denominator, 1)` with `clamp_min(denominator, 1e-9)` in both `X402PaymentFailureRateHigh` alert and `x402:settlement_rate:1h_by_offer_chain` recording rule.
- Update the comments above each rule to document why epsilon (div-by-zero guard) is the correct choice rather than `1` (which silently floored the denominator).

## The bug

`clamp_min(..., 1)` floors the denominator at 1 req/s. The intent was to guard against division-by-zero when no samples exist in the lookback window. The effect was different: on any paid offer running below 1 req/s, the rule replaces the true denominator with `1`, collapsing the ratio.

Concrete example for `X402PaymentFailureRateHigh` under light load:

- failed = 0.001 req/s
- verified = 0.001 req/s
- true denominator = failed + verified = 0.002 req/s
- true ratio = 0.001 / 0.002 = **0.5 (50% failure)**
- with `clamp_min(..., 1)`: 0.001 / max(0.002, 1) = 0.001 / 1 = **0.001 (~0% failure)**

Same arithmetic for the settlement-rate recording rule: the dashboard reads "100% settlement" on a half-broken low-traffic offer.

The 10% alert threshold (`> 0.10`) means the alert can never fire on any offer whose total `failed + verified` rate is below ~1 req/s, regardless of how badly it's failing.

## The fix

`clamp_min(..., 1e-9)` keeps the original div-by-zero protection (the denominator never reaches zero in the division) without distorting the ratio. At any non-zero traffic level the rule returns the true ratio; only the truly-zero case is clamped, and there the numerator is also zero, so the ratio is well-defined at `0`.

## Provenance

Surfaced by Expert #2 review of the PromQL design in `plans/integration-test-L7-paid-flow-20260524.md` follow-ups.

## Stack

Based on `feat/x402-asset-symbol-label` (PR #531), the current tip of the rules-file stack (#527 → #530 → #531). Will rebase onto main as the chain merges.

`grep clamp_min` over the repo returns only the two occurrences in this file, both touched here.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/embed/... ./internal/x402/...` green
- [ ] Reviewer eyeballs the PromQL diff for typos in the comments