### PR TITLE
fix(x402): strip healthPath from buyer endpoint URL construction

### DIFF
--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -35,6 +35,7 @@ import secrets
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # ---------------------------------------------------------------------------
@@ -150,12 +151,40 @@ DEFAULT_REFILL_THRESHOLD_DIVISOR = 5
 # ---------------------------------------------------------------------------
 
 def _normalize_endpoint(url):
-    """Strip trailing slashes and /v1/chat/completions from an endpoint URL."""
+    """Reduce a user-supplied endpoint URL to its canonical offer base.
+
+    The buyer always POSTs to ``<base>/v1/chat/completions``, where ``<base>``
+    is the seller's published HTTPRoute path (``/services/<offer-name>``). The
+    seller's ServiceOffer may declare ``upstream.healthPath`` (e.g. ``/api/tags``
+    for Ollama) — this is used by the controller for upstream health probes and
+    is NOT part of the public route. If a user (or copy-pasted URL) appends a
+    healthPath or another sub-path after ``/services/<name>``, blindly tacking
+    ``/v1/chat/completions`` on the end produces a 404 like
+    ``/services/foo/api/tags/v1/chat/completions``.
+
+    Normalization rules:
+      1. Strip trailing slashes.
+      2. Drop a trailing ``/v1/chat/completions`` or ``/chat/completions`` suffix.
+      3. If the path matches ``/services/<segment>/...`` truncate to
+         ``/services/<segment>`` so any healthPath / sub-path tail is removed.
+    """
     base = url.rstrip("/")
     for suffix in ["/v1/chat/completions", "/chat/completions"]:
         if base.endswith(suffix):
             base = base[:-len(suffix)]
             break
+    try:
+        parsed = urllib.parse.urlsplit(base)
+    except (ValueError, AttributeError):
+        return base
+    if parsed.scheme and parsed.netloc and parsed.path:
+        segments = parsed.path.split("/")
+        # ``/services/<name>/<extra>...`` -> keep only ``/services/<name>``.
+        if len(segments) > 3 and segments[1] == "services" and segments[2]:
+            truncated = "/" + "/".join(segments[1:3])
+            base = urllib.parse.urlunsplit(
+                (parsed.scheme, parsed.netloc, truncated, "", "")
+            )
     return base
 
 

