### PR TITLE
fix(stack): refresh x402 runtime image pins

### DIFF
--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -224,6 +224,34 @@ func TestEmbeddedImages_NamedImagesAreDigestPinned(t *testing.T) {
 	}
 }
 
+func TestEmbeddedImages_X402ControllerAndBuyerUseFixPins(t *testing.T) {
+	cases := []struct {
+		file string
+		ref  string
+	}{
+		{
+			file: "base/templates/x402.yaml",
+			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:f5d94fc@sha256:c6aa6259e3a6bc61a5f4f7203d8c68cfdd861a8d365f9629d234d13b949bf48e",
+		},
+		{
+			file: "base/templates/llm.yaml",
+			ref:  "ghcr.io/obolnetwork/x402-buyer:f5d94fc@sha256:0c431eda44e9e2fe5dd50c82cf4885f9be5037e592478781c51e9c510171265c",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ref, func(t *testing.T) {
+			data, err := ReadInfrastructureFile(tc.file)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+			if !strings.Contains(string(data), "image: "+tc.ref) {
+				t.Fatalf("%s must pin current x402 bundle image %q", tc.file, tc.ref)
+			}
+		})
+	}
+}
+
 // TestEmbeddedImages_CloudflaredHelmTagIsDigestPinned covers the cloudflared
 // chart, which uses the Helm idiom `image.repository` + `image.tag` rather
 // than a literal `image:` line. The chart template renders

--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -293,14 +293,14 @@ spec:
         - name: x402-buyer
           # Pinned by sha256 digest (multi-arch manifest list, amd64+arm64)
           # so the deployed sidecar is byte-for-byte identical across QA
-          # hosts. The :b13254e tag is preserved for human readability; the
+          # hosts. The :f5d94fc tag is preserved for human readability; the
           # digest is authoritative.
           # Previous tag-only pin allowed the local-build path to silently
           # reuse a 5-day-old `:latest` image and ate the release-smoke 503
           # investigation: stale buyer serialized X-PAYMENT with empty
           # authorization fields → facilitator /verify 400 → 503 cascade
           # across flow-08/11/14/13. See internal/embed/embed_image_pin_test.go.
-          image: ghcr.io/obolnetwork/x402-buyer:b13254e@sha256:446d730fefbe1860e8b3245289aa8979d765ae977b7f0eaa053543e2468313cb
+          image: ghcr.io/obolnetwork/x402-buyer:f5d94fc@sha256:0c431eda44e9e2fe5dd50c82cf4885f9be5037e592478781c51e9c510171265c
           imagePullPolicy: IfNotPresent
           # PSS Restricted: Go distroless:nonroot image already runs as
           # UID 65532; only the state dir under /state needs to be writeable

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -327,7 +327,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: controller
-          image: ghcr.io/obolnetwork/serviceoffer-controller:b13254e@sha256:f83bd7e55bdc5d87edb49c04e7fd9257097364e2d43e769c19dfd7c8b47d07af
+          image: ghcr.io/obolnetwork/serviceoffer-controller:f5d94fc@sha256:c6aa6259e3a6bc61a5f4f7203d8c68cfdd861a8d365f9629d234d13b949bf48e
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -781,7 +781,7 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
                 - sh
                 - -ec
                 - |
-                  mkdir -p /data/.hermes/home /data/.hermes/workspace
+                  mkdir -p /data/.hermes/home /data/.hermes/workspace /data/.hermes/logs
                   if [ ! -x /opt/hermes/.venv/bin/hermes ]; then
                     echo "Hermes binary missing from image: /opt/hermes/.venv/bin/hermes" >&2
                     exit 1

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -140,6 +140,7 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		`value: "hermes-obol-agent"`,
 		"OBOL_SKILLS_DIR",
 		"/data/.hermes/obol-skills",
