### PR TITLE
feat(agent): have sub-agents stream their responses to keep the tunnel alive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ obol
 ├── agent           init (deploys obol-agent singleton),
 │                   auth --runtime <runtime> obol-agent  (Bearer token — canonical)
 ├── network         list, install, add, remove, status, sync, delete
-├── sell            inference, http, list, status, stop, delete, pricing, register
+├── sell            inference, http, agent, list, status, stop, delete, pricing, register
+├── buy             inference  (pre-pay a paid model via the agent's wallet — exposes `paid/<model>` through LiteLLM)
 ├── hermes          onboard, setup, sync, list, delete, wallet, skills
 │                   token   (LEGACY — prefer `obol agent auth`; can print CLI usage text and poison Bearer)
 ├── openclaw        onboard, setup, sync, list, delete, dashboard, cli, token, skills
@@ -119,6 +120,10 @@ For endpoints backed by host Ollama (`sell http --upstream ollama`), requests wi
 
 **Standalone inference gateway (`obol sell inference`)**: separate from the LiteLLM+buyer path. With a live cluster + kubeconfig, `obol sell inference` disables the gateway’s built-in x402 (`NoPaymentGate`) and publishes a `ServiceOffer` so **Traefik + x402-verifier** gate traffic to the host listener; run the gateway on the host (`127.0.0.1:<port>`) so the in-cluster Service+Endpoints can reach it. For a fully standalone host (no cluster), the gateway uses its **own** x402 middleware (`verifyOnly` / settle behavior per config).
 
+**Agent-backed offers (`obol sell agent <name>`)**: wraps an existing `Agent` CR (created via `obol agent new`) with a `type=agent` ServiceOffer. The controller resolves `spec.agent.ref` → the agent's Hermes endpoint (port 8642), surfaces `agentModel`/`agentSkills`/`agentRuntime` in the 402 response's `extra`, and gates `/services/<name>/*` through `x402-verifier.HandleProxy`. Hermes serves OpenAI-compatible `/v1/chat/completions`; both streaming and non-streaming requests are handled transparently by the same path.
+
+**Prefer `stream: true` for OpenAI-compatible paid endpoints**: SSE chunks now flush per-write end-to-end through `x402-verifier.HandleProxy` (the seller gateway for `sell agent` and `sell http`) — confirmed by `internal/x402/verifier_test.go::TestVerifier_HandleProxy_StreamsSSEChunks`. For any agent inference that might exceed the Cloudflare quick tunnel's ~100s idle window, **streaming is the right answer**: a non-streaming response sends zero bytes until upstream is done, and the tunnel drops the connection before the buffered body arrives. Non-streaming still works for short calls but has no server-side keep-alive — push clients toward `stream: true` whenever the consumer (LiteLLM, OpenAI SDK, browser, curl) supports it. Regression note: `statusRecorder.Flush` in `internal/x402/verifier.go` must forward to the underlying `http.Flusher` — embedding the bare `http.ResponseWriter` interface hides the concrete Flusher and silently buffers the whole response.
+
 Quick full-cycle smoke test (sell + buy):
 1. Unpaid gate check: POST seller route without `X-PAYMENT`, expect `402` + accepts requirements.
 2. Buy auths: run `buy.py buy <name> --endpoint <url> --model <id> --count N`, expect PurchaseRequest `Ready` and sidecar `/status` shows `remaining > 0`.
@@ -130,7 +135,7 @@ PurchaseRequest status caveat:
 - `PurchaseRequest.status` (including `conditions[].message`, `remaining`, `spent`) is the controller's last reconciled snapshot, not a live per-request counter.
 - For real-time auth pool state, and for any refill decision, always check `x402-buyer` `GET /status` in the litellm pod.
 
-**CLI**: `obol sell pricing --wallet --chain`, `obol sell inference <name> --model --price|--per-mtok [--token USDC|OBOL]`, `obol sell http <name> --wallet --chain --price|--per-request|--per-mtok --upstream --port --namespace --health-path [--token USDC|OBOL]`, `obol sell list|status|stop|delete`, `obol sell register --name --private-key-file`.
+**CLI**: `obol sell pricing --wallet --chain`, `obol sell inference <name> --model --price|--per-mtok [--token USDC|OBOL]`, `obol sell http <name> --wallet --chain --price|--per-request|--per-mtok --upstream --port --namespace --health-path [--token USDC|OBOL]`, `obol sell agent <name> --price [--token USDC|OBOL] [--chain ...] [--pay-to ...]`, `obol sell list|status|stop|delete`, `obol sell register --name --private-key-file`, `obol buy inference [<name>] --seller <url> --model <id> --budget <amt> [--token USDC|OBOL]`.
 
 **`obol sell http` flag reference** (common mistakes: `--model`, `--pay-to`, `--network` do NOT exist on this command):
 ```

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -1,8 +1,10 @@
 package x402
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -549,6 +551,28 @@ type statusRecorder struct {
 func (r *statusRecorder) WriteHeader(status int) {
 	r.status = status
 	r.ResponseWriter.WriteHeader(status)
+}
+
+// Flush proxies through to the underlying ResponseWriter's Flush, when
+// supported. Without this, embedding the http.ResponseWriter interface
+// hides the concrete writer's Flush from settlementInterceptor's
+// `i.w.(http.Flusher)` type assertion — SSE streams then sit in the
+// buffer until the handler returns, breaking `obol sell agent` for any
+// OpenAI-style streaming chat frontend. See TestVerifier_HandleProxy_StreamsSSEChunks.
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying ResponseWriter so WebSocket upgrades
+// and any future protocol-switching paths keep working through the
+// settlement wrapper. Same rationale as Flush above.
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("hijacking not supported")
 }
 
 func prometheusLabels(rule *RouteRule) prometheus.Labels {

--- a/internal/x402/verifier_test.go
+++ b/internal/x402/verifier_test.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"bufio"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -439,6 +440,208 @@ func TestVerifier_HandleProxy_UpstreamFailure_DoesNotSettle(t *testing.T) {
 	}
 	if w.Header().Get("X-PAYMENT-RESPONSE") != "" {
 		t.Fatal("did not expect X-PAYMENT-RESPONSE header on upstream failure")
+	}
+}
+
+// TestVerifier_HandleProxy_StreamsSSEChunks proves the seller-gateway path
+// (Traefik → x402-verifier → upstream) preserves Server-Sent Events streaming
+// end-to-end. This is what makes `obol sell agent` usable as an OpenAI-
+// compatible streaming backend for chat frontends.
+//
+// httptest.NewRecorder buffers writes, so it cannot catch a regression where
+// the settlementInterceptor swallows flushes or where httputil.ReverseProxy
+// fails to detect text/event-stream. We therefore stand up a real httptest
+// server, time when each SSE chunk reaches the client, and assert that
+// chunks arrive with the same pacing the upstream emitted them (which can
+// only happen if every layer in the chain flushes per write).
+func TestVerifier_HandleProxy_StreamsSSEChunks(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+
+	const chunkGap = 80 * time.Millisecond
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("upstream ResponseWriter does not implement http.Flusher")
+			return
+		}
+
+		// Three deltas + the terminating [DONE] marker. Hermes emits this
+		// exact shape; mirroring it here keeps the test honest.
+		chunks := []string{
+			`data: {"choices":[{"delta":{"content":"hello"}}]}` + "\n\n",
+			`data: {"choices":[{"delta":{"content":" world"}}]}` + "\n\n",
+			`data: {"choices":[{"delta":{"content":"!"}}]}` + "\n\n",
+			"data: [DONE]\n\n",
+		}
+		for i, c := range chunks {
+			if i > 0 {
+				// Pace the chunks so we can assert the client sees them
+				// arrive progressively rather than all at once.
+				time.Sleep(chunkGap)
+			}
+			if _, err := w.Write([]byte(c)); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:     "/services/demo/*",
+		Price:       "0.0001",
+		UpstreamURL: upstream.URL,
+		StripPrefix: "/services/demo",
+	}})
+
+	// Real HTTP server so Flush() actually reaches the wire. Recorder
+	// would swallow flushes and give us a false positive.
+	srv := httptest.NewServer(http.HandlerFunc(v.HandleProxy))
+	defer srv.Close()
+
+	reqBody := strings.NewReader(`{"model":"hermes-agent","stream":true,"messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/services/demo/v1/chat/completions", reqBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream*", ct)
+	}
+	if resp.Header.Get("X-PAYMENT-RESPONSE") == "" {
+		t.Fatal("expected X-PAYMENT-RESPONSE on a streaming success")
+	}
+
+	// Read each SSE event ("data: ...\n\n") and capture the elapsed time
+	// since the request started. If anything in the chain buffers the
+	// response, all four events will land in a single tight cluster at
+	// the end instead of being spread across the upstream's pacing.
+	reader := bufio.NewReader(resp.Body)
+	var got []string
+	var arrivals []time.Duration
+	for i := 0; i < 4; i++ {
+		dataLine, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read chunk %d data line: %v", i, err)
+		}
+		arrivals = append(arrivals, time.Since(start))
+		blank, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read chunk %d blank line: %v", i, err)
+		}
+		if strings.TrimSpace(blank) != "" {
+			t.Fatalf("chunk %d separator was %q, want empty line", i, blank)
+		}
+		got = append(got, strings.TrimRight(dataLine, "\n"))
+	}
+
+	want := []string{
+		`data: {"choices":[{"delta":{"content":"hello"}}]}`,
+		`data: {"choices":[{"delta":{"content":" world"}}]}`,
+		`data: {"choices":[{"delta":{"content":"!"}}]}`,
+		"data: [DONE]",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d chunks, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("chunk %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// Streaming assertion: the last chunk must arrive at least
+	// 2 × chunkGap after the first. If the chain buffers, all chunks
+	// land together at the upstream's End-of-Body, and arrivals[3] -
+	// arrivals[0] is ≈ 0. Use 2× as the floor (out of 3 gaps) for
+	// scheduler jitter slack.
+	spread := arrivals[3] - arrivals[0]
+	if spread < 2*chunkGap {
+		t.Errorf("SSE chunks were buffered: arrivals[0]=%v arrivals[3]=%v spread=%v (want ≥ %v)\nfull timings=%v",
+			arrivals[0], arrivals[3], spread, 2*chunkGap, arrivals)
+	}
+
+	if fac.verifyCalls.Load() != 1 {
+		t.Fatalf("verify calls = %d, want 1", fac.verifyCalls.Load())
+	}
+	if fac.settleCalls.Load() != 1 {
+		t.Fatalf("settle calls = %d, want 1 (settle is one-shot per paid request, not per chunk)", fac.settleCalls.Load())
+	}
+}
+
+// TestVerifier_HandleProxy_NonStreamingResponse confirms the same gateway
+// path still handles the classic stream:false JSON response correctly —
+// i.e. the streaming fix didn't accidentally chunk-encode replies that the
+// upstream chose to deliver as a single buffered body.
+func TestVerifier_HandleProxy_NonStreamingResponse(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-x","choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+	}))
+	defer upstream.Close()
+
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:     "/services/demo/*",
+		Price:       "0.0001",
+		UpstreamURL: upstream.URL,
+		StripPrefix: "/services/demo",
+	}})
+
+	srv := httptest.NewServer(http.HandlerFunc(v.HandleProxy))
+	defer srv.Close()
+
+	reqBody := strings.NewReader(`{"model":"hermes-agent","messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/services/demo/v1/chat/completions", reqBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-PAYMENT", testPaymentHeader(t))
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json*", ct)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), `"content":"hi"`) {
+		t.Fatalf("body missing assistant content: %s", body)
+	}
+	if resp.Header.Get("X-PAYMENT-RESPONSE") == "" {
+		t.Fatal("expected X-PAYMENT-RESPONSE header on non-streaming success")
+	}
+	if fac.settleCalls.Load() != 1 {
+		t.Fatalf("settle calls = %d, want 1", fac.settleCalls.Load())
 	}
 }
 


### PR DESCRIPTION
## Problem to be solved

Cloudflare tunnels timeout on 100s of no data. Streaming an agents response may resolve that, but it also may put more complexity on the client side caller, we should consider if we need to improve paybe `buy.py` `pay` command to handle it if we haven't already. (I think its dealt with at the verifier side)

## Summary
                                                              
  obol-stack/:                                                   
  - internal/x402/verifier.go — statusRecorder.Flush() + Hijack()
   so SSE chunks actually stream (the bug from the previous      
  turn).                                                    
  - internal/x402/verifier_test.go —                             
  TestVerifier_HandleProxy_StreamsSSEChunks (over-the-wire pacing
   assertion) + TestVerifier_HandleProxy_NonStreamingResponse.   
  - CLAUDE.md:                                                 
    - Added agent to obol sell and a new obol buy inference row  
  in the CLI tree.                                               
    - Added an "Agent-backed offers" paragraph and a "Prefer   
  stream: true for OpenAI-compatible paid endpoints" block in the
   Monetize Subsystem, explicitly calling out the Cloudflare     
  tunnel ~100s idle window and citing the test as the regression
  sentinel.                                                      
    - Added obol sell agent and obol buy inference to the CLI
  flag-reference line.                          