### PR TITLE
fix(rc9): GA blockers + monetize buy-side fixes from the v0.10.0-rc9 report

### DIFF
--- a/cmd/obol/agent_crd.go
+++ b/cmd/obol/agent_crd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/agentcrd"
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
+	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/urfave/cli/v3"
 )
@@ -40,6 +41,43 @@ type createCRDAgentOptions struct {
 	Interactive  bool // when true, prompt for any missing fields with sensible defaults
 }
 
+// validatePinnedModel rejects a non-empty --model that LiteLLM doesn't serve,
+// so `obol agent new --model X` fails at creation time instead of provisioning
+// an agent whose every chat call returns "no healthy deployments for this
+// model". A transient registry-list error is a warning, not a hard failure;
+// an empty model is always allowed (the controller auto-pins the cluster
+// default at first reconcile).
+func validatePinnedModel(cfg *config.Config, u *ui.UI, modelName string) error {
+	if strings.TrimSpace(modelName) == "" {
+		return nil
+	}
+	configured, err := model.GetConfiguredModels(cfg)
+	if err != nil {
+		u.Dim(fmt.Sprintf("Could not verify model %q against LiteLLM (%v); continuing", modelName, err))
+		return nil
+	}
+	if len(configured) > 0 && !isModelConfigured(modelName, configured) {
+		return fmt.Errorf("model %q is not configured in LiteLLM\n  Available: %s\n  Run `obol model list` to see models, or omit --model to let the controller auto-pin the cluster default",
+			modelName, strings.Join(configured, ", "))
+	}
+	return nil
+}
+
+// isModelConfigured reports whether name is an exact entry in the LiteLLM model
+// list. The `paid/*` wildcard is a routing namespace, not a callable model, so
+// it is never accepted as a pin (mirrors pickAgentDefault in sell_agent.go).
+func isModelConfigured(name string, configured []string) bool {
+	if name == "paid/*" {
+		return false
+	}
+	for _, m := range configured {
+		if m == name {
+			return true
+		}
+	}
+	return false
+}
+
 // createCRDAgent does the actual host-seed + kubectl-apply work. Returns
 // when the Agent CR is in place; the controller takes over from there.
 func createCRDAgent(cfg *config.Config, u *ui.UI, opts createCRDAgentOptions) error {
@@ -71,6 +109,13 @@ func createCRDAgent(cfg *config.Config, u *ui.UI, opts createCRDAgentOptions) er
 		// will want one; the operator can decline.
 		ans := strings.TrimSpace(promptOrDefault(u, "Provision a wallet for this agent? [Y/n]", "Y"))
 		createWallet = !strings.EqualFold(ans, "n") && !strings.EqualFold(ans, "no")
+	}
+
+	// Fail fast on a pinned model LiteLLM doesn't serve. Without this the Agent
+	// CR provisions cleanly but every chat call returns "no healthy deployments
+	// for this model", which is hard to trace back to the typo.
+	if err := validatePinnedModel(cfg, u, model); err != nil {
+		return err
 	}
 
 	skills, err := agentcrd.ParseSkills(skillsCSV)

--- a/cmd/obol/agent_test.go
+++ b/cmd/obol/agent_test.go
@@ -398,3 +398,29 @@ func mkdirAgentInstance(t *testing.T, cfg *config.Config, runtime agentruntime.R
 		t.Fatalf("create %s instance %q: %v", runtime, id, err)
 	}
 }
