### PR TITLE
fix(sell): add `obol sell resume` so offers recover after a host reboot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ obol
 - `network install` has dynamic subcommands (one per supported chain; `--help` to list). `network sync [<network>/<id>]` with `--all`.
 - `sell info <name>` prints purchase instructions (URL, model, buy.py command).
 - `sell mcp [name]` runs a foreground x402-paid MCP server: forwards buyer JSON args to a backend HTTP service, injecting the seller's own API key (buyer never sees it). Payment rides MCP `_meta` (`internal/x402mcp`).
+- `sell resume` replays every persisted sell offer (inference incl. detached host-gateway relaunch; http/agent/demo-agent via the manifest ledger at `$OBOL_CONFIG_DIR/sell-http/`) — run after a host reboot; `obol stack up` runs the same path. `--install-boot-unit` adds a systemd user unit (Linux). `sell mcp` is foreground-only, no offer, not resumed.
 - `hermes` is passthrough to native hermes CLI via `hermes.CLI()` (cmd/obol/hermes.go:27). No Go-level subcommands registered.
 - `bootstrap` (cmd/obol/bootstrap.go) is a hidden command for installer use only — not user-facing.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ obol
 │   └── wallet      address, list, backup, restore
 ├── wallet          import
 ├── network         install, sync, delete, list, add, remove, status
-├── sell            inference, http, agent, mcp, demo, list, status, test, stop, update, delete, pricing, register, identity, info
+├── sell            inference, http, agent, mcp, demo, list, status, test, stop, update, delete, pricing, register, identity, info, resume
 ├── buy             inference
 ├── hermes          passthrough (SkipFlagParsing) → native hermes CLI
 │                   Token retrieval moved to `obol agent auth`

--- a/cmd/obol/agent.go
+++ b/cmd/obol/agent.go
@@ -966,6 +966,27 @@ func deleteCRDAgent(cfg *config.Config, name string, force bool, u *ui.UI) error
 			}
 		}
 		u.Successf("Agent %s/%s deleted", ns, name)
+
+		// The agent finalizer tears down the agent's children but
+		// deliberately leaves the namespace — and nothing deletes the
+		// agent's ServiceOffers, which would otherwise survive stuck on
+		// WaitingForAgent and, worse, reconcile back to Ready (selling
+		// to the DELETED agent's payTo) if an agent with the same name
+		// is ever recreated. Delete them here; the offer finalizer
+		// cleans up the route/middleware/registration children.
+		if err := kubectl.Run(bin, kc, "delete", "serviceoffers.obol.org", "--all", "-n", ns, "--ignore-not-found", "--wait=false"); err != nil {
+			u.Warnf("could not delete ServiceOffers in %s: %v — clean up with `obol sell delete <offer> -n %s`", ns, err, ns)
+		}
+
+		// Drop the resume-ledger entries for those offers. Scoped to the
+		// cluster-reachable branch on purpose: when the cluster is
+		// unreachable the CRs survive, and the ledger must keep covering
+		// them.
+		if removed, err := removePersistedServiceOffersInNamespace(cfg, ns); err != nil {
+			u.Warnf("could not clean persisted sell offers for %s: %v", ns, err)
+		} else if removed > 0 {
+			u.Dim(fmt.Sprintf("Removed %d persisted sell offer manifest(s) for %s", removed, ns))
+		}
 	} else {
 		u.Dim("Cluster unreachable; skipping CR deletion (host-side files only)")
 	}
@@ -979,17 +1000,6 @@ func deleteCRDAgent(cfg *config.Config, name string, force bool, u *ui.UI) error
 			return fmt.Errorf("remove host data dir %s: %w", root, err)
 		}
 		u.Dim("Removed host data dir " + root)
-	}
-
-	// Drop any persisted ServiceOffer manifests for this agent's
-	// namespace (offers created by `obol sell agent` / the demo flow).
-	// The CRs died with the namespace above; without this, every later
-	// `obol sell resume` / `obol stack up` replays an offer pointing at
-	// a deleted agent and warns forever.
-	if removed, err := removePersistedServiceOffersInNamespace(cfg, ns); err != nil {
-		u.Warnf("could not clean persisted sell offers for %s: %v", ns, err)
-	} else if removed > 0 {
-		u.Dim(fmt.Sprintf("Removed %d persisted sell offer manifest(s) for %s", removed, ns))
 	}
 	return nil
 }

--- a/cmd/obol/agent.go
+++ b/cmd/obol/agent.go
@@ -980,6 +980,17 @@ func deleteCRDAgent(cfg *config.Config, name string, force bool, u *ui.UI) error
 		}
 		u.Dim("Removed host data dir " + root)
 	}
+
+	// Drop any persisted ServiceOffer manifests for this agent's
+	// namespace (offers created by `obol sell agent` / the demo flow).
+	// The CRs died with the namespace above; without this, every later
+	// `obol sell resume` / `obol stack up` replays an offer pointing at
+	// a deleted agent and warns forever.
+	if removed, err := removePersistedServiceOffersInNamespace(cfg, ns); err != nil {
+		u.Warnf("could not clean persisted sell offers for %s: %v", ns, err)
+	} else if removed > 0 {
+		u.Dim(fmt.Sprintf("Removed %d persisted sell offer manifest(s) for %s", removed, ns))
+	}
 	return nil
 }
 

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -813,7 +813,7 @@ Examples:
 				if err := kubectlApply(cfg, manifest); err != nil {
 					return err
 				}
