### PR TITLE
security(controller): scope serviceoffer-controller Secret RBAC to named secrets

### DIFF
--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -791,6 +791,105 @@ func TestX402VerifierImage_CarriesAgentAuthFix(t *testing.T) {
 	}
 }
 
+// TestServiceOfferControllerSecretRBAC_Scoped guards the controller's Secret
+// access against the actual code paths in internal/serviceoffercontroller.
+// The reconciler touches exactly three Secrets by name (litellm-secrets,
+// hermes-api-server, remote-signer-keystore). Disclosure/mutation verbs
+// (get/list/watch/update/patch/delete) must therefore be resourceName-scoped
+// so a compromised controller cannot read or rewrite arbitrary cluster
+// Secrets. Only `create` may be unscoped — resourceNames cannot scope create
+// and agent namespaces are minted dynamically, but create is integrity-only
+// (it cannot read existing Secret contents).
+func TestServiceOfferControllerSecretRBAC_Scoped(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/x402.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+	docs := multiDoc(data)
+
+	role := findDocByName(docs, "ClusterRole", "serviceoffer-controller")
+	if role == nil {
+		t.Fatal("no ClusterRole 'serviceoffer-controller' found")
+	}
+	rules, ok := role["rules"].([]any)
+	if !ok {
+		t.Fatal("serviceoffer-controller ClusterRole has no rules")
+	}
+
+	// Any verb that can read or mutate an existing Secret. `create` is
+	// deliberately excluded — it cannot be resourceName-scoped.
+	scopableVerbs := map[string]bool{
+		"get": true, "list": true, "watch": true,
+		"update": true, "patch": true, "delete": true,
+	}
+	allowedNames := map[string]bool{
+		"litellm-secrets":        true,
+		"hermes-api-server":      true,
+		"remote-signer-keystore": true,
+	}
+
+	readNames := map[string]bool{}
+	deleteNames := map[string]bool{}
+	var sawCreate bool
+	for _, r := range rules {
+		rm := r.(map[string]any)
+		if !stringSet(rm["apiGroups"])[""] || !stringSet(rm["resources"])["secrets"] {
+			continue
+		}
+		verbs := stringSet(rm["verbs"])
+		names := stringSet(rm["resourceNames"])
+
+		if len(names) == 0 {
+			// Unscoped secrets rule: create is the only acceptable verb.
+			for v := range verbs {
+				if scopableVerbs[v] {
+					t.Errorf("serviceoffer-controller grants cluster-wide secrets:%q with no resourceNames — read/mutate surface must be scoped to the three named secrets", v)
+				}
+			}
+			if verbs["create"] {
+				sawCreate = true
+			}
+			continue
+		}
+
+		// Scoped rule: every name must be one the reconciler actually uses.
+		for n := range names {
+			if !allowedNames[n] {
+				t.Errorf("serviceoffer-controller secrets rule references unexpected resourceName %q (reconciler only touches litellm-secrets, hermes-api-server, remote-signer-keystore)", n)
+			}
+			if verbs["get"] {
+				readNames[n] = true
+			}
+			if verbs["delete"] {
+				deleteNames[n] = true
+			}
+		}
+		if verbs["list"] || verbs["watch"] || verbs["update"] || verbs["patch"] {
+			t.Error("serviceoffer-controller scoped secrets rule must not grant list/watch/update/patch — Secrets are create-only in the reconciler and all reads are by name")
+		}
+		if names["litellm-secrets"] && verbs["delete"] {
+			t.Error("serviceoffer-controller must not grant secrets:delete on litellm-secrets; the code only reads LITELLM_MASTER_KEY")
+		}
+	}
+
+	for _, name := range []string{"litellm-secrets", "hermes-api-server", "remote-signer-keystore"} {
+		if !readNames[name] {
+			t.Errorf("serviceoffer-controller must retain resourceName-scoped secrets:get on %s", name)
+		}
+	}
+	for _, name := range []string{"hermes-api-server", "remote-signer-keystore"} {
+		if !deleteNames[name] {
+			// tearDownAgent (agent.go) deletes these on Agent CR deletion.
+			// Without delete the teardown 403s, the finalizer never clears,
+			// and the CR is stranded in Terminating.
+			t.Errorf("serviceoffer-controller must grant resourceName-scoped secrets:delete on %s for agent teardown", name)
+		}
+	}
+	if !sawCreate {
+		t.Error("serviceoffer-controller must retain secrets:create for minting the per-agent API token + wallet keystore in dynamic namespaces")
+	}
+}
+
 func TestAgentRBAC_NoOverlyBroadPermissions(t *testing.T) {
 	data, err := ReadInfrastructureFile("base/templates/obol-agent-monetize-rbac.yaml")
 	if err != nil {

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -140,9 +140,19 @@ rules:
     resources: ["namespaces"]
     verbs: ["get", "list", "watch", "create"]
   # Per-agent runtime resources written by the Agent reconciler.
-  # `create` cannot be safely resourceName-scoped in Kubernetes RBAC,
-  # but follow-up reads/updates/deletes are limited to the fixed child
-  # object names the controller owns.
+  # ServiceAccount + PVC are namespace-scoped child resources.
+  #
+  # Secrets: the reconciler touches exactly three, by name:
+  #   - litellm-secrets        get               (read LITELLM_MASTER_KEY, ns llm)
+  #   - hermes-api-server      get/delete/create (mint the agent API token)
+  #   - remote-signer-keystore get/delete/create (mint the agent wallet keystore)
+  # Secrets are create-only in the reconciler (isCreateOnlyKind): the API token
+  # is preserved, not rotated, and the keystore is minted once and never
+  # reshaped, so no `update`/`patch` verb is needed. `litellm-secrets` is
+  # get-only; delete is confined to the two per-agent Secret names that teardown
+  # owns. `create` is split into its own rule below: resourceNames cannot scope
+  # create, and agent namespaces are minted dynamically, so create stays
+  # namespace-wide. That is an integrity surface only.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["create"]
@@ -159,11 +169,15 @@ rules:
     verbs: ["get", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create"]
+    resourceNames: ["litellm-secrets"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["hermes-api-server", "remote-signer-keystore"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
@@ -182,13 +196,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Scoped to litellm-secrets only. Needed to read LITELLM_MASTER_KEY for
-  # hot-add/hot-delete via the LiteLLM HTTP API (no pod restart — preserves
-  # the x402-buyer sidecar's pod-local consumed-auth state).
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: ["litellm-secrets"]
-    verbs: ["get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "create", "update", "patch", "delete"]

--- a/internal/serviceoffercontroller/agent.go
+++ b/internal/serviceoffercontroller/agent.go
@@ -482,15 +482,22 @@ func (c *Controller) applyAgentObject(ctx context.Context, resource dynamic.Reso
 }
 
 // isCreateOnlyKind returns true for kinds that the controller refuses to
-// Update on subsequent reconciles. Either the Update would require
-// broader RBAC than we want (Namespace), or the resource has immutable
-// spec fields that reject any wholesale Update (PVC's
-// `spec is immutable after creation`). Mutable kinds (ConfigMap, Secret
-// data, Deployment, Service ports, ServiceAccount) keep going through
-// the normal Update path so reconciles still pick up rendered changes.
+// Update on subsequent reconciles. Reasons vary by kind:
+//   - Namespace: Update would require broader RBAC than we want.
+//   - PersistentVolumeClaim: immutable spec fields reject a wholesale Update.
+//   - Secret: the controller never mutates an agent Secret in place — the API
+//     token is preserved across reconciles, not rotated (see ensureAgentAPIKey),
+//     and the wallet keystore is minted once and never reshaped (see
+//     ensureSignerKeystore). Treating Secrets as create-only lets the
+//     ClusterRole drop the `update`/`patch` verbs, shrinking the Secret write
+//     surface to create + delete.
+//
+// Other mutable kinds (ConfigMap, Deployment, Service ports, ServiceAccount)
+// keep going through the normal Update path so reconciles still pick up
+// rendered changes.
 func isCreateOnlyKind(kind string) bool {
 	switch kind {
-	case "Namespace", "PersistentVolumeClaim":
+	case "Namespace", "PersistentVolumeClaim", "Secret":
 		return true
 	}
 	return false

--- a/internal/serviceoffercontroller/agent_wallet.go
+++ b/internal/serviceoffercontroller/agent_wallet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 	"github.com/ObolNetwork/obol-stack/internal/openclaw"
@@ -80,9 +79,6 @@ func (c *Controller) ensureSignerKeystore(ctx context.Context, agent *monetizeap
 	if err == nil {
 		annotations := existing.GetAnnotations()
 		if addr := annotations[signerKeystoreAddressAnnotation]; addr != "" {
-			if err := c.ensureCanonicalKeystoreKeyAndLabels(ctx, agent, existing); err != nil {
-				return "", err
-			}
 			return addr, nil
 		}
 		// Secret exists but has no address — likely written by a
@@ -106,45 +102,6 @@ func (c *Controller) ensureSignerKeystore(ctx context.Context, agent *monetizeap
 		return "", err
 	}
 	return mat.Address, nil
-}
-
-func (c *Controller) ensureCanonicalKeystoreKeyAndLabels(ctx context.Context, agent *monetizeapi.Agent, secret *unstructured.Unstructured) error {
-	changed := ensureRemoteSignerSecretLabels(secret, agent.Name)
-	data, _, err := unstructured.NestedStringMap(secret.Object, "data")
-	if err != nil {
-		return fmt.Errorf("read %s data: %w", remoteSignerSecretName, err)
-	}
-	if data[remoteSignerKeystoreKey] == "" {
-		var candidateKey, candidateValue string
-		for key, value := range data {
-			if key == "password" || !strings.HasSuffix(key, ".json") || value == "" {
-				continue
-			}
-			if candidateKey != "" {
-				return fmt.Errorf("secret %s/%s has multiple legacy keystore JSON data keys (%q and %q); refusing to choose one", agent.Namespace, remoteSignerSecretName, candidateKey, key)
-			}
-			candidateKey = key
-			candidateValue = value
-		}
-		if candidateKey == "" {
-			return fmt.Errorf("secret %s/%s has wallet annotation but no keystore JSON data", agent.Namespace, remoteSignerSecretName)
-		}
-		data[remoteSignerKeystoreKey] = candidateValue
-		if err := unstructured.SetNestedStringMap(secret.Object, data, "data"); err != nil {
-			return fmt.Errorf("set canonical keystore key: %w", err)
-		}
-		changed = true
-	}
-	if !changed {
-		return nil
-	}
-	_, err = c.client.Resource(monetizeapi.SecretGVR).Namespace(agent.Namespace).Update(ctx, secret, metav1.UpdateOptions{
-		FieldManager: controllerFieldManager,
-	})
-	if err != nil {
-		return fmt.Errorf("update %s/%s with canonical keystore metadata: %w", agent.Namespace, remoteSignerSecretName, err)
-	}
-	return nil
 }
 
 func ensureRemoteSignerSecretLabels(secret *unstructured.Unstructured, agentName string) bool {

--- a/internal/serviceoffercontroller/agent_wallet_test.go
+++ b/internal/serviceoffercontroller/agent_wallet_test.go
@@ -80,14 +80,16 @@ func TestEnsureAgentWallet_FreshKeystore(t *testing.T) {
 
 func TestEnsureAgentWallet_ReusesExistingKeystore(t *testing.T) {
 	agent := agentWithWallet(t, "quant", "agent-quant", true)
-	// Pre-seed a Secret with a known address — the controller must
-	// recover that address rather than mint a fresh keypair.
+	// Pre-seed a Secret with the current controller-created shape and a known
+	// address. The controller must recover that address rather than mint a
+	// fresh keypair.
 	preSeeded := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
 		Address:      "0x1111111111111111111111111111111111111111",
 		KeystoreUUID: "existing-uuid",
 		KeystoreJSON: []byte(`{"crypto":{}}`),
 		Password:     "preseed",
 	})
+	ensureRemoteSignerSecretLabels(preSeeded, agent.Name)
 	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), preSeeded)
 
 	address, err := c.ensureAgentWallet(context.Background(), agent)
@@ -127,92 +129,6 @@ func TestEnsureAgentWallet_ReusesExistingKeystore(t *testing.T) {
 	}
 }
 
-func TestEnsureAgentWallet_MigratesLegacyKeystoreKey(t *testing.T) {
-	agent := agentWithWallet(t, "quant", "agent-quant", true)
-	legacySecret := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
-		Address:      "0x1111111111111111111111111111111111111111",
-		KeystoreUUID: "existing-uuid",
-		KeystoreJSON: []byte(`{"crypto":{}}`),
-		Password:     "preseed",
-	})
-	dataMap, found, err := unstructured.NestedStringMap(legacySecret.Object, "data")
-	if err != nil {
-		t.Fatalf("read generated secret data: %v", err)
-	}
-	if !found || dataMap[remoteSignerKeystoreKey] == "" {
-		t.Fatalf("generated secret missing %q data: %v", remoteSignerKeystoreKey, dataMap)
-	}
-	dataMap["existing-uuid.json"] = dataMap[remoteSignerKeystoreKey]
-	delete(dataMap, remoteSignerKeystoreKey)
-	if err := unstructured.SetNestedStringMap(legacySecret.Object, dataMap, "data"); err != nil {
-		t.Fatalf("set legacy data: %v", err)
-	}
-	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), legacySecret)
-
-	address, err := c.ensureAgentWallet(context.Background(), agent)
-	if err != nil {
-		t.Fatalf("ensureAgentWallet: %v", err)
-	}
-	if address != "0x1111111111111111111111111111111111111111" {
-		t.Errorf("address = %q, want pre-seeded value", address)
-	}
-
-	secret, err := c.client.Resource(monetizeapi.SecretGVR).Namespace("agent-quant").Get(context.Background(), remoteSignerSecretName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get secret: %v", err)
-	}
-	migrated, found, err := unstructured.NestedStringMap(secret.Object, "data")
-	if err != nil {
-		t.Fatalf("read migrated secret data: %v", err)
-	}
-	if !found {
-		t.Fatal("migrated secret has no data")
-	}
-	if migrated[remoteSignerKeystoreKey] == "" {
-		t.Fatalf("legacy keystore secret was not migrated to %q: keys=%v", remoteSignerKeystoreKey, migrated)
-	}
-	if migrated[remoteSignerKeystoreKey] != migrated["existing-uuid.json"] {
-		t.Errorf("migrated keystore data differs from legacy key")
-	}
-	if migrated["password"] != dataMap["password"] {
-		t.Error("migrated secret password changed")
-	}
-}
-
-func TestEnsureAgentWallet_RejectsAmbiguousLegacyKeystoreKeys(t *testing.T) {
-	agent := agentWithWallet(t, "quant", "agent-quant", true)
-	legacySecret := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
-		Address:      "0x1111111111111111111111111111111111111111",
-		KeystoreUUID: "existing-uuid",
-		KeystoreJSON: []byte(`{"crypto":{"id":"first"}}`),
-		Password:     "preseed",
-	})
-	dataMap := remoteSignerSecretData(t, legacySecret)
-	dataMap["existing-uuid.json"] = dataMap[remoteSignerKeystoreKey]
-	dataMap["other-uuid.json"] = base64.StdEncoding.EncodeToString([]byte(`{"crypto":{"id":"second"}}`))
-	delete(dataMap, remoteSignerKeystoreKey)
-	if err := unstructured.SetNestedStringMap(legacySecret.Object, dataMap, "data"); err != nil {
-		t.Fatalf("set ambiguous legacy data: %v", err)
-	}
-	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), legacySecret)
-
-	_, err := c.ensureAgentWallet(context.Background(), agent)
-	if err == nil {
-		t.Fatal("expected ambiguous legacy keystore error")
-	}
-	if !strings.Contains(err.Error(), "multiple legacy keystore JSON data keys") {
-		t.Fatalf("error = %v, want ambiguous legacy keystore message", err)
-	}
-	secret := getRemoteSignerSecret(t, c, "agent-quant")
-	after := remoteSignerSecretData(t, secret)
-	if after[remoteSignerKeystoreKey] != "" {
-		t.Fatal("ambiguous legacy secret should not get a canonical keystore key")
-	}
-	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
-		t.Fatal("remote-signer deployment should not be applied after ambiguous keystore error")
-	}
-}
-
 func TestEnsureAgentWallet_RejectsExistingSecretWithoutAddressAnnotation(t *testing.T) {
 	agent := agentWithWallet(t, "quant", "agent-quant", true)
 	orphaned := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
@@ -241,65 +157,6 @@ func TestEnsureAgentWallet_RejectsExistingSecretWithoutAddressAnnotation(t *test
 	}
 	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
 		t.Fatal("remote-signer deployment should not be applied after missing annotation error")
-	}
-}
-
-func TestEnsureAgentWallet_RejectsAnnotatedSecretWithoutKeystoreJSON(t *testing.T) {
-	agent := agentWithWallet(t, "quant", "agent-quant", true)
-	broken := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
-		Address:      "0x1111111111111111111111111111111111111111",
-		KeystoreUUID: "existing-uuid",
-		KeystoreJSON: []byte(`{"crypto":{}}`),
-		Password:     "preseed",
-	})
-	dataMap := remoteSignerSecretData(t, broken)
-	delete(dataMap, remoteSignerKeystoreKey)
-	if err := unstructured.SetNestedStringMap(broken.Object, dataMap, "data"); err != nil {
-		t.Fatalf("set broken data: %v", err)
-	}
-	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), broken)
-
-	_, err := c.ensureAgentWallet(context.Background(), agent)
-	if err == nil {
-		t.Fatal("expected missing keystore JSON error")
-	}
-	if !strings.Contains(err.Error(), "has wallet annotation but no keystore JSON data") {
-		t.Fatalf("error = %v, want missing keystore JSON message", err)
-	}
-	after := remoteSignerSecretData(t, getRemoteSignerSecret(t, c, "agent-quant"))
-	if after[remoteSignerKeystoreKey] != "" {
-		t.Fatal("broken secret should not get an empty canonical keystore key")
-	}
-	if after["password"] != dataMap["password"] {
-		t.Error("broken secret password changed despite migration failure")
-	}
-	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
-		t.Fatal("remote-signer deployment should not be applied after missing keystore JSON error")
-	}
-}
-
-func TestEnsureAgentWallet_RejectsMalformedSecretData(t *testing.T) {
-	agent := agentWithWallet(t, "quant", "agent-quant", true)
-	malformed := buildSignerKeystoreSecret("agent-quant", &openclaw.KeystoreMaterial{
-		Address:      "0x1111111111111111111111111111111111111111",
-		KeystoreUUID: "existing-uuid",
-		KeystoreJSON: []byte(`{"crypto":{}}`),
-		Password:     "preseed",
-	})
-	malformed.Object["data"] = map[string]any{
-		"password": float64(123),
-	}
-	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), malformed)
-
-	_, err := c.ensureAgentWallet(context.Background(), agent)
-	if err == nil {
-		t.Fatal("expected malformed Secret data error")
-	}
-	if !strings.Contains(err.Error(), "read remote-signer-keystore data") {
-		t.Fatalf("error = %v, want malformed Secret data message", err)
-	}
-	if resourceExists(t, c, "deployments", "agent-quant", remoteSignerName) {
-		t.Fatal("remote-signer deployment should not be applied after malformed Secret data error")
 	}
 }
 
