### PR TITLE
chore(frontend): bump obol-stack-front-end image to v0.1.26

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.26-rc3 (linux/amd64 + linux/arm64).
-  tag: "v0.1.26-rc3@sha256:fcbc0cfc7d0d700f65a0a7b65cf6bf259fffcc7f4e8b182460a0d32459e23f5d"
+  # review. Multi-arch index digest for v0.1.26 (linux/amd64 + linux/arm64).
+  tag: "v0.1.26@sha256:7a6109e43e3fd7461818f172b4c78fc0fb5a124a7c266cf68bd5bc08fff10858"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary
Bump the bundled `obol-stack-front-end` image from **v0.1.26-rc3** to the non-RC **v0.1.26** release.

- Updates `internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl`.
- Digest-pinned to the multi-arch index (`linux/amd64` + `linux/arm64`) published by the `v0.1.26` tag:
  `v0.1.26@sha256:7a6109e43e3fd7461818f172b4c78fc0fb5a124a7c266cf68bd5bc08fff10858`

## Context
The v0.1.26 front-end release ([ObolNetwork/obol-stack-front-end#396](https://github.com/ObolNetwork/obol-stack-front-end/pull/396), tag `v0.1.26`) promotes rc3 to non-RC. It also:
- hides the **Agents** top-nav entry for now, and
- moves the WalletConnect build-arg resolution out of this repo's `justfile` (see #579) and into the front-end repo as `scripts/build-frontend-image.sh`.

## Verification
- Digest confirmed against Docker Hub `docker.io/obolnetwork/obol-stack-front-end:v0.1.26` — OCI image index with `linux/amd64` + `linux/arm64` manifests.