--- a/tests/test_buy_normalize_endpoint.py
+++ b/tests/test_buy_normalize_endpoint.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Unit tests for buy.py's _normalize_endpoint helper.
+
+Regression suite for the bug where a seller's ServiceOffer
+upstream.healthPath (e.g. /api/tags for Ollama) leaked into the
+buyer's PurchaseRequest endpoint URL, producing dead URLs like
+``http://traefik.../services/demo-hello/api/tags/v1/chat/completions``.
+
+Root cause: ``_normalize_endpoint`` only stripped trailing
+``/v1/chat/completions`` / ``/chat/completions`` suffixes. Anything
+between ``/services/<name>`` and the LLM suffix survived, and the
+spec builder then re-appended ``/v1/chat/completions`` on top of it.
+"""
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "internal"
+    / "embed"
+    / "skills"
+    / "buy-x402"
+    / "scripts"
+    / "buy.py"
+)
+
+
+def load_buy_module():
+    spec = importlib.util.spec_from_file_location("buy_x402", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class NormalizeEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.buy = load_buy_module()
+
+    # ── existing behaviour is preserved ───────────────────────────────────
+
+    def test_strips_trailing_slash(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint("http://example.com/services/demo/"),
+            "http://example.com/services/demo",
+        )
+
+    def test_strips_v1_chat_completions(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://example.com/services/demo/v1/chat/completions"
+            ),
+            "http://example.com/services/demo",
+        )
+
+    def test_strips_chat_completions(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://example.com/services/demo/chat/completions"
+            ),
+            "http://example.com/services/demo",
+        )
+
+    def test_canonical_offer_base_unchanged(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint("http://traefik.svc/services/demo"),
+            "http://traefik.svc/services/demo",
+        )
+
+    def test_traefik_in_cluster_url(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.traefik.svc.cluster.local/services/demo-hello"
+            ),
+            "http://traefik.traefik.svc.cluster.local/services/demo-hello",
+        )
+
+    # ── healthPath leak regression ────────────────────────────────────────
+    #
+    # These cases reproduce the original bug. Before the fix
+    # ``_normalize_endpoint`` returned the input untouched, and the spec
+    # builder then formed ``.../services/demo-hello/api/tags/v1/chat/completions``.
+
+    def test_strips_health_path_api_tags(self):
+        # Ollama healthPath.
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.svc/services/demo-hello/api/tags"
+            ),
+            "http://traefik.svc/services/demo-hello",
+        )
+
+    def test_strips_health_path_health(self):
+        # Default ``/health`` healthPath.
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.svc/services/demo/health"
+            ),
+            "http://traefik.svc/services/demo",
+        )
+
+    def test_strips_nested_health_path(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.svc/services/demo/api/v1/status"
+            ),
+            "http://traefik.svc/services/demo",
+        )
+
+    def test_strips_health_path_then_chat_suffix(self):
+        # Belt-and-braces: even if both were appended, only the offer base
+        # should survive.
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.svc/services/demo/api/tags/v1/chat/completions"
+            ),
+            "http://traefik.svc/services/demo",
+        )
+
+    def test_strips_trailing_slash_on_health_path(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "http://traefik.svc/services/demo/api/tags/"
+            ),
+            "http://traefik.svc/services/demo",
+        )
+
+    # Final assembled URL: this is the load-bearing assertion. The bug
+    # produced ``/services/demo/api/tags/v1/chat/completions`` (404 from
+    # upstream); the fix must produce ``/services/demo/v1/chat/completions``.
+    def test_assembled_purchase_endpoint_drops_health_path(self):
+        normalized = self.buy._normalize_endpoint(
+            "http://traefik.svc/services/demo-hello/api/tags"
+        )
+        assembled = normalized + "/v1/chat/completions"
+        self.assertEqual(
+            assembled,
+            "http://traefik.svc/services/demo-hello/v1/chat/completions",
+        )
+        self.assertNotIn("/api/tags/", assembled)
+
+    # ── non-/services URLs must not be over-normalized ────────────────────
+
+    def test_non_services_path_preserved(self):
+        # External x402 sellers may publish offers under any path; the
+        # ``/services/<name>`` truncation must only fire for the obol
+        # storefront convention.
+        self.assertEqual(
+            self.buy._normalize_endpoint(
+                "https://seller.example.com/api/inference"
+            ),
+            "https://seller.example.com/api/inference",
+        )
+
+    def test_root_path_preserved(self):
+        self.assertEqual(
+            self.buy._normalize_endpoint("https://seller.example.com/"),
+            "https://seller.example.com",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`buy.py`'s `_normalize_endpoint` only stripped trailing `/v1/chat/completions` and `/chat/completions` suffixes. When a seller declared a non-trivial `upstream.healthPath` (e.g. `/api/tags` for Ollama) and that segment leaked into the `--endpoint` URL, the spec builder happily re-appended `/v1/chat/completions` on top, producing dead URLs like `http://traefik.../services/demo-hello/api/tags/v1/chat/completions`.

## Repro

Seller:
```
obol sell http demo-hello --upstream ollama --port 11434 --namespace llm \
  --health-path /api/tags --per-request 0.001 --chain base-sepolia --wallet 0x...
```

Buyer:
```
buy.py buy demo-hello --endpoint <URL> --model demo --count 1
```

Before fix: `PurchaseRequest.spec.endpoint = http://traefik.../services/demo-hello/api/tags/v1/chat/completions`. LiteLLM `paid/demo` POSTs through the x402-buyer sidecar to that URL → 404 from Traefik.

## Root cause

`buy.py` (skill layer). The seller-side surface was clean:

- `internal/serviceoffercontroller/render.go` and `controller.go` only ever emit `offer.EffectivePath()` (= `/services/<name>`) for storefront / `/skill.md` / registration / `status.Endpoint`. `EffectiveHealthPath()` is consumed exactly once, by the controller's upstream health probe at `controller.go:589`.
- `internal/x402/serviceoffer_source.go` sets `RouteRule.UpstreamURL` to `http://<svc>.<ns>.svc.cluster.local:<port>` (no healthPath) and `StripPrefix` to `offer.EffectivePath()`.
- `internal/x402/forwardauth.go::buildResourceURL` echoes the incoming request URI back as the 402 `resource.url`, but the seller never *advertises* a URL with healthPath in `accepts[]`.

So the bug was confined to the buyer: it accepted any user-supplied URL containing `/services/<name>/<extra>...` and didn't sanitise the `<extra>` tail before appending `/v1/chat/completions`.

## Fix

`_normalize_endpoint` now also detects `/services/<segment>/...` paths and truncates to `/services/<segment>` before appending the LLM suffix. External (non-`/services`) sellers are untouched.

## Test plan

- [x] Added `tests/test_buy_normalize_endpoint.py` (13 cases) covering:
  - existing trailing-slash / `/v1/chat/completions` / `/chat/completions` strip behaviour preserved
  - canonical `/services/<name>` URL unchanged
  - healthPath segments `/api/tags`, `/health`, nested paths, and `/api/tags/v1/chat/completions` all collapse to `/services/<name>`
  - assembled `<normalized>/v1/chat/completions` matches canonical buyer URL
  - non-`/services` URLs left intact (external x402 sellers)
- [x] `go build ./...` clean
- [x] `go test ./internal/x402/... ./internal/serviceoffercontroller/...` green
- [x] `go test ./...` green except one pre-existing failure (`TestWarnIfNoChatModel_EmitsWarnWhenNoModels` in `internal/stack` — unrelated, confirmed against `main`)
- [x] Existing Python tests in `tests/test_buy_autorefill.py` still pass (4 pre-existing socket failures from offline test env — confirmed against `main`)
- [ ] Live cluster: `obol sell http demo-hello --health-path /api/tags ...` then `buy.py buy demo-hello --endpoint http://traefik.../services/demo-hello/api/tags ...` and confirm `paid/demo` returns 200

## Coordination

Bundle PR #536 touches the same `buy.py` script area. This is a small, surgical change inside `_normalize_endpoint`; conflict resolution post-merge of #536 should be a quick rebase.