### PR TITLE
fix(hermes): reliable Hermes deploy on k3d (PVC ownership + RWO rollout)

### DIFF
--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -774,6 +774,27 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
             fsGroup: %d
             fsGroupChangePolicy: OnRootMismatch
           initContainers:
+            - name: init-hermes-perms
+              image: %s
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
+              command:
+                - sh
+                - -ec
+                - |
+                  # Hermes runs as a non-root UID, but its data PVC is a
+                  # local-path/hostPath volume where Kubernetes fsGroup is a
+                  # no-op. Chown the volume root every start so the non-root
+                  # main container can always write it, on every backend and
+                  # volume type. Do NOT replace this with fsGroup alone (see
+                  # the regression history around PVC ownership).
+                  chown -R %d:%d /data
+              volumeMounts:
+                - name: data
+                  mountPath: /data
             - name: init-hermes-data
               image: %s
               imagePullPolicy: IfNotPresent
@@ -847,7 +868,7 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
                   value: %s
                 - name: OBOL_SKILLS_DIR
                   value: /data/.hermes/%s
-	`, desc.DataPVCName, namespace, desc.ServiceName, desc.ServiceName, namespace, desc.ServiceName, desc.ServiceName, desc.ServiceName, desc.ServiceName, containerUID, containerGID, containerGID, quoteYAML(image()), desc.ServiceName, quoteYAML(image()), quoteYAML(hermesBinary), desc.DefaultPort, desc.DefaultPort, quoteYAML(primary), quoteYAML(namespace), obolSkillsDirName)
+	`, desc.DataPVCName, namespace, desc.ServiceName, desc.ServiceName, namespace, desc.ServiceName, desc.ServiceName, desc.ServiceName, desc.ServiceName, containerUID, containerGID, containerGID, quoteYAML(image()), containerUID, containerGID, quoteYAML(image()), desc.ServiceName, quoteYAML(image()), quoteYAML(hermesBinary), desc.DefaultPort, desc.DefaultPort, quoteYAML(primary), quoteYAML(namespace), obolSkillsDirName)
 
 	if agentBaseURL != "" {
 		fmt.Fprintf(&b, "                - name: AGENT_BASE_URL\n                  value: %s\n", quoteYAML(agentBaseURL))

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -757,6 +757,12 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
         app.kubernetes.io/managed-by: obol
     spec:
       replicas: 1
+      strategy:
+        # Hermes is a singleton backed by a ReadWriteOnce PVC. The default
+        # RollingUpdate surges a second pod that cannot mount the in-use RWO
+        # volume, deadlocking every redeploy/re-sync. Recreate terminates the
+        # old pod before starting the new one so the volume is free.
+        type: Recreate
       selector:
         matchLabels:
           app.kubernetes.io/name: %s

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -148,6 +148,7 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		"chown -R 10000:10000 /data",
 		"runAsUser: 0",
 		"init-hermes-data",
+		"type: Recreate",
 		`Hermes binary missing from image: /opt/hermes/.venv/bin/hermes`,
 		`Hermes image is missing required extras: web,messaging,mcp,pty,cli,acp,google`,
 		`import fastapi, uvicorn, telegram, mcp, ptyprocess, simple_term_menu, googleapiclient`,

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -144,6 +144,9 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		"containerPort: 8642",
 		"containerPort: 9119",
 		"fsGroupChangePolicy: OnRootMismatch",
+		"init-hermes-perms",
+		"chown -R 10000:10000 /data",
+		"runAsUser: 0",
 		"init-hermes-data",
 		`Hermes binary missing from image: /opt/hermes/.venv/bin/hermes`,
 		`Hermes image is missing required extras: web,messaging,mcp,pty,cli,acp,google`,
@@ -166,8 +169,6 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		"git clone",
 		"uv pip install",
 		"/data/.hermes/hermes-agent",
-		"init-hermes-perms",
-		"chown -R 10000:10000 /data",
 	} {
 		if strings.Contains(values, banned) {
 			t.Fatalf("generateValues() contains banned fragment %q:\n%s", banned, values)


### PR DESCRIPTION
## Problem
The default Hermes agent repeatedly fails to start on k3d: `init-hermes-data` crashloops with `mkdir: /data/.hermes/home: Permission denied`. This has recurred across several prior takes.

## Root causes (two — the second is unmasked by fixing the first)

1. **PVC ownership.** Hermes runs as non-root UID 10000, but its data PVC is a local-path (`local`) volume, where Kubernetes `fsGroup` ownership management is a documented no-op. #514 ("Use native fsGroup") removed the chown init container (and added a test banning it), so on local-path the volume stays owned by the host uid (1000) and the non-root container can't write it. The only 10000-chown left (`fixHermesDataPVCK3dFallback`) only fires on a separate stuck-init detection that doesn't run during `obol stack up`.

2. **RWO rollout deadlock.** With ownership fixed, Hermes — a singleton on a `ReadWriteOnce` PVC — still couldn't redeploy: the default `RollingUpdate` strategy (maxSurge 25% → 1) creates a second pod that can't mount the in-use RWO volume, so every redeploy/re-sync deadlocks ("1 old replica pending termination") until the old pod is eventually evicted, well past callers' readiness deadlines.

## Fix
1. Re-add a dedicated **root `init-hermes-perms`** init container that runs `chown -R 10000:10000 /data` before `init-hermes-data`. Deterministic and portable across volume types (local-path, hostPath, CSI) and backends — no reliance on fsGroup semantics that no-op on `local` volumes. `fsGroup` is retained for volume types where it does apply.
2. Set **`strategy.type: Recreate`** on the Hermes Deployment so the old pod is fully terminated before the new one starts, freeing the RWO volume.

`internal/hermes/hermes_test.go` now **requires** both (`init-hermes-perms` + `chown -R 10000:10000 /data` + root `runAsUser: 0`, and `type: Recreate`) so an fsGroup-only / RollingUpdate revert fails CI.

## Verification
On a fresh k3d `obol stack up` (`OBOL_DEVELOPMENT=true`):
- Hermes reaches `2/2 Running` with no manual intervention; data dir ends up owned `10000:10000`.
- A forced rollout (the redeploy/re-sync scenario) converges in ~17s (previously hung 900s+).
- `go vet`, `go build ./...`, and `go test ./internal/hermes/...` all pass.