### PR TITLE
security(controller): reject cross-namespace spec.agent.ref

### DIFF
--- a/internal/serviceoffercontroller/agent_resolver.go
+++ b/internal/serviceoffercontroller/agent_resolver.go
@@ -35,6 +35,16 @@ func (c *Controller) resolveAgentOffer(ctx context.Context, offer *monetizeapi.S
 	if ref.Name == "" || ref.Namespace == "" {
 		return false, fmt.Errorf("type=agent offer %s/%s missing spec.agent.ref", offer.Namespace, offer.Name)
 	}
+	if ref.Namespace != offer.Namespace {
+		// Confused-deputy guard: the verifier route source injects the
+		// hermes-api-server API_SERVER_KEY from ref.Namespace into the
+		// outbound Authorization header. Allowing a cross-namespace ref
+		// would let any principal with serviceoffers write in namespace A
+		// expose Hermes /api in namespace B as an x402-gated route under
+		// attacker-controlled path and payTo, granting paying buyers
+		// authenticated proxy access to the victim agent.
+		return false, fmt.Errorf("type=agent offer %s/%s: spec.agent.ref.namespace %q must equal offer namespace", offer.Namespace, offer.Name, ref.Namespace)
+	}
 
 	raw, err := c.agents.Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {

--- a/internal/serviceoffercontroller/agent_resolver_test.go
+++ b/internal/serviceoffercontroller/agent_resolver_test.go
@@ -30,6 +30,7 @@ func TestResolveAgentOffer_PopulatesFromReadyAgent(t *testing.T) {
 	c := newResolverTestController(t, agent)
 
 	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "agent-quant"},
 		Spec: monetizeapi.ServiceOfferSpec{
 			Type: "agent",
 			Agent: monetizeapi.ServiceOfferAgent{
@@ -83,6 +84,7 @@ func TestResolveAgentOffer_NotReadyAgentClearsResolution(t *testing.T) {
 	c := newResolverTestController(t, agent)
 
 	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "agent-quant"},
 		Spec: monetizeapi.ServiceOfferSpec{
 			Type: "agent",
 			Agent: monetizeapi.ServiceOfferAgent{
@@ -113,6 +115,7 @@ func TestResolveAgentOffer_MissingAgentReturnsNotReady(t *testing.T) {
 	c := newResolverTestController(t)
 
 	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "agent-missing"},
 		Spec: monetizeapi.ServiceOfferSpec{
 			Type: "agent",
 			Agent: monetizeapi.ServiceOfferAgent{
@@ -144,6 +147,52 @@ func TestResolveAgentOffer_RejectsMissingRef(t *testing.T) {
 
 	if _, err := c.resolveAgentOffer(context.Background(), offer, &status); err == nil {
 		t.Fatal("expected error for missing spec.agent.ref")
+	}
+}
+
+// TestResolveAgentOffer_RejectsCrossNamespaceRef guards the confused-deputy
+// invariant: an offer in namespace A must not be allowed to reference an agent
+// in namespace B, because the verifier route source injects ref.Namespace's
+// hermes-api-server API_SERVER_KEY as the upstream Authorization. Allowing a
+// cross-namespace ref would let any principal with serviceoffers write expose
+// another tenant's Hermes /api as an x402-gated route under attacker-controlled
+// path + payTo.
+func TestResolveAgentOffer_RejectsCrossNamespaceRef(t *testing.T) {
+	agent := &monetizeapi.Agent{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "obol.org/v1alpha1", Kind: "Agent"},
+		ObjectMeta: metav1.ObjectMeta{Name: "victim", Namespace: "agent-victim"},
+		Status: monetizeapi.AgentStatus{
+			Phase:    monetizeapi.AgentPhaseReady,
+			Endpoint: "http://hermes.agent-victim.svc.cluster.local:8642",
+		},
+	}
+	c := newResolverTestController(t, agent)
+
+	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoof", Namespace: "attacker-ns"},
+		Spec: monetizeapi.ServiceOfferSpec{
+			Type: "agent",
+			Agent: monetizeapi.ServiceOfferAgent{
+				Ref: monetizeapi.ServiceOfferAgentRef{Name: "victim", Namespace: "agent-victim"},
+			},
+		},
+	}
+	status := monetizeapi.ServiceOfferStatus{
+		AgentResolution: &monetizeapi.ServiceOfferAgentResolution{Model: "stale"},
+	}
+
+	ok, err := c.resolveAgentOffer(context.Background(), offer, &status)
+	if err == nil {
+		t.Fatal("expected error for cross-namespace spec.agent.ref")
+	}
+	if ok {
+		t.Fatal("expected ok=false for cross-namespace ref")
+	}
+	if status.AgentResolution == nil || status.AgentResolution.Model != "stale" {
+		// Guard fires before touching status: the caller is responsible for
+		// the failure-mode condition update, and we should not silently wipe
+		// a prior AgentResolution.
+		t.Errorf("guard must reject without mutating status.AgentResolution; got %+v", status.AgentResolution)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the confused-deputy gap flagged by @OisinKyne on #556 ([review comment](https://github.com/ObolNetwork/obol-stack/pull/556#issuecomment-4564245687)).

`resolveAgentOffer` accepted any `spec.agent.ref.namespace`, while the verifier route source (introduced in #556) keys the `hermes-api-server` `API_SERVER_KEY` lookup off `offer.Spec.Agent.Ref.Namespace`. Combined with the cluster-wide `openclaw-monetize-write` ClusterRoleBinding, any principal holding the Hermes obol-agent SA token could publish a ServiceOffer in their own namespace referencing another tenant's Agent. The route would be published with the victim's `API_SERVER_KEY` as upstream `Authorization`, attacker-controlled `path`, and attacker-controlled `payment.payTo`. Paying buyers would gain authenticated proxy access to the victim Hermes `/api/*` (chat, skills, sub-agent management, wallet ops).

## Fix

Single fail-closed guard at the controller boundary: if `spec.agent.ref.namespace != metadata.namespace`, the offer is rejected before any route is published or any bearer is resolved. Matches the existing missing-ref error pattern; the legitimate flow (mother creates the offer in the agent's own namespace) is preserved.

```go
if ref.Namespace != offer.Namespace {
    return false, fmt.Errorf("type=agent offer %s/%s: spec.agent.ref.namespace %q must equal offer namespace", offer.Namespace, offer.Name, ref.Namespace)
}
```

## Why now

Not exploitable in today's single Hermes mother layout (only one principal has `serviceoffers` write, and it already has cluster-wide `agents`/`secrets` write over its own children). Becomes exploitable the moment sub-agent SAs split out of the mother or multi-mother marketplace mode lands. Cheap to enforce the invariant now.

## Validation

```bash
go test ./internal/serviceoffercontroller/... ./internal/x402/... -count=1
```

New regression: `TestResolveAgentOffer_RejectsCrossNamespaceRef` asserts the guard fires and `status.AgentResolution` is not mutated. Existing happy-path tests updated to set `metadata.namespace` so they exercise the post-guard codepath.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/... ./internal/x402/...` passes
- [x] New `TestResolveAgentOffer_RejectsCrossNamespaceRef` covers the guard
- [x] Pre-existing happy-path tests still pass (`metadata.namespace` now set)
- [ ] Reviewer to confirm invariant is acceptable vs. an allow-list / SAR-based approach for future cross-tenant flows