### PR TITLE
feat(buy-x402): --set-default — agent self-adopts paid/<model> as its primary model

### DIFF
--- a/internal/embed/skills/buy-x402/SKILL.md
+++ b/internal/embed/skills/buy-x402/SKILL.md
@@ -10,6 +10,7 @@ Purchase access to remote x402-gated services. There are two flows, picked by us
 
 - **`pay <url>`** — single-shot. Probe the URL, sign **one** payment authorization, attach `X-PAYMENT`, send the request, return the response. Stateless. Use for `type:http` services and any one-off purchase. Max loss = price of one request.
 - **`buy <name>`** — pre-payment budget. Pre-sign **N** authorizations, declare them in a `PurchaseRequest` CR, let the `x402-buyer` sidecar spend them transparently as the agent calls the model through LiteLLM at `paid/<remote-model>`. Use for long-running paid inference. Max loss = N × price; runtime path holds zero signer access.
+- **`buy <name> --model <id> --set-default`** — same as `buy` above, then adopt `paid/<remote-model>` as the agent's **own primary model**, in-pod, by itself: an atomic `hermes config set model.default` that Hermes re-reads per request (effective next chat turn, **no restart**, no host-side `obol model prefer`/`obol model sync`). Refuses if the model isn't selectable in LiteLLM. Pair with `--auto-refill` so the primary model doesn't brick when the pre-signed pool empties.
 
 Both flows auto-detect the token + transfer method from the seller's 402 response. Currently supported: **USDC via EIP-3009** (Base Sepolia, Base Mainnet, Ethereum Mainnet) and **OBOL via Permit2** (Ethereum Mainnet).
 
@@ -150,6 +151,7 @@ python3 ${OBOL_SKILLS_DIR:-/data/.openclaw/skills}/buy-x402/scripts/buy.py maint
 | `probe <url> [--model <id>] [--type http\|inference] [--method GET\|POST]` | Send request without payment, parse 402 response for pricing |
 | `pay <url> [--type http\|inference] [--method GET\|POST] [--data <body>]` | Single-shot paid request: sign 1 auth, attach X-PAYMENT, send |
 | `buy <name> --endpoint <url> --model <id> [--budget N] [--count N]` | Pre-sign auths, create/update `PurchaseRequest`, expose `paid/<model>` |
+| `buy <name> --endpoint <url> --model <id> --set-default [--auto-refill]` | As above, then set `paid/<model>` as the agent's own primary model in-pod (no restart, no host CLI) |
 | `process <name> \| --all` | Reconcile `autoRefill` policies against live `x402-buyer` status |
 | `list` | List purchased providers + remaining auth counts |
 | `status <name>` | Check sidecar pod status + remaining auths |

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -18,7 +18,7 @@ Commands:
     buy <name> --endpoint <url> --model <id>      Pre-sign + author PurchaseRequest
         [--budget <micro-units>] [--count <N>]
         [--auto-refill[=true|false]] [--refill-threshold <N>]
-        [--refill-count <N>]
+        [--refill-count <N>] [--set-default]
     list                                          List purchased providers + remaining auths
     status <name>                                 Check sidecar health + remaining auths
     process <name>|--all                          Reconcile auto-refill policies
@@ -32,6 +32,8 @@ import base64
 import json
 import os
 import secrets
+import shutil
+import subprocess
 import sys
 import time
 import urllib.error
@@ -1527,6 +1529,160 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
     print(f"The model is now available as: paid/{model_id}")
     print("Use 'process --all' from a heartbeat/cron loop to reconcile auto-refill policies.")
 
