### PR TITLE
chore(deps): migrate x402 SDK to x402-foundation/x402/go (unlocks upto + batch-settlement)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.1
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a
 	github.com/cucumber/godog v0.15.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
@@ -22,6 +21,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/urfave/cli/v2 v2.27.5
 	github.com/urfave/cli/v3 v3.6.2
+	github.com/x402-foundation/x402/go v0.0.0-20260529172747-45d81d46e5bd
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwP
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a h1:L8ZxbOqBxB7LYXdypWYA7Qq0iQtFaS6PCwjnhij4Oks=
-github.com/coinbase/x402/go v0.0.0-20260331075907-bff876de232a/go.mod h1:8xt63HO8mECoUwoI8E9xOjPiOzgFUvUx+Svrok+Wkss=
 github.com/consensys/gnark-crypto v0.19.2 h1:qrEAIXq3T4egxqiliFFoNrepkIWVEeIYwt3UL0fvS80=
 github.com/consensys/gnark-crypto v0.19.2/go.mod h1:rT23F0XSZqE0mUA0+pRtnL56IbPxs6gp4CeRsBk4XS0=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -320,6 +318,8 @@ github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/urfave/cli/v3 v3.6.2 h1:lQuqiPrZ1cIz8hz+HcrG0TNZFxU70dPZ3Yl+pSrH9A8=
 github.com/urfave/cli/v3 v3.6.2/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+github.com/x402-foundation/x402/go v0.0.0-20260529172747-45d81d46e5bd h1:Bb+VbLsDEQ7g69MZNfUkOva2qKuB5TCSgGXXOPTB0Qw=
+github.com/x402-foundation/x402/go v0.0.0-20260529172747-45d81d46e5bd/go.mod h1:58Cdk20g83eAI3QvxAiQJze7qWUgkjCj9uZlPb4M4HM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/inference/gateway.go
+++ b/internal/inference/gateway.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/enclave"
 	"github.com/ObolNetwork/obol-stack/internal/tee"
 	x402pkg "github.com/ObolNetwork/obol-stack/internal/x402"
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // GatewayConfig holds configuration for the x402 inference gateway.

--- a/internal/inference/gateway_test.go
+++ b/internal/inference/gateway_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	x402pkg "github.com/ObolNetwork/obol-stack/internal/x402"
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // ── Mock facilitator ──────────────────────────────────────────────────────────

--- a/internal/serviceoffercontroller/openapi_components.go
+++ b/internal/serviceoffercontroller/openapi_components.go
@@ -7,7 +7,7 @@ package serviceoffercontroller
 // Two principles:
 //
 //  1. x402 components mirror the canonical Coinbase types/v2 wire format
-//     (github.com/coinbase/x402/go/types). Field names, optionality, and
+//     (github.com/x402-foundation/x402/go/types). Field names, optionality, and
 //     X402Version=2 must stay in sync with that upstream — internal/x402
 //     re-exports the same structs and lockstep is enforced by 402 smoke
 //     tests, not by a generator. Update both together when the spec moves.

--- a/internal/x402/agent_extras_test.go
+++ b/internal/x402/agent_extras_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 func TestMergeAgentExtras_Noop_NonAgentRule(t *testing.T) {

--- a/internal/x402/buyer/config.go
+++ b/internal/x402/buyer/config.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // Config is the top-level sidecar configuration, loaded from a JSON file

--- a/internal/x402/buyer/encoding.go
+++ b/internal/x402/buyer/encoding.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // EncodePayment converts a v2 PaymentPayload to a base64-encoded JSON string

--- a/internal/x402/buyer/encoding_test.go
+++ b/internal/x402/buyer/encoding_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 func TestEncodePayment_RoundTrip(t *testing.T) {

--- a/internal/x402/buyer/proxy.go
+++ b/internal/x402/buyer/proxy.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // userAgent is sent on every outbound HTTP request the sidecar makes to an

--- a/internal/x402/buyer/signer.go
+++ b/internal/x402/buyer/signer.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // authExpirySafetyMarginSec is how far before its on-chain deadline an auth is

--- a/internal/x402/buyer/signer_test.go
+++ b/internal/x402/buyer/signer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 func TestPreSignedSigner_CanSign(t *testing.T) {

--- a/internal/x402/buyer/types.go
+++ b/internal/x402/buyer/types.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // Signer produces x402 v2 payment payloads for a specific network and scheme.

--- a/internal/x402/chains.go
+++ b/internal/x402/chains.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"strings"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // ChainInfo holds chain-specific configuration for x402 payment gating.
@@ -52,7 +52,7 @@ type AssetInfo struct {
 	EIP2612GasSponsoring bool
 }
 
-// Chain constants — USDC addresses verified against coinbase/x402/go v2.7.0
+// Chain constants — USDC addresses verified against x402-foundation/x402/go (formerly coinbase/x402) v2.7.0
 // mechanisms/evm/constants.go and on-chain contract deployments.
 var (
 	ChainBaseMainnet = ChainInfo{

--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // ForwardAuthConfig configures the ForwardAuth x402 middleware.

--- a/internal/x402/forwardauth_test.go
+++ b/internal/x402/forwardauth_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // mockFacilitator returns an httptest.Server that accepts /verify and /settle.

--- a/internal/x402/paymentrequired.go
+++ b/internal/x402/paymentrequired.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 // displayTokenRe is the allowed charset for ServiceOffer-sourced strings

--- a/internal/x402/paymentrequired_test.go
+++ b/internal/x402/paymentrequired_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 )
 
 const (

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/internal/x402/verifier_test.go
+++ b/internal/x402/verifier_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	x402types "github.com/coinbase/x402/go/types"
+	x402types "github.com/x402-foundation/x402/go/types"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )


### PR DESCRIPTION
## What

Migrates the x402 Go SDK from `github.com/coinbase/x402/go` → **`github.com/x402-foundation/x402/go`** and pins `v0.0.0-20260529172747`.

This is a **module-path migration, not a version bump**: the SDK renamed its module path in the post-2026-03-31 releases, so a plain `go get @latest` fails with:

```
module declares its path as: github.com/x402-foundation/x402/go
        but was required as:  github.com/coinbase/x402/go
```

The foundation module is the maintained path (and the one where new schemes land). Only one import path is used across the tree — `…/go/types` (aliased `x402types`) — rewritten in 18 files. The **types API is unchanged**: `PaymentRequirements`, `PaymentPayload`, `PaymentRequired`, `ResourceInfo` all present with the same shape, so this is a pure path swap.

## Why now

Unlocks the schemes we need for the demand-side / escrow direction, already shipped in this pin under `mechanisms/evm/`:

- **`upto`** — usage-metered, Permit2 `witness.to` recipient-bound, settle ≤ authorized max (incl. 0). Entry points: `NewUptoEvmScheme`, `CreateUptoPermit2Payload`, `SettleUptoPermit2`.
- **`batch-settlement`** — deferred/payment-channel batch settle (`ComputeChannelId`, `CreateBatchedPermit2DepositPayload`, deposit/claim/refund).

The funds-locked **`authCapture` escrow scheme is still in-flight** (draft `x402-foundation/x402#2298`; spec already on that repo's `main`) — not in this pin. Leveling up to it later is just a pin bump once it merges, no second migration.

## Testing

- `go build ./...` ✅
- Full unit suite: **34 packages, 0 failures** ✅ (incl. `internal/x402/...`, `internal/x402/buyer`, `internal/serviceoffercontroller`, `internal/inference`)
- `go.sum` clean of `coinbase/x402`

🤖 Generated with [Claude Code](https://claude.com/claude-code)