### PR TITLE
fix(hermes): clear stale rollingUpdate so obol model sync reaches the agent

### DIFF
--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -131,6 +131,10 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 }
 
 func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
+	// Only auto-promote models the user named explicitly. Auto-detecting every
+	// pulled model (the len==0 branch below) must not reshuffle the model_list.
+	explicit := setupPromoteList(models)
+
 	if len(models) == 0 {
 		// Diagnostic: check Ollama connectivity
 		u.Info("Checking Ollama connectivity...")
@@ -177,7 +181,7 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 
 	u.Successf("Ollama configured. To change later, run: obol model setup (or obol model remove <name>)")
 
-	return syncAgentModels(cfg, u)
+	return promoteAndSync(cfg, u, explicit)
 }
 
 func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, models []string) error {
@@ -237,13 +241,48 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 	u.Print("")
 	u.Successf("Model configured. To change later, run: obol model setup (or obol model remove <name>)")
 
-	return syncAgentModels(cfg, u)
+	return promoteAndSync(cfg, u, models)
 }
 
 // syncAgentModels re-renders the stack-managed Hermes default agent from the
 // current LiteLLM model inventory.
 func syncAgentModels(cfg *config.Config, u *ui.UI) error {
 	return hermes.SyncDefaultModels(cfg, u)
+}
+
+// setupPromoteList decides which models a provider setup should promote to
+// primary. Explicitly named models are promoted (so `obol model setup` makes
+// the just-configured model the agent's primary). When a setup auto-discovers
+// its full inventory instead (Ollama with no --model), the slice is empty and
+// nothing is promoted — auto-detection must never silently reshuffle the
+// operator's model_list (the spark2 footgun). Returns a fresh slice so the
+// caller can mutate its own copy without aliasing this one.
+func setupPromoteList(userSpecified []string) []string {
+	return append([]string(nil), userSpecified...)
+}
+
+// promoteAndSync moves the just-configured model(s) to the head of the LiteLLM
+// model_list so the first becomes the agent's primary, then syncs the agent.
+// `obol model setup` configures providers by appending to the model_list, so a
+// newly added model would otherwise sit at the tail and never become primary —
+// users had to run `obol model prefer` manually for setup to "take". Promoting
+// by default makes a freshly configured model take effect immediately; users
+// reorder afterward with `obol model prefer`.
+//
+// Promotion is best-effort: the provider is already configured, so a promote
+// failure (e.g. an unexpected name mismatch) warns and still syncs rather than
+// failing the whole setup. An empty list (e.g. Ollama auto-detect of every
+// pulled model) skips promotion and just syncs.
+func promoteAndSync(cfg *config.Config, u *ui.UI, models []string) error {
+	if len(models) > 0 {
+		if err := model.PreferModels(cfg, u, models); err != nil {
+			u.Warnf("Configured, but could not promote %s to primary: %v", strings.Join(models, ", "), err)
+			u.Dim("  Set the primary yourself with: obol model prefer " + models[0])
+		} else {
+			u.Successf("Primary model is now %s (reorder anytime with: obol model prefer <model>)", models[0])
+		}
+	}
+	return syncAgentModels(cfg, u)
 }
 
 func modelSyncCommand(cfg *config.Config) *cli.Command {
@@ -286,7 +325,7 @@ func modelSetupCustomCommand(cfg *config.Config) *cli.Command {
 			if cmd.Bool("no-sync") {
 				return nil
 			}
-			return syncAgentModels(cfg, u)
+			return promoteAndSync(cfg, u, []string{modelName})
 		},
 	}
 }

--- a/cmd/obol/model_test.go
+++ b/cmd/obol/model_test.go
@@ -36,3 +36,36 @@ func TestModelCommand_Structure(t *testing.T) {
 		}
 	}
 }
+
+// TestSetupPromoteList pins the contract that `obol model setup` auto-promotes
+// explicitly named models to primary but never the auto-detected full Ollama
+// inventory. Promoting on auto-detect would silently reshuffle the operator's
+// model_list (the spark2 footgun); promoting on an explicit --model is what
+// makes a freshly configured provider take effect without a manual prefer.
+func TestSetupPromoteList(t *testing.T) {
+	t.Run("auto-detect (no explicit models) promotes nothing", func(t *testing.T) {
+		if got := setupPromoteList(nil); len(got) != 0 {
+			t.Fatalf("setupPromoteList(nil) = %v, want empty (auto-detect must not reshuffle)", got)
+		}
+		if got := setupPromoteList([]string{}); len(got) != 0 {
+			t.Fatalf("setupPromoteList([]) = %v, want empty", got)
+		}
+	})
+
+	t.Run("explicit models are promoted in order", func(t *testing.T) {
+		in := []string{"claude-sonnet-4-6"}
+		got := setupPromoteList(in)
+		if len(got) != 1 || got[0] != "claude-sonnet-4-6" {
+			t.Fatalf("setupPromoteList(%v) = %v, want [claude-sonnet-4-6]", in, got)
+		}
+	})
+
+	t.Run("returns a fresh slice, not an alias of the input", func(t *testing.T) {
+		in := []string{"a", "b"}
+		got := setupPromoteList(in)
+		got[0] = "mutated"
+		if in[0] != "a" {
+			t.Fatalf("setupPromoteList aliased its input: mutating the result changed in[0] to %q", in[0])
+		}
+	})
+}

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -229,6 +229,13 @@ func Sync(cfg *config.Config, id string, u *ui.UI) error {
 		return err
 	}
 
