### PR TITLE
feat(buy-inference): positional URL, interactive         prompts, default seller storefront 

### DIFF
--- a/.agents/skills/obol-stack-dev/SKILL.md
+++ b/.agents/skills/obol-stack-dev/SKILL.md
@@ -87,6 +87,39 @@ OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=serviceoffer-controller,x402-buyer obol stac
 
 Values: `true`/`all` → all; comma-separated short names → those only; unset/`false`/`0` → reuse cached. Image set: `x402-verifier`, `serviceoffer-controller`, `x402-buyer`, `demo-server`, `obol-stack-public-storefront` (alias `public-storefront`). The "Local dev images ready" summary line surfaces this hint when nothing was rebuilt.
 
+## Rebuild Hints by Changed Path
+
+| Changed path | What it lands in | Needs CLI rebuild? | Needs image rebuild? | Skill PVC re-seed? |
+|---|---|---|---|---|
+| `cmd/obol/**`, `internal/{config,stack,agent,model,network,kubectl,monetizeapi,ui,validate,...}/*.go` | host CLI only | yes (`just build`) | no | no |
+| `cmd/x402-verifier/**`, `internal/x402/**` *(except `buyer/`)* | x402-verifier image + host CLI | yes | `x402-verifier` | no |
+| `cmd/serviceoffer-controller/**`, `internal/serviceoffercontroller/**`, `internal/schemas/service_catalog*` | controller image | no¹ | `serviceoffer-controller` | no |
+| `internal/x402/buyer/**`, `cmd/x402-buyer/**` | buyer sidecar image | no¹ | `x402-buyer` | no |
+| `internal/embed/skills/**` | host CLI (embedded) + agent PVC via `CopySkills` on `obol stack up` / `obol agent sync` | yes | no | yes (auto on `stack up`) |
+| `internal/embed/infrastructure/**` (templates/values) | host CLI (embedded helmfile) | yes | no | no |
+| `web/public-storefront/**`, `Dockerfile.public-storefront` | storefront image | no | `obol-stack-public-storefront` | no |
+| `flows/**`, `plans/**`, `docs/**`, `*.md`, `*_test.go` | nothing runtime | no | no | no |
+
+¹ Controller/buyer changes don't strictly need a CLI rebuild, but if your edit also touches a shared package (e.g. `internal/monetizeapi`, `internal/schemas`) the CLI needs to rebuild too — when in doubt, `just build` is cheap.
+
+Multiple categories at once → comma-join the image names: `OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=x402-verifier,serviceoffer-controller obol stack up`.
+
+## Turn-End Rebuild Command (REQUIRED when source changed)
+
+When a turn modifies any of the source paths in the table above, end the turn with the exact command the user needs to test the change. Format:
+
+```bash
+just build && OBOL_DEVELOPMENT=true OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=<csv> obol stack up
+```
+
+Pick `<csv>` by walking the diff against the table. Drop the env var entirely when nothing under an image-backed path changed (CLI-only or skill-only iterations). Drop `just build` when only image-backed Go source changed without CLI surface. Surface the command in a fenced block, not buried in prose — the user copy-pastes it directly.
+
+Examples:
+- Only `cmd/obol/*.go` edited → `just build`
+- Only `internal/x402/paymentrequired.go` edited → `just build && OBOL_DEVELOPMENT=true OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=x402-verifier obol stack up`
+- `internal/embed/skills/buy-x402/scripts/buy.py` + `internal/x402/setup.go` → `just build && OBOL_DEVELOPMENT=true obol stack up` (no image rebuild; CLI carries both the embedded script and the constant)
+- Tests/docs only → no rebuild command; say so.
+
 ## Pre-Push Local Checks
 
 ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ build/
 .cache/
 .workspace/
 .workspace-*/
+# kubectl discovery + HTTP cache (default $HOME/.kube/cache; some kubectl
+# invocations without HOME inherited drop it in cwd — the underlying bug
+# should be fixed at the caller, but ignoring it here keeps accidental
+# leakage out of git).
+.kube/
 
 # Go binaries
 /obol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ obol
 └── version
 ```
 
+- `buy inference [<seller-url>]`: positional seller URL (default `https://inference.v1337.org/`). Walks `/api/services.json`, auto-resolves model + token from the catalog asset, prompts in a TTY (auto-top-up Y/N → count with cost preview → confirm), and pre-signs via the agent's remote signer. `--agent X` pays from X AND switches X's hermes-config to `paid/<model>` in-pod (no global model_list reorder); `--set-default` promotes globally + syncs every agent. `--cost-cap` bounds future top-ups against price hikes (reconcile loop re-probes seller pricing). Identity verification is opt-in via `--expected-agent-id`.
 - `agent auth` (alias `token`): `--runtime [hermes|openclaw|all]`, `--regenerate`; positional `[instance-name]` defaults to stack-managed agent. Replaces legacy `hermes token`.
 - `agent new` (alias `onboard`): CRD-declared sub-agent via `--model`, `--skills`, `--objective`, `--create-wallet`. Without positional name, falls back to legacy host-rendered Hermes/OpenClaw onboard.
 - `network install` has dynamic subcommands (one per supported chain; `--help` to list). `network sync [<network>/<id>]` with `--all`.

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -5,11 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"path/filepath"
 	"strings"
 
 	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
 	"github.com/ObolNetwork/obol-stack/internal/buy"
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/kubectl"
+	"github.com/ObolNetwork/obol-stack/internal/model"
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/ObolNetwork/obol-stack/internal/validate"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/urfave/cli/v3"
@@ -23,6 +28,18 @@ const (
 	hermesPython    = "/opt/hermes/.venv/bin/python3"
 	hermesBuyPyPath = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
 	defaultBuyName  = "default-paid"
+
+	// defaultInteractiveCount is the count we propose when the user accepts
+	// the interactive default. Small enough to feel like a try-before-trust
+	// purchase on most providers, large enough to be useful for a quick
+	// chat session.
+	defaultInteractiveCount = 50
+
+	// costCapMarkupBps is the default headroom over the seller's quoted
+	// per-request price that we apply when --cost-cap is not set
+	// explicitly. 5000 basis points = 50% above current, matching the
+	// "default 50% more than current N" UX agreed in the design doc.
+	costCapMarkupBps = 5000
 )
 
 func buyCommand(cfg *config.Config) *cli.Command {
@@ -39,55 +56,58 @@ func buyInferenceCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:      "inference",
 		Usage:     "Buy paid inference from an x402-gated seller via the obol-agent",
-		ArgsUsage: "[<name>]",
-		Description: `Pre-pays an x402-gated inference seller through the obol-agent's wallet.
+		ArgsUsage: "[<seller-url>]",
+		Description: `Pre-pays an x402-gated inference seller through an obol-agent's wallet.
 
-Identity is verified before signing: the seller's
-/.well-known/agent-registration.json must advertise the requested service
-endpoint and list an ERC-8004 agentId that matches --expected-agent-id on the
-same priced payment network that the seller advertises in its 402 response. Use
---no-verify-identity to bypass during development.
+Hand the command a seller URL — either a storefront base
+("https://inference.v1337.org") or a specific offer
+("https://inference.v1337.org/services/aeon") — and the CLI will walk
+/api/services.json, pick the inference offer, and pre-sign authorizations
+via the agent's remote signer.
 
-Today the baked default seller placeholders are not yet provisioned, so the
-practical path is to pass an explicit --seller, --model, and either
---expected-agent-id or --no-verify-identity.
+With no URL, the public ` + x402verifier.DefaultBuySellerURL + ` storefront is used.
+
+In a TTY, the CLI prompts for auto-refill, request count, and
+confirmation. Pass --yes / -y for non-interactive runs (CI, scripts) —
+--count is required in that mode.
 
 Examples:
-	obol buy inference my-buy --seller https://seller.example/services/x \
-	                     --model qwen3.5:9b --expected-agent-id 42 --budget 1
-	obol buy inference --seller https://seller.example/services/x \
-	                     --model qwen3.5:9b --no-verify-identity --budget 1
-	obol buy inference --seller https://inference.v1337.org/services/aeon \
-	                     --model aeon --no-verify-identity --budget 0.023 --token OBOL`,
+    obol buy inference
+    obol buy inference https://inference.v1337.org/services/aeon
+    obol buy inference https://seller.example/services/foo --yes --count 100
+    obol buy inference https://seller.example/services/foo --auto-refill --refill-threshold 5 --refill-count 25`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "seller",
-				Usage: fmt.Sprintf("Seller endpoint (defaults to the Obol-operated %s demo seller placeholder)", x402verifier.DefaultBuySellerChain),
-				Value: x402verifier.DefaultBuySellerURL,
+				Usage: "Seller URL (alternative to positional). When neither is set the default storefront is used.",
 			},
 			&cli.StringFlag{
-				Name:     "model",
-				Usage:    "Remote model id to buy (required until a default seller/model are provisioned, e.g. qwen3.5:9b)",
-				Required: true,
+				Name:  "name",
+				Usage: "PurchaseRequest name (defaults to the seller offer name, then to \"" + defaultBuyName + "\")",
 			},
 			&cli.StringFlag{
-				Name:     "budget",
-				Usage:    "Spending cap in the payment token (e.g. \"10\" for 10 USDC, or \"5\" for 5 OBOL). Converted to base units before passing to the agent.",
-				Required: true,
+				Name:  "agent",
+				Usage: "Agent instance whose wallet pays for the purchase (default: the master/stack-managed agent)",
+			},
+			&cli.StringFlag{
+				Name:  "model",
+				Usage: "Remote model id to buy (optional; required only when the seller offers multiple inference models on this URL)",
+			},
+			&cli.StringFlag{
+				Name:  "budget",
+				Usage: "Spending cap in the payment token (e.g. \"1.5\" for 1.5 USDC). When unset the budget is derived from --count × seller price.",
 			},
 			&cli.StringFlag{
 				Name:  "token",
-				Usage: fmt.Sprintf("Payment token to use (default \"USDC\"). Supported: %s. Must match the seller's priced asset.", strings.Join(x402verifier.SupportedTokens(), ", ")),
-				Value: "USDC",
+				Usage: fmt.Sprintf("Payment token override. Supported: %s. By default the token is derived from the seller's offer.", strings.Join(x402verifier.SupportedTokens(), ", ")),
+			},
+			&cli.IntFlag{
+				Name:  "count",
+				Usage: "How many requests (perRequest pricing) or million-tokens (perMTok pricing) of capacity to pre-pay. Required in non-interactive mode.",
 			},
 			&cli.IntFlag{
 				Name:  "expected-agent-id",
-				Usage: "Expected ERC-8004 agentId of the seller (default: DefaultBuySellerAgentID)",
-				Value: int(x402verifier.DefaultBuySellerAgentID),
-			},
-			&cli.BoolFlag{
-				Name:  "no-verify-identity",
-				Usage: "Skip the ERC-8004 identity pre-flight (NOT recommended)",
+				Usage: "Expected ERC-8004 agentId of the seller. Opt-in identity check; default skips verification.",
 			},
 			&cli.BoolFlag{
 				Name:  "auto-refill",
@@ -102,86 +122,214 @@ Examples:
 				Usage: "How many auths to sign each refill (requires --auto-refill)",
 			},
 			&cli.StringFlag{
-				Name:  "id",
-				Usage: "Obol agent instance id",
-				Value: agentruntime.DefaultInstanceID,
+				Name:  "cost-cap",
+				Usage: "Maximum per-request price (in payment-token base units) to accept on a refill. Skips refills that would re-sign above this ceiling.",
+			},
+			&cli.BoolFlag{
+				Name:    "yes",
+				Aliases: []string{"y"},
+				Usage:   "Skip interactive confirmation prompts (required for non-TTY runs unless --count is also set)",
+			},
+			&cli.BoolFlag{
+				Name:  "set-default",
+				Usage: "After the buy lands, promote paid/<model> to the head of LiteLLM's model_list and sync every agent. Default: prompted in TTY, off otherwise unless --agent is set.",
+			},
+			&cli.BoolFlag{
+				Name:  "replace",
+				Usage: "Delete any existing PurchaseRequest with the same name before creating a fresh one (default: top up the existing auth pool)",
 			},
 			&cli.BoolFlag{
 				Name:  "force",
-				Usage: "Pass-through to buy.py: replace an existing PurchaseRequest and bypass certain balance/overwrite safety checks",
+				Usage: "Pass-through to buy.py: proceed even when wallet balance is below total cost (some auths may fail on-chain)",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			u := getUI(cmd)
-
-			name := cmd.Args().First()
-			if name == "" {
-				name = defaultBuyName
-			}
-			if err := validate.Name(name); err != nil {
-				return err
-			}
-
-			seller := strings.TrimSpace(cmd.String("seller"))
-			if seller == "" {
-				return errors.New("--seller is empty and no DefaultBuySellerURL is configured")
-			}
-
-			token := strings.ToUpper(strings.TrimSpace(cmd.String("token")))
-			budgetBase, err := budgetToBaseUnits(cmd.String("budget"), token)
-			if err != nil {
-				return err
-			}
-
-			u.Infof("Probing seller pricing at %s …", seller)
-			pricing, err := buy.FetchSellerPricing(ctx, seller, cmd.String("model"))
-			if err != nil {
-				return fmt.Errorf("pricing pre-flight: %w", err)
-			}
-
-			if err := buy.ValidateTokenAgainstPricing(token, pricing); err != nil {
-				return err
-			}
-			if err := buy.ValidateBudgetAgainstPricing(budgetBase, pricing); err != nil {
-				return err
-			}
-
-			if !cmd.Bool("no-verify-identity") {
-				expected := cmd.Int("expected-agent-id")
-				if expected == 0 {
-					return errors.New("expected-agent-id is 0 — set --expected-agent-id, configure DefaultBuySellerAgentID, or pass --no-verify-identity to bypass")
-				}
-				u.Infof("Verifying seller identity at %s …", seller)
-				reg, err := buy.FetchSellerRegistration(ctx, seller)
-				if err != nil {
-					return fmt.Errorf("identity pre-flight: %w", err)
-				}
-				if err := buy.VerifySellerEndpoint(reg, seller); err != nil {
-					return err
-				}
-				if err := buy.VerifyAgentIDForPricing(reg, int64(expected), pricing); err != nil {
-					return err
-				}
-				u.Infof("Identity OK: agentId=%d", expected)
-			} else {
-				u.Warn("Skipping ERC-8004 identity check (--no-verify-identity).")
-			}
-
-			argv := buildBuyPyArgv(buyPyOptions{
-				Name:            name,
-				Seller:          seller,
-				Model:           cmd.String("model"),
-				BudgetMicro:     budgetBase,
-				AutoRefill:      cmd.Bool("auto-refill"),
-				RefillThreshold: cmd.Int("refill-threshold"),
-				RefillCount:     cmd.Int("refill-count"),
-				Force:           cmd.Bool("force"),
-			})
-
-			u.Infof("Dispatching to obol-agent (instance=%s) …", cmd.String("id"))
-			return agentruntime.ExecInPod(cfg, agentruntime.Hermes, cmd.String("id"), argv)
+			return runBuyInference(ctx, cfg, cmd)
 		},
 	}
+}
+
+// runBuyInference is the orchestrator for the new flow. Kept separate from
+// the cli.Command literal so the steps stay scannable: resolve agent →
+// resolve seller URL → pick catalog entry → resolve token+count+budget →
+// confirm → exec buy.py → optional model prefer + agent sync.
+func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) error {
+	u := getUI(cmd)
+
+	target, err := resolveBuyAgent(cfg, cmd)
+	if err != nil {
+		return err
+	}
+
+	sellerURL, err := resolveSellerURL(cmd)
+	if err != nil {
+		return err
+	}
+
+	u.Infof("Fetching service catalog from %s …", sellerURL)
+	entries, err := buy.FetchServiceCatalog(ctx, sellerURL)
+	if err != nil {
+		return fmt.Errorf("seller catalog: %w (pass --seller to override, or contact the operator)", err)
+	}
+	entry, err := buy.PickCatalogEntry(entries, sellerURL)
+	if err != nil {
+		return err
+	}
+
+	// Build the canonical offer URL we hand buy.py. If the caller passed a
+	// storefront base, lift /services/<name> from the catalog entry.
+	offerURL, err := canonicalOfferURL(sellerURL, entry)
+	if err != nil {
+		return err
+	}
+
+	// Resolve model: flag wins, else use the catalog entry's. Mismatch
+	// errors loudly so users see the typo instead of a controller-side
+	// "no such model" later.
+	chosenModel, err := resolveBuyModel(cmd.String("model"), entry)
+	if err != nil {
+		return err
+	}
+
+	// Probe the live 402 to confirm the seller is gating this offer and to
+	// recover the on-the-wire amount + asset for ValidateTokenAgainstPricing.
+	u.Infof("Probing seller pricing …")
+	pricing, err := buy.FetchSellerPricing(ctx, offerURL, chosenModel)
+	if err != nil {
+		return fmt.Errorf("pricing pre-flight: %w", err)
+	}
+
+	token, err := resolveBuyToken(cmd.String("token"), entry, pricing)
+	if err != nil {
+		return err
+	}
+	if err := buy.ValidateTokenAgainstPricing(token, pricing); err != nil {
+		return err
+	}
+
+	// Optional ERC-8004 identity check — opt-in via --expected-agent-id.
+	if expected := cmd.Int("expected-agent-id"); expected != 0 {
+		u.Infof("Verifying seller identity (expected agentId=%d) …", expected)
+		reg, err := buy.FetchSellerRegistration(ctx, offerURL)
+		if err != nil {
+			return fmt.Errorf("identity pre-flight: %w", err)
+		}
+		if err := buy.VerifySellerEndpoint(reg, offerURL); err != nil {
+			return err
+		}
+		if err := buy.VerifyAgentIDForPricing(reg, int64(expected), pricing); err != nil {
+			return err
+		}
+		u.Infof("Identity OK: agentId=%d", expected)
+	}
+
+	// Inspect any existing PurchaseRequest for this name in the agent's
+	// namespace — we either top up (default) or replace (--replace).
+	prName := strings.TrimSpace(cmd.String("name"))
+	if prName == "" {
+		prName = strings.TrimSpace(entry.Name)
+	}
+	if prName == "" {
+		prName = defaultBuyName
+	}
+	if err := validate.Name(prName); err != nil {
+		return err
+	}
+
+	existing, err := getPurchaseRequest(cfg, target, prName)
+	if err != nil {
+		return err
+	}
+	mode, err := resolveBuyMode(u, cmd, existing)
+	if err != nil {
+		return err
+	}
+	if mode == buyModeReplace && existing != "" {
+		u.Infof("Deleting existing PurchaseRequest %s/%s before creating a fresh one …", prName, agentruntime.Namespace(target.Runtime, target.ID))
+		if err := deletePurchaseRequest(cfg, target, prName); err != nil {
+			return err
+		}
+		existing = "" // top-up logic below shouldn't think one is still there
+	}
+
+	priceAtomic, priceUnit, err := pricingPerUnit(entry, pricing)
+	if err != nil {
+		return err
+	}
+
+	autoRefill, err := promptAutoRefill(u, cmd)
+	if err != nil {
+		return err
+	}
+
+	count, err := promptCount(u, cmd, priceUnit, autoRefill.enabled, existing != "")
+	if err != nil {
+		return err
+	}
+
+	budgetAtomic, err := resolveBudget(cmd.String("budget"), token, count, priceAtomic)
+	if err != nil {
+		return err
+	}
+
+	costCapAtomic, err := resolveCostCap(cmd.String("cost-cap"), token, priceAtomic, autoRefill.enabled)
+	if err != nil {
+		return err
+	}
+
+	// Wallet preflight: surface the paying address + balance before the
+	// final confirmation. The agent pod walks the signer + eRPC for us, so
+	// failures here are non-fatal (we still let the buy proceed if e.g.
+	// the chain alias isn't installed — buy.py re-checks balance itself).
+	walletInfo := fetchWalletInfoBestEffort(cfg, target, token, paymentChainForDisplay(pricing), u)
+
+	summary := buySummary{
+		Agent:         target,
+		PRName:        prName,
+		OfferURL:      offerURL,
+		Model:         chosenModel,
+		Count:         count,
+		PriceAtomic:   priceAtomic,
+		PriceUnit:     priceUnit,
+		Token:         token,
+		BudgetAtomic:  budgetAtomic,
+		AutoRefill:    autoRefill,
+		CostCapAtomic: costCapAtomic,
+		Wallet:        walletInfo,
+		Mode:          mode,
+	}
+	printBuySummary(u, summary)
+	if !confirmBuy(u, cmd) {
+		return errors.New("buy cancelled")
+	}
+
+	setDefault := resolveSetDefault(u, cmd, chosenModel)
+
+	argv := buildBuyPyArgv(buyPyOptions{
+		Name:            prName,
+		Seller:          offerURL,
+		Model:           chosenModel,
+		BudgetMicro:     budgetAtomic.String(),
+		AutoRefill:      autoRefill.enabled,
+		RefillThreshold: autoRefill.threshold,
+		RefillCount:     autoRefill.count,
+		CostCap:         costCapAtomic,
+		Force:           cmd.Bool("force"),
+		SetDefault:      false, // we do model prefer/agent sync from Go side
+	})
+
+	u.Infof("Dispatching to agent %s (instance=%s) …", target.Runtime, target.ID)
+	if err := agentruntime.ExecInPod(cfg, target.Runtime, target.ID, argv); err != nil {
+		return err
+	}
+
+	if setDefault {
+		if err := promoteAndSyncModel(cfg, u, chosenModel); err != nil {
+			u.Warnf("Set-default partially failed: %v", err)
+			u.Dim("  The purchase landed; rerun `obol model prefer paid/" + chosenModel + " && obol agent sync` to retry.")
+		}
+	}
+	return nil
 }
 
 // buyPyOptions captures everything needed to invoke `buy.py buy` inside the
@@ -194,7 +342,9 @@ type buyPyOptions struct {
 	AutoRefill      bool
 	RefillThreshold int
 	RefillCount     int
+	CostCap         *big.Int // when non-nil, sets --cost-cap on the buy.py call
 	Force           bool
+	SetDefault      bool
 }
 
 // buildBuyPyArgv composes the argv for `python3 buy.py buy <name> ...`.
@@ -216,6 +366,12 @@ func buildBuyPyArgv(opts buyPyOptions) []string {
 			argv = append(argv, "--refill-count", fmt.Sprintf("%d", opts.RefillCount))
 		}
 	}
+	if opts.CostCap != nil && opts.CostCap.Sign() > 0 {
+		argv = append(argv, "--cost-cap", opts.CostCap.String())
+	}
+	if opts.SetDefault {
+		argv = append(argv, "--set-default")
+	}
 	if opts.Force {
 		argv = append(argv, "--force")
 	}