+
+// TestIsModelConfigured covers the membership check behind the `obol agent new
+// --model X` preflight: known models pass, unknown ones are rejected, and the
+// `paid/*` wildcard meta route is never accepted as a pin.
+func TestIsModelConfigured(t *testing.T) {
+	configured := []string{"qwen3.6", "qwen3.5:9b", "paid/*", "paid/aeon"}
+	cases := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"known model", "qwen3.6", true},
+		{"known tagged model", "qwen3.5:9b", true},
+		{"concrete paid model", "paid/aeon", true},
+		{"unknown model", "gpt-9000", false},
+		{"wildcard meta route is not a pin", "paid/*", false},
+		{"empty is not a member", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isModelConfigured(tc.model, configured); got != tc.want {
+				t.Errorf("isModelConfigured(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}

--- a/flows/lib-dual-stack.sh
+++ b/flows/lib-dual-stack.sh
@@ -139,6 +139,18 @@ stack_init_and_up_with_retry() {
             sleep 10
             continue
         fi
+        # Docker Desktop (macOS) intermittently fails to create the gRPC-FUSE
+        # mount source for a k3d node's workspace dir under sustained
+        # cluster-churn, so the k3s node never reports ready and k3d rolls the
+        # cluster back. The host dir exists (reset_flow_workspace mkdir's it);
+        # this is a daemon-side file-sharing race. A fresh cluster on retry
+        # clears it.
+        if [ "$attempt" -lt 3 ] && echo "$out" | grep -qiE "error while creating mount source path|failed to get ready: error waiting for log line|status=restarting|Cluster creation FAILED"; then
+            echo "  $label stack up hit a transient k3d/Docker mount race; retrying (attempt $((attempt + 1))/3)"
+            "$runner" stack down >/dev/null 2>&1 || true
+            sleep 10
+            continue
+        fi
 
         fail "$label: stack up failed (exit $rc)"
         emit_metrics

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -791,6 +791,28 @@ func TestX402VerifierImage_CarriesAgentAuthFix(t *testing.T) {
 	}
 }
 
+// TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix is the tripwire
+// for the per-agent provisioning 403 (GA blocker). The controller ClusterRole
+// in x402.yaml grants no secrets update/patch verb because the reconciler
+// treats Secret as create-only (isCreateOnlyKind). The image MUST therefore be
+// built from source that has that behaviour — the prior f5d94fc side-branch pin
+// did not, so the deployed binary Updated the per-agent Secrets on re-reconcile
+// and 403'd. 503016b (rc9 commit 503016bf, image 0.10.0-rc9) carries the fix.
+// Bumping this pin requires a conscious, documented change here so a future
+// downgrade can't silently re-ship the bug.
+func TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix(t *testing.T) {
+	data, err := ReadInfrastructureFile("base/templates/x402.yaml")
+	if err != nil {
+		t.Fatalf("ReadInfrastructureFile: %v", err)
+	}
+
+	const ref = "ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957"
+	if !strings.Contains(string(data), "image: "+ref) {
+		t.Fatalf("serviceoffer-controller image must carry the Secret-create-only reconciler fix "+
+			"(else per-agent provisioning 403s under the no-update/patch Secret RBAC): %s", ref)
+	}
+}
+
 // TestServiceOfferControllerSecretRBAC_Scoped guards the controller's Secret
 // access against the actual code paths in internal/serviceoffercontroller.
 // The reconciler touches exactly three Secrets by name (litellm-secrets,

--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -230,8 +230,12 @@ func TestEmbeddedImages_X402ControllerAndBuyerUseFixPins(t *testing.T) {
 		ref  string
 	}{
 		{
+			// Repinned off the f5d94fc side-branch build (which predated the
+			// Secret-create-only reconciler change) to the rc9 release image
+			// (commit 503016b, image 0.10.0-rc9).
+			// See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
 			file: "base/templates/x402.yaml",
-			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:f5d94fc@sha256:c6aa6259e3a6bc61a5f4f7203d8c68cfdd861a8d365f9629d234d13b949bf48e",
+			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957",
 		},
 		{
 			file: "base/templates/llm.yaml",

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -343,7 +343,15 @@ spec:
           type: RuntimeDefault
       containers:
         - name: controller
-          image: ghcr.io/obolnetwork/serviceoffer-controller:f5d94fc@sha256:c6aa6259e3a6bc61a5f4f7203d8c68cfdd861a8d365f9629d234d13b949bf48e
+          # MUST be an image whose reconciler treats Secret as create-only
+          # (isCreateOnlyKind includes "Secret"). The ClusterRole above grants
+          # NO secrets update/patch verb, so a controller that Updates the
+          # per-agent hermes-api-server / remote-signer-keystore Secrets on
+          # re-reconcile 403s and per-agent provisioning never converges. The
+          # prior pin (f5d94fc) predated that source change and shipped the
+          # bug; 503016b (rc9 commit 503016bf, image 0.10.0-rc9) carries it.
+          # See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
+          image: ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -499,6 +499,60 @@ def _active_auth_pool(existing_auths, live_status):
     return auths[-remaining:]
 
 
+def _auth_deadline(auth):
+    """Return the unix expiry of a pre-signed auth, or None if none is set.
+
+    Permit2 (OBOL) vouchers carry permit2Authorization.deadline; ERC-3009 (USDC)
+    vouchers carry authorization.validBefore (USDC uses a far-future value). The
+    legacy flat validBefore is a fallback. Mirrors authDeadlineUnix in the Go
+    buyer sidecar (internal/x402/buyer/signer.go)."""
+    auth = auth or {}
+    payload = (auth.get("payment") or {}).get("payload") or {}
+    for value in (
+        (payload.get("permit2Authorization") or {}).get("deadline"),
+        (payload.get("authorization") or {}).get("validBefore"),
+        auth.get("validBefore"),
+    ):
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _count_valid_auths(auths, now=None):
+    """Split an auth pool into (valid, expired) counts by on-chain deadline.
+
+    Auths with no discoverable deadline count as valid (USDC validBefore is
+    ~year 2106). Used to make the displayed "remaining" expiry-aware so an
+    operator/agent does not treat an all-expired pool as ready to spend."""
+    if now is None:
+        now = int(time.time())
+    valid = expired = 0
+    for a in auths or []:
+        deadline = _auth_deadline(a)
+        if deadline is not None and deadline <= now:
+            expired += 1
+        else:
+            valid += 1
+    return valid, expired
+
+
+def _expired_in_active_pool(spec, live_status):
+    """Count expired auths among the currently-active pool, defensively.
+
+    Falls back to the full preSignedAuths list if the live remaining count
+    can't be reconciled with the pool (e.g. sidecar mid-reload)."""
+    try:
+        pool = _active_auth_pool(spec.get("preSignedAuths"), live_status)
+    except ValueError:
+        pool = spec.get("preSignedAuths") or []
+    _, expired = _count_valid_auths(pool)
+    return expired
+
+
 def _build_active_auth_pool(existing_auths, live_status, new_auths):
     return _active_auth_pool(existing_auths, live_status) + list(new_auths or [])
 
@@ -1558,9 +1612,11 @@ def cmd_list():
         alias = live.get("public_model") or status.get("publicModel") or f"paid/{spec.get('model', name)}"
         price = (spec.get("payment") or {}).get("price", "?")
         chain = live.get("network") or (spec.get("payment") or {}).get("network", "?")
+        expired = _expired_in_active_pool(spec, live)
+        remaining_col = f"{remaining} ({expired} expired)" if expired else f"{remaining}"
         print(f"{name:<20} {alias:<32} "
               f"{str(price):<12} {chain:<15} "
-              f"{remaining}")
+              f"{remaining_col}")
 
 
 # ---------------------------------------------------------------------------
@@ -1585,7 +1641,12 @@ def cmd_status(name):
     print(f"Endpoint: {live_status.get('url') or _normalize_endpoint(spec.get('endpoint', '?'))}")
     print(f"Model:    {live_status.get('remote_model') or spec.get('model', '?')}")
     print(f"Chain:    {live_status.get('network') or (spec.get('payment') or {}).get('network', '?')}")
-    print(f"Auths remaining: {live_status.get('remaining', status.get('remaining', 0))}")
+    remaining_display = live_status.get('remaining', status.get('remaining', 0))
+    expired = _expired_in_active_pool(spec, live_status)
+    print(f"Auths remaining: {remaining_display}")
+    if expired:
+        print(f"  WARNING: {expired} of {remaining_display} remaining auth(s) are EXPIRED and unusable; "
+              f"run `buy {name} ...` to top up with fresh authorizations")
     print(f"Auths spent:     {live_status.get('spent', status.get('spent', 0))}")
     print()
 

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -181,6 +181,10 @@ func (g *Gateway) buildHandler(upstreamURL string) (http.Handler, error) {
 	paymentMiddleware := x402pkg.NewForwardAuthMiddleware(x402pkg.ForwardAuthConfig{
 		FacilitatorURL: g.config.FacilitatorURL,
 		VerifyOnly:     g.config.VerifyOnly,
+		// The standalone inference gateway is in-process and settlement-aware,
+		// so a configured VerifyOnly=false is correct by design — suppress the
+		// misleading per-request warning on this path.
+		SettlesInProcess: true,
 	}, []x402types.PaymentRequirements{requirement})
 
 	// Initialise key backend: TEE (Linux) or SE (macOS), mutually exclusive.

--- a/internal/serviceoffercontroller/purchase.go
+++ b/internal/serviceoffercontroller/purchase.go
@@ -95,6 +95,16 @@ func (c *Controller) reconcilePurchase(ctx context.Context, key string) error {
 	return nil
 }
 
+// isSidecarUpstreamGone reports whether a checkBuyerStatus error means the
+// x402-buyer sidecar no longer lists the upstream at all. That is the signal
+// that a delete-drain is complete: there is nothing left for the sidecar to
+// consume. It is deliberately a string match on the error checkBuyerStatus
+// returns (purchase_helpers.go) so both the entry switch and the terminal
+// cleanup check in reconcileDeletingPurchase agree on what "drained" means.
+func isSidecarUpstreamGone(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found in sidecar status")
+}
+
 func (c *Controller) reconcileDeletingPurchase(ctx context.Context, pr *monetizeapi.PurchaseRequest, raw *unstructured.Unstructured) error {
 	buyerNS := pr.EffectiveBuyerNamespace()
 	status := pr.Status
@@ -105,6 +115,17 @@ func (c *Controller) reconcileDeletingPurchase(ctx context.Context, pr *monetize
 	case err == nil:
 		status.Remaining = remaining
 		status.Spent = spent
+	case isSidecarUpstreamGone(err):
+		// The sidecar no longer reports this upstream. That deleted-upstream
+		// signal IS the drain-done signal: collapse Remaining to 0 so cleanup
+		// and finalizer removal proceed below. Without this case, a Configured
+		// purchase with Remaining>0 fell through to the next case, kept
+		// Remaining>0, and requeued every 5s forever — stranding the CR in
+		// Terminating until its finalizer was force-removed by hand. The
+		// terminal not-found check at the end of this function already treats
+		// the same signal as drain-complete; this keeps the entry switch
+		// consistent with it.
+		status.Remaining = 0
 	case purchaseConditionIsTrue(status.Conditions, "Configured") && status.Remaining > 0:
 		log.Printf("purchase %s/%s: delete drain waiting for sidecar status: %v", pr.Namespace, pr.Name, err)
 	default:
@@ -146,7 +167,7 @@ func (c *Controller) reconcileDeletingPurchase(ctx context.Context, pr *monetize
 		}
 		c.purchaseQueue.AddAfter(pr.Namespace+"/"+pr.Name, 5*time.Second)
 		return nil
-	} else if !strings.Contains(err.Error(), "not found in sidecar status") {
+	} else if !isSidecarUpstreamGone(err) {
 		setPurchaseCondition(
 			&status.Conditions,
 			"Deleting",

--- a/internal/serviceoffercontroller/purchase_pure_test.go
+++ b/internal/serviceoffercontroller/purchase_pure_test.go
@@ -1,11 +1,41 @@
 package serviceoffercontroller
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
 )
+
+// --- isSidecarUpstreamGone (delete-drain finalizer hang regression) ----------
+
+// TestIsSidecarUpstreamGone locks in the fix for the delete-drain hang: a
+// PurchaseRequest stuck in Terminating because reconcileDeletingPurchase kept
+// Remaining>0 forever when checkBuyerStatus reported the upstream gone. Only
+// the specific "not found in sidecar status" signal must count as drained;
+// transient errors (e.g. the litellm pod unreachable) must NOT.
+func TestIsSidecarUpstreamGone(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error is not gone", nil, false},
+		{"upstream gone (bare)", errors.New(`upstream "docuseal" not found in sidecar status`), true},
+		{"upstream gone (wrapped)", fmt.Errorf("checkBuyerStatus: %w", errors.New(`upstream "x" not found in sidecar status`)), true},
+		{"transient: no litellm pods is NOT gone", errors.New("no litellm pods in llm"), false},
+		{"transient: connection refused is NOT gone", errors.New("dial tcp 10.0.0.1:8402: connect: connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSidecarUpstreamGone(tc.err); got != tc.want {
+				t.Errorf("isSidecarUpstreamGone(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 // --- purchaseConditionIsTrue ------------------------------------------------
 

--- a/internal/x402/buyer/signer.go
+++ b/internal/x402/buyer/signer.go
@@ -3,12 +3,108 @@ package buyer
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/big"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	x402types "github.com/coinbase/x402/go/types"
 )
+
+// authExpirySafetyMarginSec is how far before its on-chain deadline an auth is
+// considered already expired for selection. The window between picking an auth
+// and the facilitator settling it is a few seconds; dropping auths inside this
+// margin avoids racing a voucher that expires mid-flight (which the facilitator
+// rejects as invalid_payment_expired, surfacing as a 503 to the caller).
+const authExpirySafetyMarginSec int64 = 10
+
+// authDeadlineUnix returns the unix expiry of a pre-signed auth and whether one
+// was found. Permit2 vouchers (OBOL) carry a real "deadline" (~5 min out);
+// ERC-3009 vouchers (USDC) carry "validBefore". The value lives in the v2
+// payment payload; the legacy flat ValidBefore field is a fallback. Auths with
+// no discoverable deadline are treated as non-expiring (ok=false) and never
+// dropped — only an explicitly-past deadline removes an auth from the pool.
+func authDeadlineUnix(a *PreSignedAuth) (int64, bool) {
+	if a == nil {
+		return 0, false
+	}
+	if a.Payment != nil {
+		if d, ok := payloadDeadlineUnix(a.Payment.Payload); ok {
+			return d, true
+		}
+	}
+	return parseUnixValue(a.ValidBefore)
+}
+
+// payloadDeadlineUnix extracts the expiry from a v2 payment payload, covering
+// both the Permit2 (permit2Authorization.deadline) and ERC-3009
+// (authorization.validBefore) shapes.
+func payloadDeadlineUnix(payload map[string]any) (int64, bool) {
+	if payload == nil {
+		return 0, false
+	}
+	if p2, ok := payload["permit2Authorization"].(map[string]any); ok {
+		if d, ok := parseUnixValue(p2["deadline"]); ok {
+			return d, true
+		}
+	}
+	if authz, ok := payload["authorization"].(map[string]any); ok {
+		if d, ok := parseUnixValue(authz["validBefore"]); ok {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+// parseUnixValue coerces a unix-timestamp field that may arrive as a JSON
+// string, float64, json.Number, or integer into an int64.
+func parseUnixValue(v any) (int64, bool) {
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseInt(t, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	case json.Number:
+		n, err := t.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	case float64:
+		return int64(t), true
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	default:
+		return 0, false
+	}
+}
+
+// dropExpiredAuthsLocked removes auths whose deadline is at or inside the safety
+// margin from the head of the pool. Caller must hold s.mu. It returns the number
+// dropped. Auths with no discoverable deadline (e.g. USDC validBefore in 2106)
+// are kept.
+func (s *PreSignedSigner) dropExpiredAuthsLocked(now int64) int {
+	dropped := 0
+	for len(s.auths) > 0 {
+		dl, ok := authDeadlineUnix(s.auths[0])
+		if ok && dl <= now+authExpirySafetyMarginSec {
+			s.auths = s.auths[1:]
+			dropped++
+			continue
+		}
+		break
+	}
+	return dropped
+}
 
 // PreSignedSigner implements Signer using pre-signed ERC-3009
 // TransferWithAuthorization vouchers. It pops one auth from the pool per
@@ -117,6 +213,16 @@ func (s *PreSignedSigner) HoldSign(req *x402types.PaymentRequirements) (*x402typ
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Discard auths that have expired (or expire within the safety margin)
+	// before picking. The pool is FIFO and a pre-signed batch shares roughly
+	// one deadline, so without this an expired batch is served auth-by-auth,
+	// each returning a 503 invalid_payment_expired from the verifier, until the
+	// whole expired batch is burned through. USDC vouchers carry a far-future
+	// validBefore and are never dropped here.
+	if dropped := s.dropExpiredAuthsLocked(time.Now().Unix()); dropped > 0 {
+		log.Printf("x402-buyer: dropped %d expired pre-signed auth(s) before signing (%d remaining)", dropped, len(s.auths))
+	}
 
 	if len(s.auths) == 0 {
 		return nil, nil, fmt.Errorf("pre-signed auth pool exhausted (spent %d): %w",

--- a/internal/x402/buyer/signer_test.go
+++ b/internal/x402/buyer/signer_test.go
@@ -2,8 +2,10 @@ package buyer
 
 import (
 	"encoding/json"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	x402types "github.com/coinbase/x402/go/types"
 )
@@ -340,7 +342,7 @@ func TestPreSignedSigner_SignGenericPayment(t *testing.T) {
 				"from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
 				"spender": "0x402085c248EeA27D92E8b30b2C58ed07f9E20001",
 				"nonce": "42",
-				"deadline": "99",
+				"deadline": "99999999999",
 				"permitted": {
 					"token": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
 					"amount": "1000"
@@ -397,5 +399,107 @@ func makeAuth(sig string) *PreSignedAuth {
 		ValidAfter:  "0",
 		ValidBefore: "4294967295",
 		Nonce:       "0xdeadbeef" + sig,
+	}
+}
+
+// makePermit2Auth builds a Permit2 (OBOL) pre-signed auth with the given
+// on-chain deadline (unix seconds) carried in the v2 payment payload — the
+// shape buy.py emits for the OBOL path.
+func makePermit2Auth(id string, deadline int64) *PreSignedAuth {
+	payment := &x402types.PaymentPayload{
+		X402Version: 2,
+		Accepted: x402types.PaymentRequirements{
+			Scheme:  "exact",
+			Network: "eip155:84532",
+			Amount:  "1000",
+			PayTo:   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+			Asset:   "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		},
+		Payload: map[string]any{
+			"signature": "0x" + id,
+			"permit2Authorization": map[string]any{
+				"from":     "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+				"nonce":    id,
+				"deadline": strconv.FormatInt(deadline, 10),
+			},
+		},
+	}
+	return &PreSignedAuth{ID: id, Payment: payment}
+}
+
+// TestAuthDeadlineUnix covers expiry extraction across the Permit2, nested
+// ERC-3009, and legacy-flat shapes — the load-bearing helper behind the
+// expired-auth filter.
+func TestAuthDeadlineUnix(t *testing.T) {
+	if d, ok := authDeadlineUnix(makePermit2Auth("1", 1234567890)); !ok || d != 1234567890 {
+		t.Errorf("permit2 deadline: got (%d,%v), want (1234567890,true)", d, ok)
+	}
+	// Legacy flat ERC-3009 validBefore (USDC path) — far future, parsed.
+	if d, ok := authDeadlineUnix(makeAuth("a")); !ok || d != 4294967295 {
+		t.Errorf("flat validBefore: got (%d,%v), want (4294967295,true)", d, ok)
+	}
+	// Nested ERC-3009 authorization.validBefore.
+	nested := &PreSignedAuth{Payment: &x402types.PaymentPayload{Payload: map[string]any{
+		"authorization": map[string]any{"validBefore": "1700000000"},
+	}}}
+	if d, ok := authDeadlineUnix(nested); !ok || d != 1700000000 {
+		t.Errorf("nested validBefore: got (%d,%v), want (1700000000,true)", d, ok)
+	}
+	// No deadline anywhere -> not found (never dropped).
+	if _, ok := authDeadlineUnix(&PreSignedAuth{Payment: &x402types.PaymentPayload{Payload: map[string]any{}}}); ok {
+		t.Error("auth with no deadline must report ok=false")
+	}
+	if _, ok := authDeadlineUnix(nil); ok {
+		t.Error("nil auth must report ok=false")
+	}
+}
+
+// TestPreSignedSigner_DropsExpiredAuths is the regression for the 503
+// invalid_payment_expired cascade: HoldSign must skip expired Permit2 vouchers
+// at the head of the FIFO pool instead of serving them.
+func TestPreSignedSigner_DropsExpiredAuths(t *testing.T) {
+	now := time.Now().Unix()
+	expiredA := makePermit2Auth("expA", now-60)
+	expiredB := makePermit2Auth("expB", now-5) // inside the safety margin
+	fresh := makePermit2Auth("fresh", now+3600)
+
+	signer := NewPreSignedSigner(
+		"base-sepolia",
+		"0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+		"0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		"1000", "OBOL", 18,
+		[]*PreSignedAuth{expiredA, expiredB, fresh},
+		0, nil,
+	)
+
+	req := &x402types.PaymentRequirements{
+		Network: "eip155:84532",
+		PayTo:   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+		Asset:   "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		Amount:  "1000",
+	}
+
+	_, held, err := signer.HoldSign(req)
+	if err != nil {
+		t.Fatalf("HoldSign: %v", err)
+	}
+	if held.ID != "fresh" {
+		t.Fatalf("expected the fresh auth to be served, got %q (expired auths were not skipped)", held.ID)
+	}
+	if r := signer.Remaining(); r != 0 {
+		t.Fatalf("expected pool drained to 0 after serving the only fresh auth, got %d", r)
+	}
+
+	// A pool of only-expired auths must exhaust, not serve an expired voucher.
+	expiredOnly := NewPreSignedSigner(
+		"base-sepolia",
+		"0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+		"0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		"1000", "OBOL", 18,
+		[]*PreSignedAuth{makePermit2Auth("x", now-100), makePermit2Auth("y", now-100)},
+		0, nil,
+	)
+	if _, _, err := expiredOnly.HoldSign(req); err == nil {
+		t.Fatal("expected exhausted-pool error when all auths are expired, got nil")
 	}
 }

--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -47,6 +47,15 @@ type ForwardAuthConfig struct {
 	// "ways to pay" prompts) while x402-aware clients keep getting JSON.
 	// Nil keeps today's behaviour: every 402 is JSON.
 	SendPaymentRequired SendPaymentRequiredFunc
+
+	// SettlesInProcess marks the in-process seller-gateway path (HandleProxy /
+	// obol sell inference) where VerifyOnly=false is correct BY DESIGN — the
+	// middleware proxies to the real upstream and settles only after a <400
+	// response, so the verifyOnly=false warning would be misleading noise on
+	// every paid request. When true, that warning is suppressed. It does NOT
+	// change settlement behaviour; the genuinely-dangerous Traefik ForwardAuth
+	// path leaves this false and still warns if an operator flips VerifyOnly.
+	SettlesInProcess bool
 }
 
 // facilitatorVerifyRequest is the JSON body sent to POST /verify and /settle.
@@ -97,7 +106,7 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 	verifyClient := &http.Client{Timeout: facilitatorVerifyTimeout}
 	settleClient := &http.Client{Timeout: facilitatorSettleTimeout}
 
-	if !cfg.VerifyOnly {
+	if !cfg.VerifyOnly && !cfg.SettlesInProcess {
 		log.Printf("x402: WARNING verifyOnly=false — settlement will run after upstream success. " +
 			"This is ONLY safe for in-process middleware (e.g. obol sell inference) that sees " +
 			"the real upstream status. Behind Traefik ForwardAuth this debits the payer before " +

--- a/internal/x402/forwardauth_test.go
+++ b/internal/x402/forwardauth_test.go
@@ -497,3 +497,36 @@ func TestForwardAuth_VerifyOnlyTrue_NoStartupWarning(t *testing.T) {
 		t.Fatalf("did not expect verifyOnly warning when VerifyOnly=true, got:\n%s", gotLog)
 	}
 }
+
+// TestForwardAuth_SettlesInProcess_SuppressesWarning pins the fix for the
+// per-request log spam on the in-process seller gateway (HandleProxy / obol
+// sell inference): that path sets VerifyOnly=false BY DESIGN (it proxies to the
+// real upstream and settles after a <400 response), so the verifyOnly=false
+// warning is misleading there. SettlesInProcess=true must silence it while
+// leaving the dangerous Traefik ForwardAuth path (SettlesInProcess=false) loud.
+func TestForwardAuth_SettlesInProcess_SuppressesWarning(t *testing.T) {
+	var buf bytes.Buffer
+
+	origFlags := log.Flags()
+	origOutput := log.Writer()
+
+	log.SetFlags(0)
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetFlags(origFlags)
+		log.SetOutput(origOutput)
+	})
+
+	_ = NewForwardAuthMiddleware(ForwardAuthConfig{
+		FacilitatorURL:   "http://example.invalid",
+		VerifyOnly:       false,
+		SettlesInProcess: true,
+	}, []x402types.PaymentRequirements{{
+		Scheme:  "exact",
+		Network: "eip155:84532",
+	}})
+
+	if gotLog := buf.String(); strings.Contains(gotLog, "verifyOnly=false") {
+		t.Fatalf("SettlesInProcess=true must suppress the verifyOnly=false warning, got:\n%s", gotLog)
+	}
+}

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -239,8 +239,13 @@ func (v *Verifier) HandleProxy(w http.ResponseWriter, r *http.Request) {
 	display := buildPaymentDisplay(rule, chain, asset, wallet, requirement.Amount)
 
 	middleware := NewForwardAuthMiddleware(ForwardAuthConfig{
-		FacilitatorURL:      cfg.FacilitatorURL,
+		FacilitatorURL: cfg.FacilitatorURL,
+		// HandleProxy is the in-process seller gateway: it proxies to the real
+		// upstream and settles only after a <400 response, so verifyOnly=false
+		// is correct here. SettlesInProcess suppresses the (otherwise
+		// per-request) verifyOnly=false warning on this safe path.
 		VerifyOnly:          false,
+		SettlesInProcess:    true,
 		Extensions:          extensions,
 		SendPaymentRequired: NewHTMLAwarePaymentRequired(display),
 	}, []x402types.PaymentRequirements{requirement})


### PR DESCRIPTION
## Summary

What changed: Fixes the v0.10.0-rc9 upgrade-report issues. Each was validated against rc9
source (adversarially re-checked) before fixing.

- **#1 (GA blocker)** — repin `serviceoffer-controller` from the `f5d94fc` side-branch build
  (which predated the Secret-create-only reconciler change) to `503016b@sha256:bec62ea0`
  (rc9 commit `503016bf`, image `0.10.0-rc9`). The old pin `Update`s per-agent Secrets, which
  the tightened RBAC (no `secrets:update/patch`) 403s → per-agent provisioning never converges.
  Added a tripwire test.
- **#3** — `x402-buyer` `HoldSign` now drops expired pre-signed auths before signing
  (Permit2 deadline / ERC-3009 validBefore), ending the `503 invalid_payment_expired` cascade.
- **#4** — `buy.py status/list` count is expiry-aware (valid vs expired auths).
- **#5** — `reconcileDeletingPurchase` finalizes the delete-drain on the `not found in sidecar
  status` signal instead of requeueing forever (stranded `Terminating`).
- **P1** — suppress the per-request `verifyOnly=false` warning on the in-process settle path
  (`HandleProxy` / `obol sell inference`); the Traefik ForwardAuth path still warns.
- **P2** — `obol agent new --model X` validates X against the LiteLLM registry; fails fast.

Issue **#2** (master-Hermes PVC ownership on k3d local-path) is already fixed on `main`
(`eb985bd`/`671c8ac` root-chown init container); this branch inherits it. Per-agent Hermes was
confirmed *not* a residual (it seeds via Secret, not host PVC writes).

Why it matters: #1 and #2 are GA blockers from the rc9 report; the rest are buy-side
correctness / UX fixes on the monetize path.

Risk level: low — the controller fix is a pin bump to an already-published rc9 image; the rest
are narrow, regression-tested behaviour changes. No RBAC widened, no security surface added.

Commit under test: `8cfd0ca1` (live-chain evidence captured at `b90118fd`; `8cfd0ca1`
adds only the dual-stack flows retry, no runtime behaviour change)

Base branch: `main`

## Scope

- [x] Code
- [x] Charts / manifests
- [x] Flows / QA scripts
- [x] Docs / skills
- [x] Images / dependencies
- [ ] Other:

## Validation

CI checks:

| Check | Status | Link |
|-------|--------|------|
| (added on push) | pending | |

Unit tests:

```text
go test ./...            → ok (33 packages), gofmt + go vet clean
new regression tests (all PASS, #3/P1 fail without the fix):
  internal/x402/buyer        TestPreSignedSigner_DropsExpiredAuths, TestAuthDeadlineUnix (#3)
  internal/serviceoffercontroller  TestIsSidecarUpstreamGone (#5)
  internal/x402              TestForwardAuth_SettlesInProcess_SuppressesWarning (P1)
  cmd/obol                   TestIsModelConfigured (P2)
  internal/embed             TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix (#1)
                             + dev-rewrite/production-pin guards updated for the new pin
commit: b90118fd
```

Integration tests:

```text
n/a — covered by the release smoke below.
```

Flow tests (best result per flow across 3 full smoke runs on local darwin/arm64, k3d):

| Flow | Network | Result | Evidence |
|------|---------|--------|----------|
| flow-01..10 (single stack incl. buy+lifecycle) | base-sepolia (anvil) | PASS | run5 + run6 |
| flow-11 dual-stack (USDC) | base-sepolia (anvil) | PASS | run6 |
| flow-13 dual-stack-obol (anvil fork) | base-sepolia (anvil fork) | PASS | run5 |
| flow-14 live-obol | base-sepolia (LIVE) | PASS | run5 + run6 — on-chain receipts below |

Release smoke:

```text
RELEASE_SMOKE_INCLUDE_OBOL=true RELEASE_SMOKE_INCLUDE_OBOL_FORK=true \
  OBOL_LLM_ENDPOINT=http://<spark>:8000/v1 OBOL_LLM_MODEL=qwen36-deep \
  bash flows/release-smoke.sh
LLM routed through vLLM qwen36-deep (DGX Spark over tailscale).

Every flow passed; no single run reached 13/13 because this macOS/Docker-Desktop +
cloudflare-quick-tunnel box hit a DIFFERENT environment-side transient each pass
(none code-related):
  run5: 12/13 — flow-11 Docker Desktop gRPC-FUSE mount race on Alice cluster create
  run6: 12/13 — flow-13 same mount race on Bob cluster create
  run7:        — flow-07/08 cloudflare quick-tunnel failed to establish (local 402 gate PASS)
The mount race now has a retry (commit 8cfd0ca1). The tunnel flake is external (trycloudflare).

#1 pin bump validated separately on a live cluster: deploying 503016b@sha256:bec62ea0 made a
per-agent `obol agent new` reach Ready with no 403; the prior f5d94fc image reproduces the 403.
Dev-mode rebuilds controller/buyer/verifier from this branch's source, so the smoke exercises
the source fixes directly.
```

## Live Chain Evidence

Network: Base Sepolia (eip155:84532)

RPC/provider: paid drpc load-balancer (redacted)

Facilitator: https://x402.gcp.obol.tech (prometheus-overlay)

Contracts and tokens:

| Name | Address | Version / notes |
|------|---------|-----------------|
| OBOL token | 0x0a09371a8b011d5110656ceBCc70603e53FD2c78 | Obol Network / OBOL / 18 dp, Permit2 |
| ERC-8004 Identity Registry | 0x8004a818bfb912233c491871b3d84c89a494bd9e | mint = agentId |

Wallet roles:

| Role | Address | Source |
|------|---------|--------|
| Alice / seller / register | 0xC0De030F6C37f490594F93fB99e2756703c4297E | seller payTo + funded EOA |
| Bob / buyer / payer | 0x57b0eF875DeB5A37301F1640E469a2129Da9490E | deterministic 2nd-derived from REMOTE_SIGNER_PRIVATE_KEY; bobSigner == BOB_WALLET ✓ |

Balances:

| Token | Address | Before | After | Expected delta | Actual delta |
|-------|---------|--------|-------|----------------|--------------|
| OBOL (Bob) | 0x0a09371a… | 4949000000000000000 wei | 4948000000000000000 wei | -1000000000000000 (0.001 OBOL) | -1000000000000000 ✓ exact |
| OBOL (Alice) | 0x0a09371a… | — | — | +1000000000000000 (0.001 OBOL) | +1000000000000000 ✓ exact |

Transaction receipts:

| Purpose | Tx hash | From | To | Amount / event | Status |
|---------|---------|------|----|----------------|--------|
| ERC-8004 registration | 0xff4cdbbdeea75e578728f097eb35ba230c42cc2410eb67fb2ce910782d2c2863 | Alice | Identity Registry 0x8004a818… | mint agentId 6724 | 0x1 |
| Metadata / service offer | 0x19055e9680e6f6072e0783310364e80c72f89c9836e4700ad78f841894a010c4 | Alice | Identity Registry | setMetadata | 0x1 |
| Settlement transfer | 0x81f86c63992089802beba5fad18525f5bcd2509bcdc95913958c310df400f455 | Bob 0x57b0eF… | Alice 0xC0De03… | OBOL 0.001 (Permit2) | 0x1 |

## Runtime Evidence

QA environment:

| Item | Value |
|------|-------|
| OS / arch | macOS (darwin) / arm64 |
| Backend | k3d (rancher/k3s v1.35.1-k3s1) |
| Tool versions | kubectl 1.35.3, helm 3.20.1, helmfile 1.4.3, k3d 5.8.3 |
| QA agent/model | Hermes via LiteLLM → vLLM qwen36-deep (27B-class) |

Images:

| Component | Image | Tag / digest | Source |
|-----------|-------|--------------|--------|
| serviceoffer-controller (release pin) | ghcr.io/obolnetwork/serviceoffer-controller | 503016b@sha256:bec62ea0…121957 | rc9 (this PR's repin) |
| serviceoffer-controller/buyer/verifier (smoke) | ghcr.io/obolnetwork/… | :latest | built from this branch (dev mode) |

Kubernetes / stack:

| Item | Value |
|------|-------|
| Stack IDs | per-run default + alice/bob (petnames) |
| Namespaces | hermes-obol-agent, llm, x402, erpc, traefik, agent-* |
| Pod readiness | all core pods Running (per flow checks) |
| Cleanup result | stacks torn down by release-smoke cleanup trap |

Model and routing:

| Item | Value |
|------|-------|
| Agent/model used | qwen36-deep (vLLM, enable_thinking=false) |
| LiteLLM route | custom endpoint → host-reachable vLLM; paid/* → x402-buyer sidecar |
| Paid endpoint status | paid/qwen3.5:9b Ready (5 auths loaded) |
| Auth token source | obol agent auth (LiteLLM master key for upstream) |

Artifacts and logs:

| Artifact | Location / link | Notes |
|----------|-----------------|-------|
| Release report | .tmp/release-smoke-20260603-130613/RELEASE_REPORT.md | run6 per-flow table |
| flow-14 receipts | .tmp/release-smoke-20260603-130613/flow-14-receipts | run6 registration + settlement JSON |

Demo readiness:

| Item | Status | Notes |
|------|--------|-------|
| Seller visible / registered | ✓ | ERC-8004 agentId on Base Sepolia |
| Buyer discovery works | ✓ | 402 → probe → pre-sign → PurchaseRequest |
| Paid route works | ✓ | paid/* → 200 |
| Settlement visible on-chain | ✓ | OBOL Transfer, status 0x1 |

## Review Notes

Known gaps:
- The #3 (buyer) and #5 (controller) source fixes reach **release** installs only once the
  buyer/controller images are rebuilt at this branch's commit and their pins bumped (the normal
  release-image step). They take effect immediately in dev mode (validated by the smoke). The #1
  repin already points at a published rc9 image, so it fixes release installs as-is.
- During QA, a shared-Docker-daemon hazard surfaced (pitfall #4): a concurrent marketplace-branch
  build poisoned `serviceoffer-controller:latest`; forcing/rebuilding from this branch resolves it.

Follow-ups:
- Rebuild + repin x402-buyer / serviceoffer-controller images at the post-merge commit to ship
  #3/#5 to release installs.

Reviewer focus:
- `internal/embed/infrastructure/base/templates/x402.yaml` controller pin + `embed_crd_test.go`
  tripwire (no RBAC widened).
- `internal/x402/buyer/signer.go` expiry filter (USDC validBefore=2106 never dropped).
- `internal/serviceoffercontroller/purchase.go` not-found drain case (transient errors still requeue).
