### PR TITLE
chore: bump frontend image to v0.1.27-rc0

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.26 (linux/amd64 + linux/arm64).
-  tag: "v0.1.26@sha256:7a6109e43e3fd7461818f172b4c78fc0fb5a124a7c266cf68bd5bc08fff10858"
+  # review. Multi-arch index digest for v0.1.27-rc0 (linux/amd64 + linux/arm64).
+  tag: "v0.1.27-rc0@sha256:e2f0d557cca41f6348149627d17ba306703dfac7f8e12f162500e006761ce490"
 
 service:
   type: ClusterIP

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.25 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.27-rc0@sha256:e2f0d557cca41f6348149627d17ba306703dfac7f8e12f162500e006761ce490 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
## Summary
- bump obol-stack-front-end to v0.1.27-rc0
- pin the frontend Helm values and dev reset helper to multi-arch digest sha256:e2f0d557cca41f6348149627d17ba306703dfac7f8e12f162500e006761ce490

Release: https://github.com/ObolNetwork/obol-stack-front-end/releases/tag/v0.1.27-rc0

## Validation
- go test ./internal/embed/...
- go test ./...

Note: `just --fmt --check` was attempted locally, but `just` is not installed in this shell.