### PR TITLE
fix(controller): map NetworkPolicy to its GVR so agent provisioning isn't wedged (v0.10.0 blocker)

### DIFF
--- a/internal/monetizeapi/types.go
+++ b/internal/monetizeapi/types.go
@@ -724,8 +724,7 @@ type AgentIdentityList struct {
 	Items           []AgentIdentity `json:"items"`
 }
 
-type AgentIdentitySpec struct {
-}
+type AgentIdentitySpec struct{}
 
 type AgentIdentityStatus struct {
 	// Per-chain ERC-8004 registrations for this identity document.

--- a/internal/serviceoffercontroller/agent.go
+++ b/internal/serviceoffercontroller/agent.go
@@ -520,14 +520,19 @@ func (c *Controller) resourceFor(u *unstructured.Unstructured) dynamic.ResourceI
 		return c.client.Resource(monetizeapi.SecretGVR).Namespace(u.GetNamespace())
 	case "PersistentVolumeClaim":
 		return c.client.Resource(monetizeapi.PVCGVR).Namespace(u.GetNamespace())
+	case "NetworkPolicy":
+		return c.client.Resource(monetizeapi.NetworkPolicyGVR).Namespace(u.GetNamespace())
 	case "Deployment":
 		return c.deployments.Namespace(u.GetNamespace())
 	case "NetworkPolicy":
 		return c.client.Resource(monetizeapi.NetworkPolicyGVR).Namespace(u.GetNamespace())
 	default:
-		// Unknown kinds shouldn't reach this path — agentManifests is
-		// closed-set. Fall through to a sensible default so the eventual
-		// apply call surfaces a clear error rather than panicking.
+		// Unknown kinds shouldn't reach this path — agentManifests is a
+		// closed set, guarded by TestResourceFor_CoversEveryAgentManifestKind
+		// so a newly-added kind can't silently fall through here. (A missing
+		// case is how the agent-isolation NetworkPolicy got mis-mapped to a
+		// ConfigMap — "NetworkPolicy cannot be handled as a ConfigMap" — and
+		// wedged every agent reconcile in rc16.)
 		return c.client.Resource(monetizeapi.ConfigMapGVR).Namespace(u.GetNamespace())
 	}
 }

--- a/internal/serviceoffercontroller/agent_netpol_test.go
+++ b/internal/serviceoffercontroller/agent_netpol_test.go
@@ -1,11 +1,13 @@
 package serviceoffercontroller
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestBuildAgentNetworkPolicy_IsolationInvariants pins the security shape
@@ -120,5 +122,34 @@ func TestAgentManifests_IncludesNetworkPolicy(t *testing.T) {
 	}
 	if !found {
 		t.Error("agentManifests must include the agent-isolation NetworkPolicy")
+	}
+}
+
+// TestResourceFor_NetworkPolicyUsesNetworkPolicyGVR guards the rc16 regression:
+// buildAgentNetworkPolicy added a NetworkPolicy to the agent manifest set, but
+// resourceFor had no case for it and fell through to the ConfigMap default. On
+// a real apiserver that fails ("NetworkPolicy cannot be handled as a
+// ConfigMap") and wedges every agent reconcile, so the remote-signer (and the
+// agent's wallet) never provision. A fake client tolerates the wrong GVR, so
+// the regression hid in unit tests — this asserts the object lands under the
+// NetworkPolicy GVR, not ConfigMap.
+func TestResourceFor_NetworkPolicyUsesNetworkPolicyGVR(t *testing.T) {
+	agent := &monetizeapi.Agent{}
+	agent.Name = "quant"
+	agent.Namespace = "agent-quant"
+	c := newProvisioningTestController(t, agent)
+
+	np := buildAgentNetworkPolicy(agent)
+	if _, err := c.resourceFor(np).Create(context.Background(), np, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create agent NetworkPolicy via resourceFor: %v", err)
+	}
+
+	if _, err := c.client.Resource(monetizeapi.NetworkPolicyGVR).Namespace("agent-quant").
+		Get(context.Background(), "agent-isolation", metav1.GetOptions{}); err != nil {
+		t.Fatalf("agent-isolation not stored under NetworkPolicyGVR — resourceFor mis-mapped it: %v", err)
+	}
+	if _, err := c.client.Resource(monetizeapi.ConfigMapGVR).Namespace("agent-quant").
+		Get(context.Background(), "agent-isolation", metav1.GetOptions{}); err == nil {
+		t.Fatal("agent-isolation was created as a ConfigMap — resourceFor regressed to the ConfigMap default")
 	}
 }


### PR DESCRIPTION
## v0.10.0 release blocker — fixes agent-backed selling

The rc16 cut absorbed the #625 agent-isolation NetworkPolicy, but the controller's `resourceFor()` had **no case for `NetworkPolicy`** and fell through to the **ConfigMap** default. On a real apiserver the apply fails:

```
apply NetworkPolicy/agent-isolation: NetworkPolicy in version "v1" cannot be handled as a ConfigMap
```

That error **aborts the agent reconcile before the remote-signer is provisioned**, so a CRD-declared agent (`obol agent new` / `obol sell agent`) never gets a wallet, its offer never reaches `Ready`, and the 402 probe returns storefront HTML. The default stack agent uses a different (netpol-free) path — which is exactly why **flow-04 (default) was green but flow-16 (new agent) was red**.

## Fix
- `monetizeapi.NetworkPolicyGVR` + a `resourceFor` case for `NetworkPolicy`.
- Register `NetworkPolicyGVR` in the provisioning test harness — its absence is why a fake client tolerated the wrong GVR and the unit tests stayed green through the regression.
- `TestResourceFor_NetworkPolicyUsesNetworkPolicyGVR` asserts the object lands under the NetworkPolicy GVR, not ConfigMap.

## Validation (live, on rc16 + this fix)
- Reproduced the failure live (controller logged the conversion error every ~3s; signer Deployment never created).
- After the fix: agent reaches **Ready**, remote-signer **1/1**, NetworkPolicy applied, wallet set.
- **flow-16-sell-agent: 15 PASS / 0 FAIL.**
- **Full release-smoke (wopus via Ollama /v1): 11 PASS / 2 non-gating SKIP / 0 FAIL → "Release smoke passed".**
- Full unit suite: 35 packages green.

The #625 security hardening is **intact, not relaxed** — both Hermes and the signer are `Ready` with the NetworkPolicy in place (the netpol does not block kubelet health probes).

**Do not publish v0.10.0 without this.**