### PR TITLE
feat(sell): explain ERC-8004 registration consequences at publish time

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -489,9 +489,21 @@ Examples:
 								ExpectedOwner: wallet,
 							}); err != nil {
 								u.Warnf("automatic sell registration failed: %v", err)
-								u.Dim("  Re-run later with: obol sell register " + name + " -n " + svcNs)
+								aw, _ := hermes.ResolveWalletAddress(cfg)
+								printRegistrationNotice(u, registrationNotice{
+									Mode:        regNoticeAutoFailed,
+									Chain:       cmd.String("chain"),
+									PayTo:       wallet,
+									AgentWallet: aw,
+									OfferName:   name,
+									Namespace:   svcNs,
+								})
 							}
 						}
+						// Registration enabled but auto-register not attempted (e.g.
+						// the tunnel URL was not ready): surface the Ready=False
+						// consequence + completion path instead of failing silently.
+						noticeInferenceRegistrationSkipped(u, cfg, soSpec, cmd.String("chain"), wallet, name, svcNs)
 					}
 				}
 			}
@@ -873,6 +885,15 @@ Examples:
 						AgentDesc:     registrationDescriptionForPrompt(name, reg),
 						ExpectedOwner: wallet,
 					}); err != nil {
+						aw, _ := hermes.ResolveWalletAddress(cfg)
+						printRegistrationNotice(u, registrationNotice{
+							Mode:        regNoticeAutoFailed,
+							Chain:       cmd.String("chain"),
+							PayTo:       wallet,
+							AgentWallet: aw,
+							OfferName:   name,
+							Namespace:   ns,
+						})
 						return fmt.Errorf("automatic sell registration failed: %w", err)
 					}
 				}
@@ -972,12 +993,38 @@ func shouldAutoRegisterSell(spec map[string]any, tunnelURL string) bool {
 	if tunnelURL == "" {
 		return false
 	}
+	return registrationEnabledInSpec(spec)
+}
+
+// registrationEnabledInSpec reports whether a ServiceOffer spec map has
+// ERC-8004 registration enabled.
+func registrationEnabledInSpec(spec map[string]any) bool {
 	reg, ok := spec["registration"].(map[string]any)
 	if !ok {
 		return false
 	}
 	enabled, _ := reg["enabled"].(bool)
 	return enabled
+}
+
+// noticeInferenceRegistrationSkipped prints the cluster-routed `sell inference`
+// advisory for the case where registration is enabled but the auto-register
+// step was not attempted (e.g. the tunnel URL was not ready in time). It is a
+// no-op when registration is disabled. Extracted so the inference Action stays
+// within the control-flow nesting budget.
+func noticeInferenceRegistrationSkipped(u *ui.UI, cfg *config.Config, soSpec map[string]any, chain, payTo, name, ns string) {
+	if !registrationEnabledInSpec(soSpec) {
+		return
+	}
+	aw, _ := hermes.ResolveWalletAddress(cfg)
+	printRegistrationNotice(u, registrationNotice{
+		Mode:        regNoticeAutoSkipped,
+		Chain:       chain,
+		PayTo:       payTo,
+		AgentWallet: aw,
+		OfferName:   name,
+		Namespace:   ns,
+	})
 }
 
 func registrationNameForPrompt(fallback string, reg map[string]any) string {

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -499,11 +499,12 @@ Examples:
 									Namespace:   svcNs,
 								})
 							}
+						} else {
+							// Registration enabled but auto-register not attempted (e.g.
+							// the tunnel URL was not ready): surface the Ready=False
+							// consequence + completion path instead of failing silently.
+							noticeInferenceRegistrationSkipped(u, cfg, soSpec, cmd.String("chain"), wallet, name, svcNs)
 						}
-						// Registration enabled but auto-register not attempted (e.g.
-						// the tunnel URL was not ready): surface the Ready=False
-						// consequence + completion path instead of failing silently.
-						noticeInferenceRegistrationSkipped(u, cfg, soSpec, cmd.String("chain"), wallet, name, svcNs)
 					}
 				}
 			}

