### PR TITLE
fix(rbac): grant frontend read access to PurchaseRequest + RegistrationRequest

### DIFF
--- a/internal/embed/infrastructure/base/templates/obol-frontend.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-frontend.yaml
@@ -77,6 +77,18 @@ rules:
   - apiGroups: ["obol.org"]
     resources: ["serviceoffers", "serviceoffers/status"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # PurchaseRequest CRD — /api/marketplace/purchases lists agent buys
+  # cluster-wide so the My Purchases page can show every signed auth
+  # paying to the connected wallet. Read-only: the agent owns writes.
+  - apiGroups: ["obol.org"]
+    resources: ["purchaserequests", "purchaserequests/status"]
+    verbs: ["get", "list", "watch"]
+  # RegistrationRequest CRD — surfaces ERC-8004 registration state on
+  # listing rows ("Registered" vs "Pending"). Read-only: the controller
+  # owns writes.
+  - apiGroups: ["obol.org"]
+    resources: ["registrationrequests", "registrationrequests/status"]
+    verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Adds two read-only RBAC rules to the frontend ClusterRole so /api/marketplace/purchases and registration-status badges work without 403s.

## Bug discovered during validation

Running the bundle (#536) deployment + visiting `/marketplace/purchases` produced:

```
Failed to list PurchaseRequests
```

Frontend pod logs:

```
code: 403,
message: 'purchaserequests.obol.org is forbidden:
  User "system:serviceaccount:obol-frontend:obol-frontend" cannot list
  resource "purchaserequests" in API group "obol.org" at the cluster scope'
```

The existing ClusterRole (`obol-frontend-openclaw-discovery`) granted CRUD on ServiceOffers but nothing for PurchaseRequests or RegistrationRequests — both of which the marketplace UI lists cluster-wide for the "purchases paying to this wallet" and "ERC-8004 registered" badges.

## Fix

```yaml
- apiGroups: ["obol.org"]
  resources: ["purchaserequests", "purchaserequests/status"]
  verbs: ["get", "list", "watch"]
- apiGroups: ["obol.org"]
  resources: ["registrationrequests", "registrationrequests/status"]
  verbs: ["get", "list", "watch"]
```

Read-only is sufficient: the agent owns PurchaseRequest writes via the buy-x402 skill; the controller owns RegistrationRequest writes.

## Stack

Stacked on `feat/marketplace-bundle` (#536) where `internal/embed/infrastructure/base/templates/obol-frontend.yaml` lives. Merge after #536.

## Test plan

- [x] go build clean
- [x] go test ./internal/embed/... green
- [x] Verified on a live cluster: applied an out-of-band ClusterRole with the same rules → `/api/marketplace/purchases` returns 200, My Purchases page renders rows with chevron drawer expansion (validated via Chrome MCP).
- [ ] Reviewer: after merge, redeploy and confirm 'kubectl auth can-i list purchaserequests --as=system:serviceaccount:obol-frontend:obol-frontend' returns yes