### PR TITLE
Release v0.10.0-rc9

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.26-rc1 (linux/amd64 + linux/arm64).
-  tag: "v0.1.26-rc1@sha256:b018235dcb379fd81cbff97246e44a70f4d255bfde3ccea3dd05601dd71b5709"
+  # review. Multi-arch index digest for v0.1.26-rc3 (linux/amd64 + linux/arm64).
+  tag: "v0.1.26-rc3@sha256:fcbc0cfc7d0d700f65a0a7b65cf6bf259fffcc7f4e8b182460a0d32459e23f5d"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary
- bump embedded obol-stack-front-end image to v0.1.26-rc3 and its multi-arch digest
- include merged #574 cloudflared 2026.5.2 digest pin
- include merged #577 frontend ServiceOffer least-privilege RBAC

## Validation
- git diff --check
- jq empty renovate.json
- bash -n flows/*.sh
- helm lint internal/embed/infrastructure/cloudflared
- helm template cloudflared internal/embed/infrastructure/cloudflared | rg 'cloudflare/cloudflared:'
- docker buildx imagetools inspect cloudflare/cloudflared:2026.5.2 --format '{{ .Manifest.Digest }}'
- docker buildx imagetools inspect obolnetwork/obol-stack-front-end:v0.1.26-rc3 --format '{{ .Manifest.Digest }}'
- go test ./internal/embed -count=1
- go test ./cmd/obol ./internal/tunnel ./internal/stack -count=1
- local base helm template duplicate-identity smoke
- local base helm lint smoke