-				if persistErr := persistSellHTTPOffer(cfg, ns, name, manifest); persistErr != nil {
+				if persistErr := persistServiceOffer(cfg, ns, name, manifest); persistErr != nil {
 					u.Warnf("could not persist offer for stack-up resume: %v", persistErr)
 				}
 				u.Successf("ServiceOffer %s/%s created from JSON", ns, name)
@@ -989,7 +989,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			if persistErr := persistSellHTTPOffer(cfg, ns, name, manifest); persistErr != nil {
+			if persistErr := persistServiceOffer(cfg, ns, name, manifest); persistErr != nil {
 				u.Warnf("could not persist offer for stack-up resume: %v", persistErr)
 			}
 			action := "created"
@@ -1667,6 +1667,25 @@ Example:
 			applyOut, err := kubectlApplyOutput(cfg, soManifest)
 			if err != nil {
 				return fmt.Errorf("apply ServiceOffer: %w", err)
+			}
+			// Persist the whole demo bundle (namespace + backend Deployment
+			// + Service + ServiceOffer) as one v1 List so `obol sell
+			// resume` restores a working demo, not an offer with a missing
+			// upstream. kubectl applies List manifests natively; the List
+			// metadata only keys the ledger file.
+			items := make([]any, 0, 4)
+			for _, res := range buildDemoResources(name, spec, chain) {
+				items = append(items, res)
+			}
+			items = append(items, soManifest)
+			bundle := map[string]any{
+				"apiVersion": "v1",
+				"kind":       "List",
+				"metadata":   map[string]any{"name": name, "namespace": demoNamespace},
+				"items":      items,
+			}
+			if persistErr := persistServiceOffer(cfg, demoNamespace, name, bundle); persistErr != nil {
+				u.Warnf("could not persist demo offer for resume: %v", persistErr)
 			}
 			action := "created"
 			if strings.Contains(applyOut, "configured") || strings.Contains(applyOut, "unchanged") {
@@ -2703,6 +2722,15 @@ Examples:
 				return fmt.Errorf("failed to patch serviceoffer: %w", err)
 			}
 
+			// Refresh the resume ledger from the live (post-patch) object.
+			// Without this, the persisted manifest keeps the OLD payment
+			// terms and the next `obol sell resume` / `obol stack up`
+			// kubectl-applies them back — silently reverting a payTo or
+			// price change the operator made on purpose.
+			if err := refreshPersistedServiceOffer(cfg, ns, name); err != nil {
+				u.Warnf("could not refresh persisted offer for resume: %v", err)
+			}
+
 			u.Successf("ServiceOffer %s/%s updated", ns, name)
 			u.Info("The controller will reconcile the new payment config.")
 			u.Infof("Check status: obol sell status %s -n %s", name, ns)
@@ -2775,7 +2803,7 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 			// either, by design (the descriptor is what `obol sell
 			// inference list/status` reads). For HTTP we keep no such
 			// post-delete state, so removing the file is the right shape.
-			if removeErr := removeSellHTTPOffer(cfg, ns, name); removeErr != nil {
+			if removeErr := removePersistedServiceOffer(cfg, ns, name); removeErr != nil {
 				u.Warnf("could not remove persisted sell-http offer at %s/%s: %v", ns, name, removeErr)
 			}
 
@@ -3753,8 +3781,10 @@ func sellResumeCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:  "resume",
 		Usage: "Re-apply persisted sell offers and relaunch host gateways (run after a host reboot)",
-		Description: `Replays every locally-persisted sell offer against the cluster and
-relaunches the detached host gateway for each sell-inference offer.
+		Description: `Replays every locally-persisted sell offer against the cluster —
+all ServiceOffer types: inference (re-applies cluster artifacts AND
+relaunches the detached host gateway), http, agent, and demo-created
+agent offers — so one command brings the whole catalog back.
 
 After a host reboot, Docker's restart policy brings the k3d cluster back
 automatically — but the host-side x402 gateways started by
@@ -3765,7 +3795,12 @@ offers survive in etcd with UpstreamHealthy=False, so the public catalog
 'obol stack up' already runs this resume path; this command exposes it
 directly so a reboot does not require a full stack-up to recover.
 
-Idempotent: offers whose gateway is still running are skipped.
+Idempotent: offers whose gateway is still running are skipped, and the
+kubectl applies re-assert existing objects. A replayed agent offer needs
+its Agent CR: still present after a reboot, but after a full stack
+recreation the offer waits (controller reports the missing agent) until
+'obol agent new' recreates it. 'sell mcp' servers are foreground
+processes with no ServiceOffer and are not resumed.
 
 Examples:
   obol sell resume                      Resume all persisted offers now
@@ -3945,53 +3980,51 @@ func installResumeBootUnit(cfg *config.Config, u *ui.UI) error {
 // Best-effort. Per-offer failures emit a warning and the loop continues,
 // so one broken descriptor cannot block stack-up.
 func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
+	_ = ctx // reserved for cancellation support; current resume calls are synchronous and short
+
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
-		// No cluster — nothing to reattach for either inference or http.
+		// No cluster — nothing to reattach.
 		return nil
 	}
 
+	// 1. Inference offers: the only type with a host-side process. Each
+	//    descriptor re-applies its cluster artifacts AND relaunches the
+	//    detached x402 gateway.
 	store := inference.NewStore(cfg.ConfigDir)
 	deployments, err := store.List()
 	if err != nil {
 		return fmt.Errorf("list inference deployments: %w", err)
 	}
 
-	if len(deployments) == 0 {
-		// No inference offers; fall through to http resume below.
-		if err := resumeSellHTTPOffers(cfg, u); err != nil {
-			u.Warnf("resume sell-http offers: %v", err)
+	if len(deployments) > 0 {
+		u.Blank()
+		u.Infof("Resuming %d locally-persisted sell-inference offer(s)...", len(deployments))
+
+		var resumed int
+		for _, d := range deployments {
+			if err := resumeOneInferenceOffer(cfg, u, d); err != nil {
+				u.Warnf("resume %s: %v", d.Name, err)
+				continue
+			}
+			resumed++
+			u.Successf("Resumed sell-inference offer %q", d.Name)
 		}
-		return nil
-	}
 
-	u.Blank()
-	u.Infof("Resuming %d locally-persisted sell-inference offer(s)...", len(deployments))
-
-	var resumed int
-	for _, d := range deployments {
-		if err := resumeOneInferenceOffer(cfg, u, d); err != nil {
-			u.Warnf("resume %s: %v", d.Name, err)
-			continue
+		if resumed > 0 {
+			u.Dim("  Gateways spawned as detached background processes — check <state>/sell-inference/<name>/gateway.log for output.")
 		}
-		resumed++
-		u.Successf("Resumed sell-inference offer %q", d.Name)
 	}
 
-	if resumed > 0 {
-		u.Dim("  Gateways spawned as detached background processes — check <state>/sell-inference/<name>/gateway.log for output.")
+	// 2. Every other offer type (http, agent, demo-agent): pure manifest
+	//    replay from the shared ledger — no host process to relaunch.
+	//    The two stores stay separate on disk because the inference
+	//    descriptor is rich (listen addr, asset, registration, gateway
+	//    PID) while the ledger holds only rendered ServiceOffer manifests.
+	if err := resumePersistedServiceOffers(cfg, u); err != nil {
+		u.Warnf("resume persisted sell offers: %v", err)
 	}
 
-	// Replay persisted `obol sell http` offers as well. The two stores are
-	// independent on disk (sell-http manifests live at
-	// <ConfigDir>/sell-http/, sell-inference descriptors at
-	// <ConfigDir>/inference/) but the operator wants one stack-up to
-	// bring every paid offer back regardless of type.
-	if err := resumeSellHTTPOffers(cfg, u); err != nil {
-		u.Warnf("resume sell-http offers: %v", err)
-	}
-
-	_ = ctx // reserved for cancellation support; current resume calls are synchronous and short
 	return nil
 }
 
@@ -4445,31 +4478,29 @@ func buildInferenceServiceOfferSpec(d *inference.Deployment, pt schemas.PriceTab
 	return spec, nil
 }
 
-// sellHTTPStoreDir returns the on-disk root for persisted `obol sell http`
-// ServiceOffer manifests. Schema is one YAML file per offer at
+// sellOfferStoreDir returns the on-disk ledger of persisted ServiceOffer
+// manifests — one YAML file per offer at
 // <ConfigDir>/sell-http/<namespace>__<name>.yaml so two offers with the
-// same name in different namespaces never collide.
+// same name in different namespaces never collide. (The dir name is
+// historical: it predates the ledger covering more than `sell http`.
+// Renaming it would orphan offers persisted by already-shipped CLIs.)
 //
-// Unlike `obol sell inference`, http offers don't have a host-side
-// foreground process to track — the upstream is an in-cluster Service.
-// The on-disk artifact is just the rendered ServiceOffer manifest; the
-// resume path kubectl-applies it to bring the offer back identically.
-//
-// Long-term we should fold this into a single sell-offer store (one
-// schema for both inference and http), so resume is one walk instead of
-// two. Keeping them separate for now because the inference store is
-// rich (host listen addr, asset symbol, registration block) while http
-// only needs the rendered manifest — collapsing them would force
-// inference-only fields onto every http descriptor.
-func sellHTTPStoreDir(cfg *config.Config) string {
+// EVERY offer type without a host-side process persists here: `sell
+// http`, `sell agent`, and the demo agent flow. The on-disk artifact is
+// just the rendered ServiceOffer manifest; the resume path
+// kubectl-applies it to bring the offer back identically. `sell
+// inference` keeps its own richer store (<ConfigDir>/inference/) because
+// it additionally tracks the host gateway (listen addr, asset terms,
+// registration, PID).
+func sellOfferStoreDir(cfg *config.Config) string {
 	return filepath.Join(cfg.ConfigDir, "sell-http")
 }
 
-func sellHTTPStorePath(cfg *config.Config, namespace, name string) string {
-	return filepath.Join(sellHTTPStoreDir(cfg), namespace+"__"+name+".yaml")
+func sellOfferStorePath(cfg *config.Config, namespace, name string) string {
+	return filepath.Join(sellOfferStoreDir(cfg), namespace+"__"+name+".yaml")
 }
 
-// persistSellHTTPOffer writes the rendered ServiceOffer manifest to disk
+// persistServiceOffer writes the rendered ServiceOffer manifest to disk
 // so `obol stack up` can replay it after a stack-down/up cycle wipes
 // etcd. Idempotent: subsequent calls overwrite atomically (write to a
 // `.tmp` sibling, rename into place) so a crash mid-write doesn't leave
@@ -4479,18 +4510,18 @@ func sellHTTPStorePath(cfg *config.Config, namespace, name string) string {
 // should warn but not abort the sell command, because the cluster-side
 // offer is already in place. Returning an error lets the caller pick
 // the surface.
-func persistSellHTTPOffer(cfg *config.Config, namespace, name string, manifest map[string]any) error {
+func persistServiceOffer(cfg *config.Config, namespace, name string, manifest map[string]any) error {
 	if cfg == nil || namespace == "" || name == "" {
-		return errors.New("persistSellHTTPOffer: missing cfg / namespace / name")
+		return errors.New("persistServiceOffer: missing cfg / namespace / name")
 	}
-	if err := os.MkdirAll(sellHTTPStoreDir(cfg), 0o755); err != nil {
+	if err := os.MkdirAll(sellOfferStoreDir(cfg), 0o755); err != nil {
 		return fmt.Errorf("create store dir: %w", err)
 	}
 	data, err := yaml.Marshal(manifest)
 	if err != nil {
 		return fmt.Errorf("marshal manifest: %w", err)
 	}
-	final := sellHTTPStorePath(cfg, namespace, name)
+	final := sellOfferStorePath(cfg, namespace, name)
 	tmp := final + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)
@@ -4502,52 +4533,160 @@ func persistSellHTTPOffer(cfg *config.Config, namespace, name string, manifest m
 	return nil
 }
 
-// removeSellHTTPOffer deletes the on-disk manifest for a single offer
+// removePersistedServiceOffer deletes the on-disk manifest for a single offer
 // when `obol sell delete` succeeds. Without this, the resume path on
 // the next `obol stack up` would re-create an offer the operator
 // intentionally deleted. Best-effort — a missing file is a no-op.
-func removeSellHTTPOffer(cfg *config.Config, namespace, name string) error {
+func removePersistedServiceOffer(cfg *config.Config, namespace, name string) error {
 	if cfg == nil || namespace == "" || name == "" {
 		return nil
 	}
-	path := sellHTTPStorePath(cfg, namespace, name)
+	path := sellOfferStorePath(cfg, namespace, name)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
 }
 
-// resumeSellHTTPOffers re-applies every persisted `obol sell http`
-// manifest after `obol stack up` rebuilds the cluster. Mirror of the
+// refreshPersistedServiceOffer re-renders the ledger entry for one offer
+// from the live cluster object, after an in-place mutation (`obol sell
+// update`). Reads the CR, strips server-managed fields down to
+// apiVersion/kind/metadata(name, namespace, labels)/spec, and overwrites
+// the persisted manifest. When the existing ledger file is a demo v1
+// List bundle, only the inner ServiceOffer item is replaced so the
+// backend manifests survive.
+//
+// Also ADOPTS offers that were never persisted (e.g. created by an
+// agent via raw kubectl): an explicit `sell update` is operator intent,
+// so the offer earns resume coverage from then on.
+func refreshPersistedServiceOffer(cfg *config.Config, ns, name string) error {
+	out, err := kubectlOutput(cfg, "get", "serviceoffers.obol.org", name, "-n", ns, "-o", "yaml")
+	if err != nil {
+		return fmt.Errorf("read live offer: %w", err)
+	}
+	var live map[string]any
+	if err := yaml.Unmarshal([]byte(out), &live); err != nil {
+		return fmt.Errorf("parse live offer: %w", err)
+	}
+	spec, ok := live["spec"].(map[string]any)
+	if !ok {
+		return errors.New("live offer has no spec")
+	}
+	metadata := map[string]any{"name": name, "namespace": ns}
+	if md, ok := live["metadata"].(map[string]any); ok {
+		if labels, ok := md["labels"].(map[string]any); ok && len(labels) > 0 {
+			metadata["labels"] = labels
+		}
+	}
+	fresh := map[string]any{
+		"apiVersion": "obol.org/v1alpha1",
+		"kind":       "ServiceOffer",
+		"metadata":   metadata,
+		"spec":       spec,
+	}
+
+	// Demo bundles persist as a v1 List; swap the inner offer in place.
+	if data, err := os.ReadFile(sellOfferStorePath(cfg, ns, name)); err == nil {
+		var existing map[string]any
+		if yaml.Unmarshal(data, &existing) == nil && existing["kind"] == "List" {
+			items, _ := existing["items"].([]any)
+			for i, it := range items {
+				m, ok := it.(map[string]any)
+				if ok && m["kind"] == "ServiceOffer" {
+					items[i] = fresh
+				}
+			}
+			existing["items"] = items
+			return persistServiceOffer(cfg, ns, name, existing)
+		}
+	}
+
+	return persistServiceOffer(cfg, ns, name, fresh)
+}
+
+// removePersistedServiceOffersInNamespace drops every ledger manifest
+// whose metadata.namespace matches ns. Used by `obol agent delete`: the
+// namespace deletion takes the agent's ServiceOffers with it, so their
+// persisted manifests must go too or resume replays ghosts. Returns the
+// number of files removed.
+func removePersistedServiceOffersInNamespace(cfg *config.Config, ns string) (int, error) {
+	if cfg == nil || ns == "" {
+		return 0, nil
+	}
+	manifests, err := loadPersistedServiceOffers(sellOfferStoreDir(cfg), ui.New(false))
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, m := range manifests {
+		if m.Namespace != ns {
+			continue
+		}
+		if err := os.Remove(m.Path); err != nil && !os.IsNotExist(err) {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// resumePersistedServiceOffers re-applies every ServiceOffer manifest in
+// the ledger (http, agent, demo-agent — every type without a host-side
+// process) after a reboot or a stack-down/up cycle. Mirror of the
 // inference resume loop: walk the store dir, kubectl apply each file,
 // warn-and-continue on per-offer failures so one corrupt YAML can't
 // block the rest.
+//
+// A replayed type=agent offer needs its Agent CR to exist before it can
+// reach Ready. After a reboot the CR is still in etcd; after a full
+// stack recreation the controller reports the missing agent on the
+// offer's conditions until the operator recreates it (`obol agent new`).
 //
 // Skipped silently when the store dir is missing (no offers ever
 // persisted) or when no kubeconfig is present (stack up hasn't reached
 // the cluster yet). Counts and announces what was reattached so the
 // operator sees the same "Resumed N offers" feedback they get for
 // inference.
-func resumeSellHTTPOffers(cfg *config.Config, u *ui.UI) error {
-	dir := sellHTTPStoreDir(cfg)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read store dir: %w", err)
-	}
-	if len(entries) == 0 {
-		return nil
-	}
-
+func resumePersistedServiceOffers(cfg *config.Config, u *ui.UI) error {
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 	if _, statErr := os.Stat(kubeconfigPath); statErr != nil {
 		return nil // no cluster yet
 	}
 
+	manifests, err := loadPersistedServiceOffers(sellOfferStoreDir(cfg), u)
+	if err != nil {
+		return err
+	}
+	if len(manifests) == 0 {
+		return nil
+	}
+
 	u.Blank()
-	var manifests []sellHTTPStoredOffer
+	u.Infof("Resuming %d locally-persisted sell offer(s)...", len(manifests))
+	for _, m := range manifests {
+		if err := kubectlApply(cfg, m.Manifest); err != nil {
+			u.Warnf("resume %s %s/%s: %v", m.label(), m.Namespace, m.Name, err)
+			continue
+		}
+		u.Successf("Resumed %s offer %s/%s", m.label(), m.Namespace, m.Name)
+	}
+	return nil
+}
+
+// loadPersistedServiceOffers walks a ledger dir and parses every
+// *.yaml manifest in it. Unreadable or malformed files warn and are
+// skipped — the resume loop must survive one corrupt entry. A missing
+// dir means no offers were ever persisted and returns an empty slice.
+func loadPersistedServiceOffers(dir string, u *ui.UI) ([]persistedServiceOffer, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read store dir: %w", err)
+	}
+
+	var manifests []persistedServiceOffer
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
@@ -4564,28 +4703,37 @@ func resumeSellHTTPOffers(cfg *config.Config, u *ui.UI) error {
 			continue
 		}
 		ns, name := manifestNSName(manifest)
-		manifests = append(manifests, sellHTTPStoredOffer{Path: path, Manifest: manifest, Namespace: ns, Name: name})
-	}
-	if len(manifests) == 0 {
-		return nil
-	}
-
-	u.Infof("Resuming %d locally-persisted sell-http offer(s)...", len(manifests))
-	for _, m := range manifests {
-		if err := kubectlApply(cfg, m.Manifest); err != nil {
-			u.Warnf("resume http %s/%s: %v", m.Namespace, m.Name, err)
+		if ns == "" || name == "" {
+			u.Warnf("skip %s: manifest has no metadata.namespace/name", path)
 			continue
 		}
-		u.Successf("Resumed sell-http offer %s/%s", m.Namespace, m.Name)
+		manifests = append(manifests, persistedServiceOffer{
+			Path:      path,
+			Manifest:  manifest,
+			Namespace: ns,
+			Name:      name,
+			Type:      manifestOfferType(manifest),
+		})
 	}
-	return nil
+	return manifests, nil
 }
 
-type sellHTTPStoredOffer struct {
+type persistedServiceOffer struct {
 	Path      string
 	Manifest  map[string]any
 	Namespace string
 	Name      string
+	Type      string // spec.type (http, agent, inference, ...); empty when absent
+}
+
+// label renders the offer for resume messaging: "sell-agent" /
+// "sell-http" / plain "sell" when the manifest carries no spec.type
+// (legacy files persisted before the type was recorded).
+func (m persistedServiceOffer) label() string {
+	if m.Type == "" {
+		return "sell"
+	}
+	return "sell-" + m.Type
 }
 
 // manifestNSName pulls metadata.namespace + metadata.name out of an
@@ -4599,4 +4747,28 @@ func manifestNSName(manifest map[string]any) (string, string) {
 	ns, _ := md["namespace"].(string)
 	name, _ := md["name"].(string)
 	return ns, name
+}
+
+// manifestOfferType pulls spec.type out of an unmarshaled ServiceOffer
+// manifest; empty string when absent or malformed. For v1 List bundles
+// (the legacy demo persists backend + offer together) it reports the
+// inner ServiceOffer's type.
+func manifestOfferType(manifest map[string]any) string {
+	if manifest["kind"] == "List" {
+		items, _ := manifest["items"].([]any)
+		for _, it := range items {
+			m, ok := it.(map[string]any)
+			if !ok || m["kind"] != "ServiceOffer" {
+				continue
+			}
+			return manifestOfferType(m)
+		}
+		return ""
+	}
+	spec, ok := manifest["spec"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	t, _ := spec["type"].(string)
+	return t
 }

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3845,6 +3845,14 @@ const resumeBootUnitName = "obol-sell-resume.service"
 // itself has no cluster dependency, and resumeSellOffers warns-and-
 // continues per offer, so a still-starting cluster degrades gracefully
 // rather than failing the unit.
+//
+// RemainAfterExit=yes is load-bearing: the relaunched gateway is
+// spawned into the unit's cgroup (setsid detaches the session, NOT the
+// cgroup), and when a plain oneshot unit deactivates systemd kills
+// every process left in the cgroup — observed on the live reboot test
+// as "unit finished OK, gateway dead, log empty". Keeping the unit
+// active (exited) preserves the cgroup and the gateway with it; as a
+// bonus, `systemctl --user stop` becomes a deliberate gateway kill.
 func renderResumeBootUnit(obolBin, configDir string) string {
 	return `[Unit]
 Description=Obol sell offer resume (relaunch x402 gateways after boot)
@@ -3853,6 +3861,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStartPre=/bin/sleep 30
 Environment=OBOL_CONFIG_DIR=` + configDir + `
 ExecStart=` + obolBin + ` sell resume

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -2617,6 +2617,17 @@ Flags:
 				return fmt.Errorf("failed to drain serviceoffer: %w", err)
 			}
 
+			// Refresh the resume ledger so an etcd-wiping stack-down/up
+			// replays the offer in its drained state (an elapsed drainAt
+			// reconciles straight to torn-down) instead of resurrecting a
+			// deliberately stopped offer fully live. Reboot-resume was
+			// already safe — client-side apply leaves drainAt alone because
+			// it never owned the field — but the ledger replay IS the
+			// last-applied state after a recreation.
+			if err := refreshPersistedServiceOffer(cfg, ns, name); err != nil {
+				u.Warnf("could not refresh persisted offer for resume: %v", err)
+			}
+
 			if grace == 0 {
 				u.Successf("ServiceOffer %s/%s draining; route will be removed on the next reconcile (--force).", ns, name)
 			} else {
@@ -2796,15 +2807,35 @@ func sellDeleteCommand(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			// Drop the on-disk sell-http manifest so the next `obol stack
-			// up` doesn't replay an offer the operator just deleted. The
-			// inference path doesn't need this hook — `obol sell delete`
-			// doesn't currently remove the inference.Store descriptor
-			// either, by design (the descriptor is what `obol sell
-			// inference list/status` reads). For HTTP we keep no such
-			// post-delete state, so removing the file is the right shape.
+			// Drop the offer's manifest from the resume ledger so the next
+			// `obol stack up` / `obol sell resume` doesn't replay an offer
+			// the operator just deleted. Covers every ledger-persisted type
+			// (http, agent, demo bundles).
 			if removeErr := removePersistedServiceOffer(cfg, ns, name); removeErr != nil {
-				u.Warnf("could not remove persisted sell-http offer at %s/%s: %v", ns, name, removeErr)
+				u.Warnf("could not remove persisted sell offer manifest at %s/%s: %v", ns, name, removeErr)
+			}
+
+			// Tombstone the inference descriptor when this was a
+			// sell-inference offer: the descriptor is kept on disk for
+			// `sell inference list/status` history, but without a marker
+			// the resume loop would rebuild the offer and relaunch its
+			// host gateway — undoing the delete. Re-running
+			// `obol sell inference <name>` rewrites the descriptor and
+			// clears the tombstone. Namespace-guarded so deleting an
+			// unrelated same-name offer elsewhere can't tombstone it.
+			if store := inference.NewStore(cfg.ConfigDir); store != nil {
+				if d, getErr := store.Get(name); getErr == nil && d != nil && d.DeletedAt == "" {
+					dNS := d.ServiceNamespace
+					if dNS == "" {
+						dNS = "llm"
+					}
+					if dNS == ns {
+						d.DeletedAt = time.Now().UTC().Format(time.RFC3339)
+						if updErr := store.Update(d); updErr != nil {
+							u.Warnf("could not tombstone inference descriptor for %s: %v", name, updErr)
+						}
+					}
+				}
 			}
 
 			// Clean up demo backend resources if this is a demo service.
@@ -3990,12 +4021,15 @@ func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
 
 	// 1. Inference offers: the only type with a host-side process. Each
 	//    descriptor re-applies its cluster artifacts AND relaunches the
-	//    detached x402 gateway.
+	//    detached x402 gateway. Tombstoned descriptors (offer deleted via
+	//    `obol sell delete`; kept on disk for list/status history) are
+	//    excluded — replaying one would undo the delete.
 	store := inference.NewStore(cfg.ConfigDir)
-	deployments, err := store.List()
+	all, err := store.List()
 	if err != nil {
 		return fmt.Errorf("list inference deployments: %w", err)
 	}
+	deployments := activeInferenceDeployments(all)
 
 	if len(deployments) > 0 {
 		u.Blank()
@@ -4026,6 +4060,20 @@ func resumeSellOffers(ctx context.Context, cfg *config.Config, u *ui.UI) error {
 	}
 
 	return nil
+}
+
+// activeInferenceDeployments filters out tombstoned descriptors —
+// offers removed by `obol sell delete` whose on-disk state survives for
+// `sell inference list/status`. Pure so the resume exclusion is
+// testable on its own.
+func activeInferenceDeployments(ds []*inference.Deployment) []*inference.Deployment {
+	var active []*inference.Deployment
+	for _, d := range ds {
+		if d != nil && d.DeletedAt == "" {
+			active = append(active, d)
+		}
+	}
+	return active
 }
 
 // resumeOneInferenceOffer re-creates the cluster-side artifacts that
@@ -4605,10 +4653,11 @@ func refreshPersistedServiceOffer(cfg *config.Config, ns, name string) error {
 }
 
 // removePersistedServiceOffersInNamespace drops every ledger manifest
-// whose metadata.namespace matches ns. Used by `obol agent delete`: the
-// namespace deletion takes the agent's ServiceOffers with it, so their
-// persisted manifests must go too or resume replays ghosts. Returns the
-// number of files removed.
+// whose metadata.namespace matches ns. Used by `obol agent delete`
+// alongside its in-cluster ServiceOffer deletion (the agent finalizer
+// tears down the agent's children but leaves the namespace and offers):
+// once the CRs are deleted there, the ledger entries must go too or
+// resume replays ghosts. Returns the number of files removed.
 func removePersistedServiceOffersInNamespace(cfg *config.Config, ns string) (int, error) {
 	if cfg == nil || ns == "" {
 		return 0, nil
@@ -4639,8 +4688,11 @@ func removePersistedServiceOffersInNamespace(cfg *config.Config, ns string) (int
 //
 // A replayed type=agent offer needs its Agent CR to exist before it can
 // reach Ready. After a reboot the CR is still in etcd; after a full
-// stack recreation the controller reports the missing agent on the
-// offer's conditions until the operator recreates it (`obol agent new`).
+// stack recreation the replayed bundle re-creates the agent NAMESPACE
+// (see agentOfferBundle) so the offer lands and the controller reports
+// the missing agent on its conditions until the operator recreates it
+// (`obol agent new`). The Agent CR itself is never replayed — that
+// would mint a fresh wallet.
 //
 // Skipped silently when the store dir is missing (no offers ever
 // persisted) or when no kubeconfig is present (stack up hasn't reached

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3778,6 +3778,14 @@ Examples:
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
+			// At boot the k3d API server lags Docker by a minute or
+			// more, and resumeOneInferenceOffer's kubectl applies run
+			// BEFORE the gateway relaunch and warn-and-continue on
+			// failure — without this wait a too-early resume silently
+			// resumes nothing and nothing retries.
+			if err := waitForClusterAPI(ctx, cfg, u, 3*time.Minute); err != nil {
+				u.Warnf("cluster API not ready: %v (continuing — per-offer applies may fail)", err)
+			}
 			if err := resumeSellOffers(ctx, cfg, u); err != nil {
 				return err
 			}
@@ -3786,6 +3794,41 @@ Examples:
 			}
 			return nil
 		},
+	}
+}
+
+// waitForClusterAPI blocks until the cluster API server answers a
+// /readyz probe, or the timeout elapses. A missing kubeconfig returns
+// nil immediately — no cluster means nothing to wait for and the resume
+// loop already degrades gracefully. Used by `obol sell resume` because
+// its main caller is a boot unit racing the k3d node container's
+// startup; `obol stack up` doesn't need it (cluster creation blocks).
+func waitForClusterAPI(ctx context.Context, cfg *config.Config, u *ui.UI, timeout time.Duration) error {
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+	if _, err := os.Stat(kubeconfigPath); err != nil {
+		return nil
+	}
+	bin, kc := kubectl.Paths(cfg)
+	deadline := time.Now().Add(timeout)
+	waited := false
+	for {
+		if _, err := kubectl.Output(bin, kc, "get", "--raw=/readyz"); err == nil {
+			if waited {
+				u.Dim("  Cluster API ready.")
+			}
+			return nil
+		} else if time.Now().After(deadline) {
+			return fmt.Errorf("cluster API not ready within %s: %w", timeout, err)
+		}
+		if !waited {
+			u.Dim("  Waiting for cluster API (boot race: k3d needs a moment after Docker starts)...")
+			waited = true
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
 	}
 }
 
@@ -3833,13 +3876,13 @@ func installResumeBootUnit(cfg *config.Config, u *ui.UI) error {
 		return fmt.Errorf("--install-boot-unit requires Linux with systemd (detected %s); run `obol sell resume` manually after reboot instead", runtime.GOOS)
 	}
 
-	obolBin := filepath.Join(cfg.BinDir, "obol")
-	if _, err := os.Stat(obolBin); err != nil {
-		exe, exeErr := os.Executable()
-		if exeErr != nil {
-			return fmt.Errorf("locate obol binary: %w", exeErr)
-		}
-		obolBin = exe
+	// Pin the binary running THIS command into ExecStart — the operator
+	// just proved it has `sell resume`. The installed BinDir copy may be
+	// an older release without the subcommand (rc11 on the live seller
+	// box), which would make the unit fail on every boot.
+	obolBin, err := resumeGatewayBinary(cfg)
+	if err != nil {
+		return err
 	}
 
 	home, err := os.UserHomeDir()
@@ -3855,6 +3898,7 @@ func installResumeBootUnit(cfg *config.Config, u *ui.UI) error {
 		return fmt.Errorf("write unit file: %w", err)
 	}
 	u.Successf("Installed boot unit %s", unitPath)
+	u.Dim("  Unit runs: " + obolBin + " sell resume — keep this binary at this path, or re-run --install-boot-unit after moving/upgrading it.")
 
 	for _, args := range [][]string{
 		{"--user", "daemon-reload"},

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -305,12 +305,12 @@ Examples:
 			// requests fall through to the buyer sidecar with a 404 (see
 			// CLAUDE.md and the obol-agent's recent buy report). Reject
 			// up-front and suggest a `--` separator that survives the route.
-			if strings.Contains(modelFlag, "/") {
-				return fmt.Errorf(
-					"--model %q contains '/', which breaks LiteLLM's `paid/*` wildcard on the buyer side; "+
-						"use `--` (or another non-slash separator) — e.g. `%s` instead of `%s`",
-					modelFlag, strings.ReplaceAll(modelFlag, "/", "--"), modelFlag,
-				)
+			// Resume replays of descriptors persisted before this rule
+			// existed are tolerated with a warning instead.
+			if warn, vErr := validateSellInferenceModelName(modelFlag, os.Getenv(resumeReplayEnv) == "1"); vErr != nil {
+				return vErr
+			} else if warn != "" {
+				u.Warnf("%s", warn)
 			}
 
 			teeType := cmd.String("tee")
@@ -4043,14 +4043,9 @@ func startDetachedInferenceGateway(cfg *config.Config, u *ui.UI, d *inference.De
 		return nil
 	}
 
-	obolBin := filepath.Join(cfg.BinDir, "obol")
-	if _, statErr := os.Stat(obolBin); statErr != nil {
-		// Fall back to whatever obol the parent process is running as.
-		exe, exeErr := os.Executable()
-		if exeErr != nil {
-			return fmt.Errorf("locate obol binary: %w", exeErr)
-		}
-		obolBin = exe
+	obolBin, err := resumeGatewayBinary(cfg)
+	if err != nil {
+		return err
 	}
 
 	args := buildResumeGatewayArgs(d)
@@ -4064,7 +4059,7 @@ func startDetachedInferenceGateway(cfg *config.Config, u *ui.UI, d *inference.De
 	cmd.Stdout = logF
 	cmd.Stderr = logF
 	cmd.SysProcAttr = detachedSysProcAttr()
-	cmd.Env = os.Environ()
+	cmd.Env = resumeGatewayEnviron()
 
 	if err := cmd.Start(); err != nil {
 		_ = logF.Close()
@@ -4085,6 +4080,62 @@ func startDetachedInferenceGateway(cfg *config.Config, u *ui.UI, d *inference.De
 	}
 	u.Successf("Gateway started in background (pid %d, log %s)", gatewayPID, logFile)
 	return nil
+}
+
+// resumeReplayEnv marks a spawned gateway process as a resume replay of
+// a previously-persisted offer. Validation that only exists to guard
+// *new* offer creation (e.g. the slash-in-model LiteLLM rule, added
+// after descriptors with slashed names were already on disk) downgrades
+// to a warning when this is set — tightening CLI validation must never
+// permanently strand an offer that was legal when it was created.
+const resumeReplayEnv = "OBOL_SELL_RESUME_REPLAY"
+
+// resumeGatewayEnviron is the environment for the relaunched gateway:
+// the parent's environment plus the resume-replay marker.
+func resumeGatewayEnviron() []string {
+	return append(os.Environ(), resumeReplayEnv+"=1")
+}
+
+// resumeGatewayBinary picks the obol binary used to relaunch a gateway.
+// It must be the binary running THIS process: buildResumeGatewayArgs
+// encodes the current version's flag surface, and handing those args to
+// a different (typically older, installed) obol re-parses them against
+// a different flag set. Live-debugged on the spark reboot test: the
+// installed rc11 predates the --description spelling and the relaunched
+// gateway died instantly with "flag provided but not defined". The
+// BinDir copy is only a fallback for the degenerate case where the
+// running executable's path cannot be resolved.
+func resumeGatewayBinary(cfg *config.Config) (string, error) {
+	if exe, err := os.Executable(); err == nil {
+		return exe, nil
+	}
+	obolBin := filepath.Join(cfg.BinDir, "obol")
+	if _, err := os.Stat(obolBin); err != nil {
+		return "", fmt.Errorf("locate obol binary: %w", err)
+	}
+	return obolBin, nil
+}
+
+// validateSellInferenceModelName enforces the no-slash model-name rule
+// for new offers, and relaxes it to a warning for resume replays of
+// descriptors that predate the rule. Returns a non-empty warning string
+// (for the caller to surface) when the name is tolerated on replay.
+func validateSellInferenceModelName(model string, resumeReplay bool) (string, error) {
+	if !strings.Contains(model, "/") {
+		return "", nil
+	}
+	suggestion := strings.ReplaceAll(model, "/", "--")
+	if resumeReplay {
+		return fmt.Sprintf(
+			"model %q contains '/' — tolerated because this is a resume replay of an existing offer, but LiteLLM `paid/*` buyers will see 404s; recreate the offer with a non-slash name (e.g. %q) when convenient",
+			model, suggestion,
+		), nil
+	}
+	return "", fmt.Errorf(
+		"--model %q contains '/', which breaks LiteLLM's `paid/*` wildcard on the buyer side; "+
+			"use `--` (or another non-slash separator) — e.g. `%s` instead of `%s`",
+		model, suggestion, model,
+	)
 }
 
 // buildResumeGatewayArgs reconstructs the `obol sell inference` flag set
@@ -4132,7 +4183,12 @@ func buildResumeGatewayArgs(d *inference.Deployment) []string {
 			args = append(args, "--register-name", v)
 		}
 		if v, _ := d.Registration["description"].(string); v != "" {
-			args = append(args, "--description", v)
+			// --register-description, not --description: it is the one
+			// spelling every released CLI parses (primary name through
+			// rc11, kept alias since the rc12 rename), so a replayed
+			// descriptor survives being parsed by an older installed
+			// binary on the BinDir fallback path.
+			args = append(args, "--register-description", v)
 		}
 		if v, _ := d.Registration["image"].(string); v != "" {
 			args = append(args, "--register-image", v)

--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -63,6 +63,7 @@ func sellCommand(cfg *config.Config) *cli.Command {
 			sellRegisterCommand(cfg),
 			sellIdentityCommand(cfg),
 			sellInfoCommand(cfg),
+			sellResumeCommand(cfg),
 		},
 	}
 }
@@ -3744,20 +3745,149 @@ func loadProvenance(path string) (*inference.Provenance, error) {
 //
 // Kubernetes Endpoints require an IP address, not a hostname. We resolve the
 // host IP using the same strategy as ollamaHostIPForBackend in internal/stack.
+// ---------------------------------------------------------------------------
+// sell resume — re-apply persisted offers + relaunch host gateways
+// ---------------------------------------------------------------------------
+
+func sellResumeCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "resume",
+		Usage: "Re-apply persisted sell offers and relaunch host gateways (run after a host reboot)",
+		Description: `Replays every locally-persisted sell offer against the cluster and
+relaunches the detached host gateway for each sell-inference offer.
+
+After a host reboot, Docker's restart policy brings the k3d cluster back
+automatically — but the host-side x402 gateways started by
+'obol sell inference' die with the host and nothing restarts them. The
+offers survive in etcd with UpstreamHealthy=False, so the public catalog
+(/api/services.json) goes empty even though the stack looks up.
+
+'obol stack up' already runs this resume path; this command exposes it
+directly so a reboot does not require a full stack-up to recover.
+
+Idempotent: offers whose gateway is still running are skipped.
+
+Examples:
+  obol sell resume                      Resume all persisted offers now
+  obol sell resume --install-boot-unit  Also run automatically at boot (Linux/systemd)`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "install-boot-unit",
+				Usage: "Install + enable a systemd user unit that runs 'obol sell resume' at boot (Linux only)",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			u := getUI(cmd)
+			if err := resumeSellOffers(ctx, cfg, u); err != nil {
+				return err
+			}
+			if cmd.Bool("install-boot-unit") {
+				return installResumeBootUnit(cfg, u)
+			}
+			return nil
+		},
+	}
+}
+
+// resumeBootUnitName is the systemd user unit installed by
+// `obol sell resume --install-boot-unit`.
+const resumeBootUnitName = "obol-sell-resume.service"
+
+// renderResumeBootUnit produces the systemd user unit that re-runs the
+// sell resume path at boot. Pure so tests can pin the contents.
+//
+// The unit sleeps before resuming: Docker restarts the k3d node
+// containers on boot, but the API server inside them needs a moment
+// before the resume path's kubectl applies succeed. The gateway relaunch
+// itself has no cluster dependency, and resumeSellOffers warns-and-
+// continues per offer, so a still-starting cluster degrades gracefully
+// rather than failing the unit.
+func renderResumeBootUnit(obolBin, configDir string) string {
+	return `[Unit]
+Description=Obol sell offer resume (relaunch x402 gateways after boot)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sleep 30
+Environment=OBOL_CONFIG_DIR=` + configDir + `
+ExecStart=` + obolBin + ` sell resume
+
+[Install]
+WantedBy=default.target
+`
+}
+
+// installResumeBootUnit writes and enables a systemd user unit so the
+// resume path runs automatically after a host reboot. Linux-only: the
+// host gateways this exists to relaunch run on headless Linux sellers;
+// macOS operators run `obol sell resume` manually (launchd support can
+// follow if asked for).
+//
+// systemctl calls are best-effort — the unit file on disk is the
+// durable artifact, and the printed hints cover the enable steps when
+// systemctl is unavailable (e.g. containers, exotic inits).
+func installResumeBootUnit(cfg *config.Config, u *ui.UI) error {
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("--install-boot-unit requires Linux with systemd (detected %s); run `obol sell resume` manually after reboot instead", runtime.GOOS)
+	}
+
+	obolBin := filepath.Join(cfg.BinDir, "obol")
+	if _, err := os.Stat(obolBin); err != nil {
+		exe, exeErr := os.Executable()
+		if exeErr != nil {
+			return fmt.Errorf("locate obol binary: %w", exeErr)
+		}
+		obolBin = exe
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		return fmt.Errorf("create systemd user dir: %w", err)
+	}
+	unitPath := filepath.Join(unitDir, resumeBootUnitName)
+	if err := os.WriteFile(unitPath, []byte(renderResumeBootUnit(obolBin, cfg.ConfigDir)), 0o644); err != nil {
+		return fmt.Errorf("write unit file: %w", err)
+	}
+	u.Successf("Installed boot unit %s", unitPath)
+
+	for _, args := range [][]string{
+		{"--user", "daemon-reload"},
+		{"--user", "enable", resumeBootUnitName},
+	} {
+		if out, cmdErr := exec.Command("systemctl", args...).CombinedOutput(); cmdErr != nil {
+			u.Warnf("systemctl %s failed: %v (%s)", strings.Join(args, " "), cmdErr, strings.TrimSpace(string(out)))
+			u.Dim("  Enable manually: systemctl --user daemon-reload && systemctl --user enable " + resumeBootUnitName)
+		}
+	}
+
+	u.Dim("  User units only run at boot when lingering is on — run once: loginctl enable-linger $USER")
+	return nil
+}
+
 // resumeSellOffers re-applies the cluster-side artifacts (Service +
 // Endpoints + ServiceOffer) for every locally-persisted `obol sell
-// inference` deployment after `obol stack up` brings a fresh cluster
-// online. Without this step the cluster has no record of operator-created
-// offers (CRs live in etcd, which is destroyed by `obol stack down`),
-// even though the host-side descriptors at
-// `<ConfigDir>/inference/<name>/` still exist.
+// inference` deployment, and relaunches each offer's host gateway as a
+// detached background process. Without this step the cluster has no
+// record of operator-created offers (CRs live in etcd, which is
+// destroyed by `obol stack down`), even though the host-side descriptors
+// at `<ConfigDir>/inference/<name>/` still exist.
 //
-// The foreground gateway is NOT restarted here — `obol sell inference`
-// is an interactive operator action and we don't want stack-up to launch
-// long-running processes. The operator re-runs `obol sell inference
-// <name>` after stack-up to bring the gateway back; this step ensures
-// the cluster side is already in place so the gateway hits a "service
-// healthy" reconcile instead of "create from scratch".
+// Two entrypoints share this path:
+//   - `obol stack up` (cmd/obol/main.go) — fresh-cluster case.
+//   - `obol sell resume` — host-reboot case. Docker's restart policy
+//     brings the k3d cluster back on boot WITHOUT a `stack up`, so the
+//     offers survive in etcd but the host gateway processes are gone and
+//     every sell-inference offer sits at UpstreamHealthy=False (empty
+//     /api/services.json catalog) until something relaunches them.
+//
+// Idempotent: gateway relaunch is skipped when a live PID is on disk and
+// the kubectl applies re-assert existing objects.
 //
 // Best-effort. Per-offer failures emit a warning and the loop continues,
 // so one broken descriptor cannot block stack-up.

--- a/cmd/obol/sell_agent.go
+++ b/cmd/obol/sell_agent.go
@@ -238,7 +238,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("apply ServiceOffer: %w", err)
 			}
-			if persistErr := persistServiceOffer(cfg, offerNs, name, manifest); persistErr != nil {
+			if persistErr := persistServiceOffer(cfg, offerNs, name, agentOfferBundle(offerNs, name, manifest)); persistErr != nil {
 				u.Warnf("could not persist offer for resume: %v", persistErr)
 			}
 			action := "created"
@@ -440,7 +440,7 @@ func runAgentBackedDemo(
 	if err != nil {
 		return fmt.Errorf("apply ServiceOffer: %w", err)
 	}
-	if persistErr := persistServiceOffer(cfg, offerNs, name, soManifest); persistErr != nil {
+	if persistErr := persistServiceOffer(cfg, offerNs, name, agentOfferBundle(offerNs, name, soManifest)); persistErr != nil {
 		u.Warnf("could not persist offer for resume: %v", persistErr)
 	}
 	action := "created"
@@ -636,4 +636,37 @@ func agentOfferRegistrationMetadata(agent *agentRefForSale, price, symbol, chain
 		metadata["model"] = strings.TrimSpace(agent.Model)
 	}
 	return metadata
+}
+
+// agentOfferBundle wraps an agent-typed ServiceOffer manifest together
+// with its namespace in a v1 List for the resume ledger. After a full
+// stack recreation the agent namespace is gone, and a bare offer
+// manifest would fail at apply with "namespaces not found" — bundling
+// the namespace lets the replay land and park the offer on the
+// controller's missing-agent condition until `obol agent new` recreates
+// the agent. The Agent CR itself is deliberately NOT bundled: replaying
+// it would mint a fresh wallet and orphan any funds held by the old
+// one. Labels match the canonical namespace creators (agent_crd.go /
+// the demo flow); kubectl ignores List metadata, which only keys the
+// ledger file.
+func agentOfferBundle(offerNs, name string, offer map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"metadata":   map[string]any{"name": name, "namespace": offerNs},
+		"items": []any{
+			map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]any{
+					"name": offerNs,
+					"labels": map[string]any{
+						"obol.org/agent-namespace":     "true",
+						"app.kubernetes.io/managed-by": "obol-cli",
+					},
+				},
+			},
+			offer,
+		},
+	}
 }

--- a/cmd/obol/sell_agent.go
+++ b/cmd/obol/sell_agent.go
@@ -238,6 +238,9 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("apply ServiceOffer: %w", err)
 			}
+			if persistErr := persistServiceOffer(cfg, offerNs, name, manifest); persistErr != nil {
+				u.Warnf("could not persist offer for resume: %v", persistErr)
+			}
 			action := "created"
 			if strings.Contains(out, "configured") || strings.Contains(out, "unchanged") {
 				action = "updated"
@@ -436,6 +439,9 @@ func runAgentBackedDemo(
 	applyOut, err := kubectlApplyOutput(cfg, soManifest)
 	if err != nil {
 		return fmt.Errorf("apply ServiceOffer: %w", err)
+	}
+	if persistErr := persistServiceOffer(cfg, offerNs, name, soManifest); persistErr != nil {
+		u.Warnf("could not persist offer for resume: %v", persistErr)
 	}
 	action := "created"
 	if strings.Contains(applyOut, "configured") || strings.Contains(applyOut, "unchanged") {

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1419,7 +1419,7 @@ func TestBuildResumeGatewayArgs(t *testing.T) {
 				"--per-mtok", "23",
 				"--facilitator", "https://x402.gcp.obol.tech",
 				"--register-name", "Qwen3.6-27B AEON Ultimate",
-				"--description", "Uncensored Qwen3.6-27B abliteration",
+				"--register-description", "Uncensored Qwen3.6-27B abliteration",
 				"--register-skills", "llm/inference",
 				"--register-skills", "llm/uncensored",
 				"--register-domains", "inference.v1337.org",
@@ -1427,6 +1427,9 @@ func TestBuildResumeGatewayArgs(t *testing.T) {
 			wantNoSub: []string{
 				"--price", // perMTok set, perRequest must not also be passed
 				"--no-register",
+				// the rc12+ spelling — replay must emit the spelling
+				// every released CLI parses (--register-description)
+				"--description",
 			},
 		},
 		{
@@ -1496,6 +1499,86 @@ func TestBuildResumeGatewayArgs(t *testing.T) {
 			}
 			if nameIdx < 0 || firstFlagIdx < 0 || nameIdx > firstFlagIdx {
 				t.Errorf("name positional must come before flags; got %v", joined)
+			}
+		})
+	}
+}
+
+// TestResumeGatewayBinaryPrefersRunningExecutable pins the binary-skew
+// fix from the spark2 reboot test: buildResumeGatewayArgs encodes the
+// running version's flag surface, so the relaunch must spawn the running
+// executable — even when an installed (possibly older) obol exists at
+// BinDir. Spawning the BinDir copy is how the live relaunch died with
+// "flag provided but not defined: -description" against rc11.
+func TestResumeGatewayBinaryPrefersRunningExecutable(t *testing.T) {
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "obol"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake installed obol: %v", err)
+	}
+	cfg := &config.Config{BinDir: binDir}
+
+	got, err := resumeGatewayBinary(cfg)
+	if err != nil {
+		t.Fatalf("resumeGatewayBinary: %v", err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if got != exe {
+		t.Errorf("resumeGatewayBinary = %q; want running executable %q (BinDir copy must not win)", got, exe)
+	}
+}
+
+// TestResumeGatewayEnviron pins the replay marker on the spawned gateway
+// environment. Without it, validation added after a descriptor was
+// persisted (the slash-in-model rule) rejects the replayed flags and the
+// offer can never resume — the second failure mode from the spark2
+// reboot test.
+func TestResumeGatewayEnviron(t *testing.T) {
+	want := resumeReplayEnv + "=1"
+	for _, kv := range resumeGatewayEnviron() {
+		if kv == want {
+			return
+		}
+	}
+	t.Errorf("resumeGatewayEnviron() missing %q", want)
+}
+
+// TestValidateSellInferenceModelName pins the two-mode behavior of the
+// slash-in-model rule: hard error for new offers, warning-only for
+// resume replays of descriptors that predate the rule.
+func TestValidateSellInferenceModelName(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		replay     bool
+		wantErr    bool
+		wantWarn   bool
+		wantInText string
+	}{
+		{"clean name, new offer", "aeon-ultimate", false, false, false, ""},
+		{"clean name, replay", "aeon-ultimate", true, false, false, ""},
+		{"slash, new offer rejected", "AEON-7/Qwen3.6", false, true, false, "AEON-7--Qwen3.6"},
+		{"slash, replay tolerated with warning", "AEON-7/Qwen3.6", true, false, true, "resume replay"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warn, err := validateSellInferenceModelName(tc.model, tc.replay)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v; wantErr = %v", err, tc.wantErr)
+			}
+			if (warn != "") != tc.wantWarn {
+				t.Fatalf("warn = %q; wantWarn = %v", warn, tc.wantWarn)
+			}
+			if tc.wantInText != "" {
+				combined := warn
+				if err != nil {
+					combined += err.Error()
+				}
+				if !strings.Contains(combined, tc.wantInText) {
+					t.Errorf("output %q missing %q", combined, tc.wantInText)
+				}
 			}
 		})
 	}

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -2154,12 +2154,20 @@ func TestRemovePersistedServiceOffersInNamespace(t *testing.T) {
 	if n, err := removePersistedServiceOffersInNamespace(cfg, ""); n != 0 || err != nil {
 		t.Errorf("empty ns: n=%d err=%v", n, err)
 	}
+	if n, err := removePersistedServiceOffersInNamespace(nil, "agent-quant"); n != 0 || err != nil {
+		t.Errorf("nil cfg: n=%d err=%v", n, err)
+	}
 }
 
 // TestDeleteCRDAgent_CleansPersistedOffers is the source-level guard
-// that `obol agent delete` removes the agent's persisted sell offers —
-// the namespace deletion already took the CRs, so a survivor ledger
-// file would make every later resume replay a ghost offer.
+// that `obol agent delete` (a) deletes the agent's ServiceOffer CRs
+// in-cluster — nothing else does: the agent finalizer leaves the
+// namespace and offers, and a surviving offer would reconcile back to
+// Ready (paying the DELETED agent's wallet) if the name is ever reused
+// — and (b) withdraws their ledger entries so resume doesn't replay
+// ghosts. The ledger sweep must live in the cluster-reachable branch:
+// when the cluster is unreachable the CRs survive and the ledger must
+// keep covering them.
 func TestDeleteCRDAgent_CleansPersistedOffers(t *testing.T) {
 	src, err := os.ReadFile("agent.go")
 	if err != nil {
@@ -2175,8 +2183,16 @@ func TestDeleteCRDAgent_CleansPersistedOffers(t *testing.T) {
 		t.Fatal("could not delimit deleteCRDAgent body")
 	}
 	scope := body[start : start+1+end]
+	if !strings.Contains(scope, `"delete", "serviceoffers.obol.org", "--all", "-n", ns`) {
+		t.Fatal("deleteCRDAgent must delete the namespace's ServiceOffer CRs — the agent finalizer doesn't, and survivors resurrect against a recreated agent")
+	}
 	if !strings.Contains(scope, "removePersistedServiceOffersInNamespace(") {
 		t.Fatal("deleteCRDAgent must call removePersistedServiceOffersInNamespace — otherwise resume replays offers for deleted agents forever")
+	}
+	unreachable := strings.Index(scope, "Cluster unreachable")
+	sweep := strings.Index(scope, "removePersistedServiceOffersInNamespace(")
+	if unreachable >= 0 && sweep > unreachable {
+		t.Fatal("ledger sweep must run in the cluster-reachable branch only — when the cluster is unreachable the CRs survive and the ledger must keep covering them")
 	}
 }
 
@@ -2264,5 +2280,113 @@ func TestSellUpdateCommand_RefreshesLedger(t *testing.T) {
 	scope := body[start : start+1+end]
 	if !strings.Contains(scope, "refreshPersistedServiceOffer(") {
 		t.Fatal("sellUpdateCommand must call refreshPersistedServiceOffer after the patch — else resume reverts updated payment terms")
+	}
+}
+
+// TestSellStopCommand_RefreshesLedger mirrors the sell-update guard for
+// the drain path: without a ledger refresh, an etcd-wiping
+// stack-down/up replays the pre-drain manifest and a deliberately
+// stopped offer comes back fully live.
+func TestSellStopCommand_RefreshesLedger(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellStopCommand(")
+	if start < 0 {
+		t.Fatal("sellStopCommand not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit sellStopCommand body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "refreshPersistedServiceOffer(") {
+		t.Fatal("sellStopCommand must refresh the ledger after the drain patch — else resume resurrects a stopped offer fully live")
+	}
+}
+
+// TestSellDeleteCommand_TombstonesInference is the source-level guard
+// for the inference half of delete⇒no-resume: the descriptor survives
+// for list/status history, so without a tombstone the resume loop
+// rebuilds the offer and relaunches the host gateway the operator just
+// deleted.
+func TestSellDeleteCommand_TombstonesInference(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellDeleteCommand(")
+	if start < 0 {
+		t.Fatal("sellDeleteCommand not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit sellDeleteCommand body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "DeletedAt") {
+		t.Fatal("sellDeleteCommand must tombstone the inference descriptor (DeletedAt) — else resume undoes the delete")
+	}
+}
+
+// TestActiveInferenceDeployments pins the resume-side tombstone filter.
+func TestActiveInferenceDeployments(t *testing.T) {
+	live := &inference.Deployment{Name: "live"}
+	dead := &inference.Deployment{Name: "dead", DeletedAt: "2026-06-10T00:00:00Z"}
+	got := activeInferenceDeployments([]*inference.Deployment{live, dead, nil})
+	if len(got) != 1 || got[0].Name != "live" {
+		t.Fatalf("activeInferenceDeployments = %v, want [live]", got)
+	}
+}
+
+// TestAgentOfferBundle_RoundTrip pins the agent persist shape: a v1
+// List carrying the agent NAMESPACE (so replay after stack recreation
+// can land at all) plus the offer — and explicitly NOT an Agent CR
+// (replaying one would mint a fresh wallet). The ledger loader must key
+// it by List metadata and label it from the inner offer's type.
+func TestAgentOfferBundle_RoundTrip(t *testing.T) {
+	offer := map[string]any{
+		"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
+		"metadata": map[string]any{"name": "quant", "namespace": "agent-quant"},
+		"spec":     map[string]any{"type": "agent"},
+	}
+	bundle := agentOfferBundle("agent-quant", "quant", offer)
+
+	items, _ := bundle["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("bundle has %d items, want 2 (Namespace + ServiceOffer)", len(items))
+	}
+	nsItem := items[0].(map[string]any)
+	nsMeta, _ := nsItem["metadata"].(map[string]any)
+	if nsItem["kind"] != "Namespace" || nsMeta["name"] != "agent-quant" {
+		t.Errorf("first item must be the agent namespace, got %v", nsItem)
+	}
+	labels, _ := nsMeta["labels"].(map[string]any)
+	if labels["obol.org/agent-namespace"] != "true" {
+		t.Error("namespace must carry the obol.org/agent-namespace label")
+	}
+	for _, it := range items {
+		if it.(map[string]any)["kind"] == "Agent" {
+			t.Fatal("bundle must NOT contain an Agent CR — replaying one mints a fresh wallet")
+		}
+	}
+
+	cfg := newTestConfig(t)
+	if err := persistServiceOffer(cfg, "agent-quant", "quant", bundle); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	offers, err := loadPersistedServiceOffers(sellOfferStoreDir(cfg), ui.New(false))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(offers) != 1 {
+		t.Fatalf("got %d offers, want 1", len(offers))
+	}
+	o := offers[0]
+	if o.Namespace != "agent-quant" || o.Name != "quant" || o.label() != "sell-agent" {
+		t.Errorf("got %s/%s label=%s, want agent-quant/quant label=sell-agent", o.Namespace, o.Name, o.label())
 	}
 }

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1584,6 +1584,32 @@ func TestValidateSellInferenceModelName(t *testing.T) {
 	}
 }
 
+// TestWaitForClusterAPI pins the two fast paths of the boot-race wait:
+// no kubeconfig means no cluster and returns nil immediately; an
+// unreachable cluster surfaces an error once the deadline passes
+// instead of blocking resume forever.
+func TestWaitForClusterAPI(t *testing.T) {
+	u := ui.New(false)
+
+	t.Run("no kubeconfig returns nil immediately", func(t *testing.T) {
+		cfg := &config.Config{ConfigDir: t.TempDir(), BinDir: t.TempDir()}
+		if err := waitForClusterAPI(context.Background(), cfg, u, 0); err != nil {
+			t.Fatalf("expected nil without kubeconfig, got %v", err)
+		}
+	})
+
+	t.Run("unreachable cluster errors after deadline", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "kubeconfig.yaml"), []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+			t.Fatalf("write kubeconfig: %v", err)
+		}
+		cfg := &config.Config{ConfigDir: dir, BinDir: t.TempDir()}
+		if err := waitForClusterAPI(context.Background(), cfg, u, 0); err == nil {
+			t.Fatal("expected error for unreachable cluster with zero timeout")
+		}
+	})
+}
+
 // TestReadGatewayPID pins the on-disk PID file format. The file must be a
 // single decimal integer in ASCII (no JSON, no trailing newlines that
 // confuse trivial readers) so other tools — `tail -f .../gateway.log` and

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1843,4 +1844,83 @@ func TestBuildDemoResources_UsesImportedImageAndERPCPath(t *testing.T) {
 	}
 
 	t.Fatal("ERPC_URL not set for chain-backed demo")
+}
+
+// TestSellResumeCommand_Registered pins `obol sell resume` as a
+// first-class subcommand. The resume path used to be reachable only via
+// `obol stack up`, which never runs after a host reboot (Docker's
+// restart policy resurrects the k3d cluster by itself) — so persisted
+// sell-inference offers sat at UpstreamHealthy=False with an empty
+// public catalog until the operator manually re-ran stack-up. Dropping
+// this registration silently re-opens that gap.
+func TestSellResumeCommand_Registered(t *testing.T) {
+	cfg := newTestConfig(t)
+	for _, sub := range sellCommand(cfg).Commands {
+		if sub.Name != "resume" {
+			continue
+		}
+		for _, f := range sub.Flags {
+			for _, n := range f.Names() {
+				if n == "install-boot-unit" {
+					return
+				}
+			}
+		}
+		t.Fatal("sell resume must expose --install-boot-unit for reboot persistence")
+	}
+	t.Fatal("`obol sell resume` is not registered under `obol sell`")
+}
+
+// TestRenderResumeBootUnit pins the systemd unit emitted by
+// `obol sell resume --install-boot-unit`. Each assertion guards a
+// production behavior: ExecStart is the actual resume entrypoint,
+// OBOL_CONFIG_DIR pins the unit to the stack that installed it,
+// default.target makes it run at (lingering) login/boot, and the
+// pre-start sleep gives the Docker-restarted k3d API server time to
+// accept the resume path's kubectl applies.
+func TestRenderResumeBootUnit(t *testing.T) {
+	unit := renderResumeBootUnit("/home/op/.local/bin/obol", "/home/op/.config/obol")
+	for _, want := range []string{
+		"ExecStart=/home/op/.local/bin/obol sell resume",
+		"Environment=OBOL_CONFIG_DIR=/home/op/.config/obol",
+		"WantedBy=default.target",
+		"ExecStartPre=/bin/sleep",
+		"After=network-online.target docker.service",
+		"Type=oneshot",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("boot unit missing %q:\n%s", want, unit)
+		}
+	}
+}
+
+// TestInstallResumeBootUnit_PlatformBehavior pins both GOOS branches:
+// non-Linux must refuse with actionable guidance (launchd is not wired
+// up), Linux must write the unit file under $HOME even when systemctl
+// is unavailable — the on-disk unit is the durable artifact and the
+// systemctl enable steps are best-effort warnings.
+func TestInstallResumeBootUnit_PlatformBehavior(t *testing.T) {
+	cfg := newTestConfig(t)
+	u := ui.New(false)
+
+	if runtime.GOOS != "linux" {
+		if err := installResumeBootUnit(cfg, u); err == nil {
+			t.Fatal("non-Linux install must return an error, got nil")
+		}
+		return
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	if err := installResumeBootUnit(cfg, u); err != nil {
+		t.Fatalf("linux install must succeed even without systemctl: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", resumeBootUnitName)
+	body, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("unit file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "sell resume") {
+		t.Errorf("unit file does not invoke sell resume:\n%s", body)
+	}
 }

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1984,9 +1984,11 @@ func TestSellResumeCommand_Registered(t *testing.T) {
 // `obol sell resume --install-boot-unit`. Each assertion guards a
 // production behavior: ExecStart is the actual resume entrypoint,
 // OBOL_CONFIG_DIR pins the unit to the stack that installed it,
-// default.target makes it run at (lingering) login/boot, and the
+// default.target makes it run at (lingering) login/boot, the
 // pre-start sleep gives the Docker-restarted k3d API server time to
-// accept the resume path's kubectl applies.
+// accept the resume path's kubectl applies, and RemainAfterExit keeps
+// the unit's cgroup alive — without it systemd kills the detached
+// gateway the moment the oneshot finishes (live reboot-test failure).
 func TestRenderResumeBootUnit(t *testing.T) {
 	unit := renderResumeBootUnit("/home/op/.local/bin/obol", "/home/op/.config/obol")
 	for _, want := range []string{
@@ -1996,6 +1998,7 @@ func TestRenderResumeBootUnit(t *testing.T) {
 		"ExecStartPre=/bin/sleep",
 		"After=network-online.target docker.service",
 		"Type=oneshot",
+		"RemainAfterExit=yes",
 	} {
 		if !strings.Contains(unit, want) {
 			t.Errorf("boot unit missing %q:\n%s", want, unit)

--- a/cmd/obol/sell_test.go
+++ b/cmd/obol/sell_test.go
@@ -1693,8 +1693,8 @@ func TestPersistSellHTTPOffer_RoundTrip(t *testing.T) {
 			},
 		},
 	}
-	if err := persistSellHTTPOffer(cfg, "default", "my-api", manifest); err != nil {
-		t.Fatalf("persistSellHTTPOffer: %v", err)
+	if err := persistServiceOffer(cfg, "default", "my-api", manifest); err != nil {
+		t.Fatalf("persistServiceOffer: %v", err)
 	}
 
 	expected := filepath.Join(cfg.ConfigDir, "sell-http", "default__my-api.yaml")
@@ -1734,10 +1734,10 @@ func TestPersistSellHTTPOffer_NamespaceIsolation(t *testing.T) {
 			"spec":       map[string]any{"type": "http"},
 		}
 	}
-	if err := persistSellHTTPOffer(cfg, "team-a", "shared", stub("team-a")); err != nil {
+	if err := persistServiceOffer(cfg, "team-a", "shared", stub("team-a")); err != nil {
 		t.Fatalf("persist team-a: %v", err)
 	}
-	if err := persistSellHTTPOffer(cfg, "team-b", "shared", stub("team-b")); err != nil {
+	if err := persistServiceOffer(cfg, "team-b", "shared", stub("team-b")); err != nil {
 		t.Fatalf("persist team-b: %v", err)
 	}
 	for _, ns := range []string{"team-a", "team-b"} {
@@ -1760,28 +1760,28 @@ func TestRemoveSellHTTPOffer_DropsPersistedManifest(t *testing.T) {
 		"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
 		"metadata": map[string]any{"name": "doomed", "namespace": "llm"},
 	}
-	if err := persistSellHTTPOffer(cfg, "llm", "doomed", manifest); err != nil {
+	if err := persistServiceOffer(cfg, "llm", "doomed", manifest); err != nil {
 		t.Fatalf("persist: %v", err)
 	}
 	path := filepath.Join(cfg.ConfigDir, "sell-http", "llm__doomed.yaml")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("manifest must exist before remove: %v", err)
 	}
-	if err := removeSellHTTPOffer(cfg, "llm", "doomed"); err != nil {
+	if err := removePersistedServiceOffer(cfg, "llm", "doomed"); err != nil {
 		t.Errorf("remove: %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("manifest still exists after remove: %v", err)
 	}
 	// Idempotent: removing the missing file must not error.
-	if err := removeSellHTTPOffer(cfg, "llm", "doomed"); err != nil {
+	if err := removePersistedServiceOffer(cfg, "llm", "doomed"); err != nil {
 		t.Errorf("second remove must be no-op, got: %v", err)
 	}
 	// Defensive: empty inputs are silent no-ops, not panics.
-	if err := removeSellHTTPOffer(cfg, "", "foo"); err != nil {
+	if err := removePersistedServiceOffer(cfg, "", "foo"); err != nil {
 		t.Errorf("empty namespace: %v", err)
 	}
-	if err := removeSellHTTPOffer(cfg, "llm", ""); err != nil {
+	if err := removePersistedServiceOffer(cfg, "llm", ""); err != nil {
 		t.Errorf("empty name: %v", err)
 	}
 }
@@ -1799,14 +1799,14 @@ func TestResumeSellHTTPOffers_EmptyStoreNoOp(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cfg.ConfigDir, "kubeconfig.yaml"), []byte("placeholder"), 0o600); err != nil {
 		t.Fatalf("seed kubeconfig: %v", err)
 	}
-	if err := resumeSellHTTPOffers(cfg, ui.New(false)); err != nil {
+	if err := resumePersistedServiceOffers(cfg, ui.New(false)); err != nil {
 		t.Errorf("empty-store resume must succeed: %v", err)
 	}
 }
 
 // TestSellDeleteAction_CallsRemoveSellHTTPOffer is a source-level guard
 // against the obvious post-delete leak: forget to call
-// removeSellHTTPOffer in the sell delete handler and the next
+// removePersistedServiceOffer in the sell delete handler and the next
 // `obol stack up` resurrects the offer the operator just killed. The
 // only signal would be "deleted offers spookily come back" which is
 // hard to attribute, hence the test.
@@ -1825,8 +1825,8 @@ func TestSellDeleteAction_CallsRemoveSellHTTPOffer(t *testing.T) {
 		t.Fatal("could not delimit sellDeleteCommand body")
 	}
 	scope := body[start : start+1+end]
-	if !strings.Contains(scope, "removeSellHTTPOffer(") {
-		t.Fatal("sellDeleteCommand must call removeSellHTTPOffer — otherwise the on-disk manifest survives the kubectl delete and `obol stack up` resurrects the offer")
+	if !strings.Contains(scope, "removePersistedServiceOffer(") {
+		t.Fatal("sellDeleteCommand must call removePersistedServiceOffer — otherwise the on-disk manifest survives the kubectl delete and `obol stack up` resurrects the offer")
 	}
 }
 
@@ -1847,7 +1847,7 @@ func TestResumeSellOffers_HTTPOnlyStore(t *testing.T) {
 		"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
 		"metadata": map[string]any{"name": "only-http", "namespace": "llm"},
 	}
-	if err := persistSellHTTPOffer(cfg, "llm", "only-http", manifest); err != nil {
+	if err := persistServiceOffer(cfg, "llm", "only-http", manifest); err != nil {
 		t.Fatalf("persist: %v", err)
 	}
 	// kubectl apply will fail against the fake kubeconfig — that's
@@ -2034,5 +2034,235 @@ func TestInstallResumeBootUnit_PlatformBehavior(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "sell resume") {
 		t.Errorf("unit file does not invoke sell resume:\n%s", body)
+	}
+}
+
+// TestLoadPersistedServiceOffers_MixedTypes pins the ledger walk that
+// `obol sell resume` relies on: every *.yaml ServiceOffer manifest is
+// returned regardless of spec.type (http, agent, legacy files persisted
+// before the type was recorded), while corrupt YAML, non-YAML files,
+// and subdirectories are skipped without failing the walk.
+func TestLoadPersistedServiceOffers_MixedTypes(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("llm__api.yaml", "apiVersion: obol.org/v1alpha1\nkind: ServiceOffer\nmetadata:\n  name: api\n  namespace: llm\nspec:\n  type: http\n")
+	write("agent-quant__quant.yaml", "apiVersion: obol.org/v1alpha1\nkind: ServiceOffer\nmetadata:\n  name: quant\n  namespace: agent-quant\nspec:\n  type: agent\n")
+	write("llm__legacy.yaml", "apiVersion: obol.org/v1alpha1\nkind: ServiceOffer\nmetadata:\n  name: legacy\n  namespace: llm\n")
+	write("corrupt.yaml", "::: not yaml {{{")
+	write("notes.txt", "not a manifest")
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	offers, err := loadPersistedServiceOffers(dir, ui.New(false))
+	if err != nil {
+		t.Fatalf("loadPersistedServiceOffers: %v", err)
+	}
+
+	got := map[string]string{} // "ns/name" -> label
+	for _, o := range offers {
+		got[o.Namespace+"/"+o.Name] = o.label()
+	}
+	want := map[string]string{
+		"agent-quant/quant": "sell-agent",
+		"llm/api":           "sell-http",
+		"llm/legacy":        "sell",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d offers (%v), want %d", len(got), got, len(want))
+	}
+	for k, label := range want {
+		if got[k] != label {
+			t.Errorf("offer %s label = %q, want %q", k, got[k], label)
+		}
+	}
+
+	// Missing dir: no offers, no error — first run on a fresh host.
+	none, err := loadPersistedServiceOffers(filepath.Join(dir, "missing"), ui.New(false))
+	if err != nil || len(none) != 0 {
+		t.Fatalf("missing dir: offers=%v err=%v, want empty/nil", none, err)
+	}
+}
+
+// TestSellAgentPaths_PersistOffers is the source-level guard that BOTH
+// agent-offer creation sites — `obol sell agent <name>` and the
+// agent-backed demo flow — persist the rendered manifest into the
+// ledger. Without it, agent offers silently drop out of `obol sell
+// resume` coverage while http and inference offers come back, which is
+// exactly the inconsistency this ledger exists to prevent.
+func TestSellAgentPaths_PersistOffers(t *testing.T) {
+	src, err := os.ReadFile("sell_agent.go")
+	if err != nil {
+		t.Fatalf("read sell_agent.go: %v", err)
+	}
+	body := string(src)
+	for _, fn := range []string{"func sellAgentCommand(", "func runAgentBackedDemo("} {
+		start := strings.Index(body, fn)
+		if start < 0 {
+			t.Fatalf("%s not found", fn)
+		}
+		end := strings.Index(body[start+1:], "\nfunc ")
+		scope := body[start:]
+		if end >= 0 {
+			scope = body[start : start+1+end]
+		}
+		if !strings.Contains(scope, "persistServiceOffer(") {
+			t.Errorf("%s must call persistServiceOffer so agent offers are covered by `obol sell resume`", fn)
+		}
+	}
+}
+
+// TestRemovePersistedServiceOffersInNamespace pins the `obol agent
+// delete` cleanup: removing one agent's namespace drops exactly that
+// namespace's ledger entries and leaves every other offer alone.
+func TestRemovePersistedServiceOffersInNamespace(t *testing.T) {
+	cfg := newTestConfig(t)
+	manifest := func(ns, name string) map[string]any {
+		return map[string]any{
+			"apiVersion": "obol.org/v1alpha1", "kind": "ServiceOffer",
+			"metadata": map[string]any{"name": name, "namespace": ns},
+			"spec":     map[string]any{"type": "agent"},
+		}
+	}
+	if err := persistServiceOffer(cfg, "agent-quant", "quant", manifest("agent-quant", "quant")); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if err := persistServiceOffer(cfg, "llm", "api", manifest("llm", "api")); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	removed, err := removePersistedServiceOffersInNamespace(cfg, "agent-quant")
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if _, err := os.Stat(sellOfferStorePath(cfg, "agent-quant", "quant")); !os.IsNotExist(err) {
+		t.Error("agent-quant manifest must be gone")
+	}
+	if _, err := os.Stat(sellOfferStorePath(cfg, "llm", "api")); err != nil {
+		t.Errorf("llm manifest must survive: %v", err)
+	}
+
+	// Empty namespace and nil cfg are no-ops, not panics.
+	if n, err := removePersistedServiceOffersInNamespace(cfg, ""); n != 0 || err != nil {
+		t.Errorf("empty ns: n=%d err=%v", n, err)
+	}
+}
+
+// TestDeleteCRDAgent_CleansPersistedOffers is the source-level guard
+// that `obol agent delete` removes the agent's persisted sell offers —
+// the namespace deletion already took the CRs, so a survivor ledger
+// file would make every later resume replay a ghost offer.
+func TestDeleteCRDAgent_CleansPersistedOffers(t *testing.T) {
+	src, err := os.ReadFile("agent.go")
+	if err != nil {
+		t.Fatalf("read agent.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func deleteCRDAgent(")
+	if start < 0 {
+		t.Fatal("deleteCRDAgent not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit deleteCRDAgent body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "removePersistedServiceOffersInNamespace(") {
+		t.Fatal("deleteCRDAgent must call removePersistedServiceOffersInNamespace — otherwise resume replays offers for deleted agents forever")
+	}
+}
+
+// TestLoadPersistedServiceOffers_DemoListBundle pins the demo-bundle
+// shape: the legacy demo persists a v1 List (namespace + backend +
+// ServiceOffer). The loader must key it from the List metadata and
+// report the inner offer's spec.type.
+func TestLoadPersistedServiceOffers_DemoListBundle(t *testing.T) {
+	dir := t.TempDir()
+	bundle := `apiVersion: v1
+kind: List
+metadata:
+  name: hello
+  namespace: demo
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: demo
+  - apiVersion: obol.org/v1alpha1
+    kind: ServiceOffer
+    metadata:
+      name: hello
+      namespace: demo
+    spec:
+      type: http
+`
+	if err := os.WriteFile(filepath.Join(dir, "demo__hello.yaml"), []byte(bundle), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	offers, err := loadPersistedServiceOffers(dir, ui.New(false))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(offers) != 1 {
+		t.Fatalf("got %d offers, want 1", len(offers))
+	}
+	o := offers[0]
+	if o.Namespace != "demo" || o.Name != "hello" || o.label() != "sell-http" {
+		t.Errorf("got %s/%s label=%s, want demo/hello label=sell-http", o.Namespace, o.Name, o.label())
+	}
+}
+
+// TestSellDemoCommand_PersistsBundle is the source-level guard that the
+// legacy demo path persists its bundle for resume coverage.
+func TestSellDemoCommand_PersistsBundle(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellDemoCommand(")
+	if start < 0 {
+		t.Fatal("sellDemoCommand not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit sellDemoCommand body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "persistServiceOffer(") {
+		t.Fatal("sellDemoCommand must persist its demo bundle so `obol sell resume` restores a working demo")
+	}
+}
+
+// TestSellUpdateCommand_RefreshesLedger is the source-level guard for
+// the staleness bug class: `sell update` patches the live CR, and
+// without a ledger refresh the next resume kubectl-applies the OLD
+// payment terms back — silently reverting an intentional payTo or
+// price change.
+func TestSellUpdateCommand_RefreshesLedger(t *testing.T) {
+	src, err := os.ReadFile("sell.go")
+	if err != nil {
+		t.Fatalf("read sell.go: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func sellUpdateCommand(")
+	if start < 0 {
+		t.Fatal("sellUpdateCommand not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not delimit sellUpdateCommand body")
+	}
+	scope := body[start : start+1+end]
+	if !strings.Contains(scope, "refreshPersistedServiceOffer(") {
+		t.Fatal("sellUpdateCommand must call refreshPersistedServiceOffer after the patch — else resume reverts updated payment terms")
 	}
 }

--- a/internal/inference/store.go
+++ b/internal/inference/store.go
@@ -126,6 +126,15 @@ type Deployment struct {
 
 	// UpdatedAt is the RFC3339 timestamp of the most recent update.
 	UpdatedAt string `json:"updated_at,omitempty"`
+
+	// DeletedAt is set when `obol sell delete` removes the offer from
+	// the cluster. The descriptor stays on disk for `sell inference
+	// list/status` history, but resume must not replay a tombstoned
+	// offer (it would re-create the ServiceOffer and relaunch the host
+	// gateway, undoing the delete). Re-creating the offer with
+	// `obol sell inference <name>` rewrites the descriptor and clears
+	// the tombstone.
+	DeletedAt string `json:"deleted_at,omitempty"`
 }
 
 // Provenance tracks how a model or service was produced.


### PR DESCRIPTION
## Problem

After a host reboot, the public seller catalog stays empty even though the stack looks healthy: storefront serves 200, controller/verifier/catalog pods are all Running, but `/api/services.json` returns `[]`.

Root cause (diagnosed live on the rc14 prod seller after a reboot):

1. Docker's restart policy resurrects the k3d node containers at boot, so the cluster comes back **without anyone running `obol stack up`**.
2. The sell-resume path (`resumeSellOffers` → re-apply ServiceOffer → `startDetachedInferenceGateway`) is only invoked from the `stack up` action (`cmd/obol/main.go`), so it never fires.
3. The host-side x402 gateway started by `obol sell inference` died with the host. The ServiceOffer survives in etcd but sits at:
   ```
   UpstreamHealthy=False: Get "http://<name>.llm.svc.cluster.local:8402/health": connect: connection refused
   Ready=False
   ```
   → excluded from the catalog → `[]` → buyers see nothing.

## Fix

- **`obol sell resume`** — exposes the existing resume path as a first-class subcommand so a reboot no longer requires a full `stack up` to recover. Idempotent: gateways with a live PID on disk are skipped; the kubectl applies re-assert existing objects.
- **`obol sell resume --install-boot-unit`** (Linux/systemd, opt-in) — writes + enables a systemd user unit (`obol-sell-resume.service`, `WantedBy=default.target`, pre-start sleep for the API server) so resume runs automatically at boot. Prints the `loginctl enable-linger` hint required for boot-without-login. Non-Linux returns actionable guidance instead.
- Refreshes the stale `resumeSellOffers` doc comment (it still claimed gateways are not restarted; `startDetachedInferenceGateway` has done so since the resume feature shipped).

No behavior change to `obol stack up` — it keeps calling the same resume path.

## Tests

- `TestSellResumeCommand_Registered` — registration + `--install-boot-unit` guard (mirrors the existing `TestStackUpAction_CallsResumeSellOffers` source-guard pattern).
- `TestRenderResumeBootUnit` — pins ExecStart/Environment/WantedBy/pre-start sleep of the emitted unit.
- `TestInstallResumeBootUnit_PlatformBehavior` — non-Linux refuses with guidance; Linux writes the unit under `$HOME` even when `systemctl` is unavailable (enable steps are best-effort warnings).

`go build ./...` and `go test ./cmd/obol -count=1` green. Branched off latest `main` (tree-identical to `v0.10.0-rc14`).

## Follow-up (out of scope)

The long-term shape noted in the existing code comment stands: package the inference gateway as an in-cluster Deployment so the cluster supervises it like Traefik/LiteLLM and the host-side PID plumbing disappears.

## Coverage: all ServiceOffer types (review follow-up)

Per review feedback, `c7ca58f` generalizes resume beyond inference+http: the `sell-http/` store becomes the persisted-ServiceOffer **ledger** (dir name kept for already-shipped files), and every offer surface persists into it — `sell agent` (both creation sites), the agent-backed demo (offer only; replaying an Agent CR would mint a fresh wallet), and the legacy demo as a `v1 List` bundle (namespace + backend + offer) so resume restores a *working* demo. `sell mcp` has no ServiceOffer and is documented as not resumed. Lifecycle holes closed: `agent delete` drops the agent's ledger entries; `sell update` refreshes the ledger from the live CR so resume can't revert a payTo/price change. `resumeSellOffers` simplifies to one guard + two phases with a pure, tested loader.