@@ -353,6 +210,7 @@ func TestReconcileAgent_WithExistingWallet_DoesNotRotateKeyMaterial(t *testing.T
 		KeystoreJSON: []byte(`{"crypto":{"ciphertext":"preserved"}}`),
 		Password:     "preseed",
 	})
+	ensureRemoteSignerSecretLabels(preSeeded, agent.Name)
 	wantData := remoteSignerSecretData(t, preSeeded)
 	c := newProvisioningTestController(t, agent, litellmSecretObject(t, "key"), preSeeded)
 


### PR DESCRIPTION
## Summary

This PR hardens the `serviceoffer-controller` Secret RBAC after the agent-backed readiness/teardown fix in #572. It is intentionally stacked on `fix/agent-backed-readiness` because the RBAC change and the safe teardown guard share the same Secret ownership contract.

The old ClusterRole granted `secrets: [get, create, update, patch]` cluster-wide with no `resourceNames`. The reconciler only needs three named Secrets:

| Secret | Namespace | Verbs used by code | Why |
|---|---|---|---|
| `litellm-secrets` | `llm` | `get` | read `LITELLM_MASTER_KEY` |
| `hermes-api-server` | agent namespace | `get` / `create` / `delete` | preserve or mint the Hermes API token, then clean it up |
| `remote-signer-keystore` | agent namespace | `get` / `create` / `delete` | preserve or mint the wallet keystore, then clean it up |