+		"/data/.hermes/logs",
 		"containerPort: 8642",
 		"containerPort: 9119",
 		"fsGroupChangePolicy: OnRootMismatch",

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -222,7 +222,7 @@ func buildAgentProfileInitContainer() map[string]any {
 		"image":           hermesImage(),
 		"imagePullPolicy": "IfNotPresent",
 		"command":         []any{"/bin/sh", "-ceu"},
-		"args": []any{`mkdir -p /data/.hermes/home /data/.hermes/workspace /data/.hermes/obol-skills
+		"args": []any{`mkdir -p /data/.hermes/home /data/.hermes/workspace /data/.hermes/logs /data/.hermes/obol-skills
 
 seed=/profile-seed/profile.tar.gz
 marker=/data/.hermes/.obol-profile-seed-imported

--- a/internal/serviceoffercontroller/agent_render_test.go
+++ b/internal/serviceoffercontroller/agent_render_test.go
@@ -213,6 +213,7 @@ func TestAgentManifests_ProfileSeedInitContainer(t *testing.T) {
 		"/profile-seed/profile.tar.gz",
 		".obol-profile-seed-imported",
 		"/data/.hermes/SOUL.md",
+		"/data/.hermes/logs",
 		"cp -R",
 	} {
 		if !strings.Contains(script, must) {


### PR DESCRIPTION
## Summary

Fixes the rc6 runtime-image mismatch behind two reported upgrade findings:

- `/skill.md` could fail under the new restricted Pod Security admission because the released `serviceoffer-controller` image was still the rc0-era `b13254e` build, which did not render restricted security contexts for controller-owned httpd workloads.
- Per-agent Hermes pods could render without the later fsGroup / profile-seed changes for the same reason: the embedded manifest pointed at an old controller image while the rc6 source and tests already contained the fix.

This PR pins the controller and buyer sidecar to branch-built multi-arch images and adds tests that prevent these refs from drifting back to stale runtime builds.

## Root Cause

The rc6 source at `98fa406` contains the intended controller-render fixes, but the embedded production manifest still deployed a stale controller image:

```mermaid
flowchart TD
    A[v0.10.0-rc6 source tag<br/>98fa406] --> B[Restricted PSS render code present]
    A --> C[Agent pod fsGroupChangePolicy present]
    D[embedded x402.yaml] --> E[serviceoffer-controller:b13254e]
    E --> F[Controller runs old renderer]
    F --> G[obol-skill-md missing restricted fields]
    F --> H[per-agent Hermes misses later pod spec fixes]
```

The corrected deployment path is:

```mermaid
flowchart TD
    A[Fix branch source<br/>f5d94fc] --> B[Published multi-arch images<br/>f5d94fc@sha256]
    B --> C[embedded templates]
    C --> D[serviceoffer-controller renders restricted httpd workloads]
    C --> E[serviceoffer-controller renders per-agent fsGroup fields]
    D --> F[PodSecurity restricted admission succeeds]
    E --> G[per-agent Hermes PVC ownership path matches fixed source]
```

## Changes

- Pin `serviceoffer-controller` to `f5d94fc@sha256:c6aa...`, the branch-built image containing the controller-side hardening.
- Pin `x402-buyer` to `f5d94fc@sha256:0c431...` so the buyer sidecar stays on the same x402 branch build.
- Leave the verifier image to PR #556, which owns the agent upstream-auth verifier change and pins its own branch-built verifier image. This avoids merge-order regressions where one PR would overwrite the other component's runtime pin.
- Add image-pin coverage that fails if the controller or buyer refs drift back to stale runtime images.
- Add `/data/.hermes/logs` to both default Hermes and controller-rendered per-agent Hermes init paths, with test assertions. This is a narrow hardening for the exact path reported in the crash loop.

## Validation

```bash
go test ./internal/embed -run 'TestEmbeddedImages_X402ControllerAndBuyerUseFixPins|TestEmbeddedImages_NamedImagesAreDigestPinned' -count=1
go test ./internal/serviceoffercontroller -run 'TestAgentManifests_DeploymentUsesFSGroup|TestAgentManifests_ProfileSeedInitContainer|TestBuildSkillCatalogDeployment_RestrictedPSS|TestBuildAgentIdentityRegistrationDeployment_RestrictedPSS' -count=1
go test ./internal/embed ./internal/serviceoffercontroller ./internal/hermes -count=1
```

Image publication:

```bash
gh workflow run docker-publish-x402.yml --ref fix/x402-rc6-runtime-image-pins
docker buildx imagetools inspect ghcr.io/obolnetwork/serviceoffer-controller:f5d94fc --format '{{ .Manifest.Digest }}'
# sha256:c6aa6259e3a6bc61a5f4f7203d8c68cfdd861a8d365f9629d234d13b949bf48e
docker buildx imagetools inspect ghcr.io/obolnetwork/x402-buyer:f5d94fc --format '{{ .Manifest.Digest }}'
# sha256:0c431eda44e9e2fe5dd50c82cf4885f9be5037e592478781c51e9c510171265c
```

Live sanity check against the existing smoke cluster, without teardown:

```mermaid
sequenceDiagram
    participant CLI as obol agent new --create-wallet
    participant Controller as serviceoffer-controller latest local image
    participant K8s as k3d cluster
    participant Hermes as per-agent Hermes

    CLI->>K8s: Apply Agent rc6-pvc-probe
    Controller->>K8s: Render namespace, PVC, Deployment, remote-signer
    K8s->>Hermes: Start pod with fsGroupChangePolicy
    Hermes-->>K8s: Running 1/1
```

Observed: per-agent Hermes and remote-signer reached `Running` with no manual PVC chown on the live smoke cluster.

## Remaining smoke gate

Full flow smoke is running from a combined branch with forced local dev images, but it is currently blocked on the local sudo prompt. The LLM-gated dual-stack flows are also blocked because `silvermesh.v1337.lan:8081` is reachable on the LAN but refusing TCP connections.