### PR TITLE
Limit frontend ServiceOffer RBAC

### DIFF
--- a/internal/embed/embed_frontend_rbac_test.go
+++ b/internal/embed/embed_frontend_rbac_test.go
@@ -88,3 +88,36 @@ func TestObolFrontendDiscoveryRBAC_DoesNotGrantBroadSecretAccess(t *testing.T) {
 		}
 	}
 }
+
+func TestObolFrontendDiscoveryRBAC_ServiceOfferLeastPrivilege(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/obol-frontend.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+	docs := multiDoc(data)
+
+	role := findDocByName(docs, "ClusterRole", "obol-frontend-openclaw-discovery")
+	if role == nil {
+		t.Fatal("no ClusterRole 'obol-frontend-openclaw-discovery' found")
+	}
+	rules, ok := role["rules"].([]any)
+	if !ok || len(rules) == 0 {
+		t.Fatal("frontend discovery ClusterRole has no rules")
+	}
+
+	for _, required := range []string{"get", "list", "create", "patch"} {
+		if !hasVerbOnResource(rules, "obol.org", "serviceoffers", required) {
+			t.Fatalf("frontend ServiceOffer RBAC missing required verb %q", required)
+		}
+	}
+	for _, forbidden := range []string{"update", "delete"} {
+		if hasVerbOnResource(rules, "obol.org", "serviceoffers", forbidden) {
+			t.Fatalf("frontend ServiceOffer RBAC grants forbidden verb %q", forbidden)
+		}
+	}
+	for _, forbidden := range []string{"get", "list", "watch", "create", "update", "patch", "delete"} {
+		if hasVerbOnResource(rules, "obol.org", "serviceoffers/status", forbidden) {
+			t.Fatalf("frontend ServiceOffer RBAC grants status-subresource verb %q", forbidden)
+		}
+	}
+}

--- a/internal/embed/infrastructure/base/templates/obol-frontend.yaml
+++ b/internal/embed/infrastructure/base/templates/obol-frontend.yaml
@@ -78,10 +78,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "configmaps"]
     verbs: ["get", "list"]
-  # ServiceOffer CRD — frontend sell modal creates offers
+  # ServiceOffer CRD — frontend sell modal creates offers and stop/drain patches
   - apiGroups: ["obol.org"]
-    resources: ["serviceoffers", "serviceoffers/status"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
+    resources: ["serviceoffers"]
+    verbs: ["get", "list", "create", "patch"]
   # PurchaseRequest CRD — My Purchases lists agent buys. Read-only: the
   # agent and controller own writes.
   - apiGroups: ["obol.org"]


### PR DESCRIPTION
## Summary
- reduce obol-frontend ServiceOffer RBAC to the verbs still used by the frontend backend
- keep get/list/create/patch for listing, create, and stop/drain
- remove ServiceOffer delete/update and status-subresource permissions from the frontend ClusterRole
- add an embed regression test for the least-privilege ServiceOffer rule

## Why
The frontend lifecycle UI is moving to stop/drain only. Leaving delete/update/status capabilities on the frontend service account would preserve a backend capability with no browser route or product surface.

## Validation
- go test ./internal/embed -run TestObolFrontend -count=1
- go test ./internal/embed -count=1
- git diff --check

## Note
A direct helm template smoke is still blocked by the existing llm.yaml OLLAMA_HOST_IP template placeholder in this checkout.
