### PR TITLE
fix: bugfix on rc16

### DIFF
--- a/internal/monetizeapi/types.go
+++ b/internal/monetizeapi/types.go
@@ -64,6 +64,7 @@ var (
 	NamespaceGVR      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 	ServiceAccountGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
 	PVCGVR            = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
+	NetworkPolicyGVR  = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
 )
 
 // ── ServiceOffer ────────────────────────────────────────────────────────────

--- a/internal/serviceoffercontroller/agent.go
+++ b/internal/serviceoffercontroller/agent.go
@@ -522,6 +522,8 @@ func (c *Controller) resourceFor(u *unstructured.Unstructured) dynamic.ResourceI
 		return c.client.Resource(monetizeapi.PVCGVR).Namespace(u.GetNamespace())
 	case "Deployment":
 		return c.deployments.Namespace(u.GetNamespace())
+	case "NetworkPolicy":
+		return c.client.Resource(monetizeapi.NetworkPolicyGVR).Namespace(u.GetNamespace())
 	default:
 		// Unknown kinds shouldn't reach this path — agentManifests is
 		// closed-set. Fall through to a sensible default so the eventual

--- a/internal/serviceoffercontroller/agent_test.go
+++ b/internal/serviceoffercontroller/agent_test.go
@@ -202,6 +202,7 @@ func TestReconcileAgent_HappyPath_ProvisionsAndPins(t *testing.T) {
 		{"secrets", "agent-quant", "hermes-api-server"},
 		{"deployments", "agent-quant", "hermes"},
 		{"services", "agent-quant", "hermes"},
+		{"networkpolicies", "agent-quant", "agent-isolation"},
 	} {
 		if !resourceExists(t, c, kind.gvr, kind.ns, kind.name) {
 			t.Errorf("%s/%s/%s not applied", kind.gvr, kind.ns, kind.name)
@@ -426,6 +427,7 @@ func newProvisioningTestController(t *testing.T, agent *monetizeapi.Agent, seedO
 			monetizeapi.SecretGVR:         "SecretList",
 			monetizeapi.DeploymentGVR:     "DeploymentList",
 			monetizeapi.ServiceGVR:        "ServiceList",
+			monetizeapi.NetworkPolicyGVR:  "NetworkPolicyList",
 		},
 		objects...,
 	)
@@ -469,8 +471,11 @@ func litellmSecretObject(t *testing.T, masterKey string) *unstructured.Unstructu
 func resourceExists(t *testing.T, c *Controller, resource, namespace, name string) bool {
 	t.Helper()
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: resource}
-	if resource == "deployments" {
+	switch resource {
+	case "deployments":
 		gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: resource}
+	case "networkpolicies":
+		gvr = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: resource}
 	}
 	dyn := c.dynClient.Resource(gvr)
 	if namespace != "" {


### PR DESCRIPTION
## Summary
Bug: Controller.resourceFor in interna
  l/serviceoffercontroller/agent.go:509 
  has no case "NetworkPolicy", so the   
  agent-isolation NetworkPolicy returned
   from agentManifests                
  (agent_render.go:84) falls through to
  the default arm and is applied via the
   ConfigMap dynamic client. Real
  apiserver rejects the kind mismatch →
  provisionAgent errors → Agent CR parks
   at phase=Provisioning → type=agent
  ServiceOffers depending on that agent
  never publish their HTTPRoute →
  /services/<name> 404. RBAC for
  networking.k8s.io/networkpolicies was
  already correct (x402.yaml:190-194);
  only the GVR mapping was missing.

  Why the fake-client tests didn't catch
   it: dynamicfake stores objects keyed
  by the GVR you call .Create on without
   re-validating the payload's kind, so
  the "configmap" of payload-kind     
  NetworkPolicy was silently accepted.

  Changes (3 files):                    
  - internal/monetizeapi/types.go — add
  NetworkPolicyGVR constant.            
  - internal/serviceoffercontroller/agen
  t.go:509 — add case "NetworkPolicy"   
  arm using the new GVR.              
  - internal/serviceoffercontroller/agen
  t_test.go — register NetworkPolicyGVR
  in the fake client, assert networkpoli
  cies/agent-quant/agent-isolation lands
   in the happy-path test, teach        
  resourceExists about the            
  networking.k8s.io group.            

  Verified:
  - go build ./... clean.
  - go test ./internal/monetizeapi/... 
  ./internal/serviceoffercontroller/...
  green.                                
  - Removed just the case 
  "NetworkPolicy" arm temporarily and   
  the new assertion failed with networkp
  olicies/agent-quant/agent-isolation 
  not applied — so the regression net   
  works.                              
                                      
  Untouched on purpose:
  - tearDownAgent still leaves the
  NetworkPolicy alone, matching the     
  existing "namespace deletion     
  garbage-collects per-agent resources" 
  stance (agent.go:409-412). Expanding 
  teardown is out of scope for this fix.
  - No RBAC edits — the networkpolicies 
  CRUD verbs were already granted      
  (x402.yaml:190-194). 