+    if ready and opts.get("set_default"):
+        print()
+        _set_agent_default_model(model_id, auto_refill)
+
+
+# ---------------------------------------------------------------------------
+# Set-default: adopt a freshly-bought paid/<model> as the agent's primary model
+# ---------------------------------------------------------------------------
+
+HERMES_CONFIG_PATH = "/data/.hermes/config.yaml"
+HERMES_BIN_CANDIDATES = ("/opt/hermes/.venv/bin/hermes",)
+
+
+def _find_hermes_bin():
+    """Locate the in-pod Hermes binary, or None."""
+    for cand in HERMES_BIN_CANDIDATES:
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return shutil.which("hermes")
+
+
+def _read_hermes_model_cfg():
+    """Return (base_url, api_key) from the Hermes config, or (None, None)."""
+    try:
+        import yaml  # PyYAML ships in the agent runtime
+
+        with open(HERMES_CONFIG_PATH) as f:
+            data = yaml.safe_load(f) or {}
+        model = data.get("model") or {}
+        return model.get("base_url"), model.get("api_key")
+    except Exception:
+        return None, None
+
+
+def _litellm_has_model(alias):
+    """Best-effort check that `alias` is published in LiteLLM /v1/models.
+
+    Returns True if confirmed present OR if the check could not run (the
+    PurchaseRequest already reconciled Ready, which implies publication).
+    Returns False only when LiteLLM answered and the alias is absent.
+    """
+    base_url, api_key = _read_hermes_model_cfg()
+    if not base_url:
+        return True  # cannot verify; rely on PurchaseRequest Ready
+    url = base_url.rstrip("/") + "/models"
+    try:
+        req = urllib.request.Request(
+            url, headers={"Authorization": "Bearer " + (api_key or "")}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            payload = json.loads(resp.read().decode())
+        ids = {m.get("id") for m in payload.get("data", [])}
+        if alias in ids:
+            return True
+        print(f"  LiteLLM /v1/models does not list {alias!r}.", file=sys.stderr)
+        return False
+    except Exception as exc:
+        print(
+            f"  (could not query LiteLLM /v1/models: {exc}; "
+            f"relying on PurchaseRequest Ready)",
+            file=sys.stderr,
+        )
+        return True
+
+
+def _set_default_via_yaml(alias):
+    """Fallback writer: set model.default in the Hermes config, preserving siblings."""
+    try:
+        import yaml
+
+        with open(HERMES_CONFIG_PATH) as f:
+            data = yaml.safe_load(f) or {}
+        model = data.setdefault("model", {})
+        model["default"] = alias
+        tmp = HERMES_CONFIG_PATH + ".tmp"
+        with open(tmp, "w") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=True)
+        os.replace(tmp, HERMES_CONFIG_PATH)
+        print(
+            f"  Agent default model set to {alias!r} via config edit "
+            f"(effective next chat turn)."
+        )
+        return True
+    except Exception as exc:
+        print(f"  Failed to set agent default model via config edit: {exc}", file=sys.stderr)
+        return False
+
+
+def _set_agent_default_model(model_id, auto_refill):
+    """Adopt paid/<model_id> as the Hermes primary model, in-pod, no restart.
+
+    Prefers the native `hermes config set` writer (atomic write + per-request
+    re-read => no restart); falls back to a direct YAML edit. Refuses if the
+    model is not actually selectable in LiteLLM.
+    """
+    alias = f"paid/{model_id}"
+    if not os.path.isfile(HERMES_CONFIG_PATH):
+        print(
+            f"  --set-default skipped: {HERMES_CONFIG_PATH} not found "
+            f"(only the Hermes runtime is supported).",
+            file=sys.stderr,
+        )
+        return False
+    # Safety: a paid primary model bricks chat once the pre-signed pool empties.
+    if not (auto_refill and auto_refill.get("enabled")):
+        print(
+            "  WARNING: --set-default without --auto-refill. Once this is your primary",
+            file=sys.stderr,
+        )
+        print(
+            "           model, every chat turn fails when the pre-signed pool empties.",
+            file=sys.stderr,
+        )
+        print(
+            "           Re-run with --auto-refill, or run 'process --all' on a schedule.",
+            file=sys.stderr,
+        )
+    # Existence guard: never point the agent at an unpublished model.
+    if not _litellm_has_model(alias):
+        print(
+            f"  Refusing --set-default: {alias!r} is not selectable in LiteLLM; "
+            f"leaving the agent default unchanged.",
+            file=sys.stderr,
+        )
+        return False
+    # Primary path: native Hermes writer (atomic; per-request re-read, no restart).
+    hermes_bin = _find_hermes_bin()
+    if hermes_bin:
+        try:
+            res = subprocess.run(
+                [hermes_bin, "config", "set", "model.default", alias],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if res.returncode == 0:
+                print(
+                    f"  Agent default model set to {alias!r} "
+                    f"(effective next chat turn; no restart)."
+                )
+                return True
+            detail = (res.stderr or res.stdout or "").strip()
+            print(
+                f"  'hermes config set' failed (rc={res.returncode}): {detail}; "
+                f"falling back to config edit.",
+                file=sys.stderr,
+            )
+        except Exception as exc:
+            print(
+                f"  'hermes config set' error: {exc}; falling back to config edit.",
+                file=sys.stderr,
+            )
+    return _set_default_via_yaml(alias)
+
 
 # ---------------------------------------------------------------------------
 # Refill
@@ -1955,7 +2111,8 @@ def usage():
     print("  buy <name> --endpoint <url> --model <id>     Pre-sign + configure paid/<model>")
     print("       [--budget <micro-units>] [--count <N>]")
     print("       [--auto-refill[=true|false]] [--refill-threshold <N>]")
-    print("       [--refill-count <N>]")
+    print("       [--refill-count <N>] [--set-default]")
+    print("       --set-default  inference only: adopt paid/<model> as the agent's primary model")
     print("  list                                         List purchased providers")
     print("  status <name>                                Check sidecar + auths")
     print("  process <name> | --all                       Reconcile auto-refill policies")


### PR DESCRIPTION
## What

Adds `--set-default` to `buy.py buy <name> --model <id>`. After a persistent inference buy publishes the paid model in LiteLLM as `paid/<remote-model>`, the obol-agent adopts it as its **own primary chat model, in-pod, by itself** — with **no** host-side `obol model prefer`/`obol model sync`, **no** new RBAC, **no** controller change, **no** LiteLLM mutation, and **no** pod restart.

This closes the last manual step in "agent buys paid inference → agent uses it": previously a human had to run `obol model prefer paid/<id> && obol model sync` from the host.

## Mechanism

- On a successful inference buy (PurchaseRequest `Ready`), the agent runs the native `hermes config set model.default paid/<id>` — an atomic write to its own `/data/.hermes/config.yaml` (the PVC it already owns rw). Hermes resolves `model.default` per request (`_resolve_gateway_model`), and the atomic inode swap busts its mtime-keyed config cache, so the change takes effect on the **next chat turn with no restart**.
- **Existence guard:** queries LiteLLM `/v1/models` and refuses if `paid/<id>` isn't selectable (never points the agent at an unpublished model).
- **Auto-refill safety:** `--set-default` without `--auto-refill` warns loudly — once a paid model is the primary, every turn fails when the pre-signed pool empties.
- **Fallback:** if the `hermes` binary path moves or the call fails, a PyYAML edit of `config.yaml` preserves sibling keys.

Why this design (validated by a 10-agent design + adversarial-validation workflow): it needs none of the permissions the agent lacks (`kubectl auth can-i` confirms the agent cannot patch configmaps/deployments or exec pods), and it reuses Hermes' own config writer + per-request model resolution instead of reordering LiteLLM's `model_list`.

## Test results — live CLI smoke against a running obol-agent

Cluster `eager-airedale`; seller `aeon7` = `AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` on **Ethereum mainnet (OBOL/Permit2)**; agent wallet `0xf441…F373`.

1. **Buy + set-default** (CLI, in-pod):
   ```
   buy.py buy aeon7 --endpoint https://inference.v1337.org/services/aeon7 \
     --model AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 \
     --count 8 --auto-refill --refill-threshold 3 --refill-count 8 --set-default
   ```
   → PurchaseRequest `Ready`, controller published `paid/AEON-7/…`, auto-refill armed → `Agent default model set to 'paid/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4' (effective next chat turn; no restart).`
2. **Config write confirmed:** `/data/.hermes/config.yaml` → `model.default: paid/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` (siblings `api_key`/`base_url`/`provider` preserved), via the native `hermes config set` path (no fallback, guard passed).
3. **Live-chat proof:** a chat through the agent with **no model specified** (so it used its default) drove the x402-buyer pool **spent 0 → 1, remaining 8 → 7** on `aeon7` — a real on-chain settlement via `paid/AEON-7`, proving the new default took effect on the next turn with **no restart**.
4. **Rollback verified:** `hermes config set model.default qwen36-deep` reverts cleanly.

Spend: 0.008 OBOL (8 auths) + 0.001 OBOL (1 chat).

### Build / static
- `python3 -m py_compile internal/embed/skills/buy-x402/scripts/buy.py` ✓
- `go build ./cmd/obol` ✓ (embed intact)
- repo pre-commit Python checks ✓

## Notes / follow-ups
- The chat response's cosmetic `model` label still reflects the static `API_SERVER_MODEL_NAME` (e.g. `qwen36-deep`); it does **not** govern routing — the x402-buyer spend is the ground truth. Cosmetic-only.
- **Auto-refill needs a scheduled runner** (`buy.py process --all` on a cron/heartbeat) so a paid *primary* model stays funded. The flag records intent and the controller honors it on reconcile, but nothing currently invokes `process --all` on a schedule for the default agent. Tracked as a follow-up.

## Scope
Two files, additive: `internal/embed/skills/buy-x402/scripts/buy.py` (+159) and `internal/embed/skills/buy-x402/SKILL.md` (+2). No changes to the controller, RBAC, LiteLLM config, or any Go code.
