### PR TITLE
chore(deps): bump obol-stack-front-end to v0.1.26-rc1

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.25-rc4 (linux/amd64 + linux/arm64).
-  tag: "v0.1.25@sha256:1d594f2a291fc5f47c0e62f59147159da7aa57e9da047739ad14714c3b0165b6"
+  # review. Multi-arch index digest for v0.1.26-rc1 (linux/amd64 + linux/arm64).
+  tag: "v0.1.26-rc1@sha256:b018235dcb379fd81cbff97246e44a70f4d255bfde3ccea3dd05601dd71b5709"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

Bumps the frontend image pin to **v0.1.26-rc1**, which collapses 14 dependabot dep bumps shipped via ObolNetwork/obol-stack-front-end#355.

- npm (10): `@copilotkit/{react-core,react-ui,runtime}` 1.57.1 → 1.57.4, `@react-native-async-storage/async-storage` 3.0.2 → 3.1.0, `@tanstack/react-query` 5.100.10 → 5.100.14, `@typescript-eslint/eslint-plugin` 8.59.2 → 8.59.4, `@types/node` 25.9.0 → 25.9.1, `@types/react` 19.2.14 → 19.2.15, `react-hook-form` 7.75.0 → 7.76.1, `viem` 2.49.3 → 2.51.0
- GH-actions (4): `docker/{build-push,login,metadata,setup-buildx}`

All within-major.

## Diff

```
-  # review. Multi-arch index digest for v0.1.25-rc4 (linux/amd64 + linux/arm64).
-  tag: "v0.1.25@sha256:1d594f2a291fc5f47c0e62f59147159da7aa57e9da047739ad14714c3b0165b6"
+  # review. Multi-arch index digest for v0.1.26-rc1 (linux/amd64 + linux/arm64).
+  tag: "v0.1.26-rc1@sha256:b018235dcb379fd81cbff97246e44a70f4d255bfde3ccea3dd05601dd71b5709"
```

Digest pulled from the docker.io multi-arch index (`linux/amd64` + `linux/arm64`) published by ObolNetwork/obol-stack-front-end Build/Push workflow run 26516942177.

## Test plan
- [x] `go build ./...` clean
- [ ] CI green
- [ ] Smoke: `obol stack up` → frontend pod boots on new image