### PR TITLE
ci(release): auto-repin embedded x402 image pins + release freshness gate

### DIFF
--- a/.github/scripts/lib-ghcr.sh
+++ b/.github/scripts/lib-ghcr.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Shared helper: resolve the multi-arch index digest GHCR serves for an
+# obolnetwork image tag. Sourced by repin-x402-images.sh (to write pins) and
+# verify-x402-pins.sh (to bind embedded digests to their tags).
+#
+# fetch_index_digest <image> <tag>  →  prints "sha256:<64 hex>" or returns 1.
+# The value matches `docker buildx imagetools inspect --format
+# '{{ .Manifest.Digest }}'` for the same ref.
+
+fetch_index_digest() {
+    local image="$1" tag="$2" token digest
+    token="$(curl -fsS "https://ghcr.io/token?scope=repository:obolnetwork/${image}:pull" | jq -r .token)"
+    digest="$(curl -fsSI \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+        "https://ghcr.io/v2/obolnetwork/${image}/manifests/${tag}" \
+        | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" {print $2}')"
+    if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        echo "error: could not resolve index digest for ghcr.io/obolnetwork/${image}:${tag}" >&2
+        return 1
+    fi
+    printf '%s' "${digest}"
+}

--- a/.github/scripts/repin-x402-images.sh
+++ b/.github/scripts/repin-x402-images.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Repin the embedded x402 image references (x402-verifier,
+# serviceoffer-controller, x402-buyer) to the images built from a given
+# commit.
+#
+#   .github/scripts/repin-x402-images.sh <commit-ish>
+#
+# CI runs this from the repin-embedded-pins job in docker-publish-x402.yml
+# after every successful branch build, so the embedded manifests track the
+# images built from the same source. Operators can run it manually for
+# ad-hoc repins (the rc11/rc14 pattern, cf. 8fb1553 / 2db429b) — the images
+# must already exist on GHCR at the 7-char short-SHA tag, which the
+# docker-publish-x402 workflow publishes for every build.
+#
+# The script rewrites image lines in the two embedded templates and nothing
+# else. The digest written is the multi-arch index digest (amd64+arm64) —
+# the same value `docker buildx imagetools inspect --format
+# '{{ .Manifest.Digest }}'` reports.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+X402_YAML="internal/embed/infrastructure/base/templates/x402.yaml"
+LLM_YAML="internal/embed/infrastructure/base/templates/llm.yaml"
+
+COMMIT_ISH="${1:?usage: repin-x402-images.sh <commit-ish>}"
+FULL_SHA="$(git rev-parse --verify "${COMMIT_ISH}^{commit}")"
+# docker/metadata-action type=sha,format=short always emits the first 7
+# characters, independent of git's core.abbrev / collision widening.
+SHORT_SHA="${FULL_SHA:0:7}"
+
+# shellcheck source=.github/scripts/lib-ghcr.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-ghcr.sh"
+
+repin_image() {
+    local file="$1" image="$2" digest ref
+    digest="$(fetch_index_digest "${image}" "${SHORT_SHA}")" || {
+        echo "       (has the docker-publish-x402 build for ${FULL_SHA} completed?)" >&2
+        return 1
+    }
+    ref="ghcr.io/obolnetwork/${image}:${SHORT_SHA}@${digest}"
+    # BSD and GNU sed both accept -i with an attached suffix.
+    sed -E -i.repin-bak \
+        "s|image: ghcr\.io/obolnetwork/${image}:[A-Za-z0-9._-]+@sha256:[0-9a-f]{64}|image: ${ref}|" \
+        "${REPO_ROOT}/${file}"
+    rm -f "${REPO_ROOT}/${file}.repin-bak"
+    if ! grep -q "image: ${ref}" "${REPO_ROOT}/${file}"; then
+        echo "error: failed to rewrite ${image} pin in ${file}" >&2
+        return 1
+    fi
+    echo "pinned ${ref} (${file})"
+}
+
+repin_image "${X402_YAML}" "x402-verifier"
+repin_image "${X402_YAML}" "serviceoffer-controller"
+repin_image "${LLM_YAML}" "x402-buyer"
+
+# Keep the human-readability note in llm.yaml in sync with the tag.
+sed -E -i.repin-bak \
+    "s|The :[0-9a-f]{7,40} tag is preserved|The :${SHORT_SHA} tag is preserved|" \
+    "${REPO_ROOT}/${LLM_YAML}"
+rm -f "${REPO_ROOT}/${LLM_YAML}.repin-bak"
+
+if git -C "${REPO_ROOT}" diff --quiet -- "${X402_YAML}" "${LLM_YAML}"; then
+    echo "embedded pins already reference ${SHORT_SHA} with current digests; nothing to do"
+else
+    echo "embedded pins updated to ${SHORT_SHA}:"
+    git -C "${REPO_ROOT}" --no-pager diff --stat -- "${X402_YAML}" "${LLM_YAML}"
+fi

--- a/.github/scripts/verify-x402-pins.sh
+++ b/.github/scripts/verify-x402-pins.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Release gate: fail when the embedded x402 image pins are stale.
+#
+#   .github/scripts/verify-x402-pins.sh [<release-ref>]   (default: HEAD)
+#
+# "Stale" means: some commit after the pinned build commit changed source
+# that compiles into the x402-verifier / serviceoffer-controller /
+# x402-buyer binaries (computed live from `go list -deps`, plus their
+# Dockerfiles and go.mod/go.sum), so the pinned images no longer match the
+# source being released. This is the gate that makes the rc14 trap —
+# tagging a release whose embedded pins predate the release's own
+# verifier/buyer changes — structurally impossible.
+#
+# Special case: the two template files that carry the pins themselves are
+# data inside internal/embed (which the binaries import), so a pin-bump
+# commit would otherwise mark itself stale forever. For those two files
+# only, the diff is filtered to ignore image-pin lines and the pin
+# readability comment; any OTHER change to them (RBAC, env, args) still
+# counts as stale.
+#
+# Requires full git history (actions/checkout fetch-depth: 0), Go, and —
+# unless VERIFY_X402_PINS_OFFLINE=true — network access to ghcr.io to bind
+# each embedded digest to its tag.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+# shellcheck source=.github/scripts/lib-ghcr.sh
+source "${REPO_ROOT}/.github/scripts/lib-ghcr.sh"
+
+X402_YAML="internal/embed/infrastructure/base/templates/x402.yaml"
+LLM_YAML="internal/embed/infrastructure/base/templates/llm.yaml"
+RELEASE_REF="${1:-HEAD}"
+
+# extract_pin prints "<tag> <digest>" for the image's pin in file. Fails when
+# the pin is missing or when multiple DISTINCT pins exist for one image (a
+# half-done repin: the gate must not silently bless the first occurrence).
+extract_pin() {
+    local file="$1" image="$2" refs
+    refs="$(grep -Eo "image: ghcr\.io/obolnetwork/${image}:[A-Za-z0-9._-]+@sha256:[0-9a-f]{64}" "${file}" \
+        | sed -E "s|.*${image}:([A-Za-z0-9._-]+)@(sha256:[0-9a-f]{64})|\1 \2|" | sort -u)"
+    if [[ -z "${refs}" ]]; then
+        echo "error: no digest-pinned ${image} image found in ${file}" >&2
+        return 1
+    fi
+    if [[ "$(wc -l <<<"${refs}")" -ne 1 ]]; then
+        echo "error: ${file} pins ${image} more than once with different refs:" >&2
+        # shellcheck disable=SC2001  # multi-line indent; ${var//} can't anchor ^
+        sed 's/^/         /' <<<"${refs}" >&2
+        return 1
+    fi
+    printf '%s' "${refs}"
+}
+
+# Plain assignments so extract_pin failures stop the script under set -e
+# (read -r x <<<"$(cmd)" would swallow cmd's exit status).
+verifier_pin="$(extract_pin "${X402_YAML}" "x402-verifier")"
+controller_pin="$(extract_pin "${X402_YAML}" "serviceoffer-controller")"
+buyer_pin="$(extract_pin "${LLM_YAML}" "x402-buyer")"
+read -r VERIFIER_TAG VERIFIER_DIGEST <<<"${verifier_pin}"
+read -r CONTROLLER_TAG CONTROLLER_DIGEST <<<"${controller_pin}"
+read -r BUYER_TAG BUYER_DIGEST <<<"${buyer_pin}"
+
+if [[ ! ("${VERIFIER_TAG}" == "${CONTROLLER_TAG}" && "${VERIFIER_TAG}" == "${BUYER_TAG}") ]]; then
+    echo "error: embedded x402 pins do not share one build commit:" >&2
+    echo "       x402-verifier=${VERIFIER_TAG} serviceoffer-controller=${CONTROLLER_TAG} x402-buyer=${BUYER_TAG}" >&2
+    echo "       Repin all three from one commit: .github/scripts/repin-x402-images.sh <commit>" >&2
+    exit 1
+fi
+
+PIN_TAG="${VERIFIER_TAG}"
+if ! PIN_COMMIT="$(git rev-parse --verify --quiet "${PIN_TAG}^{commit}")"; then
+    echo "error: pinned image tag ':${PIN_TAG}' does not resolve to a commit in this clone." >&2
+    echo "       Either the clone is shallow (use fetch-depth: 0), the short SHA is ambiguous" >&2
+    echo "       (run: git rev-parse ${PIN_TAG} to see candidates), or the pin references a" >&2
+    echo "       commit from a deleted branch (e.g. after a squash-merge). Repin from a" >&2
+    echo "       reachable commit: .github/scripts/repin-x402-images.sh <commit>" >&2
+    exit 1
+fi
+
+# Bind each embedded digest to what GHCR actually serves for the pinned tag.
+# Without this, a fresh tag with a hand-edited or mismatched digest deploys
+# an arbitrary image while every git-based check passes — the digest, not
+# the tag, is what Kubernetes pulls.
+if [[ "${VERIFY_X402_PINS_OFFLINE:-}" == "true" ]]; then
+    echo "VERIFY_X402_PINS_OFFLINE=true: skipping registry digest binding" >&2
+else
+    for entry in \
+        "x402-verifier ${VERIFIER_DIGEST}" \
+        "serviceoffer-controller ${CONTROLLER_DIGEST}" \
+        "x402-buyer ${BUYER_DIGEST}"; do
+        read -r image embedded_digest <<<"${entry}"
+        live_digest="$(fetch_index_digest "${image}" "${PIN_TAG}")"
+        if [[ "${live_digest}" != "${embedded_digest}" ]]; then
+            echo "error: embedded digest for ${image}:${PIN_TAG} does not match the registry:" >&2
+            echo "       embedded: ${embedded_digest}" >&2
+            echo "       registry: ${live_digest}" >&2
+            echo "       Re-run .github/scripts/repin-x402-images.sh ${PIN_TAG} and commit." >&2
+            exit 1
+        fi
+    done
+fi
+
+if ! git merge-base --is-ancestor "${PIN_COMMIT}" "${RELEASE_REF}"; then
+    echo "error: pinned build commit ${PIN_COMMIT} is not an ancestor of ${RELEASE_REF}." >&2
+    echo "       The pinned images were built from a different line of history than this release." >&2
+    exit 1
+fi
+
+# Live import graph of the three image binaries, as repo-relative dirs.
+# Computed FAIL-CLOSED: a process substitution would swallow a go-list
+# failure under set -e and silently gut the gate down to the static paths,
+# turning any toolchain hiccup into a false PASS on stale pins.
+if ! deps_out="$(go list -deps ./cmd/x402-verifier ./cmd/x402-buyer ./cmd/serviceoffer-controller)"; then
+    echo "error: 'go list -deps' failed; cannot compute the component import graph." >&2
+    echo "       Refusing to pass the gate on a partial path set." >&2
+    exit 1
+fi
+graph="$(grep '^github.com/ObolNetwork/obol-stack/' <<<"${deps_out}" \
+    | sed 's|^github.com/ObolNetwork/obol-stack/||' \
+    | sort -u)"
+for must in cmd/x402-verifier cmd/x402-buyer cmd/serviceoffer-controller; do
+    if ! grep -qx "${must}" <<<"${graph}"; then
+        echo "error: import graph is missing ${must} (module path changed?); refusing to pass." >&2
+        exit 1
+    fi
+done
+
+# (while-read instead of mapfile: macOS ships bash 3.2.)
+paths=(go.mod go.sum Dockerfile.x402-verifier Dockerfile.x402-buyer Dockerfile.serviceoffer-controller)
+while IFS= read -r dir; do
+    paths+=("${dir}")
+done <<<"${graph}"
+
+# _test.go files and testdata live in graph packages but do not compile
+# into the shipped binaries — they cannot make a built image stale.
+stale_files="$(git diff --name-only "${PIN_COMMIT}..${RELEASE_REF}" -- "${paths[@]}" \
+    ":(exclude)${X402_YAML}" ":(exclude)${LLM_YAML}" \
+    | grep -Ev '(_test\.go$|/testdata/)' || true)"
+
+# The two pin-carrying templates: ignore pin lines, flag everything else.
+pin_template_drift="$(git diff --unified=0 "${PIN_COMMIT}..${RELEASE_REF}" -- "${X402_YAML}" "${LLM_YAML}" \
+    | grep -E '^[+-]' \
+    | grep -Ev '^(\+\+\+ |--- )' \
+    | grep -Ev '^[+-][[:space:]]*image: ghcr\.io/obolnetwork/(x402-verifier|serviceoffer-controller|x402-buyer):' \
+    | grep -Ev '^[+-][[:space:]]*# hosts\. The :[0-9a-f]{7,40} tag is preserved' \
+    || true)"
+
+if [[ -z "${stale_files}" && -z "${pin_template_drift}" ]]; then
+    echo "embedded x402 image pins are fresh: ${PIN_TAG} (${PIN_COMMIT}) covers all"
+    echo "verifier/controller/buyer source between the pin and ${RELEASE_REF}."
+    exit 0
+fi
+
+echo "error: embedded x402 image pins are STALE." >&2
+echo "       Pinned build commit: ${PIN_COMMIT} (tag :${PIN_TAG})" >&2
+if [[ -n "${stale_files}" ]]; then
+    echo "       Component source changed after the pin:" >&2
+    # shellcheck disable=SC2001  # multi-line indent; ${var//} can't anchor ^
+    sed 's/^/         /' <<<"${stale_files}" >&2
+fi
+if [[ -n "${pin_template_drift}" ]]; then
+    echo "       Non-pin changes in the pin-carrying templates after the pin:" >&2
+    # shellcheck disable=SC2001
+    sed 's/^/         /' <<<"${pin_template_drift}" >&2
+fi
+echo "" >&2
+echo "       Fix: build images from the release commit and repin —" >&2
+echo "         gh workflow run docker-publish-x402.yml --ref <branch>" >&2
+echo "         (the repin-embedded-pins job lands the bump automatically), or run" >&2
+echo "         .github/scripts/repin-x402-images.sh <commit> manually once the build" >&2
+echo "         finishes, commit, and re-tag." >&2
+exit 1

--- a/.github/workflows/docker-publish-x402.yml
+++ b/.github/workflows/docker-publish-x402.yml
@@ -4,12 +4,40 @@ on:
   push:
     branches:
       - main
+      # Release trains get the same build + auto-repin treatment, so a tag
+      # cut on the branch never needs a manual workflow_dispatch first.
+      - 'release/**'
     tags:
       - 'v*'
+    # Approximates the import graph of the built binaries (verifier,
+    # controller, buyer pull in far more than internal/x402 — agent
+    # rendering, embed, erc8004, tunnel, ...). The release-gate script
+    # .github/scripts/verify-x402-pins.sh computes the EXACT graph via
+    # `go list -deps` at tag time, so anything this list misses fails the
+    # release instead of shipping stale; keep the list generous.
     paths:
-      - 'internal/x402/**'
-      - 'internal/serviceoffercontroller/**'
+      - 'internal/agentruntime/**'
+      - 'internal/config/**'
+      - 'internal/defaults/**'
+      - 'internal/dns/**'
+      - 'internal/embed/**'
+      - 'internal/enclave/**'
+      - 'internal/erc8004/**'
+      - 'internal/helmcmd/**'
+      - 'internal/images/**'
+      - 'internal/inference/**'
+      - 'internal/kubectl/**'
+      - 'internal/model/**'
       - 'internal/monetizeapi/**'
+      - 'internal/openclaw/**'
+      - 'internal/schemas/**'
+      - 'internal/serviceoffercontroller/**'
+      - 'internal/tee/**'
+      - 'internal/tunnel/**'
+      - 'internal/ui/**'
+      - 'internal/version/**'
+      - 'internal/walletbackup/**'
+      - 'internal/x402/**'
       - 'internal/demo/**'
       - 'cmd/x402-verifier/**'
       - 'cmd/x402-buyer/**'
@@ -22,6 +50,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/docker-publish-x402.yml'
+      - '.github/scripts/repin-x402-images.sh'
   workflow_dispatch:
 
 concurrency:
@@ -153,3 +182,93 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
         if: always()
+
+  # ---------------------------------------------------------------------------
+  # Repin the embedded infrastructure manifests to the images just built, so
+  # the manifests the obol CLI applies always reference images built from the
+  # same source (closes the rc14 stale-pin trap; rc11 pattern, automated).
+  #
+  # Branch refs only: a tag build cannot receive a pin-bump commit, and the
+  # release workflow's verify-image-pins gate ensures tags are cut AFTER the
+  # bump landed. Pushing with GITHUB_TOKEN never triggers other workflows,
+  # so this job cannot recurse into another build.
+  #
+  # The bump is committed through the GraphQL createCommitOnBranch API, NOT
+  # `git push`: API commits are signed by GitHub itself (verified,
+  # github-actions bot), which keeps this job compatible with the repo
+  # ruleset rejecting unsigned commits — a workflow `git push` can never
+  # produce a verified commit. API commits made with GITHUB_TOKEN also do
+  # not trigger other workflows, so this job cannot recurse into a build.
+  # ---------------------------------------------------------------------------
+  repin-embedded-pins:
+    needs: build
+    if: startsWith(github.ref, 'refs/heads/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Repin embedded images to this build
+        env:
+          BUILD_SHA: ${{ github.sha }}
+        run: .github/scripts/repin-x402-images.sh "$BUILD_SHA"
+
+      - name: Commit pin bump via API (GitHub-signed)
+        # Context values are bound via env, never interpolated into the
+        # script text: branch names may contain shell metacharacters, and
+        # the runner substitutes ${{ }} before bash parses the line.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BUILD_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          changed="$(git diff --name-only)"
+          if [ -z "$changed" ]; then
+            echo "embedded pins already current; nothing to push"
+            exit 0
+          fi
+          # The repin script may only touch the two pin-carrying templates.
+          while IFS= read -r f; do
+            case "$f" in
+              internal/embed/infrastructure/base/templates/x402.yaml) ;;
+              internal/embed/infrastructure/base/templates/llm.yaml) ;;
+              *) echo "::error::repin produced an unexpected change: $f"; exit 1 ;;
+            esac
+          done <<< "$changed"
+          short="$(printf '%s' "$BUILD_SHA" | cut -c1-7)"
+          # createCommitOnBranch: GitHub signs the commit (verified) — a
+          # plain `git push` from a workflow never is, and the repo
+          # ruleset rejects unsigned commits. expectedHeadOid is the LIVE
+          # remote head (the branch may have advanced while images
+          # built); on a race the mutation fails cleanly and we retry
+          # once against the new head. Only the two guarded files are
+          # sent, so replaying onto a newer head cannot clobber anything
+          # else.
+          commit_via_api() {
+            head_oid="$(gh api "repos/$REPO/git/ref/heads/$REF_NAME" --jq .object.sha)"
+            jq -n \
+              --arg repo "$REPO" --arg branch "$REF_NAME" --arg head "$head_oid" \
+              --arg msg "chore(ci): repin x402 images to ${short} [auto]" \
+              --arg body "Automated by docker-publish-x402/repin-embedded-pins after the image build at ${BUILD_SHA}. Committed via the GitHub API so the commit is verified." \
+              --arg x402 "$(base64 < internal/embed/infrastructure/base/templates/x402.yaml | tr -d '\n')" \
+              --arg llm "$(base64 < internal/embed/infrastructure/base/templates/llm.yaml | tr -d '\n')" \
+              '{
+                query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+                variables: {input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                  expectedHeadOid: $head,
+                  message: {headline: $msg, body: $body},
+                  fileChanges: {additions: [
+                    {path: "internal/embed/infrastructure/base/templates/x402.yaml", contents: $x402},
+                    {path: "internal/embed/infrastructure/base/templates/llm.yaml", contents: $llm}
+                  ]}
+                }}
+              }' | gh api graphql --input -
+          }
+          commit_via_api || { echo "branch head moved during commit; retrying once"; sleep 5; commit_via_api; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,32 @@ permissions:
   contents: write
 
 jobs:
+  # Gate: the embedded x402 image pins (x402-verifier, serviceoffer-controller,
+  # x402-buyer) must have been built from source that contains every change to
+  # those binaries' import graph. Without this, a tag can ship manifests that
+  # deploy images predating the release's own payment-path changes (the
+  # v0.10.0-rc14 stale-pin trap). The repin-embedded-pins job in
+  # docker-publish-x402.yml normally lands the bump automatically; this gate
+  # makes sure the tag was cut after it.
+  verify-image-pins:
+    name: Verify embedded x402 image pins are fresh
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # gate only reads; don't inherit the workflow's write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Verify pins cover all component source
+        run: .github/scripts/verify-x402-pins.sh
+
   build:
     name: Build binaries
     runs-on: ubuntu-latest
@@ -142,7 +168,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [build, verify-image-pins]
     runs-on: ubuntu-latest
 
     steps:

--- a/internal/embed/embed_crd_test.go
+++ b/internal/embed/embed_crd_test.go
@@ -813,22 +813,13 @@ func TestX402VerifierRBAC_CanReadAgentAPISecrets(t *testing.T) {
 	t.Fatal("x402-verifier ClusterRole missing scoped secret get/list/watch rule")
 }
 
+// TestX402VerifierImage_CarriesAgentAuthFix: the pin VALUE is maintained by
+// the repin automation (.github/scripts/repin-x402-images.sh); what this test
+// guards is that whatever commit is pinned still descends from abfd55a (the
+// agent upstream auth fix). Bumping the pin backward past it fails here.
 func TestX402VerifierImage_CarriesAgentAuthFix(t *testing.T) {
-	data, err := ReadInfrastructureFile("base/templates/x402.yaml")
-	if err != nil {
-		t.Fatalf("ReadInfrastructureFile: %v", err)
-	}
-
-	// Bumped to 9504961 (main HEAD at release-cut) — rebuilt via
-	// docker-publish-x402 workflow_dispatch. Carries forward the rc14
-	// verifier changes: settle tx hash surfaced via X-PAYMENT-RESPONSE on
-	// the error path and ClampMaxTimeoutSeconds on the 402 wire. The agent
-	// upstream auth fix from abfd55a and ab71481's verifyOnly warning
-	// suppression remain in scope (ancestors via main).
-	const ref = "ghcr.io/obolnetwork/x402-verifier:9504961@sha256:22741770a711e3859abd3cdbd78d4e318417344449e8e6a9d8b52981caba2adb"
-	if !strings.Contains(string(data), "image: "+ref) {
-		t.Fatalf("x402-verifier image must carry agent upstream auth fix: %s", ref)
-	}
+	tag, _ := extractEmbeddedImagePin(t, "base/templates/x402.yaml", "ghcr.io/obolnetwork/x402-verifier")
+	requireGitAncestor(t, "abfd55a", tag)
 }
 
 // TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix is the tripwire
@@ -837,23 +828,12 @@ func TestX402VerifierImage_CarriesAgentAuthFix(t *testing.T) {
 // treats Secret as create-only (isCreateOnlyKind). The image MUST therefore be
 // built from source that has that behaviour — the prior f5d94fc side-branch pin
 // did not, so the deployed binary Updated the per-agent Secrets on re-reconcile
-// and 403'd. b39bcaa (post-rc10 main) carries the fix, and also ships PR #590's
-// actionable pending-registration status message. The current 9504961 pin
-// (main HEAD at release-cut) descends from b39bcaa via main, so the fix
-// remains in scope.
-// Bumping this pin requires a conscious, documented change here so a future
-// downgrade can't silently re-ship the bug.
+// and 403'd. b39bcaa (post-rc10 main) carries the fix.
+// The pin value itself is maintained by the repin automation; this test
+// asserts ancestry so a future downgrade can't silently re-ship the bug.
 func TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix(t *testing.T) {
-	data, err := ReadInfrastructureFile("base/templates/x402.yaml")
-	if err != nil {
-		t.Fatalf("ReadInfrastructureFile: %v", err)
-	}
-
-	const ref = "ghcr.io/obolnetwork/serviceoffer-controller:9504961@sha256:74d727712cf037f35e0ba31f8f1402bc3d75c606f328ff79da07160e724f4fae"
-	if !strings.Contains(string(data), "image: "+ref) {
-		t.Fatalf("serviceoffer-controller image must carry the Secret-create-only reconciler fix "+
-			"(else per-agent provisioning 403s under the no-update/patch Secret RBAC): %s", ref)
-	}
+	tag, _ := extractEmbeddedImagePin(t, "base/templates/x402.yaml", "ghcr.io/obolnetwork/serviceoffer-controller")
+	requireGitAncestor(t, "b39bcaa", tag)
 }
 
 // TestServiceOfferControllerSecretRBAC_Scoped guards the controller's Secret

--- a/internal/embed/embed_image_pin_test.go
+++ b/internal/embed/embed_image_pin_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -224,41 +226,100 @@ func TestEmbeddedImages_NamedImagesAreDigestPinned(t *testing.T) {
 	}
 }
 
-func TestEmbeddedImages_X402ControllerAndBuyerUseFixPins(t *testing.T) {
-	cases := []struct {
-		file string
-		ref  string
-	}{
-		{
-			// Repinned to 9504961 (main HEAD at release-cut) — images rebuilt
-			// from this commit via docker-publish-x402 workflow_dispatch.
-			// Carries forward everything c19ffaf (rc14) shipped:
-			//   - controller renders sub-agents with Hermes v2026.6.5 and
-			//     the UID-1000 kubelet-owned permission model (#610), and
-			//     surfaces maxTimeoutSeconds in the catalog ext (#614).
-			//   - buyer carries the settled-but-failed ConfirmSpend branch
-			//     (>=400 + settle tx hash counts as money moved) (#614).
-			// Still carries the Secret-create-only reconciler change from
-			// b39bcaa and the earlier ab71481/86b8c9f fixes (ancestors via
-			// main). See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
-			file: "base/templates/x402.yaml",
-			ref:  "ghcr.io/obolnetwork/serviceoffer-controller:9504961@sha256:74d727712cf037f35e0ba31f8f1402bc3d75c606f328ff79da07160e724f4fae",
-		},
-		{
-			file: "base/templates/llm.yaml",
-			ref:  "ghcr.io/obolnetwork/x402-buyer:9504961@sha256:3f38aeff13ad115ebc8e2370511558d74373699af7feb8d4f35e1154cd2c12d3",
-		},
+// extractEmbeddedImagePin locates the single `image:` line for repo in the
+// given embedded template and returns its (tag, digest). Fails the test when
+// the ref is missing or not of the `<repo>:<short-sha>@sha256:<digest>` form
+// the repin automation maintains (.github/scripts/repin-x402-images.sh).
+func extractEmbeddedImagePin(t *testing.T, file, repo string) (tag, digest string) {
+	t.Helper()
+
+	data, err := ReadInfrastructureFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.ref, func(t *testing.T) {
-			data, err := ReadInfrastructureFile(tc.file)
-			if err != nil {
-				t.Fatalf("read %s: %v", tc.file, err)
-			}
-			if !strings.Contains(string(data), "image: "+tc.ref) {
-				t.Fatalf("%s must pin current x402 bundle image %q", tc.file, tc.ref)
-			}
+	re := regexp.MustCompile(`image: ` + regexp.QuoteMeta(repo) + `:([0-9a-f]{7,40})@(sha256:[0-9a-f]{64})`)
+
+	m := re.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("%s: no commit-tagged, digest-pinned image ref for %s — the pin must look like "+
+			"%s:<short-sha>@sha256:<digest> (run .github/scripts/repin-x402-images.sh)", file, repo, repo)
+	}
+
+	return string(m[1]), string(m[2])
+}
+
+// requireGitAncestor asserts that ancestor is reachable from the commit the
+// pin tag names. Skips (not fails) when git or either commit is unavailable —
+// shallow clones and source tarballs can't answer ancestry questions; the
+// release workflow's verify-image-pins gate enforces freshness with full
+// history.
+func requireGitAncestor(t *testing.T, ancestor, pinTag string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; ancestry check skipped")
+	}
+
+	for _, c := range []string{ancestor, pinTag} {
+		if err := exec.Command("git", "rev-parse", "--verify", "--quiet", c+"^{commit}").Run(); err != nil {
+			t.Skipf("commit %s not resolvable in this clone (shallow checkout?); ancestry check skipped", c)
+		}
+	}
+
+	if err := exec.Command("git", "merge-base", "--is-ancestor", ancestor, pinTag).Run(); err != nil {
+		t.Fatalf("pinned image build commit %s does not descend from required fix commit %s", pinTag, ancestor)
+	}
+}
+
+// TestEmbeddedImages_X402PinsShareOneBuildCommit guards the consistency
+// invariant behind the repin automation: x402-verifier,
+// serviceoffer-controller, and x402-buyer are built together by
+// docker-publish-x402.yml, so their embedded pins must reference one build
+// commit. Mixed tags mean a partial/manual repin — exactly the state that
+// shipped a controller/buyer skew before rc11 (cf. 8fb1553) and the stale
+// base pins before rc14 (cf. 2db429b).
+func TestEmbeddedImages_X402PinsShareOneBuildCommit(t *testing.T) {
+	verifierTag, _ := extractEmbeddedImagePin(t, "base/templates/x402.yaml", "ghcr.io/obolnetwork/x402-verifier")
+	controllerTag, _ := extractEmbeddedImagePin(t, "base/templates/x402.yaml", "ghcr.io/obolnetwork/serviceoffer-controller")
+	buyerTag, _ := extractEmbeddedImagePin(t, "base/templates/llm.yaml", "ghcr.io/obolnetwork/x402-buyer")
+
+	if verifierTag != controllerTag || verifierTag != buyerTag {
+		t.Fatalf("embedded x402 pins must share one build commit; got verifier=%s controller=%s buyer=%s "+
+			"(repin all three: .github/scripts/repin-x402-images.sh <commit>)",
+			verifierTag, controllerTag, buyerTag)
+	}
+}
+
+// TestEmbeddedImages_X402PinsCarryRequiredFixes replaces the old
+// exact-ref equality tests so the repin automation can bump pins without
+// editing this file, while the "image carries fix X" guarantees get
+// stronger: ancestry-verified against git history instead of trusted via a
+// hand-maintained string. Each entry names a commit whose absence shipped a
+// real bug; bumping a pin BACKWARD past any of them fails here.
+func TestEmbeddedImages_X402PinsCarryRequiredFixes(t *testing.T) {
+	// All three images share one build commit (asserted above), so checking
+	// the controller tag covers the set.
+	tag, _ := extractEmbeddedImagePin(t, "base/templates/x402.yaml", "ghcr.io/obolnetwork/serviceoffer-controller")
+
+	// Only commits reachable from main belong here. A release-branch commit
+	// (e.g. c19ffaf, the rc14 train) stops being an ancestor of future main
+	// pins the moment the train squash-merges — the entry would hard-fail
+	// every clone that still has the branch ref and skip everywhere else.
+	// Train freshness is the release gate's job (verify-x402-pins.sh).
+	requiredFixes := []struct {
+		commit string
+		why    string
+	}{
+		{"b39bcaa", "Secret-create-only reconciler — without it per-agent provisioning 403s under the no-update/patch Secret RBAC"},
+		{"ab71481", "suppress verifyOnly=false warning on the in-process settle path (per-request log spam for sell-agent buyers)"},
+		{"86b8c9f", "buyer drops expired pre-signed auths before signing (long-running paid inference)"},
+	}
+
+	for _, fix := range requiredFixes {
+		t.Run(fix.commit, func(t *testing.T) {
+			requireGitAncestor(t, fix.commit, tag)
+			_ = fix.why // documentation; the failure message names the commit
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Automates the release-time image repin so it can never be forgotten again. Two mechanisms, belt and suspenders:

```mermaid
flowchart LR
    P["push to main / release/**<br/>(or workflow_dispatch)"] --> B["docker-publish-x402<br/>build + push images<br/>:shortsha"]
    B --> R["repin-embedded-pins job<br/>rewrite x402.yaml + llm.yaml pins<br/>commit chore(ci): repin … [auto]"]
    R --> T["operator tags vX.Y.Z"]
    T --> G{"release.yml<br/>verify-image-pins gate"}
    G -->|pins fresh| REL["binaries built,<br/>draft release"]
    G -->|stale / digest mismatch /<br/>unresolvable pin| BLOCK["release FAILS<br/>with fix instructions"]
```

1. **Auto-repin** (`repin-embedded-pins` job in `docker-publish-x402.yml`): after every successful branch image build, `.github/scripts/repin-x402-images.sh` rewrites the embedded `x402-verifier` / `serviceoffer-controller` / `x402-buyer` pins to the multi-arch index digests of the images just built, and the job pushes a `chore(ci): repin x402 images to <sha> [auto]` commit. Branch refs only — never tags.
2. **Release gate** (`verify-image-pins` in `release.yml`, `release` now needs it): `.github/scripts/verify-x402-pins.sh` fails the tag when any source in the three binaries' **live import graph** (`go list -deps`, not a hand-maintained path list) changed after the pinned build commit.

This closes the trap that hit v0.10.0-rc14: the train's pins were its own merge base (`04bebbc`), so the shipped manifests deployed images containing **none** of the train's verifier/buyer changes until a manual rebuild+repin (`2db429b`, the rc11 pattern). With this PR that manual step is automatic, and a tag cut without it cannot release.

## Gate properties (each adversarially tested)

- **Fail-closed**: a `go list` failure refuses to pass rather than silently degrading to a partial path set (reproduced: with a broken `go`, the old draft waved stale pins through; now exits 1).
- **Digest↔tag binding**: the embedded digest must match what GHCR serves for the pinned tag — a fresh tag with a hand-edited digest fails (the digest, not the tag, is what Kubernetes pulls). `VERIFY_X402_PINS_OFFLINE=true` skips for air-gapped runs.
- **No self-staleness**: the two pin-carrying templates are hunk-filtered — pin lines are ignored, any other edit to them (RBAC, args, env) still counts as stale. `_test.go`/testdata churn is ignored (doesn't compile into the binaries).
- **Consistency**: all three pins must share one build commit; multiple distinct pins for one image fail extraction.
- **Caught the real thing**: run against the pre-repin rc14 state, the gate flags `agent_render.go`, `openapi.go`, `go.mod`, … — exactly the trap.

## Workflow security

- Context values (`github.ref_name`, `github.sha`) are env-bound in the repin job, never interpolated into script text (branch names may contain shell metacharacters).
- The push step verifies the diff touches **only** the two template files before committing; job has `contents: write`, the new gate job is `contents: read`.
- The bump is committed via the GraphQL `createCommitOnBranch` API: **GitHub signs the commit itself** (verified, github-actions bot), so the job is compatible with a `required_signatures` ruleset — a workflow `git push` can never produce a verified commit. `expectedHeadOid` is the live remote head with one retry on race; only the two guarded files are ever sent. No recursion: API commits made with `GITHUB_TOKEN` don't trigger workflows.
- Path filters extended to approximate the binaries' real import graph (the gate computes the exact one at tag time, so anything the filter misses fails the release instead of shipping stale); `release/**` pushes now build+repin like main.

## Test refactor

The exact-ref equality tests (`TestEmbeddedImages_X402ControllerAndBuyerUseFixPins`, `TestX402VerifierImage_CarriesAgentAuthFix`, `TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix`) became invariant tests, so the bot can bump pins without editing Go files while the guarantees get stronger:

- pins must be `<repo>:<short-sha>@sha256:<digest>` (digest discipline already covered by `TestEmbeddedImages_NamedImagesAreDigestPinned`),
- all three must share one build commit (`TestEmbeddedImages_X402PinsShareOneBuildCommit`),
- the pinned commit must **descend from** the named fix commits — `b39bcaa` (Secret-create-only), `abfd55a` (agent auth), `ab71481`, `86b8c9f` — ancestry-verified via git (`TestEmbeddedImages_X402PinsCarryRequiredFixes`), skipped gracefully on shallow clones where the release gate covers it. Only main-reachable commits belong in that list (release-branch SHAs stop being ancestors after a squash-merge; documented in the test).

## Review

42-finding adversarial review pass (4 lenses × refutation agents): 1 major fixed (fail-open on `go list` failure), 2 minors fixed (ref_name injection, digest binding), nits fixed (gate job permissions, multi-pin extraction, diff-header anchor that could hide YAML doc-separator deletions, ambiguous-SHA error hint). Branch-protection findings refuted by measurement (no protection/rulesets on main).

## Validation

- `shellcheck` clean on all three scripts; both workflows parse.
- Gate: positive (current pins), negative × 3 (rc13 mixed pins → same-tag failure; pre-repin rc14 pins → staleness with the exact culprit files; corrupted digest → registry mismatch), fail-closed (broken `go`).
- Repin script: idempotent no-op at current pin; real bump to `2db429b` images verified end-to-end (gate + tests pass on bumped state), then restored.
- Full `go test ./...` green (34 packages).

Stacks on #616 (branched from the v0.10.0-rc14 tag commit); merge that first.



> Rebased onto current `main` (post-#616 squash) — single verified commit; the earlier stale release-branch history is gone.