### PR TITLE
Pass WalletConnect project ID to frontend dev build

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,8 +46,38 @@ dev_image    := "localhost:54103/obol-stack-front-end:dev"
 dev-frontend:
     #!/usr/bin/env bash
     set -e
+    resolve_wallet_connect_project_id() {
+        if [ -n "${NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID:-}" ]; then
+            printf '%s' "$NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID"
+            return
+        fi
+        if [ -n "${WALLET_CONNECT_PROJECT_ID:-}" ]; then
+            printf '%s' "$WALLET_CONNECT_PROJECT_ID"
+            return
+        fi
+
+        local env_file="{{ frontend_dir }}/.env.local"
+        if [ -f "$env_file" ]; then
+            local line
+            line="$(grep -E '^(NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID|WALLET_CONNECT_PROJECT_ID)=' "$env_file" | tail -n 1 || true)"
+            line="${line#*=}"
+            line="${line%\"}"
+            line="${line#\"}"
+            printf '%s' "$line"
+        fi
+    }
+
+    build_args=()
+    wallet_connect_project_id="$(resolve_wallet_connect_project_id)"
+    if [ -n "$wallet_connect_project_id" ]; then
+        echo "→ WalletConnect project ID found; baking wallet UI into the Next.js bundle"
+        build_args+=(--build-arg "NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=$wallet_connect_project_id")
+    else
+        echo "→ WalletConnect project ID not found; wallet UI will be disabled"
+    fi
+
     echo "→ Building {{ dev_image }} from {{ frontend_dir }}"
-    docker build -t {{ dev_image }} {{ frontend_dir }}
+    docker build "${build_args[@]}" -t {{ dev_image }} {{ frontend_dir }}
     echo "→ Pushing {{ dev_image }} to local registry"
     docker push {{ dev_image }}
     echo "→ Restarting frontend deployment"
@@ -61,8 +91,38 @@ dev-frontend:
 dev-frontend-rebuild:
     #!/usr/bin/env bash
     set -e
+    resolve_wallet_connect_project_id() {
+        if [ -n "${NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID:-}" ]; then
+            printf '%s' "$NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID"
+            return
+        fi
+        if [ -n "${WALLET_CONNECT_PROJECT_ID:-}" ]; then
+            printf '%s' "$WALLET_CONNECT_PROJECT_ID"
+            return
+        fi
+
+        local env_file="{{ frontend_dir }}/.env.local"
+        if [ -f "$env_file" ]; then
+            local line
+            line="$(grep -E '^(NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID|WALLET_CONNECT_PROJECT_ID)=' "$env_file" | tail -n 1 || true)"
+            line="${line#*=}"
+            line="${line%\"}"
+            line="${line#\"}"
+            printf '%s' "$line"
+        fi
+    }
+
+    build_args=()
+    wallet_connect_project_id="$(resolve_wallet_connect_project_id)"
+    if [ -n "$wallet_connect_project_id" ]; then
+        echo "→ WalletConnect project ID found; baking wallet UI into the Next.js bundle"
+        build_args+=(--build-arg "NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=$wallet_connect_project_id")
+    else
+        echo "→ WalletConnect project ID not found; wallet UI will be disabled"
+    fi
+
     echo "→ Rebuilding {{ dev_image }} (no cache)"
-    docker build --no-cache -t {{ dev_image }} {{ frontend_dir }}
+    docker build --no-cache "${build_args[@]}" -t {{ dev_image }} {{ frontend_dir }}
     echo "→ Pushing {{ dev_image }} to local registry"
     docker push {{ dev_image }}
     echo "→ Restarting frontend deployment"


### PR DESCRIPTION
## Summary
- Pass `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` as a Docker build arg for local frontend dev images.
- Resolve the ID from `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`, `WALLET_CONNECT_PROJECT_ID`, or the frontend repo `.env.local`.
- Keep the actual project ID out of tracked files while still baking WalletConnect into the Next.js client bundle at build time.

## Validation
- `just --summary`
- `FRONTEND_DIR=/Users/bussyjd/Development/Obol_Workbench/obol-stack-front-end just --dry-run dev-frontend`
- Rebuilt and pushed `localhost:54103/obol-stack-front-end:dev@sha256:31798e9df946eb9836ddb93e718f08fe3f2a898c09c5ef8c807cfcbeeab16d3b` locally.
- Rolled out the local `obol-frontend` deployment through k3d kubectl.
- Verified `http://obol.stack:8080/marketplace` renders `Connect Wallet`.