## RBAC before -> after

```diff
  - apiGroups: [""]
    resources: ["secrets"]
-   verbs: ["get", "create", "update", "patch"]          # cluster-wide
+   resourceNames: ["litellm-secrets"]
+   verbs: ["get"]
+
+ - apiGroups: [""]
+   resources: ["secrets"]
+   resourceNames: ["hermes-api-server", "remote-signer-keystore"]
+   verbs: ["get", "delete"]
+
+ - apiGroups: [""]
+   resources: ["secrets"]
+   verbs: ["create"]                                    # cannot be name-scoped
```

`create` stays unscoped because Kubernetes cannot authorize it with `resourceNames` before the object exists. All disclosure and destructive verbs are now scoped by name, and `litellm-secrets` is not deletable.

## Companion changes

- Adds `Secret` to `isCreateOnlyKind`, removing the need for Secret `update` / `patch`.
- Removes the legacy in-place keystore-key migration.
- Keeps fresh `remote-signer-keystore` Secrets labeled with `app.kubernetes.io/instance` and `obol.org/agent`, so #572's ownership-checked teardown can safely delete only controller-owned resources.
- Tightens `TestServiceOfferControllerSecretRBAC_Scoped` so it catches broad Secret reads, Secret update/patch/list/watch, and accidental delete access on `litellm-secrets`.

## Tradeoff

Existing pre-fix unlabeled keystore Secrets are reused but not relabeled in place, because relabeling would require keeping Secret `update` or `patch`. Freshly-created keystores have the correct ownership labels.

## Validation

- `go test ./internal/serviceoffercontroller ./internal/embed -count=1`
- `go test ./internal/serviceoffercontroller ./internal/embed ./internal/x402 ./cmd/obol -count=1`
- `go test ./internal/serviceoffercontroller/... ./internal/embed/... -count=1`
- `kubectl --kubeconfig /private/tmp/obol-demo-kubeconfig apply --dry-run=server -f internal/embed/infrastructure/base/templates/x402.yaml`

Release smoke was not run in this pass.