--- a/cmd/obol/sell_agent.go
+++ b/cmd/obol/sell_agent.go
@@ -255,6 +255,25 @@ Examples:
 
 			if !register {
 				u.Dim("Registration skipped (--no-register). Run `obol sell register --chain " + chain + "` later for on-chain discovery.")
+			} else {
+				// sell agent is declare-only: it sets spec.registration and
+				// relies on the controller + a manual `obol sell register`. Make
+				// the Ready=False consequence, gas need, and signer/payee split
+				// legible instead of leaving the operator to discover them.
+				aw := strings.TrimSpace(agent.WalletAddress)
+				if aw == "" {
+					if resolved, werr := hermes.ResolveWalletAddress(cfg); werr == nil {
+						aw = resolved
+					}
+				}
+				printRegistrationNotice(u, registrationNotice{
+					Mode:        regNoticeDeclareOnly,
+					Chain:       chain,
+					PayTo:       payTo,
+					AgentWallet: aw,
+					OfferName:   name,
+					Namespace:   offerNs,
+				})
 			}
 			return nil
 		},

--- a/cmd/obol/sell_registration_notice.go
+++ b/cmd/obol/sell_registration_notice.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/ui"
+)
+
+// registrationNoticeMode selects the wording for a post-publish registration
+// advisory, based on how the publishing command handles the on-chain tx.
+type registrationNoticeMode int
+
+const (
+	// regNoticeDeclareOnly: the command only declares spec.registration and
+	// relies on the controller + a manual `obol sell register` (e.g. sell agent).
+	regNoticeDeclareOnly registrationNoticeMode = iota
+	// regNoticeAutoSkipped: registration is enabled but the auto-register step
+	// was not attempted (e.g. the tunnel URL was not ready in time).
+	regNoticeAutoSkipped
+	// regNoticeAutoFailed: the auto-register step ran but returned an error
+	// (e.g. an unfunded agent wallet on mainnet, or RPC connectivity).
+	regNoticeAutoFailed
+)
+
+// registrationNotice carries everything needed to advise an operator about the
+// consequences of registration being enabled but not yet completed on-chain.
+type registrationNotice struct {
+	Mode        registrationNoticeMode
+	Chain       string // payment/registration chain (e.g. "ethereum", "base-sepolia")
+	PayTo       string // offer payout address (--wallet/--pay-to)
+	AgentWallet string // address that signs the on-chain registration tx; may be ""
+	OfferName   string
+	Namespace   string
+}
+
+// isTestnetChain reports whether a chain name denotes a test network, used only
+// to pick gas wording. Unknown names default to mainnet (the cautious choice —
+// "real funds" over "use a faucet").
+func isTestnetChain(chain string) bool {
+	c := strings.ToLower(strings.TrimSpace(chain))
+	for _, marker := range []string{"sepolia", "amoy", "fuji", "goerli", "holesky", "mumbai", "testnet", "devnet"} {
+		if strings.Contains(c, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// registrationGasPhrase describes what the on-chain registration tx costs on
+// the given chain, so operators understand why an unfunded wallet stalls it.
+func registrationGasPhrase(chain string) string {
+	chain = strings.TrimSpace(chain)
+	if chain == "" {
+		return "gas on the target chain"
+	}
+	if isTestnetChain(chain) {
+		return "testnet gas on " + chain + " (use a faucet)"
+	}
+	return "real funds for gas on " + chain
+}
+
+// formatRegistrationNotice builds the advisory lines shown after a ServiceOffer
+// is published with registration enabled but the on-chain tx not yet recorded.
+// It is pure (no UI/IO) so the wording is unit-testable. The first returned
+// line is the headline; the remainder are detail lines.
+//
+// Behaviour it makes legible (previously silent):
+//   - The offer serves paid traffic immediately, yet `obol sell status` reports
+//     Ready=False until the ERC-8004 registration tx lands, because Registered
+//     gates Ready (the storefront catalog uses a looser check and still lists
+//     the offer with a RegistrationPending badge).
+//   - The tx is signed by the agent's remote-signer wallet and needs gas — on
+//     mainnet that is real funds, which is the usual reason it stalls.
+//   - The agent wallet (registration owner) and the payout wallet are allowed
+//     to differ (hot signer / cold payee); the split is surfaced, not blocked.
+//   - `--no-register` is the escape hatch for a clean Ready=True with no tx.
+func formatRegistrationNotice(n registrationNotice) []string {
+	var lines []string
+
+	switch n.Mode {
+	case regNoticeAutoFailed:
+		lines = append(lines, "On-chain ERC-8004 registration did not complete.")
+	case regNoticeAutoSkipped:
+		lines = append(lines, "Registration is enabled but the on-chain ERC-8004 tx was not submitted (a prerequisite was not ready).")
+	default: // regNoticeDeclareOnly
+		lines = append(lines, "Registration is enabled; the on-chain ERC-8004 tx is not submitted automatically.")
+	}
+
+	lines = append(lines,
+		"The offer already serves paid traffic, but `obol sell status` reports Ready=False (AwaitingExternalRegistration) until the registration tx lands.")
+
+	complete := "Complete it with: obol sell register"
+	if name := strings.TrimSpace(n.OfferName); name != "" {
+		complete += " " + name
+	}
+	if ns := strings.TrimSpace(n.Namespace); ns != "" {
+		complete += " -n " + ns
+	}
+	if chain := strings.TrimSpace(n.Chain); chain != "" {
+		complete += " --chain " + chain
+	}
+	if wallet := strings.TrimSpace(n.AgentWallet); wallet != "" {
+		complete += fmt.Sprintf(" — signed by the agent wallet %s, which needs %s.", wallet, registrationGasPhrase(n.Chain))
+	} else {
+		complete += " — signed by the agent wallet, which needs " + registrationGasPhrase(n.Chain) + "."
+	}
+	lines = append(lines, complete)
+
+	// The auto-register path already prints the delegation note before it
+	// attempts the tx, so only the paths that never reached that point repeat it.
+	if n.Mode != regNoticeAutoFailed {
+		if note := signerPayeeDelegationNote(n.AgentWallet, n.PayTo); note != "" {
+			lines = append(lines, note)
+		}
+	}
+
+	lines = append(lines, "Don't need on-chain discovery? Re-run the sell command with --no-register for a clean Ready=True (no tx, no gas).")
+	return lines
+}
+
+// printRegistrationNotice renders a registrationNotice via the UI. Best-effort
+// and never returns an error: the headline draws attention as a warning, the
+// remaining lines are dimmed detail.
+func printRegistrationNotice(u *ui.UI, n registrationNotice) {
+	lines := formatRegistrationNotice(n)
+	if len(lines) == 0 {
+		return
+	}
+	u.Blank()
+	u.Warnf("%s", lines[0])
+	for _, line := range lines[1:] {
+		u.Dim("  " + line)
+	}
+}

--- a/cmd/obol/sell_registration_notice_test.go
+++ b/cmd/obol/sell_registration_notice_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsTestnetChain(t *testing.T) {
+	tests := []struct {
+		chain string
+		want  bool
+	}{
+		{"ethereum", false},
+		{"base", false},
+		{"polygon", false},
+		{"arbitrum-one", false},
+		{"base-sepolia", true},
+		{"polygon-amoy", true},
+		{"avalanche-fuji", true},
+		{"holesky", true},
+		{"  Base-Sepolia  ", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.chain, func(t *testing.T) {
+			if got := isTestnetChain(tt.chain); got != tt.want {
+				t.Errorf("isTestnetChain(%q) = %v; want %v", tt.chain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistrationGasPhrase(t *testing.T) {
+	tests := []struct {
+		chain string
+		want  string
+	}{
+		{"ethereum", "real funds for gas on ethereum"},
+		{"base", "real funds for gas on base"},
+		{"base-sepolia", "testnet gas on base-sepolia (use a faucet)"},
+		{"", "gas on the target chain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.chain, func(t *testing.T) {
+			if got := registrationGasPhrase(tt.chain); got != tt.want {
+				t.Errorf("registrationGasPhrase(%q) = %q; want %q", tt.chain, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatRegistrationNotice pins the operator-facing wording for each mode,
+// including the Ready=False consequence, the completing command, the gas
+// phrasing, and the conditional delegation (signer != payTo) note.
+func TestFormatRegistrationNotice(t *testing.T) {
+	const (
+		agentWallet = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		coldPayee   = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	)
+
+	mustContain := func(t *testing.T, lines []string, subs ...string) {
+		t.Helper()
+		joined := strings.Join(lines, "\n")
+		for _, s := range subs {
+			if !strings.Contains(joined, s) {
+				t.Errorf("notice missing %q; got:\n%s", s, joined)
+			}
+		}
+	}
+	mustNotContain := func(t *testing.T, lines []string, s string) {
+		t.Helper()
+		if joined := strings.Join(lines, "\n"); strings.Contains(joined, s) {
+			t.Errorf("notice unexpectedly contains %q; got:\n%s", s, joined)
+		}
+	}
+
+	t.Run("declare-only mainnet with cold payee", func(t *testing.T) {
+		lines := formatRegistrationNotice(registrationNotice{
+			Mode:        regNoticeDeclareOnly,
+			Chain:       "ethereum",
+			PayTo:       coldPayee,
+			AgentWallet: agentWallet,
+			OfferName:   "aeon7",
+			Namespace:   "hermes-obol-agent",
+		})
+		mustContain(t, lines,
+			"not submitted automatically",
+			"Ready=False",
+			"AwaitingExternalRegistration",
+			"obol sell register aeon7 -n hermes-obol-agent --chain ethereum",
+			agentWallet,
+			"real funds for gas on ethereum",
+			"--no-register",
+		)
+		// signer != payTo → delegation note present.
+		mustContain(t, lines, coldPayee)
+	})
+
+	t.Run("auto-failed omits delegation note", func(t *testing.T) {
+		lines := formatRegistrationNotice(registrationNotice{
+			Mode:        regNoticeAutoFailed,
+			Chain:       "base",
+			PayTo:       coldPayee,
+			AgentWallet: agentWallet,
+			OfferName:   "my-api",
+			Namespace:   "default",
+		})
+		mustContain(t, lines, "did not complete", "obol sell register my-api -n default --chain base")
+		// The auto-register path already printed the delegation note, so the
+		// failure advisory must not repeat the payTo address.
+		mustNotContain(t, lines, coldPayee)
+	})
+
+	t.Run("auto-skipped testnet", func(t *testing.T) {
+		lines := formatRegistrationNotice(registrationNotice{
+			Mode:        regNoticeAutoSkipped,
+			Chain:       "base-sepolia",
+			PayTo:       coldPayee,
+			AgentWallet: agentWallet,
+			OfferName:   "demo",
+			Namespace:   "default",
+		})
+		mustContain(t, lines, "was not submitted", "testnet gas on base-sepolia (use a faucet)", coldPayee)
+	})
+
+	t.Run("empty agent wallet still advises", func(t *testing.T) {
+		lines := formatRegistrationNotice(registrationNotice{
+			Mode:      regNoticeDeclareOnly,
+			Chain:     "ethereum",
+			PayTo:     coldPayee,
+			OfferName: "x",
+			Namespace: "default",
+		})
+		mustContain(t, lines, "signed by the agent wallet, which needs real funds for gas on ethereum")
+		// No signer address known → no delegation note.
+		mustNotContain(t, lines, coldPayee)
+	})
+
+	t.Run("matching payee omits delegation note", func(t *testing.T) {
+		lines := formatRegistrationNotice(registrationNotice{
+			Mode:        regNoticeDeclareOnly,
+			Chain:       "ethereum",
+			PayTo:       agentWallet,
+			AgentWallet: agentWallet,
+			OfferName:   "x",
+			Namespace:   "default",
+		})
+		// signerPayeeDelegationNote returns "" when signer == payTo, so no
+		// "differs from offer payTo" line should appear.
+		mustNotContain(t, lines, "differs from offer payTo")
+	})
+}

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -984,7 +984,7 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 			}
 
 			status.Phase = registrationPhaseAwaitingExternal
-			status.Message = "Waiting for external ERC-8004 registration"
+			status.Message = awaitingExternalRegistrationMessage(registrationChain)
 			status.RegistrationOwner = offer.Spec.Payment.PayTo
 			status.RegistrationURI = status.PublishedURL
 			fromBlock := int64(height) - 1024
@@ -1007,7 +1007,7 @@ func (c *Controller) reconcileRegistrationActive(ctx context.Context, raw *unstr
 		}
 		if !found {
 			status.Phase = registrationPhaseAwaitingExternal
-			status.Message = fmt.Sprintf("Waiting for external ERC-8004 registration for owner %s", status.RegistrationOwner)
+			status.Message = awaitingExternalRegistrationMessage(registrationChain)
 			return c.updateRegistrationStatus(ctx, raw, status)
 		}
 
@@ -1390,6 +1390,21 @@ func truncateMessage(message string) string {
 		return message
 	}
 	return message[:200]
+}
+
+// awaitingExternalRegistrationMessage builds the operator-facing message shown
+// while a ServiceOffer's registration is enabled but the on-chain ERC-8004
+// registration tx has not yet landed. The on-chain tx is submitted by the
+// operator (via `obol sell register`), never by the controller, so the message
+// names the exact command and reassures that the offer already serves paid
+// traffic — the offer is operationally usable even though Ready stays False
+// until the registration is recorded on-chain (see offerOperationallyReady).
+func awaitingExternalRegistrationMessage(chain string) string {
+	cmd := "obol sell register"
+	if chain = strings.TrimSpace(chain); chain != "" {
+		cmd += " --chain " + chain
+	}
+	return truncateMessage("Awaiting external ERC-8004 registration tx — submit with `" + cmd + "`; offer already serves paid traffic")
 }
 
 func getenvDefault(key, fallback string) string {

--- a/internal/serviceoffercontroller/registration_message_test.go
+++ b/internal/serviceoffercontroller/registration_message_test.go
@@ -1,0 +1,47 @@
+package serviceoffercontroller
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAwaitingExternalRegistrationMessage verifies the operator-facing pending
+// message names the completing command, embeds the chain when known, reassures
+// that the offer already serves traffic, and stays within the k8s condition
+// message budget enforced by truncateMessage.
+func TestAwaitingExternalRegistrationMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		chain       string
+		wantChain   string // substring that must appear ("" => no --chain flag)
+		wantNoChain bool   // when true, "--chain" must NOT appear
+	}{
+		{name: "mainnet chain", chain: "ethereum", wantChain: "--chain ethereum"},
+		{name: "testnet chain", chain: "base-sepolia", wantChain: "--chain base-sepolia"},
+		{name: "whitespace trimmed", chain: "  base  ", wantChain: "--chain base"},
+		{name: "empty chain omits flag", chain: "", wantNoChain: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := awaitingExternalRegistrationMessage(tt.chain)
+
+			if !strings.Contains(got, "obol sell register") {
+				t.Errorf("message must name the completing command; got %q", got)
+			}
+			if !strings.Contains(got, "serves paid traffic") {
+				t.Errorf("message must reassure the offer still serves traffic; got %q", got)
+			}
+			if tt.wantNoChain {
+				if strings.Contains(got, "--chain") {
+					t.Errorf("empty chain must omit the --chain flag; got %q", got)
+				}
+			} else if !strings.Contains(got, tt.wantChain) {
+				t.Errorf("message must embed %q; got %q", tt.wantChain, got)
+			}
+			if len(got) > 200 {
+				t.Errorf("message must stay within truncateMessage budget (<=200); got %d chars", len(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Registration is enabled by default on `obol sell inference`, `sell http`, and `sell agent`. With it enabled there's a confusing gap:

- The controller's `Registered` condition **gates `Ready`** (`controller.go`), but the storefront catalog uses the looser `offerOperationallyReady` check that **excludes `Registered`** (`render.go`).
- Net effect: a published offer **serves paid traffic and appears in the storefront**, yet `obol sell status` reports `Ready: False` / `AwaitingExternalRegistration` until an on-chain ERC-8004 tx lands.
- That tx is **operator-submitted** via `obol sell register` — never by the controller.

None of this was surfaced to the operator:
- `sell agent` is declare-only (sets `spec.registration`, never auto-submits) and printed **nothing** about it.
- No command explained the **gas requirement** (real funds on mainnet) or the legitimate **signer-vs-`payTo` split** (hot signer / cold payee).
- The controller's pending message (`"Waiting for external ERC-8004 registration"`) gave no next step.

The result: `--no-register` felt like arcane knowledge, and a perfectly healthy offer looked broken.

## What changes

**1. Controller — actionable pending message**
Both `AwaitingExternalRegistration` sites now call a shared `awaitingExternalRegistrationMessage(chain)` that names the exact command (`obol sell register --chain <chain>`) and reassures that the offer already serves paid traffic. Reason/phase unchanged (storefront `RegistrationPending` badge logic untouched); stays within `truncateMessage`'s 200-char budget.

**2. CLI — publish-time advisory**
New shared, pure, table-tested `formatRegistrationNotice` printed after publish, with three modes:

| Mode | When |
|------|------|
| declare-only | `sell agent` — registration enabled, tx not auto-submitted |
| auto-failed | `sell http` / `sell inference` cluster — auto-register errored |
| auto-skipped | `sell inference` cluster — enabled but not attempted (e.g. tunnel URL not ready) |

Each notice explains the offer already serves traffic but `Ready` stays `False`, names the completing command (`obol sell register <name> -n <ns> --chain <chain>`), states the gas cost (real funds on mainnet vs faucet on testnets, via `isTestnetChain`), reuses the existing `signerPayeeDelegationNote` to surface a signer/`payTo` split, and points at `--no-register` for a clean `Ready=True`. The auto-failed mode omits the delegation note because the auto-register path already prints it before attempting.

## Behavior changes

- **Additive operator-facing output only.** No change to what is published, to payment semantics, or to the existing fatal/non-fatal handling of auto-register failures (`sell http` still returns the error; `sell inference` still warns and continues).
- One controller **condition message** text changed; its `Reason` and `phase` are unchanged.

## Testing

- `go build ./...`, `go vet`, `go test ./...` — all green (no cluster required; the new logic is pure).
- New unit tests: `TestAwaitingExternalRegistrationMessage`, `TestFormatRegistrationNotice`, `TestIsTestnetChain`, `TestRegistrationGasPhrase`.
- `golangci-lint run --new-from-rev=main` — 0 new issues.

## Out of scope / follow-ups

- **Live agent-wallet gas-balance preflight** — turn "needs gas" into "wallet `0x…` holds 0; fund it or use `--no-register`". Deliberately omitted to avoid an RPC + signer port-forward on the publish hot path; natural follow-up.
- Whether `sell http` should keep returning a hard error after a registration failure (the offer is already published by then) — left as-is here to avoid a behavioral change.
