### PR TITLE
fix(flows): flow-16 unsatisfiable Ready gate; flow-04 first-inference window on local models

### DIFF
--- a/flows/flow-04-agent.sh
+++ b/flows/flow-04-agent.sh
@@ -118,15 +118,25 @@ if [ -n "${OBOL_LLM_ENDPOINT:-}" ] && [ "$model_name" != "${OBOL_LLM_MODEL:-qwen
 fi
 
 llm_payload_suffix="$(llm_disable_thinking_payload_suffix)"
-out=$(curl -sf --max-time 120 -X POST "http://localhost:${AGENT_PF_PORT}/v1/chat/completions" \
+# 300s window, NOT 120: this is the first inference ever routed through
+# the Hermes agent pipeline, which prepends a multi-thousand-token system
+# prompt. On a local Ollama model that first call pays full prompt
+# processing before the KV cache warms (~150s observed for a 27B on an
+# M-series host; Hermes' internal client retries re-pay it until the
+# cache survives one attempt). GPU-class endpoints answer in seconds.
+# No -f: an HTTP-level failure must surface its status and body in the
+# fail message instead of an empty string (a silent `-f` 401/timeout
+# here previously cost a long misdiagnosis).
+http_code=$(curl -s -o /tmp/flow04-inference.json -w "%{http_code}" --max-time 300 -X POST "http://localhost:${AGENT_PF_PORT}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
     -d "{\"model\":\"$model_name\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2?\"}],\"max_tokens\":50,\"stream\":false${llm_payload_suffix}}" 2>&1) || true
+out=$(cat /tmp/flow04-inference.json 2>/dev/null || true)
 
 if echo "$out" | grep -q "choices"; then
-    pass "Agent inference returned response"
+    pass "Agent inference returned response (HTTP $http_code)"
 else
-    fail "Agent inference failed — ${out:0:200}"
+    fail "Agent inference failed — HTTP ${http_code:-000}: ${out:0:200}"
 fi
 
 # Regression check from the model-rank fix (PR #388): a 1B-parameter local

--- a/flows/flow-16-sell-agent.sh
+++ b/flows/flow-16-sell-agent.sh
@@ -190,21 +190,36 @@ else
     fail "spec.agent.ref unexpected: name=$ref_name ns=$ref_ns"
 fi
 
-# §2.2: ServiceOffer Ready
-step "ServiceOffer $OFFER_NAME reaches Ready"
-ready=""
+# §2.2: ServiceOffer serving. NOT Ready=True: this flow creates the offer
+# with registration enabled and never submits the ERC-8004 tx, so the
+# controller keeps Ready=False / Registered=AwaitingExternalRegistration
+# by design ("offer already serves paid traffic") — a Ready=True poll can
+# never pass here (flow-11 polls Ready only AFTER running `obol sell
+# register`). Gate on the serving condition set instead, which is exactly
+# what §3's 402 probe exercises. Window is 300s: the controller's
+# UpstreamHealthy probe rides the agent's FIRST big-prompt inference,
+# and on a local Ollama model that pays full prompt processing for the
+# Hermes system prompt before the cache warms (~150s observed for a 27B
+# on an M-series host; GPU endpoints converge in seconds).
+step "ServiceOffer $OFFER_NAME reaches serving state (UpstreamHealthy+PaymentGateReady+RoutePublished)"
+serving=""
 for i in $(seq 1 60); do
-    out=$("$OBOL" sell status "$OFFER_NAME" -n "$AGENT_NS" 2>&1 || true)
-    if echo "$out" | grep -q "Ready: True\|Ready=True"; then
-        ready="yes"
+    conds=$("$OBOL" kubectl get serviceoffer "$OFFER_NAME" -n "$AGENT_NS" \
+        -o jsonpath='{range .status.conditions[*]}{.type}={.status} {end}' 2>/dev/null || true)
+    # Anchored: a bare "Ready=True" grep would substring-match
+    # "PaymentGateReady=True" (the old gate did exactly that).
+    if echo "$conds" | grep -qE '(^| )UpstreamHealthy=True' \
+        && echo "$conds" | grep -qE '(^| )PaymentGateReady=True' \
+        && echo "$conds" | grep -qE '(^| )RoutePublished=True'; then
+        serving="yes"
         break
     fi
-    sleep 2
+    sleep 5
 done
-if [ -n "$ready" ]; then
-    pass "ServiceOffer Ready"
+if [ -n "$serving" ]; then
+    pass "ServiceOffer serving (conditions: $conds)"
 else
-    fail "ServiceOffer did not reach Ready within 120s"
+    fail "ServiceOffer did not reach serving state within 300s — conditions: ${conds:-unreadable}"
 fi
 
 # §3: Probe surfaces agent metadata in 402 extra (GATED_ON_2D — needs route)


### PR DESCRIPTION
## Summary

Both release-gating FAILs from the rc14 release smoke on a local Ollama model (`qwopus3.6-27b-v2-mtp:q5_k_m`, 27B) reduce to flow bugs — the stack itself is clean. Diagnosed live against a reproducing cluster; full chain below.

## flow-16 §2.2 — the Ready gate could never pass

The flow creates its offer with registration **enabled** and never runs `obol sell register`, so the controller keeps `Ready=False / Registered=AwaitingExternalRegistration` *by design* ("offer already serves paid traffic"). A `Ready=True` poll is unsatisfiable as written — flow-11 only polls Ready after actually registering.

It historically "passed" by accident: the gate grepped `Ready=True` against `sell status` output, which **substring-matches `PaymentGateReady=True`** whenever the condition ladder converged inside the window.

Fix: poll the serving condition set — `UpstreamHealthy` + `PaymentGateReady` + `RoutePublished`, anchored greps via `obol kubectl` jsonpath — over 300s. That set is exactly what §3's 402 probe then exercises.

## flow-04 step 12 — window too tight, diagnostics swallowed

`curl -sf --max-time 120` failed reproducibly (twice, warm model) on the **first inference ever routed through the Hermes agent pipeline**: Hermes prepends a multi-thousand-token system prompt, and a local Ollama model pays full prompt processing before the KV cache warms (~150s observed; Hermes' internal client retries re-pay it until one attempt survives). The very next call answers in ~20s — which is why step 13 passed seconds later in every run. GPU-class endpoints converge in seconds and never see this.

`-f` also swallowed the response entirely, so the fail line was the empty `Agent inference failed — ` (which initially sent the investigation toward cold model loads and auth). Fix: 300s window, no `-f`, and the fail message carries HTTP status + body snippet.

## Verification

- Live cluster in the failing state: new flow-16 gate passes where the old one cannot (`UpstreamHealthy=True PaymentGateReady=True RoutePublished=True Registered=False Ready=False`); the exact flow-04 request returns 200 with correct content once the prompt cache is warm.
- `bash -n` clean on both flows; with these fixes the rc14 wopus smoke is 12 PASS / 2 SKIP (the SKIPs are waived registration-receipt sub-checks, registrations themselves succeeded on-chain).
