### PR TITLE
[codex] bump Hermes image to v2026.5.28

### DIFF
--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -33,7 +33,7 @@ const (
 	// renovate: datasource=helm depName=raw registryUrl=https://bedag.github.io/helm-charts/
 	rawChartVersion = "2.0.2"
 
-	defaultImage = "nousresearch/hermes-agent:v2026.5.7"
+	defaultImage = "nousresearch/hermes-agent:v2026.5.28"
 	// Use the upstream image venv instead of cloning Hermes into the PVC on
 	// every cold start. The init container below validates the required extras
 	// are present so image regressions fail before the gateway starts.

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -25,7 +25,7 @@ const (
 	hermesProfileSeed  = "hermes-profile-seed"
 	hermesDataPVC      = "hermes-data"
 	hermesAPIPath      = "/health"
-	defaultHermesImage = "nousresearch/hermes-agent:v2026.5.7"
+	defaultHermesImage = "nousresearch/hermes-agent:v2026.5.28"
 )
 
 // agentLabels returns the standard label set we attach to every primitive


### PR DESCRIPTION
## Summary

- Bump the stack-managed Hermes image from `nousresearch/hermes-agent:v2026.5.7` to `v2026.5.28`.
- Keep the serviceoffer-controller-rendered Agent default image in sync with the main Hermes runtime default.

## Validation

- `docker manifest inspect nousresearch/hermes-agent:v2026.5.28`
- `go test ./internal/hermes ./internal/serviceoffercontroller ./internal/stack -count=1`

Additional local live-stack smoke was run before publishing this branch: flows 01-04 passed with Hermes reporting `Hermes Agent v0.15.0 (2026.5.28)`.