+	// Clear any stale strategy.rollingUpdate before helm runs. A hermes
+	// deployment first created with the default RollingUpdate strategy keeps a
+	// k8s-defaulted rollingUpdate that helm won't remove when the manifest flips
+	// type to Recreate, so the upgrade is rejected and every obol model
+	// setup/prefer/sync silently fails to reach the running agent.
+	migrateDeploymentStrategy(cfg, agentruntime.Namespace(agentruntime.Hermes, id), u)
+
 	helmfileBinary := filepath.Join(cfg.BinDir, "helmfile")
 	syncArgs := append([]string{"-f", helmfilePath, "sync"}, helmcmd.SyncFlagsForVersion(filepath.Join(cfg.BinDir, "helm"))...)
 	cmd := exec.Command(helmfileBinary, syncArgs...)
@@ -472,6 +479,49 @@ func RegenerateToken(cfg *config.Config, id string, u *ui.UI) (string, error) {
 
 	u.Success("Token regenerated successfully")
 	return newToken, nil
+}
+
+// migrateDeploymentStrategy imperatively clears a stale
+// spec.strategy.rollingUpdate on an existing hermes deployment so a subsequent
+// helm upgrade to strategy.type=Recreate is accepted by the API server.
+//
+// A deployment that predates the Recreate template was created with the default
+// RollingUpdate strategy, which the API auto-populates with a rollingUpdate
+// block. Helm's three-way merge only patches strategy.type, leaving the stale
+// rollingUpdate in place, and the API then rejects the update ("rollingUpdate
+// may not be specified when strategy type is Recreate"). Emitting
+// rollingUpdate: null in the manifest does not survive bedag/raw + helm's null
+// handling, so a merge patch with an explicit null is the reliable fix.
+//
+// Best-effort: a missing deployment (fresh install) or already-Recreate
+// strategy makes this a harmless no-op, so failures are warned, not fatal.
+func migrateDeploymentStrategy(cfg *config.Config, namespace string, u *ui.UI) {
+	kubectlBinary := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	cmd := exec.Command(kubectlBinary, strategyMigrationPatchArgs(namespace)...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// NotFound (fresh install) is expected and benign; helm creates the
+		// deployment fresh with the Recreate strategy. Only surface other
+		// failures as a warning so sync can still proceed.
+		if !strings.Contains(string(out), "NotFound") && !strings.Contains(string(out), "not found") {
+			u.Warnf("Could not pre-clear hermes deployment strategy (continuing): %v\n%s", err, string(out))
+		}
+	}
+}
+
+// strategyMigrationPatchArgs builds the kubectl args that clear a stale
+// strategy.rollingUpdate while pinning strategy.type=Recreate on the hermes
+// deployment. The explicit null in a strategic merge patch is what removes the
+// field that blocks the RollingUpdate -> Recreate migration.
+func strategyMigrationPatchArgs(namespace string) []string {
+	return []string{
+		"patch", "deployment/hermes",
+		"-n", namespace,
+		"--type=merge",
+		"-p", `{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`,
+	}
 }
 
 func SyncDefaultModels(cfg *config.Config, u *ui.UI) error {
@@ -763,6 +813,15 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
         # volume, deadlocking every redeploy/re-sync. Recreate terminates the
         # old pod before starting the new one so the volume is free.
         type: Recreate
+        # NOTE: a deployment first created with the default RollingUpdate
+        # strategy carries a k8s-populated strategy.rollingUpdate that helm's
+        # upgrade does NOT clear when only type flips to Recreate, so the API
+        # rejects the update (rollingUpdate may not be specified when strategy
+        # type is Recreate) and obol model setup/prefer/sync then silently fail
+        # to apply the new model to the running agent. Emitting rollingUpdate:
+        # null here does not survive bedag/raw + helm's null handling, so the
+        # stale field is cleared imperatively in migrateDeploymentStrategy
+        # before each helmfile sync.
       selector:
         matchLabels:
           app.kubernetes.io/name: %s

--- a/internal/hermes/strategy_migration_test.go
+++ b/internal/hermes/strategy_migration_test.go
@@ -1,0 +1,129 @@
+package hermes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestStrategyMigrationPatchArgs guards the imperative pre-helm fix for the
+// RollingUpdate -> Recreate migration. A hermes deployment first created with
+// the default strategy keeps a k8s-populated strategy.rollingUpdate that helm
+// won't clear when the manifest only flips type to Recreate, so the API rejects
+// the update and obol model setup/prefer/sync silently fail to reach the agent.
+// The patch must be a strategic merge that pins type=Recreate AND carries an
+// explicit rollingUpdate:null — the null is what removes the offending field.
+func TestStrategyMigrationPatchArgs(t *testing.T) {
+	args := strategyMigrationPatchArgs("hermes-obol-agent")
+
+	// Sanity: targets the hermes deployment in the requested namespace via a
+	// merge patch.
+	want := map[string]bool{
+		"patch":             false,
+		"deployment/hermes": false,
+		"hermes-obol-agent": false,
+		"--type=merge":      false,
+	}
+	var patchJSON string
+	for i, a := range args {
+		if _, ok := want[a]; ok {
+			want[a] = true
+		}
+		if a == "-p" && i+1 < len(args) {
+			patchJSON = args[i+1]
+		}
+	}
+	for arg, seen := range want {
+		if !seen {
+			t.Errorf("strategyMigrationPatchArgs missing expected arg %q in %v", arg, args)
+		}
+	}
+	if patchJSON == "" {
+		t.Fatalf("strategyMigrationPatchArgs produced no -p patch body: %v", args)
+	}
+
+	var patch map[string]any
+	if err := json.Unmarshal([]byte(patchJSON), &patch); err != nil {
+		t.Fatalf("patch body is not valid JSON: %v\n%s", err, patchJSON)
+	}
+	strategy, ok := patch["spec"].(map[string]any)["strategy"].(map[string]any)
+	if !ok {
+		t.Fatalf("patch missing spec.strategy: %s", patchJSON)
+	}
+	if strategy["type"] != "Recreate" {
+		t.Errorf("patch strategy.type = %v, want Recreate", strategy["type"])
+	}
+	// The rollingUpdate KEY must be present with a null value. A strategic
+	// merge patch removes a field only when it is explicitly null; omitting the
+	// key leaves the stale live rollingUpdate in place and the migration fails.
+	ru, present := strategy["rollingUpdate"]
+	if !present {
+		t.Errorf("patch strategy is missing the rollingUpdate key; without an explicit null the stale field is not cleared: %s", patchJSON)
+	}
+	if ru != nil {
+		t.Errorf("patch strategy.rollingUpdate = %v, want explicit null", ru)
+	}
+}
+
+// TestStrategyMigrationPatchArgs_ThreadsNamespace ensures the namespace flag is
+// passed through, so non-default hermes instances are migrated in their own
+// namespace rather than a hardcoded one.
+func TestStrategyMigrationPatchArgs_ThreadsNamespace(t *testing.T) {
+	args := strategyMigrationPatchArgs("hermes-custom")
+	var nsValue string
+	for i, a := range args {
+		if a == "-n" && i+1 < len(args) {
+			nsValue = args[i+1]
+		}
+	}
+	if nsValue != "hermes-custom" {
+		t.Errorf("namespace arg = %q, want hermes-custom; args=%v", nsValue, args)
+	}
+}
+
+// TestGenerateValues_StrategyIsRecreateWithoutRollingUpdate verifies the
+// rendered deployment pins Recreate and never emits a rollingUpdate block, so
+// a fresh install starts clean and the imperative migration is only needed for
+// pre-existing RollingUpdate deployments.
+func TestGenerateValues_StrategyIsRecreateWithoutRollingUpdate(t *testing.T) {
+	values := generateValues(
+		"hermes-obol-agent",
+		"hermes-obol-agent.obol.stack",
+		"obol-agent.obol.stack",
+		"https://agent.example.com",
+		"secret-token",
+		"gpt-5.2",
+		[]byte("model:\n  default: gpt-5.2\n"),
+	)
+
+	// The values file is a bedag/raw chart: resources live under .resources.
+	var doc struct {
+		Resources []map[string]any `yaml:"resources"`
+	}
+	if err := yaml.Unmarshal([]byte(values), &doc); err != nil {
+		t.Fatalf("generateValues produced invalid YAML: %v", err)
+	}
+
+	var found bool
+	for _, res := range doc.Resources {
+		if res["kind"] != "Deployment" {
+			continue
+		}
+		found = true
+		spec, _ := res["spec"].(map[string]any)
+		strategy, ok := spec["strategy"].(map[string]any)
+		if !ok {
+			t.Fatalf("Deployment has no spec.strategy: %#v", spec)
+		}
+		if strategy["type"] != "Recreate" {
+			t.Errorf("Deployment strategy.type = %v, want Recreate", strategy["type"])
+		}
+		if _, has := strategy["rollingUpdate"]; has {
+			t.Errorf("rendered Deployment emits a rollingUpdate block (%v); it must be absent for a Recreate strategy", strategy["rollingUpdate"])
+		}
+	}
+	if !found {
+		t.Fatal("generateValues produced no Deployment resource")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the cluster of "`obol model` weird behaviour" reports. Two changes:

### 1. fix(hermes): clear stale rollingUpdate so model sync reaches the agent (ae081f11)

A hermes deployment first created with the default `RollingUpdate` strategy carries a k8s-populated `spec.strategy.rollingUpdate`. The Recreate template (required for the RWO PVC singleton) only flips `strategy.type`, and helm's three-way merge leaves the stale `rollingUpdate` in place, so the API rejects the upgrade:

```
Deployment.apps "hermes" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'
```

Every model command reorders `litellm-config` and rewrites the hermes runtime config correctly, but the `helmfile sync` that pushes the change to the **running** agent fails on this validation — so the change never reaches the agent. Users report "`obol model prefer` doesn't apply".

Fix: clear the stale field imperatively with a strategic merge patch (`{type: Recreate, rollingUpdate: null}`) before each helmfile sync. Emitting `rollingUpdate: null` in the rendered manifest was tried first but does **not** survive bedag/raw + helm's null handling (verified live — the upgrade still failed). `NotFound` (fresh install) is a benign no-op.

### 2. feat(model): auto-promote freshly configured model to agent primary (05798c91)

`obol model setup` appends new provider entries to the **tail** of `model_list`, so the agent's primary (the head) never changed — adding e.g. an Anthropic key required a separate `obol model prefer` for setup to "take". setup now promotes the just-configured model(s) to the head and syncs, so the new model is primary immediately; users reorder afterward with `obol model prefer`. Ollama auto-detect (no `--model`) still promotes nothing — auto-detection must not silently reshuffle the operator's model_list (the spark2 footgun). Promotion is best-effort (warns + still syncs on failure).

Note: `obol sell demo quant` was **not** affected by either issue — it re-resolves the default from the live `litellm-config` ConfigMap at deploy time. The broken target is specifically the long-lived default Hermes agent, which users perceived as "prefer doesn't apply to demo".

Risk level: low — scoped to the hermes sync path + model setup orchestration; best-effort, non-fatal, and no-ops on fresh installs.

Commit under test: 05798c91

Base branch: main

## Scope

- [x] Code
- [ ] Charts / manifests
- [ ] Flows / QA scripts
- [ ] Docs / skills
- [ ] Images / dependencies
- [ ] Other:

## Validation

Unit tests:

```text
go build ./...                                             # clean
go vet ./internal/hermes/ ./cmd/obol/                      # clean
go test ./internal/hermes/ ./internal/model/ ./cmd/obol/   # ok (commit 05798c91)

New tests:
- internal/hermes/strategy_migration_test.go
    TestStrategyMigrationPatchArgs                              PASS
    TestStrategyMigrationPatchArgs_ThreadsNamespace            PASS
    TestGenerateValues_StrategyIsRecreateWithoutRollingUpdate  PASS
- cmd/obol/model_test.go
    TestSetupPromoteList (explicit-promote / auto-detect-no-promote / no-alias)  PASS
Promotion mechanism (reorderModelList) already covered by internal/model/prefer_test.go.
```

Manual verification on a live cluster (k3d):

```text
# (1) Strategy migration — reproduce broken state then fix:
kubectl patch deploy hermes -n hermes-obol-agent --type=merge \
  -p '{"spec":{"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"}}}}'
obol model sync         # BEFORE: helmfile sync FAILS (rollingUpdate Forbidden)
                        # AFTER:  succeeds; strategy -> {type: Recreate}
obol model prefer <m>   # litellm-config head AND hermes-config default both update to <m>

# (2) Auto-promote:
obol model setup --provider anthropic --model claude-sonnet-4-6
# -> "Promoting claude-sonnet-4-6 to head" -> hermes-config default = claude-sonnet-4-6 (one step, no manual prefer)
```

Integration tests: n/a (no payment/chain surface touched)

Release smoke: n/a (no payment/chain surface touched)

## Live Chain Evidence

N/A — does not touch x402, settlement, registration, or any on-chain path. No transactions, wallets, or facilitators involved.

## Runtime Evidence

QA environment:

| Item | Value |
|------|-------|
| OS / arch | darwin / arm64 |
| Backend | k3d |
| QA agent/model | hermes (default agent), qwen36-deep |

Kubernetes / stack:

| Item | Value |
|------|-------|
| Namespaces | hermes-obol-agent, llm |
| Verification | hermes strategy migrated RollingUpdate -> Recreate; helmfile sync green; `obol model prefer` and `obol model setup` both update hermes-config `model.default` |
