### PR TITLE
chore(controller): repin serviceoffer-controller to b39bcaa for rc11

### DIFF
--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -797,7 +797,8 @@ func TestX402VerifierImage_CarriesAgentAuthFix(t *testing.T) {
 // treats Secret as create-only (isCreateOnlyKind). The image MUST therefore be
 // built from source that has that behaviour — the prior f5d94fc side-branch pin
 // did not, so the deployed binary Updated the per-agent Secrets on re-reconcile
-// and 403'd. 503016b (rc9 commit 503016bf, image 0.10.0-rc9) carries the fix.
+// and 403'd. b39bcaa (post-rc10 main) carries the fix, and also ships PR #590's
+// actionable pending-registration status message.
 // Bumping this pin requires a conscious, documented change here so a future
 // downgrade can't silently re-ship the bug.
 func TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix(t *testing.T) {
@@ -806,7 +807,7 @@ func TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix(t *testing.T) {
 		t.Fatalf("ReadInfrastructureFile: %v", err)
 	}
 
-	const ref = "ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957"
+	const ref = "ghcr.io/obolnetwork/serviceoffer-controller:b39bcaa@sha256:f5afbba041f83c52c1d48c61db443138da76a12afed0bd29ba719984fc73b189"
 	if !strings.Contains(string(data), "image: "+ref) {
 		t.Fatalf("serviceoffer-controller image must carry the Secret-create-only reconciler fix "+
 			"(else per-agent provisioning 403s under the no-update/patch Secret RBAC): %s", ref)

--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -230,12 +230,12 @@ func TestEmbeddedImages_X402ControllerAndBuyerUseFixPins(t *testing.T) {
 		ref  string
 	}{
 		{
-			// Repinned off the f5d94fc side-branch build (which predated the
-			// Secret-create-only reconciler change) to the rc9 release image
-			// (commit 503016b, image 0.10.0-rc9).
+			// Repinned off the rc9 image (503016b) to b39bcaa (post-rc10 main):
+			// still carries the Secret-create-only reconciler change, and adds
+			// PR #590's actionable pending-registration status message.
 			// See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
 			file: "base/templates/x402.yaml",
-			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957",
+			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:b39bcaa@sha256:f5afbba041f83c52c1d48c61db443138da76a12afed0bd29ba719984fc73b189",
 		},
 		{
 			file: "base/templates/llm.yaml",

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -349,9 +349,10 @@ spec:
           # per-agent hermes-api-server / remote-signer-keystore Secrets on
           # re-reconcile 403s and per-agent provisioning never converges. The
           # prior pin (f5d94fc) predated that source change and shipped the
-          # bug; 503016b (rc9 commit 503016bf, image 0.10.0-rc9) carries it.
+          # bug; b39bcaa (post-rc10 main) carries it, and also ships PR #590's
+          # actionable pending-registration status message.
           # See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
-          image: ghcr.io/obolnetwork/serviceoffer-controller:503016b@sha256:bec62ea04842caf62980b529a89f5d553987a106c3167eb45209a8b278121957
+          image: ghcr.io/obolnetwork/serviceoffer-controller:b39bcaa@sha256:f5afbba041f83c52c1d48c61db443138da76a12afed0bd29ba719984fc73b189
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Why

Prereq for cutting **v0.10.0-rc11**. The x402 component images are SHA-pinned in the embedded infra, and the serviceoffer-controller pin has been stuck on the **rc9** build (`503016b`) — even rc10 shipped that image. PR #590's controller change (the actionable pending-registration status message) therefore can't reach a deployed cluster until this pin is bumped.

## What

Repin `serviceoffer-controller`:

```
- 503016b@sha256:bec62ea0…  (rc9)
+ b39bcaa@sha256:f5afbba0…  (post-rc10 main)
```

`b39bcaa` is a descendant of `503016b` (verified via `git merge-base --is-ancestor`), so it **retains** the Secret-create-only reconciler fix (the per-agent provisioning 403 guard) and **adds**:
- PR #590 — `awaitingExternalRegistrationMessage` (actionable pending-registration status)
- the `purchase.go` reconcile fixes that landed on main since rc9

Updates the two provenance tripwires that assert this pin:
- `TestEmbeddedImages_X402ControllerAndBuyerUseFixPins`
- `TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix`

x402-verifier (`46e63fd`) and x402-buyer (`f5d94fc`) are intentionally **left as-is** — no code change since their pins for this scope; refresh them separately if desired.

## Verification

- `git merge-base --is-ancestor 503016b b39bcaa` → true (create-only fix retained)
- `go build ./...` — clean
- `go test ./internal/embed/...` — green
- `git diff --check` — clean

## Merge gate

Per our rules this needs **flows-green + a second human reviewer** before merge. Once merged, the rc11 cut is: tag `v0.10.0-rc11` on main → release workflow builds binaries/draft release → deploy to the prod cluster via `obol upgrade`.