@@ -224,12 +380,7 @@ func buildBuyPyArgv(opts buyPyOptions) []string {
 
 // budgetToBaseUnits parses a human-readable token amount (e.g. "10" for 10
 // USDC, "0.023" for 0.023 OBOL) and returns the equivalent in atomic base
-// units as a base-10 integer string. The token name is matched against the
-// x402 token registry to determine the correct decimal precision.
-//
-// Uses big.Rat so we don't lose precision on fractional amounts. Rejects
-// negatives and any value that isn't an integral number of base units (i.e.
-// finer than the token's smallest denomination).
+// units as a base-10 integer string.
 func budgetToBaseUnits(amount, token string) (string, error) {
 	s := strings.TrimSpace(amount)
 	if s == "" {
@@ -248,8 +399,6 @@ func budgetToBaseUnits(amount, token string) (string, error) {
 		tok = "USDC"
 	}
 
-	// Look up decimals from any chain the token is registered on — the decimal
-	// count is the same across all chains for a given token symbol.
 	chains := x402verifier.ChainsForToken(tok)
 	if len(chains) == 0 {
 		supported := strings.Join(x402verifier.SupportedTokens(), ", ")
@@ -264,4 +413,496 @@ func budgetToBaseUnits(amount, token string) (string, error) {
 		return "", fmt.Errorf("--budget %q has more precision than %s supports (%d decimals)", amount, tok, decimals)
 	}
 	return base.Num().String(), nil
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+type buyMode int
+
+const (
+	buyModeFresh   buyMode = iota // no existing PurchaseRequest
+	buyModeTopUp                  // append auths to existing PR
+	buyModeReplace                // delete then recreate
+)
+
+type autoRefillPolicy struct {
+	enabled   bool
+	threshold int
+	count     int
+}
+
+type buySummary struct {
+	Agent         agentTarget
+	PRName        string
+	OfferURL      string
+	Model         string
+	Count         int
+	PriceAtomic   *big.Int
+	PriceUnit     string // "perRequest" | "perMTok"
+	Token         string
+	BudgetAtomic  *big.Int
+	AutoRefill    autoRefillPolicy
+	CostCapAtomic *big.Int
+	Wallet        *buy.WalletInfo
+	Mode          buyMode
+}
+
+// resolveBuyAgent picks the agent instance whose wallet pays the bill. When
+// --agent is set we treat it as authoritative; otherwise we use the same
+// resolution logic as `obol agent sync` (prefer the master Hermes instance,
+// fall back to the only instance when there's exactly one).
+func resolveBuyAgent(cfg *config.Config, cmd *cli.Command) (agentTarget, error) {
+	if name := strings.TrimSpace(cmd.String("agent")); name != "" {
+		return resolveAnyAgentTarget(cfg, []string{name})
+	}
+	return resolveAnyAgentTarget(cfg, nil)
+}
+
+func resolveSellerURL(cmd *cli.Command) (string, error) {
+	if v := strings.TrimSpace(cmd.Args().First()); v != "" {
+		if !looksLikeURL(v) {
+			return "", fmt.Errorf("positional argument %q does not look like a URL — pass --name for a custom PurchaseRequest name and a URL as the positional argument", v)
+		}
+		return v, nil
+	}
+	if v := strings.TrimSpace(cmd.String("seller")); v != "" {
+		return v, nil
+	}
+	return x402verifier.DefaultBuySellerURL, nil
+}
+
+func looksLikeURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// canonicalOfferURL produces the /services/<name> URL we hand to buy.py.
+// When the user passes a storefront base, we splice the catalog endpoint;
+// when they pass a specific service URL, that URL wins (we still validated
+// it against the catalog before calling here).
+func canonicalOfferURL(userURL string, entry *buy.CatalogEntry) (string, error) {
+	if entry == nil {
+		return "", errors.New("catalog entry is nil")
+	}
+	// If the user URL already has a /services/<name> segment, just return
+	// it verbatim. This preserves any explicit base hostname they typed.
+	if strings.Contains(userURL, "/services/") {
+		return strings.TrimRight(userURL, "/"), nil
+	}
+	// Otherwise: storefront-only URL — splice the offer endpoint onto the
+	// same scheme/host.
+	base := strings.TrimRight(userURL, "/")
+	endpoint := strings.TrimSpace(entry.Endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("catalog entry for %q has empty endpoint", entry.Name)
+	}
+	// endpoint is path-only (e.g. "/services/aeon") per the controller's
+	// render. Strip /v1/chat/completions if present so buy.py can re-add
+	// the conventional suffix itself.
+	for _, suffix := range []string{"/v1/chat/completions", "/chat/completions"} {
+		endpoint = strings.TrimSuffix(endpoint, suffix)
+	}
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+	return base + endpoint, nil
+}
+
+func resolveBuyModel(flag string, entry *buy.CatalogEntry) (string, error) {
+	flag = strings.TrimSpace(flag)
+	entryModel := strings.TrimSpace(entry.Model)
+
+	if flag != "" {
+		if entryModel != "" && !strings.EqualFold(flag, entryModel) {
+			return "", fmt.Errorf("--model %q does not match seller offer model %q for %s", flag, entryModel, entry.Name)
+		}
+		return flag, nil
+	}
+	if entryModel == "" {
+		return "", fmt.Errorf("seller offer %q advertises no model id — pass --model explicitly", entry.Name)
+	}
+	return entryModel, nil
+}
+
+func resolveBuyToken(flag string, entry *buy.CatalogEntry, pricing *buy.PricingResponse) (string, error) {
+	flag = strings.ToUpper(strings.TrimSpace(flag))
+	if flag != "" {
+		return flag, nil
+	}
+	// Prefer the catalog-advertised asset symbol over the 402-derived one
+	// — the controller publishes a normalized symbol while the 402 only
+	// carries a contract address.
+	if entry != nil && entry.Asset != nil && strings.TrimSpace(entry.Asset.Symbol) != "" {
+		return strings.ToUpper(strings.TrimSpace(entry.Asset.Symbol)), nil
+	}
+	// Last-ditch: walk the supported token registry against the 402's
+	// asset/network so non-Obol storefronts that omit Asset still work.
+	if pricing != nil && len(pricing.Accepts) > 0 {
+		accept := pricing.Accepts[0]
+		for _, sym := range x402verifier.SupportedTokens() {
+			chains := x402verifier.ChainsForToken(sym)
+			for _, chain := range chains {
+				if entry, ok := x402verifier.ResolveToken(sym, chain); ok {
+					if strings.EqualFold(entry.Address, accept.Asset) {
+						return sym, nil
+					}
+				}
+			}
+		}
+	}
+	return "USDC", nil
+}
+
+// pricingPerUnit returns the atomic per-request price plus the human unit
+// label ("perRequest" or "perMTok") that the prompts/copy use.
+func pricingPerUnit(entry *buy.CatalogEntry, pricing *buy.PricingResponse) (*big.Int, string, error) {
+	unit := "perRequest"
+	if entry != nil && strings.TrimSpace(entry.PriceUnit) != "" {
+		unit = entry.PriceUnit
+	}
+	if pricing == nil || len(pricing.Accepts) == 0 {
+		return nil, unit, errors.New("pricing response has no payment options")
+	}
+	accept := pricing.Accepts[0]
+	raw := accept.Amount
+	if strings.TrimSpace(raw) == "" {
+		raw = accept.MaxAmountRequired
+	}
+	price, ok := new(big.Int).SetString(strings.TrimSpace(raw), 10)
+	if !ok || price.Sign() <= 0 {
+		return nil, unit, fmt.Errorf("invalid wire price %q", raw)
+	}
+	return price, unit, nil
+}
+
+// promptAutoRefill resolves --auto-refill / --refill-threshold /
+// --refill-count from flags, then interactively fills in the missing pieces
+// when in a TTY. In non-interactive mode the policy is exactly what the
+// flags described.
+func promptAutoRefill(u *ui.UI, cmd *cli.Command) (autoRefillPolicy, error) {
+	enabled := cmd.Bool("auto-refill")
+	threshold := cmd.Int("refill-threshold")
+	count := cmd.Int("refill-count")
+
+	if !u.IsTTY() || cmd.Bool("yes") {
+		return autoRefillPolicy{enabled: enabled, threshold: threshold, count: count}, nil
+	}
+
+	if !enabled {
+		enabled = u.Confirm("Enable auto-refill? Tops up the auth pool from the agent's wallet when it runs low.", false)
+	}
+	if !enabled {
+		return autoRefillPolicy{}, nil
+	}
+	// buy.py picks sensible defaults when these are 0; only prompt if the
+	// user wants to override.
+	if threshold == 0 {
+		v, err := promptPositiveInt(u, "Refill when remaining auths fall below", 5)
+		if err != nil {
+			return autoRefillPolicy{}, err
+		}
+		threshold = v
+	}
+	if count == 0 {
+		v, err := promptPositiveInt(u, "Auths to sign per refill", 25)
+		if err != nil {
+			return autoRefillPolicy{}, err
+		}
+		count = v
+	}
+	return autoRefillPolicy{enabled: true, threshold: threshold, count: count}, nil
+}
+
+// promptCount drives the request-or-mtoks count prompt. In non-TTY mode
+// --count is mandatory unless --yes was set (in which case we fall back to
+// the interactive default — explicit consent suppresses the safety check).
+func promptCount(u *ui.UI, cmd *cli.Command, priceUnit string, _ bool, existing bool) (int, error) {
+	if v := cmd.Int("count"); v > 0 {
+		return v, nil
+	}
+	if !u.IsTTY() {
+		if cmd.Bool("yes") {
+			return defaultInteractiveCount, nil
+		}
+		return 0, errors.New("--count is required in non-interactive mode (pass --count <N>, or run from a TTY)")
+	}
+	label := "How many requests to pre-pay?"
+	if priceUnit == "perMTok" {
+		label = "How many million tokens of inference to pre-pay?"
+	}
+	if existing {
+		label = "How many more " + countUnit(priceUnit) + " to add to the existing pool?"
+	}
+	return promptPositiveInt(u, label, defaultInteractiveCount)
+}
+
+func countUnit(priceUnit string) string {
+	if priceUnit == "perMTok" {
+		return "million-token-batches"
+	}
+	return "requests"
+}
+
+func promptPositiveInt(u *ui.UI, label string, def int) (int, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		raw, err := u.Input(label, fmt.Sprintf("%d", def))
+		if err != nil {
+			return 0, err
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return def, nil
+		}
+		v, err := parsePositiveInt(raw)
+		if err == nil {
+			return v, nil
+		}
+		u.Warnf("%v", err)
+	}
+	return 0, fmt.Errorf("invalid input for %q after 3 attempts", label)
+}
+
+func parsePositiveInt(s string) (int, error) {
+	v := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("not a positive integer: %q", s)
+		}
+		v = v*10 + int(r-'0')
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("must be > 0: %q", s)
+	}
+	return v, nil
+}
+
+// resolveBudget computes a budget cap in atomic units. Explicit --budget
+// wins; otherwise we compute count × price and add 0 headroom — buy.py
+// rounds-up at the per-auth boundary, and a tight cap is exactly what users
+// asked for when they didn't set one explicitly.
+func resolveBudget(flag, token string, count int, price *big.Int) (*big.Int, error) {
+	if flag = strings.TrimSpace(flag); flag != "" {
+		s, err := budgetToBaseUnits(flag, token)
+		if err != nil {
+			return nil, err
+		}
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return nil, fmt.Errorf("internal: budgetToBaseUnits returned non-numeric %q", s)
+		}
+		return v, nil
+	}
+	if count <= 0 || price == nil || price.Sign() <= 0 {
+		return nil, errors.New("internal: count or price is non-positive")
+	}
+	return new(big.Int).Mul(price, big.NewInt(int64(count))), nil
+}
+
+// resolveCostCap parses --cost-cap into atomic units, or computes a default
+// of price × (1 + costCapMarkupBps/10000) when auto-refill is enabled.
+func resolveCostCap(flag, token string, price *big.Int, autoRefill bool) (*big.Int, error) {
+	if flag = strings.TrimSpace(flag); flag != "" {
+		// --cost-cap is in atomic units (matches buy.py convention).
+		v, ok := new(big.Int).SetString(flag, 10)
+		if !ok || v.Sign() <= 0 {
+			// Try human-readable parsing as a fallback so users who
+			// type "0.05" still get the right thing.
+			s, err := budgetToBaseUnits(flag, token)
+			if err != nil {
+				return nil, fmt.Errorf("--cost-cap %q is neither base units nor a valid decimal amount: %w", flag, err)
+			}
+			parsed, ok := new(big.Int).SetString(s, 10)
+			if !ok {
+				return nil, fmt.Errorf("--cost-cap %q failed to parse", flag)
+			}
+			return parsed, nil
+		}
+		return v, nil
+	}
+	if !autoRefill || price == nil || price.Sign() <= 0 {
+		return nil, nil
+	}
+	cap := new(big.Int).Mul(price, big.NewInt(int64(10000+costCapMarkupBps)))
+	cap.Quo(cap, big.NewInt(10000))
+	return cap, nil
+}
+
+func paymentChainForDisplay(pricing *buy.PricingResponse) string {
+	if pricing == nil || len(pricing.Accepts) == 0 {
+		return x402verifier.DefaultBuySellerChain
+	}
+	net := strings.TrimSpace(pricing.Accepts[0].Network)
+	if net == "" {
+		return x402verifier.DefaultBuySellerChain
+	}
+	switch net {
+	case "eip155:1":
+		return "mainnet"
+	case "eip155:8453":
+		return "base"
+	case "eip155:84532":
+		return "base-sepolia"
+	}
+	return net
+}
+
+func fetchWalletInfoBestEffort(cfg *config.Config, target agentTarget, token, chain string, u *ui.UI) *buy.WalletInfo {
+	info, err := buy.FetchWalletInfo(cfg, target.Runtime, target.ID, token, chain)
+	if err != nil {
+		u.Dim(fmt.Sprintf("  (wallet balance preflight skipped: %v)", err))
+		return nil
+	}
+	return info
+}
+
+// printBuySummary mirrors the design-doc summary line so the user sees
+// exactly what they're signing before the confirmation.
+func printBuySummary(u *ui.UI, s buySummary) {
+	tokenInfo, _ := x402verifier.ResolveToken(s.Token, "")
+	human := func(v *big.Int) string {
+		if v == nil {
+			return "?"
+		}
+		dec := tokenInfo.Decimals
+		if dec == 0 {
+			dec = 6
+		}
+		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(dec)), nil)
+		r := new(big.Rat).SetFrac(v, scale)
+		return r.FloatString(6)
+	}
+
+	u.Print("")
+	u.Print("─── Purchase summary ─────────────────────────────────────────")
+	u.Print(fmt.Sprintf("  Offer:       %s", s.OfferURL))
+	u.Print(fmt.Sprintf("  Model:       %s", s.Model))
+	unit := "request"
+	if s.PriceUnit == "perMTok" {
+		unit = "million tokens"
+	}
+	u.Print(fmt.Sprintf("  Price:       %s %s per %s", human(s.PriceAtomic), s.Token, unit))
+	u.Print(fmt.Sprintf("  Count:       %d (≈ %s %s total)", s.Count, human(s.BudgetAtomic), s.Token))
+	if s.AutoRefill.enabled {
+		u.Print(fmt.Sprintf("  Auto-refill: yes (top up when remaining<%d, sign %d more each time)", s.AutoRefill.threshold, s.AutoRefill.count))
+	} else {
+		u.Print("  Auto-refill: no")
+	}
+	if s.CostCapAtomic != nil && s.CostCapAtomic.Sign() > 0 {
+		u.Print(fmt.Sprintf("  Cost cap:    refills skipped above %s %s/%s", human(s.CostCapAtomic), s.Token, unit))
+	}
+	if s.Wallet != nil {
+		u.Print(fmt.Sprintf("  Paid from:   %s (balance %s %s on %s)", s.Wallet.Address, s.Wallet.HumanBalance(), s.Token, s.Wallet.Chain))
+	} else {
+		u.Print(fmt.Sprintf("  Paid from:   agent wallet (instance %s/%s)", s.Agent.Runtime, s.Agent.ID))
+	}
+	switch s.Mode {
+	case buyModeTopUp:
+		u.Print("  Existing PR: topping up the existing auth pool")
+	case buyModeReplace:
+		u.Print("  Existing PR: replacing the existing PurchaseRequest")
+	}
+	u.Print("──────────────────────────────────────────────────────────────")
+}
+
+func confirmBuy(u *ui.UI, cmd *cli.Command) bool {
+	if cmd.Bool("yes") {
+		return true
+	}
+	if !u.IsTTY() {
+		// Non-TTY without --yes — never silently proceed. Caller will see
+		// the printed summary then the error.
+		return false
+	}
+	return u.Confirm("Confirm purchase?", true)
+}
+
+func resolveSetDefault(u *ui.UI, cmd *cli.Command, model string) bool {
+	if cmd.IsSet("set-default") {
+		return cmd.Bool("set-default")
+	}
+	if cmd.IsSet("agent") {
+		return true
+	}
+	if !u.IsTTY() {
+		return false
+	}
+	return u.Confirm(fmt.Sprintf("Set paid/%s as the default inference model for all agents (model prefer + agent sync)?", model), true)
+}
+
+func promoteAndSyncModel(cfg *config.Config, u *ui.UI, modelID string) error {
+	paidName := "paid/" + modelID
+	if err := model.PreferModels(cfg, u, []string{paidName}); err != nil {
+		return fmt.Errorf("model prefer %s: %w", paidName, err)
+	}
+	hermesIDs, err := agentruntime.ListInstanceIDs(cfg, agentruntime.Hermes)
+	if err != nil {
+		return fmt.Errorf("list hermes instances: %w", err)
+	}
+	openclawIDs, err := agentruntime.ListInstanceIDs(cfg, agentruntime.OpenClaw)
+	if err != nil {
+		return fmt.Errorf("list openclaw instances: %w", err)
+	}
+	for _, id := range hermesIDs {
+		if err := syncAgentTarget(cfg, agentTarget{Runtime: agentruntime.Hermes, ID: id}, u); err != nil {
+			return fmt.Errorf("sync hermes/%s: %w", id, err)
+		}
+	}
+	for _, id := range openclawIDs {
+		if err := syncAgentTarget(cfg, agentTarget{Runtime: agentruntime.OpenClaw, ID: id}, u); err != nil {
+			return fmt.Errorf("sync openclaw/%s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+// getPurchaseRequest returns the PurchaseRequest name when one exists in
+// the agent's namespace, "" otherwise. We use kubectl --ignore-not-found
+// instead of a dynamic client to stay consistent with how the rest of the
+// CLI talks to the API.
+func getPurchaseRequest(cfg *config.Config, target agentTarget, name string) (string, error) {
+	if err := kubectl.EnsureCluster(cfg); err != nil {
+		return "", err
+	}
+	bin, kc := kubectl.Paths(cfg)
+	ns := agentruntime.Namespace(target.Runtime, target.ID)
+	out, err := kubectl.Output(bin, kc, "get", monetizeapi.PurchaseRequestResource, name, "-n", ns, "-o", "name", "--ignore-not-found")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func deletePurchaseRequest(cfg *config.Config, target agentTarget, name string) error {
+	bin := filepath.Join(cfg.BinDir, "kubectl")
+	kc := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	ns := agentruntime.Namespace(target.Runtime, target.ID)
+	return kubectl.Run(bin, kc, "delete", monetizeapi.PurchaseRequestResource, name, "-n", ns, "--ignore-not-found", "--wait=true")
+}
+
+// resolveBuyMode decides between fresh / top-up / replace given the
+// existing PR state and user intent.
+func resolveBuyMode(u *ui.UI, cmd *cli.Command, existing string) (buyMode, error) {
+	if existing == "" {
+		return buyModeFresh, nil
+	}
+	if cmd.Bool("replace") {
+		return buyModeReplace, nil
+	}
+	if cmd.Bool("yes") || !u.IsTTY() {
+		// Non-interactive default: top up. Safer than replace.
+		return buyModeTopUp, nil
+	}
+	u.Infof("Found existing PurchaseRequest %s in agent namespace.", existing)
+	choices := []string{"Top up (sign more auths into the existing pool)", "Replace (delete and create fresh)", "Cancel"}
+	idx, err := u.Select("How would you like to proceed?", choices, 0)
+	if err != nil {
+		return buyModeFresh, err
+	}
+	switch idx {
+	case 0:
+		return buyModeTopUp, nil
+	case 1:
+		return buyModeReplace, nil
+	default:
+		return buyModeFresh, errors.New("buy cancelled")
+	}
 }

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	"github.com/ObolNetwork/obol-stack/internal/schemas"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/ObolNetwork/obol-stack/internal/validate"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
@@ -29,11 +30,14 @@ const (
 	hermesBuyPyPath = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
 	defaultBuyName  = "default-paid"
 
-	// defaultInteractiveCount is the count we propose when the user accepts
-	// the interactive default. Small enough to feel like a try-before-trust
-	// purchase on most providers, large enough to be useful for a quick
-	// chat session.
-	defaultInteractiveCount = 50
+	// defaultInteractivePerMTokCount is the default for perMTok offers:
+	// 5 million tokens is enough for a meaningful chat session without
+	// committing a large initial spend.
+	defaultInteractivePerMTokCount = 5
+
+	// defaultInteractivePerRequestCount is the default for perRequest
+	// offers — small but useful first-purchase footprint.
+	defaultInteractivePerRequestCount = 50
 
 	// costCapMarkupBps is the default headroom over the seller's quoted
 	// per-request price that we apply when --cost-cap is not set
@@ -57,7 +61,7 @@ func buyInferenceCommand(cfg *config.Config) *cli.Command {
 		Name:      "inference",
 		Usage:     "Buy paid inference from an x402-gated seller via the obol-agent",
 		ArgsUsage: "[<seller-url>]",
-		Description: `Pre-pays an x402-gated inference seller through an obol-agent's wallet.
+		Description: `Pre-authorizes an x402-gated inference seller through an obol-agent's wallet.
 
 Hand the command a seller URL — either a storefront base
 ("https://inference.v1337.org") or a specific offer
@@ -103,7 +107,7 @@ Examples:
 			},
 			&cli.IntFlag{
 				Name:  "count",
-				Usage: "How many requests (perRequest pricing) or million-tokens (perMTok pricing) of capacity to pre-pay. Required in non-interactive mode.",
+				Usage: "How many requests (perRequest pricing) or million-tokens (perMTok pricing) of capacity to pre-authorize. Required in non-interactive mode.",
 			},
 			&cli.IntFlag{
 				Name:  "expected-agent-id",
@@ -111,7 +115,7 @@ Examples:
 			},
 			&cli.BoolFlag{
 				Name:  "auto-refill",
-				Usage: "Enable agent-managed refill of the auth pool",
+				Usage: "Enable agent-managed top-up of the pre-authorized budget when it runs low",
 			},
 			&cli.IntFlag{
 				Name:  "refill-threshold",
@@ -136,7 +140,7 @@ Examples:
 			},
 			&cli.BoolFlag{
 				Name:  "replace",
-				Usage: "Delete any existing PurchaseRequest with the same name before creating a fresh one (default: top up the existing auth pool)",
+				Usage: "Delete any existing PurchaseRequest with the same name before creating a fresh one (default: top up the existing pre-authorized budget)",
 			},
 			&cli.BoolFlag{
 				Name:  "force",
@@ -155,6 +159,8 @@ Examples:
 // confirm → exec buy.py → optional model prefer + agent sync.
 func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) error {
 	u := getUI(cmd)
+
+	u.Info("Purchasing remote inference for running Obol Agents")
 
 	target, err := resolveBuyAgent(cfg, cmd)
 	if err != nil {
@@ -257,12 +263,13 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		return err
 	}
 
-	autoRefill, err := promptAutoRefill(u, cmd)
+	autoRefill, err := promptAutoRefill(u, cmd, priceUnit)
 	if err != nil {
 		return err
 	}
 
-	count, err := promptCount(u, cmd, priceUnit, autoRefill.enabled, existing != "")
+	tokenDecimalsForPrompt := resolveTokenDecimals(entry, token, paymentChainForDisplay(pricing))
+	count, err := promptCount(u, cmd, priceUnit, existing != "", token, priceAtomic, tokenDecimalsForPrompt)
 	if err != nil {
 		return err
 	}
@@ -281,7 +288,9 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 	// final confirmation. The agent pod walks the signer + eRPC for us, so
 	// failures here are non-fatal (we still let the buy proceed if e.g.
 	// the chain alias isn't installed — buy.py re-checks balance itself).
-	walletInfo := fetchWalletInfoBestEffort(cfg, target, token, paymentChainForDisplay(pricing), u)
+	chainForDisplay := paymentChainForDisplay(pricing)
+	walletInfo := fetchWalletInfoBestEffort(cfg, target, token, chainForDisplay, u)
+	decimals := resolveTokenDecimals(entry, token, chainForDisplay)
 
 	summary := buySummary{
 		Agent:         target,
@@ -292,6 +301,7 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		PriceAtomic:   priceAtomic,
 		PriceUnit:     priceUnit,
 		Token:         token,
+		TokenDecimals: decimals,
 		BudgetAtomic:  budgetAtomic,
 		AutoRefill:    autoRefill,
 		CostCapAtomic: costCapAtomic,
@@ -300,20 +310,36 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 	}
 	printBuySummary(u, summary)
 	if !confirmBuy(u, cmd) {
-		return errors.New("buy cancelled")
+		return errors.New("buy inference cancelled")
 	}
 
 	perAgent, global := resolveDefaultScopes(u, cmd, chosenModel, target)
 
+	// buy.py operates in per-auth wire units (each auth pays the per-request
+	// wire amount). For perMTok offers the user-facing natural unit is
+	// million-tokens, which maps to ApproxTokensPerRequest auths. Multiply
+	// count, refill threshold, and refill count once here so the buy.py
+	// argv stays in its native units.
+	multiplier := 1
+	if priceUnit == "perMTok" {
+		multiplier = schemas.ApproxTokensPerRequest
+	}
+	costCapForBuyPy := costCapAtomic
+	if costCapForBuyPy != nil && costCapForBuyPy.Sign() > 0 && priceUnit == "perMTok" {
+		// Cost cap is stored as per-MTok atomic; buy.py compares against
+		// per-request wire amounts, so divide before passing.
+		costCapForBuyPy = new(big.Int).Quo(costCapForBuyPy, big.NewInt(int64(schemas.ApproxTokensPerRequest)))
+	}
 	argv := buildBuyPyArgv(buyPyOptions{
 		Name:            prName,
 		Seller:          offerURL,
 		Model:           chosenModel,
 		BudgetMicro:     budgetAtomic.String(),
+		Count:           count * multiplier,
 		AutoRefill:      autoRefill.enabled,
-		RefillThreshold: autoRefill.threshold,
-		RefillCount:     autoRefill.count,
-		CostCap:         costCapAtomic,
+		RefillThreshold: autoRefill.threshold * multiplier,
+		RefillCount:     autoRefill.count * multiplier,
+		CostCap:         costCapForBuyPy,
 		Force:           cmd.Bool("force"),
 		// Per-agent default lives entirely in-pod: buy.py edits the agent's
 		// hermes-config to set model.default = paid/<model> for the agent
@@ -339,11 +365,16 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 
 // buyPyOptions captures everything needed to invoke `buy.py buy` inside the
 // agent pod. Kept as a flat struct so buildBuyPyArgv stays trivially testable.
+//
+// All count fields (Count, RefillThreshold, RefillCount) are in buy.py's
+// native per-auth wire units. The host CLI converts from natural units
+// (requests | million-tokens) before populating these fields.
 type buyPyOptions struct {
 	Name            string
 	Seller          string
 	Model           string
 	BudgetMicro     string
+	Count           int // explicit auth count; 0 lets buy.py derive from budget
 	AutoRefill      bool
 	RefillThreshold int
 	RefillCount     int
@@ -358,6 +389,9 @@ func buildBuyPyArgv(opts buyPyOptions) []string {
 		hermesPython, hermesBuyPyPath, "buy", opts.Name,
 		"--endpoint", opts.Seller,
 		"--budget", opts.BudgetMicro,
+	}
+	if opts.Count > 0 {
+		argv = append(argv, "--count", fmt.Sprintf("%d", opts.Count))
 	}
 	if m := strings.TrimSpace(opts.Model); m != "" {
 		argv = append(argv, "--model", m)
@@ -441,11 +475,12 @@ type buySummary struct {
 	PRName        string
 	OfferURL      string
 	Model         string
-	Count         int
-	PriceAtomic   *big.Int
-	PriceUnit     string // "perRequest" | "perMTok"
+	Count         int      // in natural units (requests | million-tokens)
+	PriceAtomic   *big.Int // per natural unit
+	PriceUnit     string   // "perRequest" | "perMTok"
 	Token         string
-	BudgetAtomic  *big.Int
+	TokenDecimals int      // for human formatting; catalog wins, ResolveToken fallback
+	BudgetAtomic  *big.Int // count × PriceAtomic
 	AutoRefill    autoRefillPolicy
 	CostCapAtomic *big.Int
 	Wallet        *buy.WalletInfo
@@ -481,31 +516,40 @@ func looksLikeURL(s string) bool {
 }
 
 // canonicalOfferURL produces the /services/<name> URL we hand to buy.py.
-// When the user passes a storefront base, we splice the catalog endpoint;
-// when they pass a specific service URL, that URL wins (we still validated
-// it against the catalog before calling here).
+// Real-world catalogs (inference.v1337.org) store `endpoint` as an
+// absolute URL ("https://host/services/<name>"); older/local controllers
+// emit a path-only form ("/services/<name>"). Handle both so we don't end
+// up concatenating the storefront base onto a full URL.
 func canonicalOfferURL(userURL string, entry *buy.CatalogEntry) (string, error) {
 	if entry == nil {
 		return "", errors.New("catalog entry is nil")
 	}
-	// If the user URL already has a /services/<name> segment, just return
-	// it verbatim. This preserves any explicit base hostname they typed.
+	// If the user URL already has a /services/<name> segment, trust it.
+	// Preserves any explicit hostname they typed (useful for behind-tunnel
+	// dev hosts where the catalog still publishes the public hostname).
 	if strings.Contains(userURL, "/services/") {
 		return strings.TrimRight(userURL, "/"), nil
 	}
-	// Otherwise: storefront-only URL — splice the offer endpoint onto the
-	// same scheme/host.
-	base := strings.TrimRight(userURL, "/")
+
 	endpoint := strings.TrimSpace(entry.Endpoint)
 	if endpoint == "" {
 		return "", fmt.Errorf("catalog entry for %q has empty endpoint", entry.Name)
 	}
-	// endpoint is path-only (e.g. "/services/aeon") per the controller's
-	// render. Strip /v1/chat/completions if present so buy.py can re-add
-	// the conventional suffix itself.
+	// Strip /v1/chat/completions so buy.py / FetchSellerPricing can re-add
+	// the conventional suffix themselves.
 	for _, suffix := range []string{"/v1/chat/completions", "/chat/completions"} {
 		endpoint = strings.TrimSuffix(endpoint, suffix)
 	}
+	endpoint = strings.TrimRight(endpoint, "/")
+
+	// Absolute URL — use verbatim. Don't splice onto the user's base; the
+	// catalog's hostname is the seller's source of truth.
+	if looksLikeURL(endpoint) {
+		return endpoint, nil
+	}
+
+	// Path-only — splice onto the user's scheme+host.
+	base := strings.TrimRight(userURL, "/")
 	if !strings.HasPrefix(endpoint, "/") {
 		endpoint = "/" + endpoint
 	}
@@ -557,12 +601,25 @@ func resolveBuyToken(flag string, entry *buy.CatalogEntry, pricing *buy.PricingR
 	return "USDC", nil
 }
 
-// pricingPerUnit returns the atomic per-request price plus the human unit
-// label ("perRequest" or "perMTok") that the prompts/copy use.
+// pricingPerUnit returns the atomic per-NATURAL-unit price and the unit
+// label. Natural unit means: per-request for perRequest offers, per-MTok
+// for perMTok offers. The catalog's priceAtomicUnits is the authoritative
+// value (controller derives it from priceRaw × 10^decimals); we fall back
+// to deriving from the 402 wire amount when the catalog field is empty.
+//
+// Conversion to buy.py's per-auth wire units happens at argv-build time,
+// not here, so the rest of the flow can reason in natural units.
 func pricingPerUnit(entry *buy.CatalogEntry, pricing *buy.PricingResponse) (*big.Int, string, error) {
 	unit := "perRequest"
 	if entry != nil && strings.TrimSpace(entry.PriceUnit) != "" {
 		unit = entry.PriceUnit
+	}
+	// Catalog-derived atomic is the natural-unit price the seller renders
+	// at /api/services.json. Use it when present.
+	if entry != nil && strings.TrimSpace(entry.PriceAtomicUnits) != "" {
+		if p, ok := new(big.Int).SetString(strings.TrimSpace(entry.PriceAtomicUnits), 10); ok && p.Sign() > 0 {
+			return p, unit, nil
+		}
 	}
 	if pricing == nil || len(pricing.Accepts) == 0 {
 		return nil, unit, errors.New("pricing response has no payment options")
@@ -572,18 +629,25 @@ func pricingPerUnit(entry *buy.CatalogEntry, pricing *buy.PricingResponse) (*big
 	if strings.TrimSpace(raw) == "" {
 		raw = accept.MaxAmountRequired
 	}
-	price, ok := new(big.Int).SetString(strings.TrimSpace(raw), 10)
-	if !ok || price.Sign() <= 0 {
+	wire, ok := new(big.Int).SetString(strings.TrimSpace(raw), 10)
+	if !ok || wire.Sign() <= 0 {
 		return nil, unit, fmt.Errorf("invalid wire price %q", raw)
 	}
-	return price, unit, nil
+	// Wire is always per-request. For perMTok offers, multiply by ~1000
+	// tokens-per-request to recover the per-MTok ceiling.
+	if unit == "perMTok" {
+		wire = new(big.Int).Mul(wire, big.NewInt(int64(schemas.ApproxTokensPerRequest)))
+	}
+	return wire, unit, nil
 }
 
 // promptAutoRefill resolves --auto-refill / --refill-threshold /
 // --refill-count from flags, then interactively fills in the missing pieces
 // when in a TTY. In non-interactive mode the policy is exactly what the
-// flags described.
-func promptAutoRefill(u *ui.UI, cmd *cli.Command) (autoRefillPolicy, error) {
+// flags described. Threshold and count are in NATURAL units (requests for
+// perRequest offers, million-tokens for perMTok); the buy.py argv builder
+// converts to per-auth wire units when sending to the agent.
+func promptAutoRefill(u *ui.UI, cmd *cli.Command, priceUnit string) (autoRefillPolicy, error) {
 	enabled := cmd.Bool("auto-refill")
 	threshold := cmd.Int("refill-threshold")
 	count := cmd.Int("refill-count")
@@ -593,22 +657,21 @@ func promptAutoRefill(u *ui.UI, cmd *cli.Command) (autoRefillPolicy, error) {
 	}
 
 	if !enabled {
-		enabled = u.Confirm("Enable auto-refill? Tops up the auth pool from the agent's wallet when it runs low.", false)
+		enabled = u.Confirm("Enable auto-top-up? Adds more pre-authorized inference from the agent's wallet when it runs low.", false)
 	}
 	if !enabled {
 		return autoRefillPolicy{}, nil
 	}
-	// buy.py picks sensible defaults when these are 0; only prompt if the
-	// user wants to override.
+	unit := summaryUnit(priceUnit)
 	if threshold == 0 {
-		v, err := promptPositiveInt(u, "Refill when remaining auths fall below", 5)
+		v, err := promptPositiveInt(u, fmt.Sprintf("Top up when remaining %s drop below", unit), 5)
 		if err != nil {
 			return autoRefillPolicy{}, err
 		}
 		threshold = v
 	}
 	if count == 0 {
-		v, err := promptPositiveInt(u, "Auths to sign per refill", 25)
+		v, err := promptPositiveInt(u, fmt.Sprintf("%s to add per top-up", capitalize(unit)), 25)
 		if err != nil {
 			return autoRefillPolicy{}, err
 		}
@@ -617,39 +680,101 @@ func promptAutoRefill(u *ui.UI, cmd *cli.Command) (autoRefillPolicy, error) {
 	return autoRefillPolicy{enabled: true, threshold: threshold, count: count}, nil
 }
 
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 // promptCount drives the request-or-mtoks count prompt. In non-TTY mode
 // --count is mandatory unless --yes was set (in which case we fall back to
 // the interactive default — explicit consent suppresses the safety check).
-func promptCount(u *ui.UI, cmd *cli.Command, priceUnit string, _ bool, existing bool) (int, error) {
+//
+// The interactive default is unit-aware (5 million tokens for perMTok, 50
+// requests for perRequest) and the prompt surfaces the ceiling cost inline
+// after the default chip: "... [5] (5 OBOL):".
+func promptCount(u *ui.UI, cmd *cli.Command, priceUnit string, existing bool, token string, price *big.Int, decimals int) (int, error) {
 	if v := cmd.Int("count"); v > 0 {
 		return v, nil
 	}
+	def := defaultCountForUnit(priceUnit)
 	if !u.IsTTY() {
 		if cmd.Bool("yes") {
-			return defaultInteractiveCount, nil
+			return def, nil
 		}
 		return 0, errors.New("--count is required in non-interactive mode (pass --count <N>, or run from a TTY)")
 	}
-	label := "How many requests to pre-pay?"
+	label := "How many requests to pre-authorize?"
 	if priceUnit == "perMTok" {
-		label = "How many million tokens of inference to pre-pay?"
+		label = "How many million tokens of inference to pre-authorize?"
 	}
 	if existing {
-		label = "How many more " + countUnit(priceUnit) + " to add to the existing pool?"
+		label = "How many more " + summaryUnit(priceUnit) + " to add to the existing pool?"
 	}
-	return promptPositiveInt(u, label, defaultInteractiveCount)
+	suffix := ""
+	if cost := previewCost(def, price, decimals); cost != "" {
+		suffix = fmt.Sprintf("(%s %s)", cost, token)
+	}
+	return promptPositiveIntWithSuffix(u, label, suffix, def)
 }
 
-func countUnit(priceUnit string) string {
+func defaultCountForUnit(priceUnit string) int {
 	if priceUnit == "perMTok" {
-		return "million-token-batches"
+		return defaultInteractivePerMTokCount
+	}
+	return defaultInteractivePerRequestCount
+}
+
+// summaryUnit returns the user-facing label for the natural unit ("requests"
+// or "million tokens"). Singular/plural is intentionally collapsed —
+// summary copy reads the same whether the count is 1 or 50.
+func summaryUnit(priceUnit string) string {
+	if priceUnit == "perMTok" {
+		return "million tokens"
 	}
 	return "requests"
 }
 
+// previewCost returns the "≈ X TOKEN" string for `count` units at `price`
+// each, formatted with `decimals`. Empty string when price is unavailable.
+func previewCost(count int, price *big.Int, decimals int) string {
+	if count <= 0 || price == nil || price.Sign() <= 0 {
+		return ""
+	}
+	total := new(big.Int).Mul(price, big.NewInt(int64(count)))
+	return formatTokenAmount(total, decimals)
+}
+
+// formatTokenAmount renders an atomic-units value as a human decimal with
+// the minimum number of fractional digits needed: whole values show as
+// "1" / "5", dust keeps enough digits to stay non-zero ("0.001"), and
+// fractional balances stop at the last significant digit ("0.1", "12.34").
+func formatTokenAmount(v *big.Int, decimals int) string {
+	if v == nil {
+		return "?"
+	}
+	if decimals <= 0 {
+		decimals = 6
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	r := new(big.Rat).SetFrac(v, scale)
+	s := r.FloatString(decimals)
+	if !strings.Contains(s, ".") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimSuffix(s, ".")
+	return s
+}
+
 func promptPositiveInt(u *ui.UI, label string, def int) (int, error) {
+	return promptPositiveIntWithSuffix(u, label, "", def)
+}
+
+func promptPositiveIntWithSuffix(u *ui.UI, label, suffix string, def int) (int, error) {
 	for attempt := 0; attempt < 3; attempt++ {
-		raw, err := u.Input(label, fmt.Sprintf("%d", def))
+		raw, err := u.InputWithSuffix(label, fmt.Sprintf("%d", def), suffix)
 		if err != nil {
 			return 0, err
 		}
@@ -731,6 +856,24 @@ func resolveCostCap(flag, token string, price *big.Int, autoRefill bool) (*big.I
 	return cap, nil
 }
 
+// resolveTokenDecimals picks the most reliable decimals source for the
+// chosen payment token. The catalog asset is authoritative when present;
+// otherwise we fall through to the in-binary token registry with the
+// payment chain explicit (avoids the empty-chain ResolveToken bug that
+// silently fell back to 6-decimal scaling).
+func resolveTokenDecimals(entry *buy.CatalogEntry, token, chain string) int {
+	if entry != nil && entry.Asset != nil && entry.Asset.Decimals > 0 {
+		return int(entry.Asset.Decimals)
+	}
+	if t, ok := x402verifier.ResolveToken(token, chain); ok && t.Decimals > 0 {
+		return t.Decimals
+	}
+	// Last resort: USDC-style 6 decimals. Logging the fallback at the call
+	// site is the caller's job — here we just return a deterministic value
+	// so the summary doesn't crash with a divide-by-zero scale.
+	return 6
+}
+
 func paymentChainForDisplay(pricing *buy.PricingResponse) string {
 	if pricing == nil || len(pricing.Accepts) == 0 {
 		return x402verifier.DefaultBuySellerChain
@@ -762,18 +905,8 @@ func fetchWalletInfoBestEffort(cfg *config.Config, target agentTarget, token, ch
 // printBuySummary mirrors the design-doc summary line so the user sees
 // exactly what they're signing before the confirmation.
 func printBuySummary(u *ui.UI, s buySummary) {
-	tokenInfo, _ := x402verifier.ResolveToken(s.Token, "")
 	human := func(v *big.Int) string {
-		if v == nil {
-			return "?"
-		}
-		dec := tokenInfo.Decimals
-		if dec == 0 {
-			dec = 6
-		}
-		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(dec)), nil)
-		r := new(big.Rat).SetFrac(v, scale)
-		return r.FloatString(6)
+		return formatTokenAmount(v, s.TokenDecimals)
 	}
 
 	u.Print("")
@@ -782,27 +915,29 @@ func printBuySummary(u *ui.UI, s buySummary) {
 	u.Print(fmt.Sprintf("  Model:       %s", s.Model))
 	switch s.PriceUnit {
 	case "perMTok":
-		// perMTok offers price per million tokens. The wire-level atomic
-		// amount is the seller's "up to ~1000 tokens per request" charge —
-		// x402 settles at the actual usage so unused capacity is refunded.
-		u.Print(fmt.Sprintf("  Price:       up to %s %s per request (≤ ~1000 tokens; per-MTok offer)", human(s.PriceAtomic), s.Token))
-		u.Print(fmt.Sprintf("  Pre-paying:  up to %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
-		u.Print("               x402 settles at actual usage — unused capacity isn't charged.")
+		// perMTok offers price per million tokens. x402 uses the up-to
+		// scheme: the facilitator settles each request at the actual
+		// metered usage, so unused capacity isn't charged.
+		u.Print(fmt.Sprintf("  Price:           up to %s %s per million tokens", human(s.PriceAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Pre-authorizing: up to %d million tokens (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print("                   Settled per-request after each successful response — unused capacity isn't charged.")
 	default:
-		u.Print(fmt.Sprintf("  Price:       %s %s per request", human(s.PriceAtomic), s.Token))
-		u.Print(fmt.Sprintf("  Count:       %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Price:           %s %s per request", human(s.PriceAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Pre-authorizing: %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print("                   Settled per-request after each successful response.")
 	}
 	if s.AutoRefill.enabled {
-		u.Print(fmt.Sprintf("  Auto-refill: yes (top up when remaining<%d, sign %d more each time)", s.AutoRefill.threshold, s.AutoRefill.count))
+		u.Print(fmt.Sprintf("  Auto-top-up: yes (top up when remaining < %d %s, add %d more each time)",
+			s.AutoRefill.threshold, summaryUnit(s.PriceUnit), s.AutoRefill.count))
 	} else {
-		u.Print("  Auto-refill: no")
+		u.Print("  Auto-top-up: no")
 	}
 	if s.CostCapAtomic != nil && s.CostCapAtomic.Sign() > 0 {
 		capUnit := "request"
 		if s.PriceUnit == "perMTok" {
-			capUnit = "request (~1000 tokens)"
+			capUnit = "million tokens"
 		}
-		u.Print(fmt.Sprintf("  Cost cap:    refills skipped above %s %s/%s", human(s.CostCapAtomic), s.Token, capUnit))
+		u.Print(fmt.Sprintf("  Cost cap:    auto-top-ups skipped above %s %s per %s", human(s.CostCapAtomic), s.Token, capUnit))
 	}
 	if s.Wallet != nil {
 		u.Print(fmt.Sprintf("  Paid from:   %s (balance %s %s on %s)", s.Wallet.Address, s.Wallet.HumanBalance(), s.Token, s.Wallet.Chain))
@@ -816,7 +951,7 @@ func printBuySummary(u *ui.UI, s buySummary) {
 	}
 	switch s.Mode {
 	case buyModeTopUp:
-		u.Print("  Existing PR: topping up the existing auth pool")
+		u.Print("  Existing PR: topping up the existing pre-authorized budget")
 	case buyModeReplace:
 		u.Print("  Existing PR: replacing the existing PurchaseRequest")
 	}
@@ -934,7 +1069,7 @@ func resolveBuyMode(u *ui.UI, cmd *cli.Command, existing string) (buyMode, error
 		return buyModeTopUp, nil
 	}
 	u.Infof("Found existing PurchaseRequest %s in agent namespace.", existing)
-	choices := []string{"Top up (sign more auths into the existing pool)", "Replace (delete and create fresh)", "Cancel"}
+	choices := []string{"Top up (add more pre-authorized capacity)", "Replace (delete and create fresh)", "Cancel"}
 	idx, err := u.Select("How would you like to proceed?", choices, 0)
 	if err != nil {
 		return buyModeFresh, err

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -87,7 +87,7 @@ Examples:
 			},
 			&cli.StringFlag{
 				Name:  "agent",
-				Usage: "Agent instance whose wallet pays for the purchase (default: the master/stack-managed agent)",
+				Usage: "Agent instance whose wallet pays for the purchase AND whose hermes config is switched to use paid/<model>. Default: the master/stack-managed agent (asked interactively in TTY).",
 			},
 			&cli.StringFlag{
 				Name:  "model",
@@ -132,7 +132,7 @@ Examples:
 			},
 			&cli.BoolFlag{
 				Name:  "set-default",
-				Usage: "After the buy lands, promote paid/<model> to the head of LiteLLM's model_list and sync every agent. Default: prompted in TTY, off otherwise unless --agent is set.",
+				Usage: "Promote paid/<model> to LiteLLM's head-of-list AND sync every agent in the stack to read it. Default: prompted in TTY, off in non-interactive runs. Independent of --agent: --agent only switches the paying agent's own config.",
 			},
 			&cli.BoolFlag{
 				Name:  "replace",
@@ -303,7 +303,7 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		return errors.New("buy cancelled")
 	}
 
-	setDefault := resolveSetDefault(u, cmd, chosenModel)
+	perAgent, global := resolveDefaultScopes(u, cmd, chosenModel, target)
 
 	argv := buildBuyPyArgv(buyPyOptions{
 		Name:            prName,
@@ -315,7 +315,12 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		RefillCount:     autoRefill.count,
 		CostCap:         costCapAtomic,
 		Force:           cmd.Bool("force"),
-		SetDefault:      false, // we do model prefer/agent sync from Go side
+		// Per-agent default lives entirely in-pod: buy.py edits the agent's
+		// hermes-config to set model.default = paid/<model> for the agent
+		// whose wallet just paid. No global LiteLLM reorder, no other
+		// agents touched. Global default is handled below via host-side
+		// model prefer + agent sync.
+		SetDefault: perAgent,
 	})
 
 	u.Infof("Dispatching to agent %s (instance=%s) …", target.Runtime, target.ID)
@@ -323,9 +328,9 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		return err
 	}
 
-	if setDefault {
+	if global {
 		if err := promoteAndSyncModel(cfg, u, chosenModel); err != nil {
-			u.Warnf("Set-default partially failed: %v", err)
+			u.Warnf("Set-default (global) partially failed: %v", err)
 			u.Dim("  The purchase landed; rerun `obol model prefer paid/" + chosenModel + " && obol agent sync` to retry.")
 		}
 	}
@@ -775,24 +780,39 @@ func printBuySummary(u *ui.UI, s buySummary) {
 	u.Print("─── Purchase summary ─────────────────────────────────────────")
 	u.Print(fmt.Sprintf("  Offer:       %s", s.OfferURL))
 	u.Print(fmt.Sprintf("  Model:       %s", s.Model))
-	unit := "request"
-	if s.PriceUnit == "perMTok" {
-		unit = "million tokens"
+	switch s.PriceUnit {
+	case "perMTok":
+		// perMTok offers price per million tokens. The wire-level atomic
+		// amount is the seller's "up to ~1000 tokens per request" charge —
+		// x402 settles at the actual usage so unused capacity is refunded.
+		u.Print(fmt.Sprintf("  Price:       up to %s %s per request (≤ ~1000 tokens; per-MTok offer)", human(s.PriceAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Pre-paying:  up to %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print("               x402 settles at actual usage — unused capacity isn't charged.")
+	default:
+		u.Print(fmt.Sprintf("  Price:       %s %s per request", human(s.PriceAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Count:       %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
 	}
-	u.Print(fmt.Sprintf("  Price:       %s %s per %s", human(s.PriceAtomic), s.Token, unit))
-	u.Print(fmt.Sprintf("  Count:       %d (≈ %s %s total)", s.Count, human(s.BudgetAtomic), s.Token))
 	if s.AutoRefill.enabled {
 		u.Print(fmt.Sprintf("  Auto-refill: yes (top up when remaining<%d, sign %d more each time)", s.AutoRefill.threshold, s.AutoRefill.count))
 	} else {
 		u.Print("  Auto-refill: no")
 	}
 	if s.CostCapAtomic != nil && s.CostCapAtomic.Sign() > 0 {
-		u.Print(fmt.Sprintf("  Cost cap:    refills skipped above %s %s/%s", human(s.CostCapAtomic), s.Token, unit))
+		capUnit := "request"
+		if s.PriceUnit == "perMTok" {
+			capUnit = "request (~1000 tokens)"
+		}
+		u.Print(fmt.Sprintf("  Cost cap:    refills skipped above %s %s/%s", human(s.CostCapAtomic), s.Token, capUnit))
 	}
 	if s.Wallet != nil {
 		u.Print(fmt.Sprintf("  Paid from:   %s (balance %s %s on %s)", s.Wallet.Address, s.Wallet.HumanBalance(), s.Token, s.Wallet.Chain))
 	} else {
 		u.Print(fmt.Sprintf("  Paid from:   agent wallet (instance %s/%s)", s.Agent.Runtime, s.Agent.ID))
+		u.Print("  (wallet balance preflight skipped — buy.py will re-check inside the pod)")
+	}
+	if s.Wallet != nil && s.BudgetAtomic != nil && s.Wallet.AtomicUnits != nil && s.Wallet.AtomicUnits.Cmp(s.BudgetAtomic) < 0 {
+		u.Warnf("  Wallet balance is below the requested budget — some auths will fail to settle on-chain.")
+		u.Print(fmt.Sprintf("  Top up the wallet (%s, %s on %s) before proceeding, or rerun with --force to sign anyway.", s.Wallet.Address, s.Token, s.Wallet.Chain))
 	}
 	switch s.Mode {
 	case buyModeTopUp:
@@ -815,17 +835,39 @@ func confirmBuy(u *ui.UI, cmd *cli.Command) bool {
 	return u.Confirm("Confirm purchase?", true)
 }
 
-func resolveSetDefault(u *ui.UI, cmd *cli.Command, model string) bool {
+// resolveDefaultScopes returns (perAgent, global) bools controlling the
+// post-buy "use this model" behavior:
+//
+//   - perAgent → invoke buy.py `--set-default`, which atomically edits the
+//     paying agent's hermes-config inside the pod. Other agents and the
+//     LiteLLM model_list head are untouched.
+//   - global → run `obol model prefer paid/<model>` + `obol agent sync`
+//     from the host. Reorders LiteLLM's model_list and rolls every agent
+//     so head-of-list pickers see the new primary.
+//
+// They're independent. --agent X implies perAgent (you asked for X to use
+// this) but never global. --set-default explicitly toggles global.
+// Interactive mode asks only the per-agent question (default Y) because
+// the global toggle has wider blast radius and surprised users in early
+// testing.
+func resolveDefaultScopes(u *ui.UI, cmd *cli.Command, model string, target agentTarget) (perAgent, global bool) {
 	if cmd.IsSet("set-default") {
-		return cmd.Bool("set-default")
+		global = cmd.Bool("set-default")
 	}
 	if cmd.IsSet("agent") {
-		return true
+		perAgent = true
+		return
 	}
-	if !u.IsTTY() {
-		return false
+	if cmd.Bool("yes") || !u.IsTTY() {
+		// Non-interactive default: do not touch any agent's config unless
+		// the operator was explicit (via --agent or --set-default).
+		return
 	}
-	return u.Confirm(fmt.Sprintf("Set paid/%s as the default inference model for all agents (model prefer + agent sync)?", model), true)
+	perAgent = u.Confirm(
+		fmt.Sprintf("Switch %s/%s to use paid/%s as its inference model?", target.Runtime, target.ID, model),
+		true,
+	)
+	return
 }
 
 func promoteAndSyncModel(cfg *config.Config, u *ui.UI, modelID string) error {

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -44,6 +44,13 @@ const (
 	// explicitly. 5000 basis points = 50% above current, matching the
 	// "default 50% more than current N" UX agreed in the design doc.
 	costCapMarkupBps = 5000
+
+	// permit2SafeAuthCount mirrors buy.py's PERMIT2_SAFE_AUTH_COUNT: the
+	// ConfigMap-backed exact-payment path can store ~537 auths before
+	// hitting Kubernetes' 1MiB size limit, so permit2 buys are capped at
+	// 500. Surfaced here so the host can warn users BEFORE confirmation
+	// (the in-pod cap message arrives after the spend is committed).
+	permit2SafeAuthCount = 500
 )
 
 func buyCommand(cfg *config.Config) *cli.Command {
@@ -292,12 +299,27 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 	walletInfo := fetchWalletInfoBestEffort(cfg, target, token, chainForDisplay, u)
 	decimals := resolveTokenDecimals(entry, token, chainForDisplay)
 
+	// Detect the permit2 batch cap BEFORE the summary so users can see
+	// the actual ceiling they'll get instead of finding out post-buy.
+	multiplier := 1
+	if priceUnit == "perMTok" {
+		multiplier = schemas.ApproxTokensPerRequest
+	}
+	cappedCount, capped := applyPermit2CapToCount(entry, count, multiplier)
+	if capped {
+		// The budget ceiling tracks the actual auths we'll sign, not the
+		// notional ask, so the summary doesn't overstate the spend cap.
+		budgetAtomic = new(big.Int).Mul(priceAtomic, big.NewInt(int64(cappedCount)))
+	}
+
 	summary := buySummary{
 		Agent:         target,
 		PRName:        prName,
 		OfferURL:      offerURL,
 		Model:         chosenModel,
-		Count:         count,
+		Count:         cappedCount,
+		Requested:     count,
+		Capped:        capped,
 		PriceAtomic:   priceAtomic,
 		PriceUnit:     priceUnit,
 		Token:         token,
@@ -312,18 +334,14 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 	if !confirmBuy(u, cmd) {
 		return errors.New("buy inference cancelled")
 	}
+	count = cappedCount
 
 	perAgent, global := resolveDefaultScopes(u, cmd, chosenModel, target)
 
 	// buy.py operates in per-auth wire units (each auth pays the per-request
-	// wire amount). For perMTok offers the user-facing natural unit is
-	// million-tokens, which maps to ApproxTokensPerRequest auths. Multiply
-	// count, refill threshold, and refill count once here so the buy.py
-	// argv stays in its native units.
-	multiplier := 1
-	if priceUnit == "perMTok" {
-		multiplier = schemas.ApproxTokensPerRequest
-	}
+	// wire amount). multiplier was set above when we computed the permit2
+	// cap. Refill threshold/count stay in natural units and get multiplied
+	// the same way.
 	costCapForBuyPy := costCapAtomic
 	if costCapForBuyPy != nil && costCapForBuyPy.Sign() > 0 && priceUnit == "perMTok" {
 		// Cost cap is stored as per-MTok atomic; buy.py compares against
@@ -359,6 +377,16 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 			u.Warnf("Set-default (global) partially failed: %v", err)
 			u.Dim("  The purchase landed; rerun `obol model prefer paid/" + chosenModel + " && obol agent sync` to retry.")
 		}
+	} else if perAgent {
+		// Per-agent set-default lands inside the agent pod (buy.py edits
+		// hermes-config). It does NOT touch the global LiteLLM model_list
+		// ranking, so `obol model list` still shows the previous head —
+		// surface that explicitly so users aren't confused when the
+		// "ranking" doesn't budge.
+		u.Blank()
+		u.Infof("paid/%s is now the default model for %s/%s.", chosenModel, target.Runtime, target.ID)
+		u.Dim("  Other agents are unchanged. To make this the default for every agent in the stack:")
+		u.Dim(fmt.Sprintf("    obol model prefer paid/%s", chosenModel))
 	}
 	return nil
 }
@@ -475,12 +503,14 @@ type buySummary struct {
 	PRName        string
 	OfferURL      string
 	Model         string
-	Count         int      // in natural units (requests | million-tokens)
+	Count         int      // post-cap count in natural units we'll actually sign
+	Requested     int      // natural-unit count the user asked for (pre-cap)
+	Capped        bool     // true when the permit2 batch cap reduced the count
 	PriceAtomic   *big.Int // per natural unit
 	PriceUnit     string   // "perRequest" | "perMTok"
 	Token         string
 	TokenDecimals int      // for human formatting; catalog wins, ResolveToken fallback
-	BudgetAtomic  *big.Int // count × PriceAtomic
+	BudgetAtomic  *big.Int // Count × PriceAtomic (post-cap)
 	AutoRefill    autoRefillPolicy
 	CostCapAtomic *big.Int
 	Wallet        *buy.WalletInfo
@@ -746,6 +776,18 @@ func previewCost(count int, price *big.Int, decimals int) string {
 	return formatTokenAmount(total, decimals)
 }
 
+// perRequestEstimate divides a per-MTok atomic price by the temporary
+// tokens-per-request constant the controller uses today. Until the
+// facilitator implements usage-based settlement, this is the actual
+// flat per-call charge a buyer pays — surface it so users can compare
+// against perRequest offers without converting in their head.
+func perRequestEstimate(perMTokAtomic *big.Int) *big.Int {
+	if perMTokAtomic == nil {
+		return nil
+	}
+	return new(big.Int).Quo(perMTokAtomic, big.NewInt(int64(schemas.ApproxTokensPerRequest)))
+}
+
 // formatTokenAmount renders an atomic-units value as a human decimal with
 // the minimum number of fractional digits needed: whole values show as
 // "1" / "5", dust keeps enough digits to stay non-zero ("0.001"), and
@@ -856,6 +898,33 @@ func resolveCostCap(flag, token string, price *big.Int, autoRefill bool) (*big.I
 	return cap, nil
 }
 
+// applyPermit2CapToCount caps a natural-unit count down so the per-auth
+// translation stays within buy.py's PERMIT2_SAFE_AUTH_COUNT (~537 auths
+// is the ConfigMap-backed exact path's hard limit; we mirror buy.py's
+// 500 floor). Returns the post-cap natural-unit count + a bool flag
+// signalling we trimmed. EIP-3009 / non-permit2 paths are uncapped.
+func applyPermit2CapToCount(entry *buy.CatalogEntry, naturalCount, multiplier int) (int, bool) {
+	if entry == nil || entry.Asset == nil {
+		return naturalCount, false
+	}
+	if !strings.EqualFold(strings.TrimSpace(entry.Asset.TransferMethod), "permit2") {
+		return naturalCount, false
+	}
+	if multiplier <= 0 {
+		multiplier = 1
+	}
+	auths := naturalCount * multiplier
+	if auths <= permit2SafeAuthCount {
+		return naturalCount, false
+	}
+	// Floor-divide so the natural-unit count fits inside the auth cap.
+	cappedNatural := permit2SafeAuthCount / multiplier
+	if cappedNatural < 1 {
+		cappedNatural = 1
+	}
+	return cappedNatural, true
+}
+
 // resolveTokenDecimals picks the most reliable decimals source for the
 // chosen payment token. The catalog asset is authoritative when present;
 // otherwise we fall through to the in-binary token registry with the
@@ -915,16 +984,27 @@ func printBuySummary(u *ui.UI, s buySummary) {
 	u.Print(fmt.Sprintf("  Model:       %s", s.Model))
 	switch s.PriceUnit {
 	case "perMTok":
-		// perMTok offers price per million tokens. x402 uses the up-to
-		// scheme: the facilitator settles each request at the actual
-		// metered usage, so unused capacity isn't charged.
-		u.Print(fmt.Sprintf("  Price:           up to %s %s per million tokens", human(s.PriceAtomic), s.Token))
+		// Today both pricing units settle at a flat per-request charge
+		// (the perMTok value is divided by schemas.ApproxTokensPerRequest
+		// to derive a fixed wire amount). Token-metered settlement is
+		// part of the x402 spec but not implemented on the Obol
+		// facilitator yet — don't claim "unused capacity isn't charged"
+		// until it actually isn't.
+		u.Print(fmt.Sprintf("  Price:           %s %s per million tokens (≈ %s/request at ~1000 tokens/request)", human(s.PriceAtomic), s.Token, human(perRequestEstimate(s.PriceAtomic))))
 		u.Print(fmt.Sprintf("  Pre-authorizing: up to %d million tokens (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
-		u.Print("                   Settled per-request after each successful response — unused capacity isn't charged.")
+		u.Print("                   Settled per-request at the seller's quoted estimate; token-metered settlement is on the roadmap.")
 	default:
 		u.Print(fmt.Sprintf("  Price:           %s %s per request", human(s.PriceAtomic), s.Token))
 		u.Print(fmt.Sprintf("  Pre-authorizing: %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
 		u.Print("                   Settled per-request after each successful response.")
+	}
+	if s.Capped {
+		// The seller's settlement asset uses Permit2 and we're at the
+		// per-PurchaseRequest auth ceiling. Tell the user upfront that
+		// the ask was trimmed and what to do instead, before they confirm.
+		u.Warnf("  Pre-authorization capped: %d %s requested → %d %s allowed per buy (Permit2 storage limit).",
+			s.Requested, summaryUnit(s.PriceUnit), s.Count, summaryUnit(s.PriceUnit))
+		u.Dim("  To get the full ask: enable --auto-top-up and re-run with the original count, or run `obol buy inference` again after this buy lands.")
 	}
 	if s.AutoRefill.enabled {
 		u.Print(fmt.Sprintf("  Auto-top-up: yes (top up when remaining < %d %s, add %d more each time)",

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -21,14 +21,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// In-pod paths used by `obol buy inference`. Hermes always has python3 in
-// the venv and skills mounted at $OBOL_SKILLS_DIR (see
-// internal/hermes/hermes.go where the env is wired). We reference the
-// literal paths so we don't depend on shell expansion through `kubectl exec`.
 const (
-	hermesPython    = "/opt/hermes/.venv/bin/python3"
-	hermesBuyPyPath = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
-	defaultBuyName  = "default-paid"
+	defaultBuyName = "default-paid"
 
 	// defaultInteractivePerMTokCount is the default for perMTok offers:
 	// 5 million tokens is enough for a meaningful chat session without
@@ -44,6 +38,12 @@ const (
 	// explicitly. 5000 basis points = 50% above current, matching the
 	// "default 50% more than current N" UX agreed in the design doc.
 	costCapMarkupBps = 5000
+
+	// maxBuyPyAuthCount mirrors buy.py's MAX_AUTH_COUNT. The host converts
+	// user-facing counts (requests or million-tokens) into the exact auths
+	// buy.py signs, so it must apply the same cap before presenting the
+	// confirmation summary.
+	maxBuyPyAuthCount = 1000
 
 	// permit2SafeAuthCount mirrors buy.py's PERMIT2_SAFE_AUTH_COUNT: the
 	// ConfigMap-backed exact-payment path can store ~537 auths before
@@ -281,7 +281,15 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		return err
 	}
 
-	budgetAtomic, err := resolveBudget(cmd.String("budget"), token, count, priceAtomic)
+	multiplier := authMultiplier(priceUnit)
+	requestedAuths := count * multiplier
+	auths, capped, capReason := applyAuthCap(entry, requestedAuths)
+	pricePerAuthAtomic, err := pricePerAuth(priceAtomic, multiplier)
+	if err != nil {
+		return err
+	}
+
+	budgetAtomic, err := resolveBudget(cmd.String("budget"), token, auths, pricePerAuthAtomic)
 	if err != nil {
 		return err
 	}
@@ -299,42 +307,37 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 	walletInfo := fetchWalletInfoBestEffort(cfg, target, token, chainForDisplay, u)
 	decimals := resolveTokenDecimals(entry, token, chainForDisplay)
 
-	// Detect the permit2 batch cap BEFORE the summary so users can see
-	// the actual ceiling they'll get instead of finding out post-buy.
-	multiplier := 1
-	if priceUnit == "perMTok" {
-		multiplier = schemas.ApproxTokensPerRequest
-	}
-	cappedCount, capped := applyPermit2CapToCount(entry, count, multiplier)
-	if capped {
-		// The budget ceiling tracks the actual auths we'll sign, not the
-		// notional ask, so the summary doesn't overstate the spend cap.
-		budgetAtomic = new(big.Int).Mul(priceAtomic, big.NewInt(int64(cappedCount)))
-	}
+	autoRefillThresholdAuths, autoRefillCountAuths, autoRefillCapped, autoRefillCapReason := effectiveAutoRefillAuths(autoRefill, entry, multiplier)
 
 	summary := buySummary{
-		Agent:         target,
-		PRName:        prName,
-		OfferURL:      offerURL,
-		Model:         chosenModel,
-		Count:         cappedCount,
-		Requested:     count,
-		Capped:        capped,
-		PriceAtomic:   priceAtomic,
-		PriceUnit:     priceUnit,
-		Token:         token,
-		TokenDecimals: decimals,
-		BudgetAtomic:  budgetAtomic,
-		AutoRefill:    autoRefill,
-		CostCapAtomic: costCapAtomic,
-		Wallet:        walletInfo,
-		Mode:          mode,
+		Agent:               target,
+		PRName:              prName,
+		OfferURL:            offerURL,
+		Model:               chosenModel,
+		RequestedAuths:      requestedAuths,
+		Auths:               auths,
+		Multiplier:          multiplier,
+		Capped:              capped,
+		CapReason:           capReason,
+		PriceAtomic:         priceAtomic,
+		PricePerAuthAtomic:  pricePerAuthAtomic,
+		PriceUnit:           priceUnit,
+		Token:               token,
+		TokenDecimals:       decimals,
+		BudgetAtomic:        budgetAtomic,
+		AutoRefill:          autoRefill,
+		AutoRefillThreshold: autoRefillThresholdAuths,
+		AutoRefillCount:     autoRefillCountAuths,
+		AutoRefillCapped:    autoRefillCapped,
+		AutoRefillCapReason: autoRefillCapReason,
+		CostCapAtomic:       costCapAtomic,
+		Wallet:              walletInfo,
+		Mode:                mode,
 	}
 	printBuySummary(u, summary)
 	if !confirmBuy(u, cmd) {
 		return errors.New("buy inference cancelled")
 	}
-	count = cappedCount
 
 	perAgent, global := resolveDefaultScopes(u, cmd, chosenModel, target)
 
@@ -349,14 +352,15 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 		costCapForBuyPy = new(big.Int).Quo(costCapForBuyPy, big.NewInt(int64(schemas.ApproxTokensPerRequest)))
 	}
 	argv := buildBuyPyArgv(buyPyOptions{
+		Runtime:         target.Runtime,
 		Name:            prName,
 		Seller:          offerURL,
 		Model:           chosenModel,
 		BudgetMicro:     budgetAtomic.String(),
-		Count:           count * multiplier,
+		Count:           auths,
 		AutoRefill:      autoRefill.enabled,
-		RefillThreshold: autoRefill.threshold * multiplier,
-		RefillCount:     autoRefill.count * multiplier,
+		RefillThreshold: autoRefillThresholdAuths,
+		RefillCount:     autoRefillCountAuths,
 		CostCap:         costCapForBuyPy,
 		Force:           cmd.Bool("force"),
 		// Per-agent default lives entirely in-pod: buy.py edits the agent's
@@ -398,6 +402,7 @@ func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) 
 // native per-auth wire units. The host CLI converts from natural units
 // (requests | million-tokens) before populating these fields.
 type buyPyOptions struct {
+	Runtime         agentruntime.Runtime
 	Name            string
 	Seller          string
 	Model           string
@@ -406,18 +411,17 @@ type buyPyOptions struct {
 	AutoRefill      bool
 	RefillThreshold int
 	RefillCount     int
-	CostCap         *big.Int // when non-nil, sets --cost-cap on the buy.py call
+	CostCap         *big.Int // emitted only with AutoRefill; caps future top-up prices
 	Force           bool
 	SetDefault      bool
 }
 
 // buildBuyPyArgv composes the argv for `python3 buy.py buy <name> ...`.
 func buildBuyPyArgv(opts buyPyOptions) []string {
-	argv := []string{
-		hermesPython, hermesBuyPyPath, "buy", opts.Name,
+	argv := buy.BuyPyCommand(opts.Runtime, "buy", opts.Name,
 		"--endpoint", opts.Seller,
 		"--budget", opts.BudgetMicro,
-	}
+	)
 	if opts.Count > 0 {
 		argv = append(argv, "--count", fmt.Sprintf("%d", opts.Count))
 	}
@@ -433,7 +437,7 @@ func buildBuyPyArgv(opts buyPyOptions) []string {
 			argv = append(argv, "--refill-count", fmt.Sprintf("%d", opts.RefillCount))
 		}
 	}
-	if opts.CostCap != nil && opts.CostCap.Sign() > 0 {
+	if opts.AutoRefill && opts.CostCap != nil && opts.CostCap.Sign() > 0 {
 		argv = append(argv, "--cost-cap", opts.CostCap.String())
 	}
 	if opts.SetDefault {
@@ -499,22 +503,29 @@ type autoRefillPolicy struct {
 }
 
 type buySummary struct {
-	Agent         agentTarget
-	PRName        string
-	OfferURL      string
-	Model         string
-	Count         int      // post-cap count in natural units we'll actually sign
-	Requested     int      // natural-unit count the user asked for (pre-cap)
-	Capped        bool     // true when the permit2 batch cap reduced the count
-	PriceAtomic   *big.Int // per natural unit
-	PriceUnit     string   // "perRequest" | "perMTok"
-	Token         string
-	TokenDecimals int      // for human formatting; catalog wins, ResolveToken fallback
-	BudgetAtomic  *big.Int // Count × PriceAtomic (post-cap)
-	AutoRefill    autoRefillPolicy
-	CostCapAtomic *big.Int
-	Wallet        *buy.WalletInfo
-	Mode          buyMode
+	Agent               agentTarget
+	PRName              string
+	OfferURL            string
+	Model               string
+	RequestedAuths      int      // pre-cap auths implied by the user's natural-unit count
+	Auths               int      // post-cap auths buy.py will actually sign
+	Multiplier          int      // auths per natural unit: 1 for perRequest, ~1000 for perMTok
+	Capped              bool     // true when the auth cap reduced the request
+	CapReason           string   // e.g. "Permit2 storage limit" or "buy.py signing limit"
+	PriceAtomic         *big.Int // per natural unit
+	PricePerAuthAtomic  *big.Int // per buy.py auth / settled request
+	PriceUnit           string   // "perRequest" | "perMTok"
+	Token               string
+	TokenDecimals       int // for human formatting; catalog wins, ResolveToken fallback
+	BudgetAtomic        *big.Int
+	AutoRefill          autoRefillPolicy
+	AutoRefillThreshold int
+	AutoRefillCount     int
+	AutoRefillCapped    bool
+	AutoRefillCapReason string
+	CostCapAtomic       *big.Int
+	Wallet              *buy.WalletInfo
+	Mode                buyMode
 }
 
 // resolveBuyAgent picks the agent instance whose wallet pays the bill. When
@@ -776,6 +787,13 @@ func previewCost(count int, price *big.Int, decimals int) string {
 	return formatTokenAmount(total, decimals)
 }
 
+func authMultiplier(priceUnit string) int {
+	if priceUnit == "perMTok" {
+		return schemas.ApproxTokensPerRequest
+	}
+	return 1
+}
+
 // perRequestEstimate divides a per-MTok atomic price by the temporary
 // tokens-per-request constant the controller uses today. Until the
 // facilitator implements usage-based settlement, this is the actual
@@ -786,6 +804,20 @@ func perRequestEstimate(perMTokAtomic *big.Int) *big.Int {
 		return nil
 	}
 	return new(big.Int).Quo(perMTokAtomic, big.NewInt(int64(schemas.ApproxTokensPerRequest)))
+}
+
+func pricePerAuth(price *big.Int, multiplier int) (*big.Int, error) {
+	if price == nil || price.Sign() <= 0 {
+		return nil, errors.New("internal: price is non-positive")
+	}
+	if multiplier <= 1 {
+		return new(big.Int).Set(price), nil
+	}
+	perAuth := new(big.Int).Quo(price, big.NewInt(int64(multiplier)))
+	if perAuth.Sign() <= 0 {
+		return nil, fmt.Errorf("price %s divided by auth multiplier %d rounds to zero", price, multiplier)
+	}
+	return perAuth, nil
 }
 
 // formatTokenAmount renders an atomic-units value as a human decimal with
@@ -808,6 +840,23 @@ func formatTokenAmount(v *big.Int, decimals int) string {
 	s = strings.TrimRight(s, "0")
 	s = strings.TrimSuffix(s, ".")
 	return s
+}
+
+func capacityLabel(auths, multiplier int, priceUnit string) string {
+	if auths < 0 {
+		auths = 0
+	}
+	if multiplier <= 1 || priceUnit != "perMTok" {
+		return fmt.Sprintf("%d requests", auths)
+	}
+	r := new(big.Rat).SetFrac(big.NewInt(int64(auths)), big.NewInt(int64(multiplier)))
+	s := r.FloatString(6)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimSuffix(s, ".")
+	if s == "" {
+		s = "0"
+	}
+	return s + " million tokens"
 }
 
 func promptPositiveInt(u *ui.UI, label string, def int) (int, error) {
@@ -847,11 +896,15 @@ func parsePositiveInt(s string) (int, error) {
 	return v, nil
 }
 
-// resolveBudget computes a budget cap in atomic units. Explicit --budget
-// wins; otherwise we compute count × price and add 0 headroom — buy.py
-// rounds-up at the per-auth boundary, and a tight cap is exactly what users
-// asked for when they didn't set one explicitly.
-func resolveBudget(flag, token string, count int, price *big.Int) (*big.Int, error) {
+// resolveBudget computes the actual atomic spend represented by authCount ×
+// per-auth price. Explicit --budget remains a user cap: it must cover the
+// auths we are about to ask buy.py to sign, but it does not inflate the
+// displayed or passed budget above the exact signed total.
+func resolveBudget(flag, token string, authCount int, perAuthPrice *big.Int) (*big.Int, error) {
+	if authCount <= 0 || perAuthPrice == nil || perAuthPrice.Sign() <= 0 {
+		return nil, errors.New("internal: auth count or price is non-positive")
+	}
+	required := new(big.Int).Mul(perAuthPrice, big.NewInt(int64(authCount)))
 	if flag = strings.TrimSpace(flag); flag != "" {
 		s, err := budgetToBaseUnits(flag, token)
 		if err != nil {
@@ -861,18 +914,20 @@ func resolveBudget(flag, token string, count int, price *big.Int) (*big.Int, err
 		if !ok {
 			return nil, fmt.Errorf("internal: budgetToBaseUnits returned non-numeric %q", s)
 		}
-		return v, nil
+		if v.Cmp(required) < 0 {
+			return nil, fmt.Errorf("--budget %s is below the requested pre-authorization cost %s base units; reduce --count or raise --budget", v.String(), required.String())
+		}
 	}
-	if count <= 0 || price == nil || price.Sign() <= 0 {
-		return nil, errors.New("internal: count or price is non-positive")
-	}
-	return new(big.Int).Mul(price, big.NewInt(int64(count))), nil
+	return required, nil
 }
 
 // resolveCostCap parses --cost-cap into atomic units, or computes a default
 // of price × (1 + costCapMarkupBps/10000) when auto-refill is enabled.
 func resolveCostCap(flag, token string, price *big.Int, autoRefill bool) (*big.Int, error) {
 	if flag = strings.TrimSpace(flag); flag != "" {
+		if !autoRefill {
+			return nil, errors.New("--cost-cap requires --auto-refill because it only applies to future auto-top-ups")
+		}
 		// --cost-cap is in atomic units (matches buy.py convention).
 		v, ok := new(big.Int).SetString(flag, 10)
 		if !ok || v.Sign() <= 0 {
@@ -898,31 +953,49 @@ func resolveCostCap(flag, token string, price *big.Int, autoRefill bool) (*big.I
 	return cap, nil
 }
 
-// applyPermit2CapToCount caps a natural-unit count down so the per-auth
-// translation stays within buy.py's PERMIT2_SAFE_AUTH_COUNT (~537 auths
-// is the ConfigMap-backed exact path's hard limit; we mirror buy.py's
-// 500 floor). Returns the post-cap natural-unit count + a bool flag
-// signalling we trimmed. EIP-3009 / non-permit2 paths are uncapped.
-func applyPermit2CapToCount(entry *buy.CatalogEntry, naturalCount, multiplier int) (int, bool) {
+func authCapForEntry(entry *buy.CatalogEntry) (int, string) {
 	if entry == nil || entry.Asset == nil {
-		return naturalCount, false
+		return maxBuyPyAuthCount, "buy.py signing limit"
 	}
-	if !strings.EqualFold(strings.TrimSpace(entry.Asset.TransferMethod), "permit2") {
-		return naturalCount, false
+	if strings.EqualFold(strings.TrimSpace(entry.Asset.TransferMethod), "permit2") {
+		return permit2SafeAuthCount, "Permit2 storage limit"
+	}
+	return maxBuyPyAuthCount, "buy.py signing limit"
+}
+
+func applyAuthCap(entry *buy.CatalogEntry, requestedAuths int) (int, bool, string) {
+	limit, reason := authCapForEntry(entry)
+	if requestedAuths <= limit {
+		return requestedAuths, false, ""
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	return limit, true, reason
+}
+
+func effectiveAutoRefillAuths(policy autoRefillPolicy, entry *buy.CatalogEntry, multiplier int) (thresholdAuths, countAuths int, capped bool, reason string) {
+	if !policy.enabled {
+		return 0, 0, false, ""
 	}
 	if multiplier <= 0 {
 		multiplier = 1
 	}
-	auths := naturalCount * multiplier
-	if auths <= permit2SafeAuthCount {
-		return naturalCount, false
+	thresholdAuths = policy.threshold * multiplier
+	countAuths = policy.count * multiplier
+	limit, reason := authCapForEntry(entry)
+	if thresholdAuths > limit {
+		thresholdAuths = limit
+		capped = true
 	}
-	// Floor-divide so the natural-unit count fits inside the auth cap.
-	cappedNatural := permit2SafeAuthCount / multiplier
-	if cappedNatural < 1 {
-		cappedNatural = 1
+	if countAuths > limit {
+		countAuths = limit
+		capped = true
 	}
-	return cappedNatural, true
+	if !capped {
+		reason = ""
+	}
+	return thresholdAuths, countAuths, capped, reason
 }
 
 // resolveTokenDecimals picks the most reliable decimals source for the
@@ -990,25 +1063,34 @@ func printBuySummary(u *ui.UI, s buySummary) {
 		// part of the x402 spec but not implemented on the Obol
 		// facilitator yet — don't claim "unused capacity isn't charged"
 		// until it actually isn't.
-		u.Print(fmt.Sprintf("  Price:           %s %s per million tokens (≈ %s/request at ~1000 tokens/request)", human(s.PriceAtomic), s.Token, human(perRequestEstimate(s.PriceAtomic))))
-		u.Print(fmt.Sprintf("  Pre-authorizing: up to %d million tokens (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Price:           %s %s per million tokens (≈ %s/request at ~1000 tokens/request)", human(s.PriceAtomic), s.Token, human(s.PricePerAuthAtomic)))
+		u.Print(fmt.Sprintf("  Pre-authorizing: up to %s (≈ %s %s ceiling)", capacityLabel(s.Auths, s.Multiplier, s.PriceUnit), human(s.BudgetAtomic), s.Token))
 		u.Print("                   Settled per-request at the seller's quoted estimate; token-metered settlement is on the roadmap.")
 	default:
 		u.Print(fmt.Sprintf("  Price:           %s %s per request", human(s.PriceAtomic), s.Token))
-		u.Print(fmt.Sprintf("  Pre-authorizing: %d requests (≈ %s %s ceiling)", s.Count, human(s.BudgetAtomic), s.Token))
+		u.Print(fmt.Sprintf("  Pre-authorizing: %s (≈ %s %s ceiling)", capacityLabel(s.Auths, s.Multiplier, s.PriceUnit), human(s.BudgetAtomic), s.Token))
 		u.Print("                   Settled per-request after each successful response.")
 	}
 	if s.Capped {
-		// The seller's settlement asset uses Permit2 and we're at the
-		// per-PurchaseRequest auth ceiling. Tell the user upfront that
-		// the ask was trimmed and what to do instead, before they confirm.
-		u.Warnf("  Pre-authorization capped: %d %s requested → %d %s allowed per buy (Permit2 storage limit).",
-			s.Requested, summaryUnit(s.PriceUnit), s.Count, summaryUnit(s.PriceUnit))
+		// Tell the user upfront when the exact auth count was trimmed before
+		// dispatch, so the summary cannot overstate the spend cap.
+		u.Warnf("  Pre-authorization capped: %s requested → %s allowed per buy (%s).",
+			capacityLabel(s.RequestedAuths, s.Multiplier, s.PriceUnit),
+			capacityLabel(s.Auths, s.Multiplier, s.PriceUnit),
+			s.CapReason)
 		u.Dim("  To get the full ask: enable --auto-top-up and re-run with the original count, or run `obol buy inference` again after this buy lands.")
 	}
 	if s.AutoRefill.enabled {
-		u.Print(fmt.Sprintf("  Auto-top-up: yes (top up when remaining < %d %s, add %d more each time)",
-			s.AutoRefill.threshold, summaryUnit(s.PriceUnit), s.AutoRefill.count))
+		if s.AutoRefillThreshold > 0 || s.AutoRefillCount > 0 {
+			u.Print(fmt.Sprintf("  Auto-top-up: yes (top up when remaining < %s, add %s each time)",
+				capacityLabel(s.AutoRefillThreshold, s.Multiplier, s.PriceUnit),
+				capacityLabel(s.AutoRefillCount, s.Multiplier, s.PriceUnit)))
+		} else {
+			u.Print("  Auto-top-up: yes (agent defaults)")
+		}
+		if s.AutoRefillCapped {
+			u.Warnf("  Auto-top-up policy capped to fit %s.", s.AutoRefillCapReason)
+		}
 	} else {
 		u.Print("  Auto-top-up: no")
 	}

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -135,6 +135,21 @@ func TestBuildBuyPyArgv(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit count emits --count",
+			opts: buyPyOptions{
+				Name:        "demo",
+				Seller:      "https://s.example",
+				BudgetMicro: "5000000000000000000",
+				Count:       5000,
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "5000000000000000000",
+				"--count", "5000",
+			},
+		},
+		{
 			name: "auto-refill without explicit counts",
 			opts: buyPyOptions{
 				Name:        "demo",
@@ -279,7 +294,8 @@ func TestValidateTokenAgainstPricing(t *testing.T) {
 func TestCanonicalOfferURL(t *testing.T) {
 	t.Parallel()
 
-	asset := &buy.CatalogEntry{Name: "aeon", Endpoint: "/services/aeon/v1/chat/completions"}
+	pathOnly := &buy.CatalogEntry{Name: "aeon", Endpoint: "/services/aeon/v1/chat/completions"}
+	absolute := &buy.CatalogEntry{Name: "aeon7", Endpoint: "https://inference.v1337.org/services/aeon7"}
 	tests := []struct {
 		name    string
 		user    string
@@ -288,27 +304,39 @@ func TestCanonicalOfferURL(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:  "storefront base + endpoint splice",
+			name:  "storefront base + path endpoint splice",
 			user:  "https://inference.v1337.org/",
-			entry: asset,
+			entry: pathOnly,
 			want:  "https://inference.v1337.org/services/aeon",
 		},
 		{
 			name:  "storefront base without trailing slash",
 			user:  "https://inference.v1337.org",
-			entry: asset,
+			entry: pathOnly,
 			want:  "https://inference.v1337.org/services/aeon",
+		},
+		{
+			name:  "absolute URL endpoint used verbatim (real v1337 case)",
+			user:  "https://inference.v1337.org/",
+			entry: absolute,
+			want:  "https://inference.v1337.org/services/aeon7",
+		},
+		{
+			name:  "absolute URL endpoint, mismatched user base — catalog wins",
+			user:  "https://other-base.example/",
+			entry: absolute,
+			want:  "https://inference.v1337.org/services/aeon7",
 		},
 		{
 			name:  "service URL passed verbatim",
 			user:  "https://seller.example/services/foo",
-			entry: asset,
+			entry: pathOnly,
 			want:  "https://seller.example/services/foo",
 		},
 		{
 			name:  "service URL with trailing slash trimmed",
 			user:  "https://seller.example/services/foo/",
-			entry: asset,
+			entry: pathOnly,
 			want:  "https://seller.example/services/foo",
 		},
 		{

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
 	"github.com/ObolNetwork/obol-stack/internal/buy"
+	"github.com/ObolNetwork/obol-stack/internal/schemas"
 )
 
 func TestBudgetToBaseUnits(t *testing.T) {
@@ -59,6 +61,61 @@ func TestBudgetToBaseUnits(t *testing.T) {
 	}
 }
 
+func TestResolveBudgetEnforcesExplicitCap(t *testing.T) {
+	t.Parallel()
+
+	pricePerAuth := big.NewInt(1000)
+	tests := []struct {
+		name      string
+		flag      string
+		authCount int
+		want      *big.Int
+		wantErr   string
+	}{
+		{
+			name:      "no explicit budget returns exact signed spend",
+			authCount: 5,
+			want:      big.NewInt(5000),
+		},
+		{
+			name:      "explicit budget equal to signed spend passes",
+			flag:      "0.005",
+			authCount: 5,
+			want:      big.NewInt(5000),
+		},
+		{
+			name:      "explicit budget above signed spend still returns exact signed spend",
+			flag:      "0.01",
+			authCount: 5,
+			want:      big.NewInt(5000),
+		},
+		{
+			name:      "explicit budget below count cost errors",
+			flag:      "0.004",
+			authCount: 5,
+			wantErr:   "below the requested pre-authorization cost",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveBudget(tc.flag, "USDC", tc.authCount, pricePerAuth)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("resolveBudget err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBudget unexpected err: %v", err)
+			}
+			if got.Cmp(tc.want) != 0 {
+				t.Fatalf("resolveBudget = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildBuyPyArgv(t *testing.T) {
 	tests := []struct {
 		name string
@@ -72,15 +129,15 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				Seller:      "https://demo.example/services/x",
 				BudgetMicro: "10000000",
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "default-paid",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "default-paid"),
 				"--endpoint", "https://demo.example/services/x",
 				"--budget", "10000000",
-			},
+			),
 		},
 		{
 			name: "all optional flags",
 			opts: buyPyOptions{
+				Runtime:         agentruntime.Hermes,
 				Name:            "demo",
 				Seller:          "https://s.example",
 				Model:           "qwen3.5:9b",
@@ -92,8 +149,7 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				SetDefault:      true,
 				Force:           true,
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "5000000",
 				"--model", "qwen3.5:9b",
@@ -103,22 +159,20 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				"--cost-cap", "150000",
 				"--set-default",
 				"--force",
-			},
+			),
 		},
 		{
-			name: "cost cap without auto-refill is still emitted (host owns intent)",
+			name: "cost cap without auto-refill is suppressed",
 			opts: buyPyOptions{
 				Name:        "demo",
 				Seller:      "https://s.example",
 				BudgetMicro: "1000000",
 				CostCap:     big.NewInt(42),
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "1000000",
-				"--cost-cap", "42",
-			},
+			),
 		},
 		{
 			name: "cost cap of zero is suppressed",
@@ -128,11 +182,10 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				BudgetMicro: "1000000",
 				CostCap:     big.NewInt(0),
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "1000000",
-			},
+			),
 		},
 		{
 			name: "explicit count emits --count",
@@ -142,12 +195,11 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				BudgetMicro: "5000000000000000000",
 				Count:       5000,
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "5000000000000000000",
 				"--count", "5000",
-			},
+			),
 		},
 		{
 			name: "auto-refill without explicit counts",
@@ -157,12 +209,11 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				BudgetMicro: "1000000",
 				AutoRefill:  true,
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "1000000",
 				"--auto-refill",
-			},
+			),
 		},
 		{
 			name: "auto-refill off does not emit refill flags",
@@ -174,11 +225,10 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				RefillThreshold: 3,
 				RefillCount:     7,
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "1000000",
-			},
+			),
 		},
 		{
 			name: "model whitespace trimmed",
@@ -188,12 +238,24 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				Model:       "  qwen3.5:9b  ",
 				BudgetMicro: "1000000",
 			},
-			want: []string{
-				hermesPython, hermesBuyPyPath, "buy", "demo",
+			want: append(buy.BuyPyCommand(agentruntime.Hermes, "buy", "demo"),
 				"--endpoint", "https://s.example",
 				"--budget", "1000000",
 				"--model", "qwen3.5:9b",
+			),
+		},
+		{
+			name: "openclaw runtime uses openclaw skill mount",
+			opts: buyPyOptions{
+				Runtime:     agentruntime.OpenClaw,
+				Name:        "demo",
+				Seller:      "https://s.example",
+				BudgetMicro: "1000000",
 			},
+			want: append(buy.BuyPyCommand(agentruntime.OpenClaw, "buy", "demo"),
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
+			),
 		},
 	}
 
@@ -407,7 +469,8 @@ func TestResolveBuyModel(t *testing.T) {
 
 // resolveCostCap: explicit flag wins (in atomic units OR human decimal),
 // otherwise we apply the costCapMarkupBps markup over price when
-// auto-refill is on. No auto-refill means no auto cap.
+// auto-refill is on. Explicit --cost-cap without auto-refill is rejected so
+// it cannot accidentally create an in-pod auto-refill policy.
 func TestResolveCostCap(t *testing.T) {
 	t.Parallel()
 	price := big.NewInt(1000)
@@ -424,8 +487,9 @@ func TestResolveCostCap(t *testing.T) {
 		{name: "no flag + no auto-refill = nil", autoRefill: false, price: price, wantNil: true},
 		{name: "no flag + auto-refill = 150% markup", autoRefill: true, price: price, want: big.NewInt(1500)},
 		{name: "atomic-unit flag wins", flag: "42", autoRefill: true, price: price, want: big.NewInt(42)},
-		{name: "human-decimal USDC fallback", flag: "0.001", token: "USDC", autoRefill: false, price: price, want: big.NewInt(1000)},
-		{name: "invalid flag errors", flag: "not-a-number", token: "USDC", autoRefill: false, price: price, wantErr: "not a valid number"},
+		{name: "human-decimal USDC fallback", flag: "0.001", token: "USDC", autoRefill: true, price: price, want: big.NewInt(1000)},
+		{name: "cost cap without auto-refill errors", flag: "42", token: "USDC", autoRefill: false, price: price, wantErr: "requires --auto-refill"},
+		{name: "invalid flag errors", flag: "not-a-number", token: "USDC", autoRefill: true, price: price, wantErr: "not a valid number"},
 	}
 
 	for _, tc := range tests {
@@ -449,6 +513,70 @@ func TestResolveCostCap(t *testing.T) {
 			}
 			if got == nil || got.Cmp(tc.want) != 0 {
 				t.Fatalf("resolveCostCap = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthCapAndCapacityLabel(t *testing.T) {
+	t.Parallel()
+
+	permit2Entry := &buy.CatalogEntry{Asset: &schemas.ServiceCatalogAsset{TransferMethod: "permit2"}}
+	eip3009Entry := &buy.CatalogEntry{Asset: &schemas.ServiceCatalogAsset{TransferMethod: "eip3009"}}
+
+	tests := []struct {
+		name       string
+		entry      *buy.CatalogEntry
+		requested  int
+		wantAuths  int
+		wantCapped bool
+		wantReason string
+		wantLabel  string
+	}{
+		{
+			name:       "permit2 perMTok can cap below one natural unit",
+			entry:      permit2Entry,
+			requested:  defaultInteractivePerMTokCount * schemas.ApproxTokensPerRequest,
+			wantAuths:  permit2SafeAuthCount,
+			wantCapped: true,
+			wantReason: "Permit2 storage limit",
+			wantLabel:  "0.5 million tokens",
+		},
+		{
+			name:       "non-permit2 still mirrors buy.py max auth count",
+			entry:      eip3009Entry,
+			requested:  defaultInteractivePerMTokCount * schemas.ApproxTokensPerRequest,
+			wantAuths:  maxBuyPyAuthCount,
+			wantCapped: true,
+			wantReason: "buy.py signing limit",
+			wantLabel:  "1 million tokens",
+		},
+		{
+			name:       "small request is not capped",
+			entry:      permit2Entry,
+			requested:  25,
+			wantAuths:  25,
+			wantCapped: false,
+			wantLabel:  "25 requests",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, capped, reason := applyAuthCap(tc.entry, tc.requested)
+			if got != tc.wantAuths || capped != tc.wantCapped || reason != tc.wantReason {
+				t.Fatalf("applyAuthCap = (%d, %v, %q), want (%d, %v, %q)",
+					got, capped, reason, tc.wantAuths, tc.wantCapped, tc.wantReason)
+			}
+			unit := "perRequest"
+			multiplier := 1
+			if strings.Contains(tc.wantLabel, "million tokens") {
+				unit = "perMTok"
+				multiplier = schemas.ApproxTokensPerRequest
+			}
+			if label := capacityLabel(got, multiplier, unit); label != tc.wantLabel {
+				t.Fatalf("capacityLabel = %q, want %q", label, tc.wantLabel)
 			}
 		})
 	}

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math/big"
 	"reflect"
 	"strings"
 	"testing"
@@ -87,6 +88,8 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				AutoRefill:      true,
 				RefillThreshold: 3,
 				RefillCount:     7,
+				CostCap:         big.NewInt(150000),
+				SetDefault:      true,
 				Force:           true,
 			},
 			want: []string{
@@ -97,7 +100,38 @@ func TestBuildBuyPyArgv(t *testing.T) {
 				"--auto-refill",
 				"--refill-threshold", "3",
 				"--refill-count", "7",
+				"--cost-cap", "150000",
+				"--set-default",
 				"--force",
+			},
+		},
+		{
+			name: "cost cap without auto-refill is still emitted (host owns intent)",
+			opts: buyPyOptions{
+				Name:        "demo",
+				Seller:      "https://s.example",
+				BudgetMicro: "1000000",
+				CostCap:     big.NewInt(42),
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
+				"--cost-cap", "42",
+			},
+		},
+		{
+			name: "cost cap of zero is suppressed",
+			opts: buyPyOptions{
+				Name:        "demo",
+				Seller:      "https://s.example",
+				BudgetMicro: "1000000",
+				CostCap:     big.NewInt(0),
+			},
+			want: []string{
+				hermesPython, hermesBuyPyPath, "buy", "demo",
+				"--endpoint", "https://s.example",
+				"--budget", "1000000",
 			},
 		},
 		{
@@ -235,5 +269,178 @@ func TestValidateTokenAgainstPricing(t *testing.T) {
 				t.Fatalf("ValidateTokenAgainstPricing(%q) err = %v, want substring %q", tc.token, err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// canonicalOfferURL splices the catalog endpoint onto a storefront base when
+// the user passed no /services/<name> segment. When they did pass one, we
+// trust it verbatim and don't re-derive from the catalog (so a deliberately
+// mismatched user URL still goes through to the seller).
+func TestCanonicalOfferURL(t *testing.T) {
+	t.Parallel()
+
+	asset := &buy.CatalogEntry{Name: "aeon", Endpoint: "/services/aeon/v1/chat/completions"}
+	tests := []struct {
+		name    string
+		user    string
+		entry   *buy.CatalogEntry
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "storefront base + endpoint splice",
+			user:  "https://inference.v1337.org/",
+			entry: asset,
+			want:  "https://inference.v1337.org/services/aeon",
+		},
+		{
+			name:  "storefront base without trailing slash",
+			user:  "https://inference.v1337.org",
+			entry: asset,
+			want:  "https://inference.v1337.org/services/aeon",
+		},
+		{
+			name:  "service URL passed verbatim",
+			user:  "https://seller.example/services/foo",
+			entry: asset,
+			want:  "https://seller.example/services/foo",
+		},
+		{
+			name:  "service URL with trailing slash trimmed",
+			user:  "https://seller.example/services/foo/",
+			entry: asset,
+			want:  "https://seller.example/services/foo",
+		},
+		{
+			name:    "empty endpoint in catalog entry",
+			user:    "https://inference.v1337.org/",
+			entry:   &buy.CatalogEntry{Name: "x", Endpoint: ""},
+			wantErr: "empty endpoint",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := canonicalOfferURL(tc.user, tc.entry)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("canonicalOfferURL err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("canonicalOfferURL unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("canonicalOfferURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// resolveBuyModel: flag wins when it matches, mismatch errors loudly,
+// catalog entry's model is used when flag is empty, empty-both errors.
+func TestResolveBuyModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		flag    string
+		entry   *buy.CatalogEntry
+		want    string
+		wantErr string
+	}{
+		{name: "flag matches catalog", flag: "aeon", entry: &buy.CatalogEntry{Name: "x", Model: "aeon"}, want: "aeon"},
+		{name: "flag case-insensitive", flag: "Aeon", entry: &buy.CatalogEntry{Name: "x", Model: "aeon"}, want: "Aeon"},
+		{name: "flag mismatch errors", flag: "other", entry: &buy.CatalogEntry{Name: "x", Model: "aeon"}, wantErr: "does not match"},
+		{name: "no flag uses catalog", flag: "", entry: &buy.CatalogEntry{Name: "x", Model: "aeon"}, want: "aeon"},
+		{name: "no flag + no catalog model errors", flag: "", entry: &buy.CatalogEntry{Name: "x"}, wantErr: "advertises no model"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveBuyModel(tc.flag, tc.entry)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("resolveBuyModel err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBuyModel unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveBuyModel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// resolveCostCap: explicit flag wins (in atomic units OR human decimal),
+// otherwise we apply the costCapMarkupBps markup over price when
+// auto-refill is on. No auto-refill means no auto cap.
+func TestResolveCostCap(t *testing.T) {
+	t.Parallel()
+	price := big.NewInt(1000)
+	tests := []struct {
+		name       string
+		flag       string
+		token      string
+		price      *big.Int
+		autoRefill bool
+		wantNil    bool
+		want       *big.Int
+		wantErr    string
+	}{
+		{name: "no flag + no auto-refill = nil", autoRefill: false, price: price, wantNil: true},
+		{name: "no flag + auto-refill = 150% markup", autoRefill: true, price: price, want: big.NewInt(1500)},
+		{name: "atomic-unit flag wins", flag: "42", autoRefill: true, price: price, want: big.NewInt(42)},
+		{name: "human-decimal USDC fallback", flag: "0.001", token: "USDC", autoRefill: false, price: price, want: big.NewInt(1000)},
+		{name: "invalid flag errors", flag: "not-a-number", token: "USDC", autoRefill: false, price: price, wantErr: "not a valid number"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveCostCap(tc.flag, tc.token, tc.price, tc.autoRefill)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("resolveCostCap err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCostCap unexpected err: %v", err)
+			}
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("resolveCostCap = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Cmp(tc.want) != 0 {
+				t.Fatalf("resolveCostCap = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// looksLikeURL keeps the positional URL detection in sync with the error
+// message we surface when users pass a name-shaped positional.
+func TestLooksLikeURL(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"https://example.com":        true,
+		"http://localhost:8080":      true,
+		"https://x.example/services": true,
+		"my-buy":                     false,
+		"":                           false,
+		"ftp://example.com":          false,
+	}
+	for in, want := range cases {
+		if got := looksLikeURL(in); got != want {
+			t.Errorf("looksLikeURL(%q) = %v, want %v", in, got, want)
+		}
 	}
 }

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
+	"github.com/ObolNetwork/obol-stack/internal/buy"
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/hermes"
 	"github.com/ObolNetwork/obol-stack/internal/model"
@@ -392,7 +395,7 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 				return u.JSON(result)
 			}
 
-			u.Bold("LiteLLM gateway providers:")
+			u.Info("LiteLLM gateway providers:")
 			u.Blank()
 			u.Printf("  %-20s %-8s %-10s %-10s %s", "PROVIDER", "ENABLED", "API KEY", "MODELS", "ENV VAR")
 
@@ -416,9 +419,18 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 				u.Printf("  %-20s %-8t %-10s %-10s %s", name, s.Enabled, key, modelCount, s.EnvVar)
 			}
 
-			if len(discovered) > 0 {
+			u.Blank()
+			if printModelRanking(u, cfg, "section") {
 				u.Blank()
-				u.Bold(fmt.Sprintf("Discovered local inference servers (%d):", len(discovered)))
+			}
+
+			if printPaidPurchases(u, cfg) {
+				u.Blank()
+			}
+
+			if len(discovered) > 0 {
+				u.Infof("Discovered local inference servers (%d):", len(discovered))
+				u.Blank()
 				for _, p := range discovered {
 					noun := "models"
 					if len(p.Entries) == 1 {
@@ -426,12 +438,13 @@ func modelStatusCommand(cfg *config.Config) *cli.Command {
 					}
 					u.Printf("  %-20s %s  (%d %s)", p.Label, p.HostEndpoint, len(p.Entries), noun)
 				}
+				u.Blank()
 				u.Dim("Run 'obol model discover' for the full model list.")
 			}
 
-			u.Blank()
 			u.Dim("Run 'obol model setup' to configure a provider.")
 			u.Dim("Run 'obol model setup custom' to add a custom endpoint.")
+			u.Dim("Run 'obol model prefer <name>' to promote a model to head-of-list.")
 
 			return nil
 		},
@@ -522,14 +535,14 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 				return u.JSON(result)
 			}
 
-			// List local Ollama models
+			// Section 1: local Ollama models.
 			models, err := model.ListOllamaModels()
 			if err != nil {
 				u.Warnf("Local models (Ollama): not available (%s)", err)
 			} else if len(models) == 0 {
-				u.Info("Local models (Ollama): none pulled")
+				u.Info("Local models (Ollama):")
 				u.Blank()
-				u.Info("  Pull a model with: obol model pull")
+				u.Dim("  none pulled — obol model pull <name>")
 			} else {
 				u.Info("Local models (Ollama):")
 				u.Blank()
@@ -540,37 +553,41 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 			}
 			u.Blank()
 
-			// Show LiteLLM configured models
+			// Section 2: LiteLLM gateway by provider.
 			providerStatus, err := model.GetProviderStatus(cfg)
 			if err != nil {
-				u.Info("LiteLLM gateway: cluster not running")
+				u.Info("LiteLLM gateway providers:")
 				u.Blank()
-				u.Info("  Run 'obol stack up' then 'obol model setup' to configure a provider.")
-			} else {
-				providers := make([]string, 0, len(providerStatus))
-				for name := range providerStatus {
-					providers = append(providers, name)
+				u.Dim("  cluster not running — run 'obol stack up' then 'obol model setup'")
+				return nil
+			}
+			providers := make([]string, 0, len(providerStatus))
+			for name := range providerStatus {
+				providers = append(providers, name)
+			}
+			sort.Strings(providers)
+
+			u.Info("LiteLLM gateway providers:")
+			u.Blank()
+			u.Printf("  %-20s %-10s %s", "PROVIDER", "STATUS", "MODELS")
+			for _, name := range providers {
+				s := providerStatus[name]
+				status := "disabled"
+				if s.Enabled {
+					status = "enabled"
 				}
+				modelList := strings.Join(s.Models, ", ")
+				if modelList == "" {
+					modelList = "-"
+				}
+				u.Printf("  %-20s %-10s %s", name, status, modelList)
+			}
+			u.Blank()
 
-				sort.Strings(providers)
-
-				u.Info("LiteLLM gateway models:")
+			// Section 3: ranking (same helper as `model status` / `model prefer`).
+			if printModelRanking(u, cfg, "section") {
 				u.Blank()
-				u.Printf("  %-20s %-10s %s", "PROVIDER", "STATUS", "MODELS")
-				for _, name := range providers {
-					s := providerStatus[name]
-
-					status := "disabled"
-					if s.Enabled {
-						status = "enabled"
-					}
-
-					modelList := strings.Join(s.Models, ", ")
-					if modelList == "" {
-						modelList = "-"
-					}
-					u.Printf("  %-20s %-10s %s", name, status, modelList)
-				}
+				u.Dim("Promote a model with: obol model prefer <name>")
 			}
 
 			return nil
@@ -581,8 +598,8 @@ func modelListCommand(cfg *config.Config) *cli.Command {
 func modelPreferCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:      "prefer",
-		Usage:     "Pull one or more models to the head of the LiteLLM model_list (the head becomes the agent's primary)",
-		ArgsUsage: "<model-name> [<model-name> ...]",
+		Usage:     "Pull one or more models to the preferred choices (agents use these in order)",
+		ArgsUsage: "[<model-name> ...]",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "no-sync", Usage: "Skip the agent model sync (batch with other model commands, then run `obol model sync` once)"},
 		},
@@ -591,7 +608,15 @@ func modelPreferCommand(cfg *config.Config) *cli.Command {
 
 			names := cmd.Args().Slice()
 			if len(names) == 0 {
-				return errors.New("at least one model name is required\n\nUsage: obol model prefer <model-name> [<model-name> ...]\n\nList configured models with: obol model list")
+				// No args: show the current ranking + usage hint (read
+				// view). Renders with the dedicated "prefer-empty" style
+				// so users discover usage without re-running `--help`.
+				if !printModelRanking(u, cfg, "prefer-empty") {
+					return errors.New("LiteLLM gateway not reachable — run 'obol stack up' first")
+				}
+				u.Blank()
+				u.Dim("Usage: obol model prefer <model-name> [<model-name> ...]")
+				return nil
 			}
 
 			if err := model.PreferModels(cfg, u, names); err != nil {
@@ -601,9 +626,196 @@ func modelPreferCommand(cfg *config.Config) *cli.Command {
 			if cmd.Bool("no-sync") {
 				return nil
 			}
-			return syncAgentModels(cfg, u)
+			if err := syncAgentModels(cfg, u); err != nil {
+				return err
+			}
+			// `syncAgentModels` only re-renders the master Hermes agent.
+			// Sub-agents keep their existing `model.default` until they're
+			// individually synced — surface that explicitly so callers
+			// aren't left wondering why a sub-agent stayed on the old model.
+			printSubAgentSyncHint(cfg, u)
+			return nil
 		},
 	}
+}
+
+// printPaidPurchases queries each agent for its pre-authorized inference
+// purchases and renders a "Paid models credit:" section showing the
+// remaining spendable balance per (agent, paid-model) pair. Returns
+// false when there's nothing to show so the caller can skip the
+// trailing blank.
+//
+// Credit framing: remaining × per-request price = atomic units still
+// available to spend. Formatted with the token's own decimals so OBOL
+// renders as "0.5 OBOL", USDC as "0.001 USDC". Drains show as "0 OBOL"
+// with a `drained` state so the operator knows to top up.
+func printPaidPurchases(u *ui.UI, cfg *config.Config) bool {
+	type rowKey struct {
+		runtime agentruntime.Runtime
+		id      string
+	}
+	rows := make(map[rowKey][]buy.PurchaseSummary)
+	var keys []rowKey
+
+	for _, runtime := range []agentruntime.Runtime{agentruntime.Hermes, agentruntime.OpenClaw} {
+		ids, err := agentruntime.ListInstanceIDs(cfg, runtime)
+		if err != nil {
+			continue
+		}
+		for _, id := range ids {
+			purchases, err := buy.ListPurchases(cfg, runtime, id)
+			if err != nil || len(purchases) == 0 {
+				continue
+			}
+			k := rowKey{runtime: runtime, id: id}
+			rows[k] = purchases
+			keys = append(keys, k)
+		}
+	}
+	if len(rows) == 0 {
+		return false
+	}
+
+	u.Info("Paid models credit:")
+	u.Blank()
+	u.Printf("  %-22s %-40s %-18s %s", "AGENT", "MODEL", "CREDIT", "STATE")
+	for _, k := range keys {
+		agent := fmt.Sprintf("%s/%s", k.runtime, k.id)
+		for _, p := range rows[k] {
+			credit := formatPaidCredit(p)
+			state := "ready"
+			if p.Remaining == 0 {
+				state = "drained"
+			}
+			if p.AutoRefill {
+				state += " (auto-top-up)"
+			}
+			u.Printf("  %-22s %-40s %-18s %s", agent, truncateAlias(p.Alias, 40), credit, state)
+		}
+	}
+	u.Blank()
+	u.Dim("Top up a drained model: obol buy inference <seller-url>")
+	u.Dim("  add --auto-refill to keep it funded automatically (top-ups draw from the agent's wallet).")
+	return true
+}
+
+// formatPaidCredit returns "remaining × price" as a human token amount
+// ("0.5 OBOL"). Falls back to "<remaining> auths" when price metadata
+// is missing (older PurchaseRequests didn't surface asset decimals).
+func formatPaidCredit(p buy.PurchaseSummary) string {
+	if p.Price == "" || p.AssetSymbol == "" || p.AssetDecimals <= 0 {
+		return fmt.Sprintf("%d auths", p.Remaining)
+	}
+	priceAtomic, ok := new(big.Int).SetString(strings.TrimSpace(p.Price), 10)
+	if !ok || priceAtomic.Sign() < 0 {
+		return fmt.Sprintf("%d auths", p.Remaining)
+	}
+	credit := new(big.Int).Mul(priceAtomic, big.NewInt(int64(p.Remaining)))
+	return fmt.Sprintf("%s %s", formatAtomicTrimmed(credit, p.AssetDecimals), p.AssetSymbol)
+}
+
+// formatAtomicTrimmed mirrors cmd/obol/buy.go::formatTokenAmount but
+// lives here so the model.go file stays import-light. Trims trailing
+// zeros, drops the decimal point when not needed.
+func formatAtomicTrimmed(v *big.Int, decimals int) string {
+	if v == nil {
+		return "?"
+	}
+	if decimals <= 0 {
+		decimals = 6
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	r := new(big.Rat).SetFrac(v, scale)
+	s := r.FloatString(decimals)
+	if !strings.Contains(s, ".") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimSuffix(s, ".")
+	return s
+}
+
+func truncateAlias(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+// printSubAgentSyncHint emits a dimmed reminder when sub-agents exist
+// beyond the master Hermes instance. The master is already covered by
+// syncAgentModels; the others need an explicit `obol agent sync <name>`
+// to pick up the new head-of-list primary.
+func printSubAgentSyncHint(cfg *config.Config, u *ui.UI) {
+	hermesIDs, err := agentruntime.ListInstanceIDs(cfg, agentruntime.Hermes)
+	if err != nil {
+		return
+	}
+	openclawIDs, _ := agentruntime.ListInstanceIDs(cfg, agentruntime.OpenClaw)
+
+	var subs []string
+	for _, id := range hermesIDs {
+		if id == agentruntime.DefaultInstanceID {
+			continue
+		}
+		subs = append(subs, "hermes/"+id)
+	}
+	for _, id := range openclawIDs {
+		subs = append(subs, "openclaw/"+id)
+	}
+	if len(subs) == 0 {
+		return
+	}
+	u.Blank()
+	if len(subs) == 1 {
+		u.Dim(fmt.Sprintf("Sub-agent %s keeps its existing primary model. Run: obol agent sync %s",
+			subs[0], strings.SplitN(subs[0], "/", 2)[1]))
+		return
+	}
+	u.Dim("Sub-agents keep their existing primary model. Run, for each:")
+	for _, s := range subs {
+		u.Dim(fmt.Sprintf("  obol agent sync %s", strings.SplitN(s, "/", 2)[1]))
+	}
+}
+
+// printModelRanking renders the configured LiteLLM model_list ordering
+// with the head marked as primary. The caller picks the framing:
+//
+//   - "section" → green `==>` section header inline with the rest of
+//     `model list` / `model status` (their natural section style).
+//   - "prefer-empty" → the argless `obol model prefer` view: a top
+//     title line, a dimmed "Current order:" subtitle, the star list,
+//     and a usage hint footer. Cleaner for a read-only "show me the
+//     current state" call.
+//
+// Returns false when no models are configured (caller can fall through
+// to a "cluster not running" / "no models" message).
+func printModelRanking(u *ui.UI, cfg *config.Config, style string) bool {
+	models, err := model.GetConfiguredModels(cfg)
+	if err != nil || len(models) == 0 {
+		return false
+	}
+	primary, _ := model.Rank(models)
+
+	switch style {
+	case "prefer-empty":
+		u.Info("Model ranking (which model agents use):")
+		u.Blank()
+		u.Dim("Current order:")
+	default:
+		// "section" — used by list/status. Green `==>` arrow keeps the
+		// section header aligned with the rest of the command's output.
+		u.Info("Model order (which model agents use in order):")
+		u.Blank()
+	}
+	for i, name := range models {
+		marker := " "
+		if name == primary {
+			marker = "★"
+		}
+		u.Printf("  %s %2d. %s", marker, i+1, name)
+	}
+	return true
 }
 
 func modelRemoveCommand(cfg *config.Config) *cli.Command {

--- a/flows/flow-08-buy.sh
+++ b/flows/flow-08-buy.sh
@@ -271,11 +271,15 @@ fi
 poll_step_grep "Agent wallet funded on local Anvil" "^[1-9][0-9]{8,} " 24 5 agent_wallet_anvil_balance
 
 step "Ensure PurchaseRequest auth pool via obol buy inference"
-buy_out=$("$OBOL" buy inference "$PURCHASE_NAME" \
-    --seller "$PUBLIC_SELLER_URL" \
+# Positional arg is now the seller URL; PR name moved to --name. --yes
+# bypasses the interactive confirm (flow runs headless). Identity
+# verification is opt-in in the new CLI (default skips), so the historical
+# --no-verify-identity is no longer needed/present.
+buy_out=$("$OBOL" buy inference "$PUBLIC_SELLER_URL" \
+    --name "$PURCHASE_NAME" \
     --model "$FLOW_MODEL" \
     --budget "$BUY_BUDGET_USDC" \
-    --no-verify-identity \
+    --yes \
     --force 2>&1) || true
 if echo "$buy_out" | grep -q "Purchased upstream '$PURCHASE_NAME' configured via x402-buyer sidecar"; then
     pass "obol buy inference ensured PurchaseRequest $PURCHASE_NAME"

--- a/flows/flow-11-dual-stack.sh
+++ b/flows/flow-11-dual-stack.sh
@@ -1320,11 +1320,14 @@ if [ "$buy_mode" = "host-cli" ] && [ "$BOB_AGENT_RUNTIME" != "hermes" ]; then
 fi
 
 if [ "$buy_mode" = "host-cli" ]; then
-    if buy_output=$(bob buy inference alice-inference \
-        --seller "$TUNNEL_URL/services/alice-inference/v1/chat/completions" \
+    # New CLI: positional is the seller URL; PR name → --name. --yes skips
+    # the interactive confirm in this headless flow.
+    if buy_output=$(bob buy inference "$TUNNEL_URL/services/alice-inference/v1/chat/completions" \
+        --name alice-inference \
         --model "$OBOL_LLM_MODEL" \
         --budget "$FLOW11_BUY_BUDGET_USDC" \
-        --expected-agent-id "$AGENT_ID" 2>&1); then
+        --expected-agent-id "$AGENT_ID" \
+        --yes 2>&1); then
         buy_ec=0
     else
         buy_ec=$?

--- a/internal/buy/balance.go
+++ b/internal/buy/balance.go
@@ -1,0 +1,127 @@
+package buy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// WalletInfo is the host-side view of an agent's remote-signer wallet on a
+// given chain, including the atomic balance for one token.
+type WalletInfo struct {
+	Address     string   // 0x-prefixed signer address from buy.py.
+	Token       string   // Upper-case symbol the caller asked for (USDC, OBOL).
+	Chain       string   // Canonical chain name the balance was read on.
+	AtomicUnits *big.Int // Raw on-chain balance, scaled by the token's decimals.
+	Decimals    int      // Decimals for the token, for display formatting.
+}
+
+// HumanBalance returns the balance as a fixed-point decimal string trimmed to
+// six fractional digits, matching `buy.py balance` output for parity with
+// what users see when they run the skill directly.
+func (w WalletInfo) HumanBalance() string {
+	if w.AtomicUnits == nil {
+		return "0"
+	}
+	if w.Decimals == 0 {
+		return w.AtomicUnits.String()
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(w.Decimals)), nil)
+	r := new(big.Rat).SetFrac(w.AtomicUnits, scale)
+	return r.FloatString(6)
+}
+
+// FetchWalletInfo execs `buy.py balance --chain <chain>` inside the named
+// agent pod and parses the output to recover the signer address and the
+// balance for `token` (e.g. "USDC" or "OBOL").
+//
+// We shell out instead of re-implementing the signer + eRPC RPC walk in Go
+// because the agent pod already has SA credentials, the signer URL, and the
+// eRPC alias resolution wired up via the buy-x402 skill. Re-deriving all
+// three from the host would be a meaningful surface area expansion for what
+// is a single confirmation-line preflight.
+func FetchWalletInfo(cfg *config.Config, runtime agentruntime.Runtime, id, token, chain string) (*WalletInfo, error) {
+	token = strings.ToUpper(strings.TrimSpace(token))
+	if token == "" {
+		return nil, errors.New("token is empty")
+	}
+	chain = strings.TrimSpace(chain)
+	if chain == "" {
+		return nil, errors.New("chain is empty")
+	}
+
+	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	argv := []string{
+		"/opt/hermes/.venv/bin/python3",
+		"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
+		"balance",
+		"--chain", chain,
+	}
+	kubectlArgs := agentruntime.BuildExecArgs(runtime, id, argv, false)
+
+	cmd := exec.Command(kubectlBin, kubectlArgs...)
+	cmd.Env = append(cmd.Env, "KUBECONFIG="+kubeconfig)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("kubectl exec buy.py balance: %s", msg)
+	}
+
+	return parseBalanceOutput(stdout.String(), token, chain)
+}
+
+var balanceLineRe = regexp.MustCompile(`^([A-Z0-9]+):\s+\S+\s+\((\d+)\s+(micro-units|base-units)\)`)
+
+func parseBalanceOutput(out, token, chain string) (*WalletInfo, error) {
+	info := &WalletInfo{Token: token, Chain: chain}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Wallet:") {
+			info.Address = strings.TrimSpace(strings.TrimPrefix(line, "Wallet:"))
+			continue
+		}
+		matches := balanceLineRe.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		if !strings.EqualFold(matches[1], token) {
+			continue
+		}
+		atomic, ok := new(big.Int).SetString(matches[2], 10)
+		if !ok {
+			return nil, fmt.Errorf("parse %s balance %q: not a base-10 integer", token, matches[2])
+		}
+		info.AtomicUnits = atomic
+		// micro-units → 6 decimals, base-units → 18 decimals (per buy.py
+		// labeling). Token registry has the authoritative decimals, but we
+		// stay self-contained here so callers don't need to re-resolve.
+		if matches[3] == "micro-units" {
+			info.Decimals = 6
+		} else {
+			info.Decimals = 18
+		}
+		break
+	}
+	if info.Address == "" {
+		return nil, errors.New("buy.py balance produced no Wallet: line")
+	}
+	if info.AtomicUnits == nil {
+		return nil, fmt.Errorf("buy.py balance produced no %s row on chain %s", token, chain)
+	}
+	return info, nil
+}

--- a/internal/buy/balance.go
+++ b/internal/buy/balance.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -24,19 +25,27 @@ type WalletInfo struct {
 	Decimals    int      // Decimals for the token, for display formatting.
 }
 
-// HumanBalance returns the balance as a fixed-point decimal string trimmed to
-// six fractional digits, matching `buy.py balance` output for parity with
-// what users see when they run the skill directly.
+// HumanBalance returns the balance with the minimum fractional digits
+// needed (whole numbers render as "12", dust as "0.001"). Matches the
+// host-side summary formatter (cmd/obol/buy.go::formatTokenAmount) so
+// balance lines and budget lines look consistent.
 func (w WalletInfo) HumanBalance() string {
 	if w.AtomicUnits == nil {
 		return "0"
 	}
-	if w.Decimals == 0 {
+	dec := w.Decimals
+	if dec <= 0 {
 		return w.AtomicUnits.String()
 	}
-	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(w.Decimals)), nil)
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(dec)), nil)
 	r := new(big.Rat).SetFrac(w.AtomicUnits, scale)
-	return r.FloatString(6)
+	s := r.FloatString(dec)
+	if !strings.Contains(s, ".") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimSuffix(s, ".")
+	return s
 }
 
 // FetchWalletInfo execs `buy.py balance --chain <chain>` inside the named
@@ -70,7 +79,11 @@ func FetchWalletInfo(cfg *config.Config, runtime agentruntime.Runtime, id, token
 	kubectlArgs := agentruntime.BuildExecArgs(runtime, id, argv, false)
 
 	cmd := exec.Command(kubectlBin, kubectlArgs...)
-	cmd.Env = append(cmd.Env, "KUBECONFIG="+kubeconfig)
+	// Inherit the parent environment so kubectl can find $HOME for its
+	// discovery + HTTP cache (default $HOME/.kube/cache). Setting cmd.Env
+	// without os.Environ() leaves HOME unset and kubectl drops a .kube/
+	// folder in the current working directory on every invocation.
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/buy/balance.go
+++ b/internal/buy/balance.go
@@ -70,12 +70,7 @@ func FetchWalletInfo(cfg *config.Config, runtime agentruntime.Runtime, id, token
 	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
-	argv := []string{
-		"/opt/hermes/.venv/bin/python3",
-		"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
-		"balance",
-		"--chain", chain,
-	}
+	argv := BuyPyCommand(runtime, "balance", "--chain", chain)
 	kubectlArgs := agentruntime.BuildExecArgs(runtime, id, argv, false)
 
 	cmd := exec.Command(kubectlBin, kubectlArgs...)

--- a/internal/buy/balance_test.go
+++ b/internal/buy/balance_test.go
@@ -1,0 +1,71 @@
+package buy
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// parseBalanceOutput is the pure half of FetchWalletInfo — it parses the
+// well-known shape `buy.py balance` prints. Tested in isolation so we don't
+// need a live cluster.
+func TestParseBalanceOutput(t *testing.T) {
+	t.Parallel()
+	out := strings.Join([]string{
+		"Wallet:  0xAbCDef0000000000000000000000000000000123",
+		"Chain:   base-sepolia",
+		"USDC:    1.234567 (1234567 micro-units)",
+		"OBOL:    0.012345 (12345000000000000 base-units)",
+	}, "\n")
+
+	t.Run("USDC", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseBalanceOutput(out, "USDC", "base-sepolia")
+		if err != nil {
+			t.Fatalf("parseBalanceOutput USDC: %v", err)
+		}
+		if got.Address != "0xAbCDef0000000000000000000000000000000123" {
+			t.Fatalf("address = %q", got.Address)
+		}
+		if got.AtomicUnits.Cmp(big.NewInt(1234567)) != 0 {
+			t.Fatalf("USDC atomic = %s", got.AtomicUnits)
+		}
+		if got.Decimals != 6 {
+			t.Fatalf("USDC decimals = %d, want 6", got.Decimals)
+		}
+		if got.HumanBalance() != "1.234567" {
+			t.Fatalf("USDC human = %s, want 1.234567", got.HumanBalance())
+		}
+	})
+
+	t.Run("OBOL", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseBalanceOutput(out, "OBOL", "base-sepolia")
+		if err != nil {
+			t.Fatalf("parseBalanceOutput OBOL: %v", err)
+		}
+		want, _ := new(big.Int).SetString("12345000000000000", 10)
+		if got.AtomicUnits.Cmp(want) != 0 {
+			t.Fatalf("OBOL atomic = %s, want %s", got.AtomicUnits, want)
+		}
+		if got.Decimals != 18 {
+			t.Fatalf("OBOL decimals = %d, want 18", got.Decimals)
+		}
+	})
+
+	t.Run("missing wallet", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseBalanceOutput("USDC: 1.0 (1000000 micro-units)", "USDC", "base-sepolia")
+		if err == nil || !strings.Contains(err.Error(), "Wallet:") {
+			t.Fatalf("expected wallet-missing error, got %v", err)
+		}
+	})
+
+	t.Run("missing token row", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseBalanceOutput("Wallet:  0xabc\n", "USDC", "base-sepolia")
+		if err == nil || !strings.Contains(err.Error(), "no USDC row") {
+			t.Fatalf("expected missing-row error, got %v", err)
+		}
+	})
+}

--- a/internal/buy/catalog_test.go
+++ b/internal/buy/catalog_test.go
@@ -1,0 +1,169 @@
+package buy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCatalogURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"base URL", "https://inference.v1337.org/", "https://inference.v1337.org/api/services.json"},
+		{"service URL stripped", "https://inference.v1337.org/services/aeon", "https://inference.v1337.org/api/services.json"},
+		{"query dropped", "https://x.example/services/foo?x=1", "https://x.example/api/services.json"},
+		{"no trailing slash", "https://x.example", "https://x.example/api/services.json"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := catalogURL(tc.in)
+			if err != nil {
+				t.Fatalf("catalogURL(%q) error = %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("catalogURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCatalogURL_Invalid(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "not-a-url", "/relative/only"} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			if _, err := catalogURL(in); err == nil {
+				t.Fatalf("catalogURL(%q) returned nil err, want error", in)
+			}
+		})
+	}
+}
+
+func TestEndpointPath(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"/services/aeon":                          "/services/aeon",
+		"/services/aeon/v1/chat/completions":      "/services/aeon",
+		"/services/aeon/chat/completions":         "/services/aeon",
+		"https://x.example/services/aeon":         "/services/aeon",
+		"https://x.example/services/aeon/v1/chat": "/services/aeon", // trailing chat is not stripped fully but path still picks aeon
+		"":                                        "",
+		"/":                                       "",
+		"/something-else":                         "",
+	}
+	for in, want := range cases {
+		got := endpointPath(in)
+		if got != want {
+			t.Errorf("endpointPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestServicePathFromURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"storefront base", "https://inference.v1337.org/", ""},
+		{"service URL", "https://inference.v1337.org/services/aeon", "/services/aeon"},
+		{"service URL with subpath", "https://x.example/services/foo/v1/chat/completions", "/services/foo"},
+		{"trailing slash", "https://x.example/services/foo/", "/services/foo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := servicePathFromURL(tc.in)
+			if err != nil {
+				t.Fatalf("servicePathFromURL(%q) error = %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("servicePathFromURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// FetchServiceCatalog hits /api/services.json and parses the entries.
+func TestFetchServiceCatalog(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/services.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]CatalogEntry{
+			{Name: "aeon", Type: "inference", Model: "aeon7", Endpoint: "/services/aeon/v1/chat/completions"},
+			{Name: "http-thing", Type: "http", Endpoint: "/services/http-thing"},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := FetchServiceCatalog(context.Background(), srv.URL+"/services/aeon")
+	if err != nil {
+		t.Fatalf("FetchServiceCatalog: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].Name != "aeon" {
+		t.Fatalf("entry[0].Name = %q, want %q", got[0].Name, "aeon")
+	}
+}
+
+// PickCatalogEntry: storefront base + single inference offer picks it.
+// Multiple offers without a service path errors. Wrong type errors.
+func TestPickCatalogEntry(t *testing.T) {
+	t.Parallel()
+	entries := []CatalogEntry{
+		{Name: "aeon", Type: "inference", Model: "aeon7", Endpoint: "/services/aeon"},
+		{Name: "http-thing", Type: "http", Endpoint: "/services/http-thing"},
+	}
+	multipleInf := []CatalogEntry{
+		{Name: "aeon", Type: "inference", Endpoint: "/services/aeon"},
+		{Name: "bravo", Type: "inference", Endpoint: "/services/bravo"},
+	}
+
+	tests := []struct {
+		name    string
+		entries []CatalogEntry
+		seller  string
+		want    string
+		wantErr string
+	}{
+		{"storefront base, single inference", entries, "https://x.example/", "aeon", ""},
+		{"explicit service URL matches", entries, "https://x.example/services/aeon", "aeon", ""},
+		{"explicit service URL rejects http type", entries, "https://x.example/services/http-thing", "", "type=\"http\""},
+		{"unknown service URL", entries, "https://x.example/services/ghost", "", "no entry for endpoint"},
+		{"multiple inference offers, no service URL", multipleInf, "https://x.example/", "", "multiple inference offers"},
+		{"no inference offers", []CatalogEntry{{Name: "x", Type: "http", Endpoint: "/services/x"}}, "https://x.example/", "", "no inference offers"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := PickCatalogEntry(tc.entries, tc.seller)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("PickCatalogEntry err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PickCatalogEntry unexpected err: %v", err)
+			}
+			if got == nil || got.Name != tc.want {
+				t.Fatalf("PickCatalogEntry name = %v, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -24,8 +24,13 @@ import (
 	"time"
 
 	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+	"github.com/ObolNetwork/obol-stack/internal/schemas"
 	internalx402 "github.com/ObolNetwork/obol-stack/internal/x402"
 )
+
+// CatalogEntry re-exports the wire schema so callers don't have to import
+// internal/schemas just to read a /api/services.json response.
+type CatalogEntry = schemas.ServiceCatalogEntry
 
 const (
 	// wellKnownPath is the canonical ERC-8004 registration document path.
@@ -164,6 +169,93 @@ func FetchSellerPricing(ctx context.Context, sellerURL, model string) (*PricingR
 		return nil, err
 	}
 	return &pricing, nil
+}
+
+// FetchServiceCatalog fetches the seller's /api/services.json feed and
+// returns the parsed catalog. sellerURL may be either the seller's base URL
+// (storefront hostname) or any /services/<name>/... URL — the path component
+// is replaced with /api/services.json.
+func FetchServiceCatalog(ctx context.Context, sellerURL string) ([]CatalogEntry, error) {
+	catalogURL, err := catalogURL(sellerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, registrationFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build catalog request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", catalogURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: HTTP %d", catalogURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read catalog body: %w", err)
+	}
+
+	var entries []CatalogEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("parse catalog JSON: %w", err)
+	}
+	return entries, nil
+}
+
+// PickCatalogEntry picks the entry whose endpoint matches sellerURL.
+// When sellerURL is a bare storefront base (no /services/<name>) and exactly
+// one inference entry is advertised, that entry is returned. Returns a
+// human-readable error listing the inference offers otherwise.
+func PickCatalogEntry(entries []CatalogEntry, sellerURL string) (*CatalogEntry, error) {
+	wantPath, err := servicePathFromURL(sellerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var inferenceOnly []CatalogEntry
+	for _, e := range entries {
+		if strings.EqualFold(strings.TrimSpace(e.Type), "inference") {
+			inferenceOnly = append(inferenceOnly, e)
+		}
+	}
+
+	// Exact-match a /services/<name> URL against the catalog.
+	if wantPath != "" {
+		for i, e := range entries {
+			if endpointPath(e.Endpoint) == wantPath {
+				if !strings.EqualFold(strings.TrimSpace(e.Type), "inference") {
+					return nil, fmt.Errorf("seller offer %q has type=%q; obol buy inference only supports type=inference", e.Name, e.Type)
+				}
+				return &entries[i], nil
+			}
+		}
+		return nil, fmt.Errorf("seller catalog has no entry for endpoint %s", wantPath)
+	}
+
+	switch len(inferenceOnly) {
+	case 0:
+		return nil, errors.New("seller advertises no inference offers (type=inference)")
+	case 1:
+		e := inferenceOnly[0]
+		return &e, nil
+	default:
+		names := make([]string, 0, len(inferenceOnly))
+		for _, e := range inferenceOnly {
+			names = append(names, e.Name)
+		}
+		return nil, fmt.Errorf("seller advertises multiple inference offers (%s); pass a service URL like <seller>%s",
+			strings.Join(names, ", "), inferenceOnly[0].Endpoint)
+	}
 }
 
 // VerifyAgentID returns nil iff at least one of reg.Registrations matches the
@@ -326,13 +418,13 @@ func verifyAgentID(reg *erc8004.AgentRegistration, expected int64, expectedRegis
 		return errors.New("nil registration")
 	}
 	if expected == 0 {
-		return errors.New("expected agentId is 0; default seller is not yet provisioned — pass --seller and --no-verify-identity to bypass, or set DefaultBuySellerAgentID")
+		return errors.New("expected agentId is 0; --expected-agent-id is opt-in and must be a real on-chain tokenId — drop the flag to skip identity verification, or pass the seller's actual agentId")
 	}
 	if len(reg.Registrations) == 0 {
 		return errors.New("seller didn't publish on-chain identity: agent-registration.json has no `registrations[]` field.\n" +
 			"This usually means: (a) the seller didn't run `obol sell register` on-chain, or\n" +
 			"(b) the seller is on an older obol-stack version that pre-dates the AgentIdentity CRD.\n" +
-			"Re-run with --no-verify-identity to buy without identity verification, or contact the seller to publish their agentId.")
+			"Drop --expected-agent-id to skip identity verification, or contact the seller to publish their agentId.")
 	}
 	for _, r := range reg.Registrations {
 		if r.AgentID != expected {
@@ -348,9 +440,9 @@ func verifyAgentID(reg *erc8004.AgentRegistration, expected int64, expectedRegis
 		got = append(got, fmt.Sprintf("%d@%s", r.AgentID, r.AgentRegistry))
 	}
 	if expectedRegistry == "" {
-		return fmt.Errorf("seller agentId mismatch: expected %d, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, strings.Join(got, ", "))
+		return fmt.Errorf("seller agentId mismatch: expected %d, got [%s] — drop --expected-agent-id to skip the identity check, or pass the correct id", expected, strings.Join(got, ", "))
 	}
-	return fmt.Errorf("seller registration mismatch: expected agentId %d on %s, got [%s] — re-run with --no-verify-identity to bypass if you trust the URL", expected, expectedRegistry, strings.Join(got, ", "))
+	return fmt.Errorf("seller registration mismatch: expected agentId %d on %s, got [%s] — drop --expected-agent-id to skip the identity check, or pass the correct id", expected, expectedRegistry, strings.Join(got, ", "))
 }
 
 func firstPaymentOption(pricing *PricingResponse) (*PaymentOption, error) {
@@ -442,6 +534,79 @@ func pricingURL(sellerURL string) (string, error) {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String(), nil
+}
+
+// catalogURL replaces the path of sellerURL with /api/services.json. Any
+// /services/<name>/... suffix is stripped so callers can hand us either a
+// storefront base or a specific service URL.
+func catalogURL(sellerURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(sellerURL))
+	if err != nil {
+		return "", fmt.Errorf("parse seller URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("seller URL must include scheme and host: %q", sellerURL)
+	}
+	u.Path = "/api/services.json"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+// servicePathFromURL extracts a "/services/<name>" prefix from sellerURL. If
+// no such segment is present, returns "" (caller treats this as "storefront
+// base, pick from catalog").
+func servicePathFromURL(sellerURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(sellerURL))
+	if err != nil {
+		return "", fmt.Errorf("parse seller URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("seller URL must include scheme and host: %q", sellerURL)
+	}
+	path := strings.TrimRight(u.Path, "/")
+	if !strings.HasPrefix(path, "/services/") {
+		return "", nil
+	}
+	// Trim trailing /v1/chat/completions style suffixes so an endpoint and
+	// pricing URL pointing at the same offer normalize identically.
+	for _, suffix := range []string{"/v1/chat/completions", "/chat/completions"} {
+		path = strings.TrimSuffix(path, suffix)
+	}
+	parts := strings.SplitN(strings.TrimPrefix(path, "/services/"), "/", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "", nil
+	}
+	return "/services/" + parts[0], nil
+}
+
+// endpointPath returns the "/services/<name>" prefix for a catalog endpoint
+// string. Catalog entries store this as a path-only value (e.g.
+// "/services/aeon"), so the implementation is intentionally minimal.
+func endpointPath(endpoint string) string {
+	e := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	for _, suffix := range []string{"/v1/chat/completions", "/chat/completions"} {
+		e = strings.TrimSuffix(e, suffix)
+	}
+	if e == "" {
+		return ""
+	}
+	if strings.HasPrefix(e, "/services/") {
+		parts := strings.SplitN(strings.TrimPrefix(e, "/services/"), "/", 2)
+		if len(parts) == 0 || parts[0] == "" {
+			return ""
+		}
+		return "/services/" + parts[0]
+	}
+	// Absolute URL form ("https://host/services/foo") — fall back to a
+	// parse to recover the path. Bail if the parse didn't actually
+	// re-shape the input (paths like "/something-else" or bare names),
+	// otherwise the recursive call loops forever.
+	u, err := url.Parse(e)
+	if err != nil || u.Path == "" || u.Path == e {
+		return ""
+	}
+	return endpointPath(u.Path)
 }
 
 func normalizedEndpointIdentity(raw string) (string, error) {

--- a/internal/buy/discover.go
+++ b/internal/buy/discover.go
@@ -408,7 +408,7 @@ func ValidateBudgetAgainstPricing(budgetBase string, pricing *PricingResponse) e
 		return fmt.Errorf("pricing response has invalid amount %q", priceRaw)
 	}
 	if budget.Cmp(price) < 0 {
-		return fmt.Errorf("--budget %s is smaller than one request price %s on %s; raise the budget or buy.py will round up to one auth and exceed the requested cap", budget.String(), price.String(), payment.Network)
+		return fmt.Errorf("--budget %s is smaller than one request price %s on %s; raise the budget or buy.py will round up to one authorization and exceed the requested ceiling", budget.String(), price.String(), payment.Network)
 	}
 	return nil
 }

--- a/internal/buy/discover_test.go
+++ b/internal/buy/discover_test.go
@@ -151,7 +151,7 @@ func TestVerifyAgentIDForPricing(t *testing.T) {
 func TestVerifyAgentIDForPricing_EmptyRegistrations(t *testing.T) {
 	// Seller returned a valid registration document but with no registrations[]
 	// (e.g. they never ran `obol sell register`, or are on an older stack version).
-	// The error must explain the situation and hint at --no-verify-identity.
+	// The error must explain the situation and hint at the new opt-in flag.
 	reg := &erc8004.AgentRegistration{}
 	pricing := &PricingResponse{Accepts: []PaymentOption{{Network: "base-sepolia", Amount: "1000"}}}
 
@@ -160,7 +160,7 @@ func TestVerifyAgentIDForPricing_EmptyRegistrations(t *testing.T) {
 		t.Fatal("VerifyAgentIDForPricing(empty regs) = nil, want error")
 	}
 	msg := err.Error()
-	for _, want := range []string{"no `registrations[]` field", "--no-verify-identity"} {
+	for _, want := range []string{"no `registrations[]` field", "--expected-agent-id"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error %q missing expected substring %q", msg, want)
 		}

--- a/internal/buy/purchases.go
+++ b/internal/buy/purchases.go
@@ -45,12 +45,7 @@ func ListPurchases(cfg *config.Config, runtime agentruntime.Runtime, id string) 
 	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
-	argv := []string{
-		"/opt/hermes/.venv/bin/python3",
-		"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
-		"list",
-		"--json",
-	}
+	argv := BuyPyCommand(runtime, "list", "--json")
 	kubectlArgs := agentruntime.BuildExecArgs(runtime, id, argv, false)
 
 	cmd := exec.Command(kubectlBin, kubectlArgs...)

--- a/internal/buy/purchases.go
+++ b/internal/buy/purchases.go
@@ -1,0 +1,91 @@
+package buy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
+	"github.com/ObolNetwork/obol-stack/internal/config"
+)
+
+// PurchaseSummary is the host-side view of one paid-inference subscription
+// the agent is funding. The fields mirror buy.py's `list --json` payload —
+// rename in lockstep with internal/embed/skills/buy-x402/scripts/buy.py
+// (cmd_list `as_json=True`) when changing either side.
+type PurchaseSummary struct {
+	Name          string `json:"name"`
+	Alias         string `json:"alias"`
+	Model         string `json:"model"`
+	Remaining     int    `json:"remaining"`
+	Spent         int    `json:"spent"`
+	TotalSigned   int    `json:"totalSigned"`
+	Expired       int    `json:"expired"`
+	Price         string `json:"price"` // per-request atomic amount
+	Chain         string `json:"chain"`
+	Endpoint      string `json:"endpoint"`
+	AutoRefill    bool   `json:"autoRefill"`
+	AssetSymbol   string `json:"assetSymbol"`
+	AssetDecimals int    `json:"assetDecimals"`
+}
+
+// ListPurchases shells `buy.py list --json` inside the named agent pod
+// and returns the parsed payload. Used by `obol model status` to surface
+// pre-authorized budgets alongside the provider table.
+//
+// Returns an empty slice + nil error when the agent has no purchases, so
+// callers can render a "no paid models" message without distinguishing
+// from the "buy.py failed" case.
+func ListPurchases(cfg *config.Config, runtime agentruntime.Runtime, id string) ([]PurchaseSummary, error) {
+	kubectlBin := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfig := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	argv := []string{
+		"/opt/hermes/.venv/bin/python3",
+		"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
+		"list",
+		"--json",
+	}
+	kubectlArgs := agentruntime.BuildExecArgs(runtime, id, argv, false)
+
+	cmd := exec.Command(kubectlBin, kubectlArgs...)
+	// Inherit os.Environ so kubectl finds $HOME for its discovery cache
+	// (otherwise the cache leaks into $PWD/.kube — see balance.go).
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("kubectl exec buy.py list: %s", msg)
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	if out == "" || out == "null" {
+		return nil, nil
+	}
+	var purchases []PurchaseSummary
+	if err := json.Unmarshal([]byte(out), &purchases); err != nil {
+		return nil, fmt.Errorf("parse buy.py list output: %w (raw: %s)", err, truncate(out, 200))
+	}
+	return purchases, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// ErrNoAgent is returned when no agent target is available to query the
+// purchase list (e.g. `obol stack up` not yet run, or no agents created).
+var ErrNoAgent = errors.New("no agent instance available to query purchases")

--- a/internal/buy/script.go
+++ b/internal/buy/script.go
@@ -1,0 +1,25 @@
+package buy
+
+import "github.com/ObolNetwork/obol-stack/internal/agentruntime"
+
+const (
+	hermesPythonPath = "/opt/hermes/.venv/bin/python3"
+	hermesBuyPyPath  = "/data/.hermes/obol-skills/buy-x402/scripts/buy.py"
+
+	openClawPythonPath = "python3"
+	openClawBuyPyPath  = "/data/.openclaw/skills/buy-x402/scripts/buy.py"
+)
+
+// BuyPyCommand returns the in-pod argv prefix for the buy-x402 helper in the
+// selected runtime. Hermes carries its own venv; OpenClaw exposes python3 on
+// PATH and mounts skills under /data/.openclaw/skills.
+func BuyPyCommand(runtime agentruntime.Runtime, args ...string) []string {
+	python := hermesPythonPath
+	script := hermesBuyPyPath
+	if runtime == agentruntime.OpenClaw {
+		python = openClawPythonPath
+		script = openClawBuyPyPath
+	}
+	argv := []string{python, script}
+	return append(argv, args...)
+}

--- a/internal/buy/script_test.go
+++ b/internal/buy/script_test.go
@@ -1,0 +1,49 @@
+package buy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
+)
+
+func TestBuyPyCommandRuntimePaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		runtime agentruntime.Runtime
+		want    []string
+	}{
+		{
+			name:    "hermes",
+			runtime: agentruntime.Hermes,
+			want: []string{
+				"/opt/hermes/.venv/bin/python3",
+				"/data/.hermes/obol-skills/buy-x402/scripts/buy.py",
+				"list",
+				"--json",
+			},
+		},
+		{
+			name:    "openclaw",
+			runtime: agentruntime.OpenClaw,
+			want: []string{
+				"python3",
+				"/data/.openclaw/skills/buy-x402/scripts/buy.py",
+				"list",
+				"--json",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuyPyCommand(tc.runtime, "list", "--json")
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("BuyPyCommand() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/embed/embed_skills_test.go
+++ b/internal/embed/embed_skills_test.go
@@ -244,6 +244,53 @@ func TestMonetizePy_Syntax(t *testing.T) {
 	}
 }
 
+func TestBuyPyAutoRefillCostCapRequiresAutoRefill(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+
+	destDir := t.TempDir()
+	if err := CopySkills(destDir); err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	buyPy := filepath.Join(destDir, "buy-x402", "scripts", "buy.py")
+	script := `
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("buy", sys.argv[1])
+buy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(buy)
+
+def expect_error(opts, message):
+    try:
+        buy._resolve_auto_refill(opts, 100, {})
+    except ValueError as exc:
+        if message not in str(exc):
+            raise SystemExit(f"wrong error {exc!r}, wanted {message!r}")
+        return
+    raise SystemExit(f"expected ValueError for {opts!r}")
+
+expect_error({"cost_cap": "42"}, "requires --auto-refill")
+expect_error({"cost_cap": "42", "auto_refill": "false"}, "requires --auto-refill")
+
+policy = buy._resolve_auto_refill({"cost_cap": "42", "auto_refill": "true"}, 100, {})
+if not policy.get("enabled") or policy.get("maxUnitPrice") != "42":
+    raise SystemExit(f"cost cap with auto-refill did not persist: {policy!r}")
+
+existing = {"enabled": True, "threshold": 10, "count": 20}
+policy = buy._resolve_auto_refill({"cost_cap": "43"}, 100, existing)
+if not policy.get("enabled") or policy.get("maxUnitPrice") != "43":
+    raise SystemExit(f"cost cap update on existing policy failed: {policy!r}")
+`
+	cmd := exec.Command("python3", "-c", script, buyPy)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("buy.py auto-refill policy regression failed:\n%s\n%v", output, err)
+	}
+}
+
 func TestAgentFactoryPy_Syntax(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")

--- a/internal/embed/skills/buy-x402/SKILL.md
+++ b/internal/embed/skills/buy-x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: buy-x402
-description: "Buy from any x402-gated endpoint. Two flows: `pay` for one-shot HTTP services (single auth, no sidecar), and `buy` for long-running paid inference budgets (pre-signed batch via PurchaseRequest, exposed as `paid/<remote-model>`). Supports USDC (EIP-3009) and OBOL (Permit2). Zero signer access at runtime — spending is capped by design."
+description: "Buy from any x402-gated endpoint. Two flows: `pay` for one-shot HTTP services (single authorization, no sidecar), and `buy` for long-running paid inference (pre-authorized batch via PurchaseRequest, exposed as `paid/<remote-model>`). Supports USDC (EIP-3009) and OBOL (Permit2). Zero signer access at runtime — spending is capped by design and nothing moves on-chain until a voucher is spent."
 metadata: { "openclaw": { "emoji": "\ud83d\uded2", "requires": { "bins": ["python3"] } } }
 ---
 
@@ -8,9 +8,9 @@ metadata: { "openclaw": { "emoji": "\ud83d\uded2", "requires": { "bins": ["pytho
 
 Purchase access to remote x402-gated services. There are two flows, picked by usage shape:
 
-- **`pay <url>`** — single-shot. Probe the URL, sign **one** payment authorization, attach `X-PAYMENT`, send the request, return the response. Stateless. Use for `type:http` services and any one-off purchase. Max loss = price of one request.
-- **`buy <name>`** — pre-payment budget. Pre-sign **N** authorizations, declare them in a `PurchaseRequest` CR, let the `x402-buyer` sidecar spend them transparently as the agent calls the model through LiteLLM at `paid/<remote-model>`. Use for long-running paid inference. Max loss = N × price; runtime path holds zero signer access.
-- **`buy <name> --model <id> --set-default`** — same as `buy` above, then adopt `paid/<remote-model>` as the agent's **own primary model**, in-pod, by itself: an atomic `hermes config set model.default` that Hermes re-reads per request (effective next chat turn, **no restart**, no host-side `obol model prefer`/`obol model sync`). Refuses if the model isn't selectable in LiteLLM. Pair with `--auto-refill` so the primary model doesn't brick when the pre-signed pool empties.
+- **`pay <url>`** — single-shot. Probe the URL, sign **one** payment authorization, attach `X-PAYMENT`, send the request, return the response. Stateless. Use for `type:http` services and any one-off purchase. Max loss = price of one request; nothing settles on-chain until that one request succeeds.
+- **`buy <name>`** — pre-authorize a budget. Sign **N** authorizations up front (the buyer pays nothing yet), declare them in a `PurchaseRequest` CR, let the `x402-buyer` sidecar redeem them transparently as the agent calls the model through LiteLLM at `paid/<remote-model>`. Use for long-running paid inference. Max loss = N × price (only as vouchers are spent); runtime path holds zero signer access.
+- **`buy <name> --model <id> --set-default`** — same as `buy` above, then adopt `paid/<remote-model>` as the agent's **own primary model**, in-pod, by itself: an atomic `hermes config set model.default` that Hermes re-reads per request (effective next chat turn, **no restart**, no host-side `obol model prefer`/`obol model sync`). Refuses if the model isn't selectable in LiteLLM. Pair with `--auto-refill` so the primary model doesn't brick when the pre-authorized budget runs out.
 
 Both flows auto-detect the token + transfer method from the seller's 402 response. Currently supported: **USDC via EIP-3009** (Base Sepolia, Base Mainnet, Ethereum Mainnet) and **OBOL via Permit2** (Ethereum Mainnet).
 
@@ -293,9 +293,9 @@ flowchart LR
 2. **Pre-sign**: The agent signs N ERC-3009 `TransferWithAuthorization` vouchers via the remote-signer. Each voucher has a random nonce and is single-use (consumed on-chain when the facilitator settles).
 
 3. **Delete / drain behavior**: deleting a `PurchaseRequest` does not
-   immediately remove the paid route if there are still auths remaining. The
+   immediately remove the paid route if there are still authorizations remaining. The
    controller marks the purchase as draining, keeps `paid/<model>` live, and
-   only tears the route down after the remaining auth pool reaches zero. While
+   only tears the route down after the pre-authorized budget reaches zero. While
    draining:
    - `buy.py list` and `buy.py status <name>` still show the purchase
    - the purchase still owns `paid/<model>`

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -379,10 +379,22 @@ def _resolve_auto_refill(opts, desired_count, existing_policy=None):
     auto_refill = _parse_boolish(opts.get("auto_refill"), "--auto-refill")
     threshold = _parse_positive_int(opts.get("refill_threshold"), "--refill-threshold", minimum=0)
     refill_count = _parse_positive_int(opts.get("refill_count"), "--refill-count", minimum=1)
+    # --cost-cap is a per-unit price ceiling (atomic units) the refill loop
+    # checks against the seller's current quote before re-signing. It does
+    # NOT bound the initial buy — the initial buy's protection is --budget.
+    cost_cap_raw = opts.get("cost_cap")
+    cost_cap = None
+    if cost_cap_raw is not None:
+        try:
+            cost_cap = int(str(cost_cap_raw))
+        except (TypeError, ValueError):
+            raise ValueError(f"--cost-cap must be an integer atomic-units value, got {cost_cap_raw!r}")
+        if cost_cap <= 0:
+            raise ValueError("--cost-cap must be > 0")
 
     has_policy_override = any(
         value is not None
-        for value in (auto_refill, threshold, refill_count)
+        for value in (auto_refill, threshold, refill_count, cost_cap)
     )
     if not has_policy_override:
         return existing_policy or None
@@ -390,7 +402,7 @@ def _resolve_auto_refill(opts, desired_count, existing_policy=None):
     enabled = auto_refill
     if enabled is None:
         enabled = bool(existing_policy.get("enabled")) or any(
-            value is not None for value in (threshold, refill_count)
+            value is not None for value in (threshold, refill_count, cost_cap)
         )
     if not enabled:
         return {"enabled": False}
@@ -416,6 +428,10 @@ def _resolve_auto_refill(opts, desired_count, existing_policy=None):
         "threshold": resolved_threshold,
         "count": resolved_count,
     }
+    if cost_cap is not None:
+        policy["maxUnitPrice"] = str(cost_cap)
+    elif existing_policy.get("maxUnitPrice"):
+        policy["maxUnitPrice"] = str(existing_policy["maxUnitPrice"])
     return policy
 
 
@@ -1195,6 +1211,47 @@ def _reconcile_purchase_autorefill(pr, live_status, signer_address):
     if not pay_to or not price:
         print(f"{name}: incomplete payment config; skipping")
         return False
+
+    # Re-probe the seller's current quote so a price hike doesn't silently
+    # burn the wallet on auto-refill. The CR's `payment.price` is the
+    # originally-purchased quote and gets stale; the seller's 402 response
+    # carries the live one. `_probe_endpoint` returns the parsed 402 body or
+    # None — we only update the price when we get an unambiguous fresh
+    # quote so a transient seller error never silently rewrites the cap.
+    endpoint = spec.get("endpoint") or ""
+    if endpoint:
+        try:
+            live = _probe_endpoint(_normalize_endpoint(endpoint), spec.get("model") or "")
+            if live and live.get("accepts"):
+                live_amount = str(
+                    live["accepts"][0].get("maxAmountRequired")
+                    or live["accepts"][0].get("amount")
+                    or ""
+                ).strip()
+                if live_amount and live_amount != str(price):
+                    print(
+                        f"{name}: seller price moved {price} → {live_amount} (atomic units); "
+                        "refilling at seller's quote",
+                    )
+                    price = live_amount
+        except Exception as exc:  # network blip, malformed 402 — keep old price
+            print(f"{name}: live price re-probe failed ({exc}); using stored price", file=sys.stderr)
+
+    max_unit_price = policy.get("maxUnitPrice")
+    if max_unit_price is not None:
+        try:
+            if int(price) > int(max_unit_price):
+                print(
+                    f"{name}: seller price {price} exceeds cost cap {max_unit_price} "
+                    f"({asset} on {chain}); skipping refill"
+                )
+                return False
+        except (TypeError, ValueError):
+            print(
+                f"{name}: invalid maxUnitPrice {max_unit_price!r}; skipping",
+                file=sys.stderr,
+            )
+            return False
 
     balance = int(_get_usdc_balance(signer_address, asset, chain))
     total_cost = refill_count * int(price)
@@ -2154,8 +2211,10 @@ def usage():
     print("  buy <name> --endpoint <url> --model <id>     Pre-sign + configure paid/<model>")
     print("       [--budget <micro-units>] [--count <N>]")
     print("       [--auto-refill[=true|false]] [--refill-threshold <N>]")
-    print("       [--refill-count <N>] [--auth-ttl <seconds|never>] [--set-default]")
+    print("       [--refill-count <N>] [--cost-cap <atomic-units>]")
+    print("       [--auth-ttl <seconds|never>] [--set-default]")
     print("       --auth-ttl     pool expiry: seconds, or 'never' (default 30d/1mo); env OBOL_X402_AUTH_TTL")
+    print("       --cost-cap     per-unit price ceiling (atomic units) for auto-refill — refills above this are skipped")
     print("       --set-default  inference only: adopt paid/<model> as the agent's primary model")
     print("  list                                         List purchased providers")
     print("  status <name>                                Check sidecar + auths")

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -406,6 +406,19 @@ def _resolve_auto_refill(opts, desired_count, existing_policy=None):
         if cost_cap <= 0:
             raise ValueError("--cost-cap must be > 0")
 
+    if cost_cap is not None and auto_refill is False:
+        raise ValueError("--cost-cap requires --auto-refill because it only applies to future auto-refill")
+
+    existing_enabled = bool(existing_policy.get("enabled"))
+    if (
+        cost_cap is not None
+        and auto_refill is None
+        and not existing_enabled
+        and threshold is None
+        and refill_count is None
+    ):
+        raise ValueError("--cost-cap requires --auto-refill because it only applies to future auto-refill")
+
     has_policy_override = any(
         value is not None
         for value in (auto_refill, threshold, refill_count, cost_cap)
@@ -415,8 +428,8 @@ def _resolve_auto_refill(opts, desired_count, existing_policy=None):
 
     enabled = auto_refill
     if enabled is None:
-        enabled = bool(existing_policy.get("enabled")) or any(
-            value is not None for value in (threshold, refill_count, cost_cap)
+        enabled = existing_enabled or any(
+            value is not None for value in (threshold, refill_count)
         )
     if not enabled:
         return {"enabled": False}
@@ -1525,6 +1538,15 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
         print(f"  Capping permit2 pre-authorized budget from {n} to {PERMIT2_SAFE_AUTH_COUNT} authorizations to stay within current ConfigMap storage limits")
         n = PERMIT2_SAFE_AUTH_COUNT
     n = max(n, 1)
+    if budget and price_int > 0:
+        total_cost_for_count = n * price_int
+        if total_cost_for_count > budget_val:
+            print(
+                f"Error: requested count costs {total_cost_for_count} atomic units, "
+                f"which exceeds --budget {budget_val}. Reduce --count or raise --budget.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     token, _ = load_sa()
     ssl_ctx = make_ssl_context()

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -1486,7 +1486,7 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
     else:
         n = DEFAULT_AUTH_COUNT
     if extra.get("assetTransferMethod", "eip3009") == "permit2" and n > PERMIT2_SAFE_AUTH_COUNT:
-        print(f"  Capping permit2 auth pool from {n} to {PERMIT2_SAFE_AUTH_COUNT} to stay within current ConfigMap storage limits")
+        print(f"  Capping permit2 pre-authorized budget from {n} to {PERMIT2_SAFE_AUTH_COUNT} authorizations to stay within current ConfigMap storage limits")
         n = PERMIT2_SAFE_AUTH_COUNT
     n = max(n, 1)
 
@@ -1781,7 +1781,7 @@ def _set_agent_default_model(model_id, auto_refill):
 def cmd_refill(name, count=None):
     """Refill is disabled until it is implemented via PurchaseRequest reconciliation."""
     print("refill is not available in the controller-based buy path.", file=sys.stderr)
-    print("Run the buy command again with the same purchase name to top up the active auth pool.", file=sys.stderr)
+    print("Run the buy command again with the same purchase name to top up the existing pre-authorized budget.", file=sys.stderr)
     sys.exit(1)
 
 
@@ -1949,8 +1949,8 @@ def cmd_pay(url, method="GET", data=None, kind="http", network=None, timeout=Non
 
     Stateless. Does not create a PurchaseRequest, does not touch the buyer
     sidecar, and is bounded to one auth (max loss = price). Use this for
-    `type:http` services and any one-off purchase that doesn't need persistent
-    pre-payment. For long-running paid inference budgets, use `buy`.
+    `type:http` services and any one-off purchase that doesn't need a
+    persistent pre-authorized budget. For long-running paid inference, use `buy`.
 
     `network` is an optional safety guard: when set, the seller's advertised
     chain must match it or `pay` aborts before signing.

--- a/internal/embed/skills/buy-x402/scripts/buy.py
+++ b/internal/embed/skills/buy-x402/scripts/buy.py
@@ -238,13 +238,27 @@ def _asset_display_meta(asset, extra=None):
 
 
 def _format_amount(amount, asset, extra=None):
-    """Render an integer token amount with best-effort symbol/decimals."""
+    """Render an integer token amount with best-effort symbol/decimals.
+
+    Display: trim trailing zeros and drop the decimal point when the
+    scaled value is integral. Matches the Go-side `formatTokenAmount`
+    in `cmd/obol/buy.go` so the host CLI and the in-pod buy.py both
+    print "5 OBOL" / "0.001 USDC" rather than "5.000000" / "0.001000".
+    """
     symbol, decimals, units_label = _asset_display_meta(asset, extra)
     raw = int(amount)
     if decimals is None:
         return f"{raw} {units_label}"
-    scaled = raw / (10 ** decimals)
-    return f"{raw} {units_label} ({scaled:.6f} {symbol})"
+    # Use string division so we don't lose precision on large 18-decimal
+    # values when Python float-coerces the divisor.
+    scale = 10 ** decimals
+    whole, frac = divmod(raw, scale)
+    if frac == 0:
+        scaled_str = str(whole)
+    else:
+        frac_str = str(frac).zfill(decimals).rstrip("0")
+        scaled_str = f"{whole}.{frac_str}"
+    return f"{raw} {units_label} ({scaled_str} {symbol})"
 
 
 # ---------------------------------------------------------------------------
@@ -636,31 +650,53 @@ def _create_purchase_request(name, endpoint, model, count, network, pay_to, pric
 
 
 def _wait_for_purchase_ready(name, timeout=180):
-    """Wait for the PurchaseRequest to reach Ready=True."""
+    """Wait for the PurchaseRequest to reach Ready=True.
+
+    Output strategy: collapse identical consecutive messages into a single
+    line with an in-place tick counter, so a 60-second wait on the same
+    state prints once with periodic dots instead of 12 duplicate lines.
+    Fresh state transitions print on their own line so the user can see
+    progress through the controller's phases (Probed → AuthsLoaded →
+    Configured → Ready).
+    """
     token, _ = load_sa()
     ssl_ctx = make_ssl_context()
     ns = _get_agent_namespace()
     path = f"/apis/{PR_GROUP}/{PR_VERSION}/namespaces/{ns}/{PR_RESOURCE}/{name}"
 
     deadline = time.time() + timeout
+    last_msg = None
+    ticks = 0
+    is_tty = sys.stdout.isatty()
     while time.time() < deadline:
         try:
             pr = _kube_json("GET", path, token, ssl_ctx)
             ready, remaining, public_model, message = _purchase_ready(pr)
             if ready:
+                if last_msg is not None and is_tty:
+                    print()  # close the in-place line cleanly
                 print(f"  Ready: {remaining} auths, model={public_model}")
                 return True
-            if message:
-                print(f"  Not ready: {message}")
-            # Print latest condition for progress feedback.
-            conditions = pr.get("status", {}).get("conditions", [])
-            if conditions:
-                latest = conditions[-1]
-                print(f"  [{latest.get('type')}] {latest.get('message', '')}")
+            msg = message or "(no status yet)"
+            if msg != last_msg:
+                if last_msg is not None and is_tty:
+                    print()
+                print(f"  Waiting: {msg}", end="", flush=True)
+                last_msg = msg
+                ticks = 0
+            else:
+                ticks += 1
+                if is_tty:
+                    print(".", end="", flush=True)
         except Exception as e:
+            if last_msg is not None and is_tty:
+                print()
+                last_msg = None
             print(f"  Waiting... ({e})")
         time.sleep(5)
 
+    if last_msg is not None and is_tty:
+        print()
     return False
 
 
@@ -1615,7 +1651,11 @@ def cmd_buy(name, endpoint, model_id, budget=None, count=None, opts=None):
         print(f"  Auto-refill: enabled (threshold={auto_refill['threshold']}, count={auto_refill['count']})")
     print()
     print(f"The model is now available as: paid/{model_id}")
-    print("Use 'process --all' from a heartbeat/cron loop to reconcile auto-refill policies.")
+    # Only mention the auto-top-up reconcile loop when auto-top-up is on —
+    # for CLI users without it, the line below is confusing noise.
+    if auto_refill and auto_refill.get("enabled"):
+        print("Auto-top-up is enabled. The agent runtime reconciles top-ups in the background;")
+        print("you don't need to do anything else to keep this provider funded.")
 
     if ready and opts.get("set_default"):
         print()
@@ -1730,18 +1770,24 @@ def _set_agent_default_model(model_id, auto_refill):
             file=sys.stderr,
         )
         return False
-    # Safety: a paid primary model bricks chat once the pre-signed pool empties.
+    # Safety: a paid primary model bricks chat once the pre-authorized
+    # budget is exhausted, since the agent will keep trying to route
+    # through paid/<model> with nothing left to spend.
     if not (auto_refill and auto_refill.get("enabled")):
         print(
-            "  WARNING: --set-default without --auto-refill. Once this is your primary",
+            "  Heads up: auto-top-up is not enabled for this provider. Once the",
             file=sys.stderr,
         )
         print(
-            "           model, every chat turn fails when the pre-signed pool empties.",
+            "  pre-authorized budget is used up, this agent will fail to chat until",
             file=sys.stderr,
         )
         print(
-            "           Re-run with --auto-refill, or run 'process --all' on a schedule.",
+            "  you re-run `obol buy inference` to top it up, OR re-run with",
+            file=sys.stderr,
+        )
+        print(
+            "  `--auto-refill` so the agent tops itself up automatically.",
             file=sys.stderr,
         )
     # Primary path: native Hermes writer (atomic; per-request re-read, no restart).
@@ -1836,11 +1882,51 @@ def cmd_process(name=None, process_all=False):
 # List
 # ---------------------------------------------------------------------------
 
-def cmd_list():
-    """List purchased providers, keyed by live PurchaseRequests."""
+def cmd_list(as_json=False):
+    """List purchased providers, keyed by live PurchaseRequests.
+
+    `as_json=True` (driven by --json) emits a structured array the host
+    CLI parses to render an `obol model status` section. Keep field names
+    stable; obol-stack's host code is the only consumer.
+    """
     token, _ = load_sa()
     ssl_ctx = make_ssl_context()
     purchases = _list_purchase_requests(token=token, ssl_ctx=ssl_ctx)
+    if as_json:
+        out = []
+        live_status = _buyer_status() or {}
+        for pr in purchases or []:
+            metadata = pr.get("metadata") or {}
+            spec = pr.get("spec") or {}
+            status = pr.get("status") or {}
+            payment = spec.get("payment") or {}
+            name = metadata.get("name", "")
+            live = live_status.get(name) or {}
+            symbol, decimals, _ = _asset_display_meta(
+                payment.get("asset", ""),
+                {
+                    "name": payment.get("eip712Name", ""),
+                    "version": payment.get("eip712Version", ""),
+                },
+            )
+            entry = {
+                "name": name,
+                "alias": live.get("public_model") or status.get("publicModel") or f"paid/{spec.get('model', name)}",
+                "model": spec.get("model", ""),
+                "remaining": int(live.get("remaining", status.get("remaining", 0)) or 0),
+                "spent": int(live.get("spent", status.get("spent", 0)) or 0),
+                "totalSigned": int(status.get("totalSigned", 0) or 0),
+                "expired": int(_expired_in_active_pool(spec, live) or 0),
+                "price": str(payment.get("price", "")),
+                "chain": live.get("network") or payment.get("network", ""),
+                "endpoint": spec.get("endpoint", ""),
+                "autoRefill": bool(((spec.get("autoRefill") or {}).get("enabled")) or False),
+                "assetSymbol": symbol or "",
+                "assetDecimals": int(decimals) if decimals is not None else 0,
+            }
+            out.append(entry)
+        print(json.dumps(out))
+        return
     if not purchases:
         print("No purchased x402 providers.")
         return
@@ -2297,7 +2383,8 @@ if __name__ == "__main__":
         cmd_refill(positional[0], opts.get("count"))
 
     elif cmd == "list":
-        cmd_list()
+        _, opts = parse_flags(rest)
+        cmd_list(as_json=bool(opts.get("json")))
 
     elif cmd == "process":
         positional, opts = parse_flags(rest)

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -85,6 +85,15 @@ func (u *UI) Select(msg string, options []string, defaultIdx int) (int, error) {
 // Input reads a single line of text input with an optional default.
 // In non-interactive mode, returns the default or an error if no default is set.
 func (u *UI) Input(msg string, defaultVal string) (string, error) {
+	return u.InputWithSuffix(msg, defaultVal, "")
+}
+
+// InputWithSuffix reads input like Input but renders an extra dimmed suffix
+// between the default brace and the colon. Use this for hints that aren't
+// part of the question itself — e.g. "[5] (5 OBOL ceiling):". The suffix
+// is shown only when defaultVal is non-empty (so it stays adjacent to the
+// "[default]" chip).
+func (u *UI) InputWithSuffix(msg, defaultVal, suffix string) (string, error) {
 	if !u.isInteractive() {
 		if defaultVal != "" {
 			return defaultVal, nil
@@ -93,7 +102,11 @@ func (u *UI) Input(msg string, defaultVal string) (string, error) {
 	}
 
 	if defaultVal != "" {
-		fmt.Fprintf(u.stdout, "%s %s: ", msg, dimStyle.Render("["+defaultVal+"]"))
+		if strings.TrimSpace(suffix) != "" {
+			fmt.Fprintf(u.stdout, "%s %s %s: ", msg, dimStyle.Render("["+defaultVal+"]"), dimStyle.Render(suffix))
+		} else {
+			fmt.Fprintf(u.stdout, "%s %s: ", msg, dimStyle.Render("["+defaultVal+"]"))
+		}
 	} else {
 		fmt.Fprintf(u.stdout, "%s: ", msg)
 	}

--- a/internal/x402/paymentrequired.go
+++ b/internal/x402/paymentrequired.go
@@ -365,7 +365,7 @@ func normalizeOfferType(t string) string {
 }
 
 // inferenceCopy: primary CTA is `obol buy inference`, the CLI command that
-// pre-pays the seller and registers the model as `paid/<model>` in the
+// pre-authorizes the seller and registers the model as `paid/<model>` in the
 // local LiteLLM gateway. Secondary cards still expose the agent-prompt and
 // raw-JSON paths, but reframed so users understand they're buying remote
 // model time, not an agent with tools/memory.
@@ -379,7 +379,7 @@ func inferenceCopy(url string, d PaymentDisplay) typeCopy {
 	prompt := fmt.Sprintf(
 		"There's an Obol paid-inference service at %s offering the %s model. "+
 			"Explain to me how it works, then — if I'm interested — run "+
-			"`obol buy inference %s` from this host to pre-pay it and wire "+
+			"`obol buy inference %s` from this host to pre-authorize it and wire "+
 			"`paid/%s` into our local LiteLLM gateway. After it lands, switch "+
 			"yourself over to the new model and confirm.",
 		url, model, url, model,
@@ -388,7 +388,7 @@ func inferenceCopy(url string, d PaymentDisplay) typeCopy {
 	other := fmt.Sprintf(
 		"Read https://obol.org/llms.txt to learn how Obol's x402 micropayments work. "+
 			"I want to use the remote LLM at %s (model %s) as a paid OpenAI-compatible "+
-			"chat-completions endpoint. Pre-sign a budget of EIP-3009/Permit2 authorisations "+
+			"chat-completions endpoint. Pre-sign a budget of EIP-3009/Permit2 authorizations "+
 			"and POST chat-completions bodies with the X-PAYMENT header attached.",
 		url, model,
 	)
@@ -397,7 +397,7 @@ func inferenceCopy(url string, d PaymentDisplay) typeCopy {
 		Lede: template.HTML(
 			"This is a paid inference provider. Your Obol agent runs locally; the model itself runs " +
 				"on the remote operator's hardware and is gated by x402 micropayments. The CLI below " +
-				"pre-pays the provider through your agent's wallet and registers the model as " +
+				"pre-authorizes the provider through your agent's wallet and registers the model as " +
 				"<code>paid/&lt;model&gt;</code> in your local LiteLLM gateway, so every agent in your stack " +
 				"can call it like any other OpenAI-compatible model."),
 		ShowPrimary:    true,
@@ -447,7 +447,7 @@ X-PAYMENT: <pre-signed-EIP-3009-or-Permit2-voucher>
 		"Read https://obol.org/llms.txt to learn how Obol's x402 micropayments work. "+
 			"Help me call the Obol Agent at %s%s — it's an autonomous agent (tools + skills + memory), "+
 			"not a raw LLM. POST OpenAI-style chat-completions JSON with a real prompt in `messages`, "+
-			"attach a signed EIP-3009/Permit2 authorisation as `X-PAYMENT`, and report what the agent does.",
+			"attach a signed EIP-3009/Permit2 authorization as `X-PAYMENT`, and report what the agent does.",
 		url, modelLine,
 	)
 
@@ -494,16 +494,16 @@ func httpCopy(url string, d PaymentDisplay) typeCopy {
 	other := fmt.Sprintf(
 		"Read https://obol.org/llms.txt and skim https://github.com/ObolNetwork/skills "+
 			"to learn how Obol Agents pay for x402 services. Then help me buy access to %s "+
-			"for %s%s. Sign the EIP-3009 or Permit2 authorisation and call the endpoint "+
+			"for %s%s. Sign the EIP-3009 or Permit2 authorization and call the endpoint "+
 			"with the X-PAYMENT header.",
 		url, priceWord, onNet,
 	)
 
 	return typeCopy{
-		Lede:          template.HTML("This is a paid HTTP endpoint gated by x402 micropayments. Each call is a one-shot purchase — no subscription, no pre-payment, no LLM model behind it."),
+		Lede:          template.HTML("This is a paid HTTP endpoint gated by x402 micropayments. Each call is a one-shot purchase — no subscription, no pre-authorization, no LLM model behind it."),
 		ShowPrimary:   true,
 		PrimaryTitle:  "Pay with your Obol Agent",
-		PrimaryLede:   "Paste this into your Obol Agent — it has the `buy-x402` skill pre-loaded and will sign one authorisation per request.",
+		PrimaryLede:   "Paste this into your Obol Agent — it has the `buy-x402` skill pre-loaded and will sign one authorization per request.",
 		PrimaryIsCode: false,
 		// PrimaryPayload doubles as PromptObol for http; keep both
 		// populated so the template can stay symmetrical and the

--- a/internal/x402/paymentrequired.go
+++ b/internal/x402/paymentrequired.go
@@ -371,18 +371,18 @@ func normalizeOfferType(t string) string {
 // model time, not an agent with tools/memory.
 func inferenceCopy(url string, d PaymentDisplay) typeCopy {
 	model := sanitizeDisplayToken(d.Model, "<model-id>")
-	name := sanitizeDisplayToken(d.OfferName, "remote-inference")
 
-	cmd := fmt.Sprintf(
-		"obol buy inference %s \\\n  --seller %s \\\n  --model %s \\\n  --budget 1 \\\n  --no-verify-identity",
-		name, url, model,
-	)
+	// Positional seller URL, no required --model/--budget. Identity check
+	// is opt-in via --expected-agent-id, so the copy stays clean.
+	cmd := fmt.Sprintf("obol buy inference %s", url)
 
 	prompt := fmt.Sprintf(
-		"Use the buy-x402 skill's `buy` command to pre-pay %s for the %s model. "+
-			"This is remote inference — once the auths are signed, route requests "+
-			"through LiteLLM as `paid/%s` and report the response.",
-		url, model, model,
+		"There's an Obol paid-inference service at %s offering the %s model. "+
+			"Explain to me how it works, then — if I'm interested — run "+
+			"`obol buy inference %s` from this host to pre-pay it and wire "+
+			"`paid/%s` into our local LiteLLM gateway. After it lands, switch "+
+			"yourself over to the new model and confirm.",
+		url, model, url, model,
 	)
 
 	other := fmt.Sprintf(
@@ -394,12 +394,15 @@ func inferenceCopy(url string, d PaymentDisplay) typeCopy {
 	)
 
 	return typeCopy{
-		Lede: template.HTML("This is a paid inference endpoint — remote model time gated by x402 micropayments. " +
-			"The cleanest way to consume it is the Obol CLI, which loads the model into your local LiteLLM " +
-			"gateway as <code>paid/&lt;model&gt;</code> so your agent and tools can call it like any other OpenAI-compatible model."),
+		Lede: template.HTML(
+			"This is a paid inference provider. Your Obol agent runs locally; the model itself runs " +
+				"on the remote operator's hardware and is gated by x402 micropayments. The CLI below " +
+				"pre-pays the provider through your agent's wallet and registers the model as " +
+				"<code>paid/&lt;model&gt;</code> in your local LiteLLM gateway, so every agent in your stack " +
+				"can call it like any other OpenAI-compatible model."),
 		ShowPrimary:    true,
-		PrimaryTitle:   "Buy with the Obol CLI",
-		PrimaryLede:    "Pre-pays the seller through your obol-agent's wallet and exposes the model as `paid/" + model + "` in your local LiteLLM gateway. Adjust `--budget`, drop `--no-verify-identity` once the seller is registered on ERC-8004.",
+		PrimaryTitle:   "Use this service for your Obol Agent's model",
+		PrimaryLede:    "Run this from your obol-stack host. The CLI walks `/api/services.json`, prompts for auto-refill + a request count, and pre-signs the authorizations from your master agent's wallet. Pass `--yes --count <N>` for non-interactive runs.",
 		PrimaryIsCode:  true,
 		PrimaryPayload: cmd,
 		PromptObol:     prompt,

--- a/internal/x402/paymentrequired_test.go
+++ b/internal/x402/paymentrequired_test.go
@@ -196,15 +196,18 @@ func TestHTMLAware_InferenceShowsCLIPrimaryAndDescription(t *testing.T) {
 	render(w, r, []x402types.PaymentRequirements{sampleRequirement()}, nil)
 
 	body := w.Body.String()
-	mustContain(t, body, "Buy with the Obol CLI")
-	mustContain(t, body, "obol buy inference aeon7")
-	mustContain(t, body, "--model AEON-7")
-	mustContain(t, body, "https://agent.example.tunnel.dev/services/agent-quant")
-	mustContain(t, body, "paid/AEON-7")
+	mustContain(t, body, "Use this service for your Obol Agent&#39;s model")
+	// Positional seller URL; no --model / --budget / --no-verify-identity
+	// in the simplified command.
+	mustContain(t, body, "obol buy inference https://agent.example.tunnel.dev/services/agent-quant")
 	// Operator description bubbles into Service card + OG.
 	mustContain(t, body, "Remote 35B reasoning model with 32k context.")
-	// Lede explains that you're paying for remote inference, not an agent.
-	mustContain(t, body, "remote model time")
+	// Lede explains that the agent stays local but the model runs upstream
+	// at the provider's infra.
+	// Lede is rendered as trusted HTML (template.HTML), so the apostrophe
+	// in "operator's hardware" appears raw, not entity-encoded.
+	mustContain(t, body, "agent runs locally")
+	mustContain(t, body, "remote operator's hardware")
 }
 
 // Agent offers should explain that the buyer is paying an autonomous
@@ -402,7 +405,10 @@ func TestSanitizeDisplayToken(t *testing.T) {
 }
 
 // A hostile ServiceOffer must never get its raw spec.model.name /
-// metadata.name reflected into the rendered copy-paste command.
+// metadata.name reflected into the rendered copy-paste command. The
+// simplified command does not interpolate Model or OfferName anymore — the
+// only dynamic input is the service URL — but Model is still interpolated
+// into PromptObol, so check both.
 func TestInferenceCopy_StripsShellMetacharsFromCommand(t *testing.T) {
 	d := PaymentDisplay{
 		OfferType: "inference",
@@ -414,8 +420,11 @@ func TestInferenceCopy_StripsShellMetacharsFromCommand(t *testing.T) {
 		if strings.Contains(c.PrimaryPayload, bad) {
 			t.Fatalf("hostile token leaked into command payload %q (contains %q)", c.PrimaryPayload, bad)
 		}
+		if strings.Contains(c.PromptObol, bad) {
+			t.Fatalf("hostile token leaked into prompt %q (contains %q)", c.PromptObol, bad)
+		}
 	}
-	// Falls back to the safe placeholders instead.
-	mustContain(t, c.PrimaryPayload, "--model <model-id>")
-	mustContain(t, c.PrimaryPayload, "obol buy inference remote-inference")
+	// Falls back to the safe placeholder for the model in the prompt.
+	mustContain(t, c.PromptObol, "<model-id>")
+	mustContain(t, c.PrimaryPayload, "obol buy inference https://agent.example.tunnel.dev/services/x")
 }

--- a/internal/x402/setup.go
+++ b/internal/x402/setup.go
@@ -39,21 +39,22 @@ const (
 	// verification and settlement. Supports Base Mainnet and Base Sepolia.
 	DefaultFacilitatorURL = "https://x402.gcp.obol.tech"
 
-	// DefaultBuySellerURL is the Obol-operated demo seller used by
-	// `obol buy inference` when no --seller is given.
-	// TODO(buy): replace with the live URL once the default seller is provisioned.
-	DefaultBuySellerURL = "https://demo-seller.obol.tech/services/default-paid"
+	// DefaultBuySellerURL is the public Obol-operated paid-inference
+	// storefront used by `obol buy inference` when no seller URL is given.
+	// The host CLI reads /api/services.json from this base URL and picks an
+	// offer; pass a /services/<name> URL to bypass the catalog walk.
+	DefaultBuySellerURL = "https://inference.v1337.org/"
 
 	// DefaultBuySellerAgentID is the ERC-8004 tokenId the buyer expects to
-	// see in the seller's /.well-known/agent-registration.json before signing.
-	// Hard-fails on mismatch unless --no-verify-identity is passed.
-	// TODO(buy): replace with the live agentId once the default seller is registered.
+	// see in the seller's /.well-known/agent-registration.json before
+	// signing. 0 means "no expected id" — identity verification is opt-in
+	// today via --expected-agent-id; the default flow trusts the URL.
 	DefaultBuySellerAgentID int64 = 0
 
 	// DefaultBuySellerChain is the chain the default seller settles on.
 	// Used only as a hint in error messages; the actual chain is taken
 	// from the seller's 402 response by buy.py.
-	DefaultBuySellerChain = "base-sepolia"
+	DefaultBuySellerChain = "base"
 
 	// baseReleaseName matches the helmfile release in
 	// internal/embed/infrastructure/helmfile.yaml whose `chart: ./base`

--- a/plans/storefront-buy-inference-cta-handoff.md
+++ b/plans/storefront-buy-inference-cta-handoff.md
@@ -24,7 +24,7 @@ only. New copy:
 
 - **Lede**: "Your Obol agent runs locally; the model itself runs on the
   remote operator's hardware and is gated by x402 micropayments. The
-  CLI below pre-pays the provider through your agent's wallet and
+  CLI below pre-authorizes the provider through your agent's wallet and
   registers the model as `paid/<model>` in your local LiteLLM gateway."
 - **Primary CTA** ("Use this service for your Obol Agent's model"):
   copyable one-liner `obol buy inference <seller-url>`.
@@ -52,15 +52,18 @@ endpoint. For `type=inference` entries (`ServiceCatalogEntry.type ===
    prose as the 402 lede, suitable for an unauthenticated visitor. Keep
    it short (≤2 sentences).
 
-3. **"Pre-pays via your agent's wallet"** line with a small `(?)` that
-   links to the `buy-x402` skill in obol-docs for buyers who want the
-   deep-dive.
+3. **"Pre-authorizes via your agent's wallet"** line with a small `(?)`
+   that links to the `buy-x402` skill in obol-docs for buyers who want
+   the deep-dive.
 
 4. **Pricing display**: when `entry.priceUnit === "perMTok"`, show
-   "Up to $X per request (≈1k tokens)" instead of a flat per-request
-   number. x402 settles at actual usage, so unused capacity isn't
-   charged — call this out in a one-line note. Source of truth for the
-   per-unit display is `entry.price` + `entry.priceUnit`.
+   both the per-MTok headline AND the equivalent per-request charge
+   (e.g. "1 OBOL / million tokens (≈ 0.001 OBOL per request at ~1000
+   tokens/request)"). The Obol facilitator currently settles each
+   request at this flat estimate; token-metered settlement is on the
+   roadmap but NOT live, so don't claim "you only pay for what you
+   use". Source of truth for the per-unit display is `entry.price`
+   + `entry.priceUnit` + `entry.priceAtomicUnits`.
 
 5. **Type filter**: do not surface the inference CTA on `type=agent` or
    `type=http` cards. Those keep their existing prompts (agents need

--- a/plans/storefront-buy-inference-cta-handoff.md
+++ b/plans/storefront-buy-inference-cta-handoff.md
@@ -1,0 +1,119 @@
+# Storefront CTA handoff: `obol buy inference` for paid-inference offers
+
+Sibling repo: `ObolNetwork/obol-stack-front-end` (path env: `OBOL_FRONTEND_DIR`).
+
+## What we just shipped in obol-stack
+
+The `obol buy inference` CLI was reshaped (see `cmd/obol/buy.go`,
+`internal/buy/discover.go`, `internal/x402/paymentrequired.go`):
+
+- Positional seller URL: `obol buy inference [<seller-url>]`. With no URL,
+  the public Obol storefront (`https://inference.v1337.org/`) is used.
+- `--model`, `--budget`, and identity verification are now optional. The
+  CLI walks `/api/services.json`, prefers `type=inference` offers, and
+  resolves model + token from the catalog entry.
+- TTY interactive prompts for auto-refill, request count, and a final
+  confirmation. `-y`/`--yes` for headless runs.
+- `--agent X` pays from X's wallet AND switches X's hermes config to
+  `paid/<model>` (per-agent, in-pod). `--set-default` promotes the model
+  to head-of-list and syncs every agent (global).
+
+The HTTP 402 HTML page (the gate buyers see when their browser hits a
+paid `/services/<name>` URL) was updated for `type=inference` offers
+only. New copy:
+
+- **Lede**: "Your Obol agent runs locally; the model itself runs on the
+  remote operator's hardware and is gated by x402 micropayments. The
+  CLI below pre-pays the provider through your agent's wallet and
+  registers the model as `paid/<model>` in your local LiteLLM gateway."
+- **Primary CTA** ("Use this service for your Obol Agent's model"):
+  copyable one-liner `obol buy inference <seller-url>`.
+- **Obol-agent prompt card**: rephrased to instruct the receiving agent
+  to explain the service, offer to buy, and switch itself over to
+  `paid/<model>` after the buy lands.
+
+## What the storefront should mirror
+
+The `/services/<name>` detail page rendered by the Next.js storefront
+is the *non-402* parallel to the 402 HTML page — it's what someone sees
+when browsing the storefront listing rather than trying to use the
+endpoint. For `type=inference` entries (`ServiceCatalogEntry.type ===
+"inference"`), it should render the same conceptual CTA:
+
+1. **Headline tile**: "Use this service for your Obol Agent's model"
+   with a `<pre>` block:
+   ```
+   obol buy inference <seller-url>
+   ```
+   where `<seller-url>` is `${siteOrigin}${entry.endpoint}` (strip any
+   `/v1/chat/completions` suffix the controller emits).
+
+2. **Subtext** explaining the local-agent / remote-model split — same
+   prose as the 402 lede, suitable for an unauthenticated visitor. Keep
+   it short (≤2 sentences).
+
+3. **"Pre-pays via your agent's wallet"** line with a small `(?)` that
+   links to the `buy-x402` skill in obol-docs for buyers who want the
+   deep-dive.
+
+4. **Pricing display**: when `entry.priceUnit === "perMTok"`, show
+   "Up to $X per request (≈1k tokens)" instead of a flat per-request
+   number. x402 settles at actual usage, so unused capacity isn't
+   charged — call this out in a one-line note. Source of truth for the
+   per-unit display is `entry.price` + `entry.priceUnit`.
+
+5. **Type filter**: do not surface the inference CTA on `type=agent` or
+   `type=http` cards. Those keep their existing prompts (agents need
+   payload context, http is single-shot).
+
+6. **Operator description**: continue to use `entry.description` — no
+   change needed.
+
+## Wire format reference
+
+The catalog entries the storefront already consumes are typed in
+`internal/schemas/service_catalog.go` (kept in obol-stack). Relevant
+fields:
+
+```ts
+type ServiceCatalogEntry = {
+  name: string;
+  type: "inference" | "agent" | "http" | "fine-tuning";
+  model?: string;
+  endpoint: string;         // path-only, e.g. "/services/aeon"
+  price: string;            // human display, e.g. "0.01"
+  priceUnit?: "perRequest" | "perMTok" | "perHour";
+  priceAtomicUnits?: string;
+  payTo: string;
+  network: string;
+  caip2Network?: string;
+  asset?: { address, symbol, decimals, transferMethod, eip712Domain };
+  description: string;
+  skills?: string[];
+  isDemo: boolean;
+  drainEndsAt?: string;     // RFC3339; ignore if absent
+};
+```
+
+Schema is stable; this PR doesn't add or remove fields.
+
+## Out of scope for the handoff
+
+- ERC-8004 identity badge — the obol-stack CLI made identity verification
+  opt-in (default skipped), so the storefront should not gate the CTA
+  on registration status.
+- Drain banners — existing logic for `drainEndsAt` is unaffected.
+- Agent-marketplace embedding — separate effort.
+
+## Verification
+
+After implementing:
+
+1. Hit `https://inference.v1337.org/` and confirm at least one card
+   advertising `type: inference` renders the new CTA.
+2. Click into a card and confirm the copy block matches what
+   `internal/x402/paymentrequired.go::inferenceCopy` produces for the
+   same offer (modulo the host-vs-404 framing).
+3. Verify the CTA URL is `${origin}/services/<name>` (no
+   `/v1/chat/completions` suffix). `obol buy inference` accepts both
+   shapes but the cleaner form is the route base.


### PR DESCRIPTION
## Summary

  Reshapes `obol buy inference` from a flag-heavy command into a positional-URL flow with
  TTY prompts, sensible defaults, sub-agent-aware default-model switching, and a polished
  `obol model status` surface that shows remaining credit per paid model. Live-tested
  end-to-end against `https://inference.v1337.org/`: routing, settlement, voucher
  preservation, and per-agent default switching all work.

  ### `obol buy inference` — new shape

  - **Positional seller URL**: `obol buy inference [<seller-url>]`. Default is
  `https://inference.v1337.org/`.
  - **Catalog-driven discovery**: walks `/api/services.json`, accepts both path-only and
  absolute-URL endpoint forms, rejects non-inference offers, auto-resolves `--model` and
  `--token` from the catalog asset.
  - **Interactive TTY flow**: "Enable auto-top-up?" → count (cost preview inline as `[5]
  (5 OBOL)`) → wallet preflight + confirmation. `-y`/`--yes` for headless; non-TTY without
   either errors loudly.
  - **`--agent X`**: X's wallet pays AND X's hermes-config switches to `paid/<model>` (via
   buy.py's atomic in-pod `hermes config set` — no global model_list reorder).
  Post-dispatch message clarifies the model didn't move to head-of-list and prints the
  exact `obol model prefer paid/<model>` command if the user wants global.
  - **`--set-default`**: orthogonal — promotes globally + syncs every agent.
  - **Wallet preflight**: shells out to `buy.py balance` in the chosen agent pod, surfaces
   address + balance in the summary, warns + hints when balance < budget.
  - **Permit2 batch cap surfaced pre-confirmation**: the 500-auth ConfigMap ceiling is 
  detected on the host before the summary, the printed budget tracks the actual count     
  we'll sign, and a warning explains the cap + suggests `--auto-refill` as the workaround.
  - **Idempotency**: detects existing PurchaseRequest in the agent namespace and prompts  
  Top up / Replace / Cancel. Non-interactive default is top-up; `--replace` recreates.    
  - **Cost cap**: `--cost-cap` → `policy.maxUnitPrice` on the auto-top-up spec. buy.py's 
  reconcile loop re-probes the seller's 402 and skips re-signing when the live price      
  exceeds the cap. Default = `price × 1.5` when auto-top-up is on without an explicit cap.
   Distinct from `--budget` (initial spend) vs `--cost-cap` (refill price ceiling).       
  - **perMTok math**: catalog `priceAtomicUnits` is the per-natural-unit source of truth. 
  User counts × `schemas.ApproxTokensPerRequest` (1000) when calling buy.py.              
  - **Defaults**: 5 million tokens for `perMTok` offers, 50 requests for `perRequest` 
  offers.                                                                                 
  - **Number formatting**: trims trailing zeros, drops the decimal point when not needed. 
  `0.5 OBOL`, `1 OBOL`, `0.001 USDC`.                                                     
  - **Identity check opt-in**: `--no-verify-identity` removed; `--expected-agent-id` is 
  the opt-in flag (default skips verification).                                           
                                                            
  ### Copy framing                                                                        
                                                            
  - "Purchasing remote inference for running Obol Agents" intro line.
  - "auth pool" → "pre-authorized budget" (and "Auto-refill" → "Auto-top-up" in           
  user-visible copy; `--auto-refill` flag name preserved for compat).                     
  - "pre-pay" / "pre-payment" → "pre-authorize" / "pre-authorization" across `buy.go`,    
  `paymentrequired.go`, buy-x402 SKILL.md, buy.py prints, `discover.go` errors.           
  - Honest perMTok caveat: "Settled per-request at the seller's quoted estimate; 
  token-metered settlement is on the roadmap." Replaces an earlier aspirational "unused   
  capacity isn't charged" line — today the facilitator settles at the flat estimate.
  - US spelling sweep across user-visible copy.                                           
  - "paid model" / "paid inference provider" preserved (proper terms). Code identifiers 
  (`PurchaseRequest`, `paid/<model>`, `--auto-refill` flag, `x402-buyer`) unchanged.      
   
  ### 402 HTML page (`type=inference` only)                                               
                                                            
  - New primary CTA: "Use this service for your Obol Agent's model" with a one-liner `obol
   buy inference <url>`.                                                                  
  - Lede explains the local-agent + remote-model split.
  - Agent-handoff prompt rewritten to instruct the receiving agent to explain the service,
   offer to buy, and switch itself over to `paid/<model>`.                                
                                                                                          
  ### `obol model list/status/prefer` parity                                              
                                                            
  - Shared `printModelRanking(u, cfg, style)` with two render styles: `"section"` (inline 
  green header for list/status) and `"prefer-empty"` (top title + "Current order:"        
  subtitle for the argless `prefer` view).
  - `obol model prefer` (no args): shows the current ranking + usage hint instead of      
  erroring.                                                                               
  - `obol model prefer` with args: hints which sub-agents weren't auto-synced and prints 
  exact `obol agent sync <name>` commands for each. `syncAgentModels` only touches the    
  master Hermes; sub-agents previously kept their stale `model.default` silently.
  - `obol model list/status` use green `==>` section headers and the shared ranking       
  section.                                                                                
  - `obol model prefer --help` updated to "Pull one or more models to the preferred 
  choices (agents use these in order)".                                                   
                                                            
  ### `obol model status` — Paid models credit                                            
                                                                                          
  New section surfacing remaining spendable credit per (agent, paid-model) pair:
                                                                                          
  ==> Paid models credit:                                   
                                                                                          
    AGENT                  MODEL                                    CREDIT
  STATE                                                                                   
    hermes/obol-agent      paid/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 0.5 OBOL
  ready                                                                                   
    hermes/demo-quant      paid/qwen3.5:9b                          0 USDC
  drained                                                                                 
                                                            
  (auto-top-up)                                                                           
                                                            
    Top up a drained model: obol buy inference
      add --auto-refill to keep it funded automatically.
                                                                                          
  - CREDIT = `remaining × per-request-price` formatted with the token's own decimals +
  symbol (trimmed, no trailing zeros).                                                    
  - STATE: `ready` / `drained` (Remaining=0) / `(auto-top-up)` suffix when auto-top-up is
  enabled.                                                                                
  - Implementation: buy.py `list --json` (new flag, structured payload with asset symbol +
   decimals) ↔ `internal/buy/purchases.go::ListPurchases` (kubectl-exec fetcher).         
                                                            
  ### buy.py improvements                                                                 
                                                            
  - `--cost-cap` arg → `policy.maxUnitPrice` on the auto-top-up spec; reconcile loop      
  re-probes seller pricing and applies the cap.
  - `list --json` for structured output (host-CLI consumer).                              
  - Reconcile-wait loop collapses identical consecutive states into a single line with
  in-place `.` ticks (TTY) or dedup'd lines (non-TTY) — replaces the previous             
  N-duplicate-lines noise.
  - `_format_amount` trims trailing zeros, drops decimal when not needed (parity with the 
  Go formatter).                                                                          
  - "Use 'process --all' from a heartbeat/cron loop" line only printed when auto-top-up is
   actually on (was confusing CLI noise).                                                 
  - `--set-default` warning rewritten in plain English: "Heads up: auto-top-up is not
  enabled. When the pre-authorized budget is used up, this agent will fail to chat until  
  you re-run `obol buy inference` to top it up, OR re-run with `--auto-refill`…"
                                                                                          
  ### Flow scripts                                          

  - `flows/flow-08-buy.sh` and `flows/flow-11-dual-stack.sh` migrated to the new shape    
  (positional URL, `--name` for PR name, `--yes` for headless, dropped
  `--no-verify-identity`). `bash -n` clean.                                               
                                                            
  ### Internal

  - `internal/buy/balance.go`: wallet preflight via `kubectl exec buy.py balance`;        
  inherits `os.Environ()` so kubectl's `.kube/cache` lands at `~/.kube/cache` (not cwd).
  - `internal/buy/purchases.go`: host-side fetcher for the new `list --json` payload.     
  - `internal/buy/discover.go`: `FetchServiceCatalog`, `PickCatalogEntry`, `catalogURL`,  
  `endpointPath`, `servicePathFromURL`. `canonicalOfferURL` handles both path-only and    
  absolute-URL endpoints.                                                                 
  - `internal/ui/prompt.go`: `InputWithSuffix` for inline dimmed cost hint after the      
  `[default]` chip.                                                                       
  - `internal/x402/setup.go`: `DefaultBuySellerURL = "https://inference.v1337.org/"`.
  - `.gitignore`: `.kube/` added (defensive; the underlying nil-env bug is also fixed).   
  - `.agents/skills/obol-stack-dev/SKILL.md`: "Rebuild Hints by Changed Path" table +     
  turn-end requirement to emit the right rebuild command.                                 
  - `plans/storefront-buy-inference-cta-handoff.md`: handoff doc for the Next.js sibling  
  repo to mirror the new CTA, including the "settles at this flat estimate; token-metered 
  settlement is on the roadmap" caveat for perMTok display. 
  - `CLAUDE.md`: added `buy inference` explainer line summarizing the new shape.          
                                                                                          
  ### Tests
                                                                                          
  - `cmd/obol/buy_test.go`: new tests for `canonicalOfferURL` (path-only + absolute-URL   
  endpoints), `resolveBuyModel`, `resolveCostCap`, `looksLikeURL`, expanded
  `TestBuildBuyPyArgv` for `Count`/`CostCap`/`SetDefault`.                                
  - `internal/buy/catalog_test.go`: `catalogURL`, `servicePathFromURL`, `endpointPath`,
  `FetchServiceCatalog`, `PickCatalogEntry`.                                              
  - `internal/buy/balance_test.go`: `parseBalanceOutput` with USDC + OBOL fixtures.
  - `internal/x402/paymentrequired_test.go`: updated for new inference CTA copy.          
  - `internal/buy/discover_test.go`: updated for new identity-check error message.
                                                                                          
  ## Test plan                                                                            
   
  - [x] `go test ./...` clean.                                                            
  - [x] `obol buy inference --help` and `obol model prefer --help` render the new flag
  set; `obol model prefer` argless shows ranking; `obol model list/status` show the       
  ranking section.
  - [x] `bash -n flows/flow-08-buy.sh flows/flow-11-dual-stack.sh` clean.                 
  - [x] **Live end-to-end against `inference.v1337.org` (OBOL mainnet, Permit2)**:        
    - Catalog walk + offer pick: ✓                                                        
    - perMTok math: 5M tokens → 500 auths capped (Permit2 storage limit), 0.5 OBOL ceiling
   correctly surfaced pre-confirm                                                         
    - Signing: 500 auths signed, PurchaseRequest reached Ready in <60s                    
    - LiteLLM route: `paid/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` correctly registered     
  (verified via `/model/info`); buyer sidecar routes to                                   
  `https://inference.v1337.org/services/aeon7/v1/chat/completions` with `X-PAYMENT` header
    - Per-agent set-default: hermes/obol-agent's `model.default` switched in-pod, ranking 
  unchanged (matches design)                                                              
    - Failure handling: v1337's origin returned Cloudflare 502 during test; buyer
  correctly passed through the error WITHOUT consuming a voucher (`remaining` stayed at   
  500)                                                      
  - [ ] Refill smoke: bump seller price via local anvil, confirm `process --all` skips    
  with "exceeds cost cap".                                                                
  - [ ] release-smoke `flow-08-buy.sh` + `flow-11-dual-stack.sh` end-to-end.
                                                                                          
  ## Iterate-later                                                                        
                                                                                          
  1. **Token-metered settlement** (separate PR) — both perMTok and perRequest currently   
  settle at a flat per-call charge. Lifting this requires coordinated changes across
  facilitator (`/settle` accepts a "tokens used" hint), controller (publishes per-MTok    
  ceiling in 402), and buyer (signs for the ceiling, expects partial settlement). Surface
  area: `schemas.ApproxTokensPerRequest = 1000` is the temporary placeholder; the Permit2
  500-auth ConfigMap cap goes away once one auth covers a full MTok of usage.
  2. **Default seller agentId** — `DefaultBuySellerAgentID = 0`; once
  `inference.v1337.org` is registered on-chain, bake the real agentId and default         
  `--expected-agent-id` to it.
  3. **Storefront (Next.js) parity** — 402 HTML is updated; the sibling repo's service    
  detail page should mirror the CTA. Handoff at                                           
  `plans/storefront-buy-inference-cta-handoff.md`.
  4. **Third-party providers (Venice et al.)** — Venice's x402 flow diverges (hosted      
  balance, SIWX header, no `/api/services.json`, no ERC-8004). MVP: ~2-3 days; clean      
  `Provider` interface ~5 days.
  5. **Cost-cap interactive prompt** — flag wired; the TTY currently never prompts for it.
   Small follow-up if real users hit a price hike.                                        
  6. **Structured progress events from buy.py → polished Go renderer** — the in-Python `.`
   tick spinner works but is the wrong long-term layer for UI. Migrate buy.py to emit     
  JSON-lines status events; render them with a proper Go spinner. Half-day refactor.
                                                                                          
  ## Rebuild to test                                        

  ```bash
  just build && OBOL_DEVELOPMENT=true OBOL_FORCE_REBUILD_LOCAL_DEV_IMAGES=x402-verifier
  obol stack up                                                                           
   
  🤖 Generated with Claude Code                                    