### PR TITLE
feat: obol buy inference <provider> — BYOK onboarding (Venice, OpenRouter & co.) on a single provider registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,16 +262,15 @@ Caveats:
 
 **Auto-configuration**: `obol stack up` → `autoConfigureLLM()` detects host Ollama models, patches LiteLLM config. `obolup.sh` → `check_agent_model_api_key()` reads `~/.openclaw/openclaw.json`, resolves API key from `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (Anthropic) or `OPENAI_API_KEY` (OpenAI), exports for downstream.
 
-**BYOK cloud providers** (easiest getting-started path) — provider knowledge is a single registry in `internal/model/model.go` (`knownProviders` / `ProviderInfo` with `Mode`/`BaseURL`/`Default`/`SignupURL`/`Free`); adding a provider is one row, no per-provider switch. Built-in: `anthropic`, `openai`, `ollama` (native/local) + OpenAI-compatible aggregators `venice`, `openrouter`, `nvidia`, `gmi`, `novita`, `huggingface` (`Mode=openai-compatible` → `model_list` entry `openai/<id>` + explicit `api_base` + key from the provider's env var; no wildcard). When `--model` is omitted, setup uses the registry `Default` or lists the live `GET <base>/v1/models` (TTY picker / non-TTY error naming real ids). `--free` seeds only the curated free-tier model snapshot (OpenRouter).
+**BYOK cloud providers** (easiest getting-started path) — provider knowledge is a single registry in `internal/model/model.go` (`knownProviders` / `ProviderInfo` with `Mode`/`BaseURL`/`Default`/`KeyURL`/`JoinURL`/`Free`); adding a provider is one row, no per-provider switch. `KeyURL` is the API-key dashboard (assumes account); optional `JoinURL` is a new-user landing page (may carry a referral tag) used in preference to `KeyURL` for browser-open and "new to X? Sign up" hints. Built-in: `anthropic`, `openai`, `ollama` (native/local) + OpenAI-compatible aggregators `venice`, `openrouter`, `nvidia`, `gmi`, `novita`, `huggingface` (`Mode=openai-compatible` → `model_list` entry `openai/<id>` + explicit `api_base` + key from the provider's env var; no wildcard). When `--model` is omitted, setup uses the registry `Default` or lists the live `GET <base>/v1/models` (TTY picker / non-TTY error naming real ids). `--free` seeds the curated free-tier model snapshot (currently OpenRouter only) intersected against the live `/v1/models` response to drop rotated-out ids; auto-applied for `openrouter` when no `--model` is passed.
 
-Two front doors share one engine (`setupCloudProvider` in `cmd/obol/model.go`):
-- `obol buy inference <provider>` — friendly onboarding: opens the provider's `SignupURL` in the browser (`openBrowser`, hermes-style), takes the key (`--api-key` → env var → prompt), wires LiteLLM + syncs agents. `obol buy inference` with a URL/no-arg is still the **x402 crypto-paid seller** path — dispatch keys on whether the positional arg matches a registry provider id.
-- `obol model setup <provider> --api-key <key>` — the scriptable, no-browser equivalent. Unlisted endpoints still use `obol model setup custom`.
+Single front door: `obol model setup` (engine: `setupCloudProvider` in `cmd/obol/model.go`). Interactive picker defaults to OpenRouter — `obol model setup` with no flags walks a TTY user through provider pick → browser open at `JoinURL`/`KeyURL` → key prompt → free-roster seeding. Scriptable variant: `obol model setup --provider <id> --api-key <key>`. Unlisted endpoints: `obol model setup custom --endpoint … --model …`. `obol buy inference <provider>` is reserved for future credit top-ups against remote providers; today it errors with a redirect to `obol model setup`. `obol buy inference [<seller-url>]` (URL or no arg) is the **x402 crypto-paid seller** path — unchanged.
 
 ```bash
-obol buy inference venice                 # opens venice key page, prompts, wires up
-obol buy inference openrouter --free      # seeds curated free models
-obol model setup venice --api-key $VENICE_API_KEY   # scriptable / CI
+obol model setup                                       # interactive; default = openrouter + free roster
+obol model setup --provider venice                     # opens https://venice.ai/chat?ref=ZynMuD (TTY) + prompts for key
+obol model setup --provider venice --api-key $VENICE_API_KEY   # scriptable / CI
+obol model setup --provider openrouter --model openrouter/auto # paid OpenRouter (skips free-roster seeding)
 ```
 
 **External OpenAI-compatible LLM** (vLLM / sglang / mlx-lm / remote GPU) — canonical user flow, no ConfigMap surgery:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,13 @@ Caveats:
 
 **Auto-configuration**: `obol stack up` → `autoConfigureLLM()` detects host Ollama models, patches LiteLLM config. `obolup.sh` → `check_agent_model_api_key()` reads `~/.openclaw/openclaw.json`, resolves API key from `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (Anthropic) or `OPENAI_API_KEY` (OpenAI), exports for downstream.
 
+**BYOK cloud providers** (easiest getting-started path) — provider knowledge is a single registry in `internal/model/model.go` (`knownProviders` / `ProviderInfo` with `Mode`/`BaseURL`/`Default`/`Free`); adding a provider is one row, no per-provider switch. `obol model setup <provider> --api-key <key>` wires the agent's LiteLLM brain in one command. Built-in: `anthropic`, `openai`, `ollama` (native/local) + OpenAI-compatible aggregators `venice`, `openrouter`, `nvidia`, `gmi`, `novita`, `huggingface` (`Mode=openai-compatible` → `model_list` entry `openai/<id>` + explicit `api_base` + key from the provider's env var; no wildcard). When `--model` is omitted, setup uses the registry `Default` or lists the live `GET <base>/v1/models` (TTY picker / non-TTY error naming real ids). `obol model setup openrouter --free` seeds only the curated free-tier model snapshot. Distinct from `obol buy inference`, which is x402 crypto-paid sellers, NOT BYOK. Unlisted endpoints still use `obol model setup custom`.
+
+```bash
+obol model setup venice     --api-key $VENICE_API_KEY        # one command, agent ready
+obol model setup openrouter --api-key $OPENROUTER_API_KEY --free
+```
+
 **External OpenAI-compatible LLM** (vLLM / sglang / mlx-lm / remote GPU) — canonical user flow, no ConfigMap surgery:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,11 +262,16 @@ Caveats:
 
 **Auto-configuration**: `obol stack up` → `autoConfigureLLM()` detects host Ollama models, patches LiteLLM config. `obolup.sh` → `check_agent_model_api_key()` reads `~/.openclaw/openclaw.json`, resolves API key from `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (Anthropic) or `OPENAI_API_KEY` (OpenAI), exports for downstream.
 
-**BYOK cloud providers** (easiest getting-started path) — provider knowledge is a single registry in `internal/model/model.go` (`knownProviders` / `ProviderInfo` with `Mode`/`BaseURL`/`Default`/`Free`); adding a provider is one row, no per-provider switch. `obol model setup <provider> --api-key <key>` wires the agent's LiteLLM brain in one command. Built-in: `anthropic`, `openai`, `ollama` (native/local) + OpenAI-compatible aggregators `venice`, `openrouter`, `nvidia`, `gmi`, `novita`, `huggingface` (`Mode=openai-compatible` → `model_list` entry `openai/<id>` + explicit `api_base` + key from the provider's env var; no wildcard). When `--model` is omitted, setup uses the registry `Default` or lists the live `GET <base>/v1/models` (TTY picker / non-TTY error naming real ids). `obol model setup openrouter --free` seeds only the curated free-tier model snapshot. Distinct from `obol buy inference`, which is x402 crypto-paid sellers, NOT BYOK. Unlisted endpoints still use `obol model setup custom`.
+**BYOK cloud providers** (easiest getting-started path) — provider knowledge is a single registry in `internal/model/model.go` (`knownProviders` / `ProviderInfo` with `Mode`/`BaseURL`/`Default`/`SignupURL`/`Free`); adding a provider is one row, no per-provider switch. Built-in: `anthropic`, `openai`, `ollama` (native/local) + OpenAI-compatible aggregators `venice`, `openrouter`, `nvidia`, `gmi`, `novita`, `huggingface` (`Mode=openai-compatible` → `model_list` entry `openai/<id>` + explicit `api_base` + key from the provider's env var; no wildcard). When `--model` is omitted, setup uses the registry `Default` or lists the live `GET <base>/v1/models` (TTY picker / non-TTY error naming real ids). `--free` seeds only the curated free-tier model snapshot (OpenRouter).
+
+Two front doors share one engine (`setupCloudProvider` in `cmd/obol/model.go`):
+- `obol buy inference <provider>` — friendly onboarding: opens the provider's `SignupURL` in the browser (`openBrowser`, hermes-style), takes the key (`--api-key` → env var → prompt), wires LiteLLM + syncs agents. `obol buy inference` with a URL/no-arg is still the **x402 crypto-paid seller** path — dispatch keys on whether the positional arg matches a registry provider id.
+- `obol model setup <provider> --api-key <key>` — the scriptable, no-browser equivalent. Unlisted endpoints still use `obol model setup custom`.
 
 ```bash
-obol model setup venice     --api-key $VENICE_API_KEY        # one command, agent ready
-obol model setup openrouter --api-key $OPENROUTER_API_KEY --free
+obol buy inference venice                 # opens venice key page, prompts, wires up
+obol buy inference openrouter --free      # seeds curated free models
+obol model setup venice --api-key $VENICE_API_KEY   # scriptable / CI
 ```
 
 **External OpenAI-compatible LLM** (vLLM / sglang / mlx-lm / remote GPU) — canonical user flow, no ConfigMap surgery:

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -66,45 +66,27 @@ func buyCommand(cfg *config.Config) *cli.Command {
 func buyInferenceCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:      "inference",
-		Usage:     "Buy inference for your agents — a hosted BYOK provider (Venice, OpenRouter, …) or an x402-gated seller",
-		ArgsUsage: "[<provider>|<seller-url>]",
-		Description: `Two ways to give your agents inference:
+		Usage:     "Buy inference for your agents from an x402-gated seller",
+		ArgsUsage: "[<seller-url>]",
+		Description: `Buy x402-gated inference from a seller.
 
-  1. Hosted provider (BYOK) — hand the command a provider id and it opens
-     that provider's API-key page in your browser, takes the key, and wires
-     your agents' LiteLLM gateway to it:
+Hand the command a seller URL (a storefront base like
+"https://inference.v1337.org" or a specific offer ".../services/aeon") and
+the CLI walks /api/services.json, picks the inference offer, and pre-signs
+payment authorizations via the agent's remote signer. With no argument the
+public ` + x402verifier.DefaultBuySellerURL + ` storefront is used.
 
-         obol buy inference venice
-         obol buy inference openrouter --free
+In a TTY the flow prompts for auto-refill, request count, and confirmation.
+Pass --yes / -y for non-interactive runs (--count required).
 
-     Built-in providers: venice, openrouter, nvidia, gmi, novita,
-     huggingface (plus anthropic, openai). The key is read from the
-     provider's env var when already set, so this stays non-interactive in CI.
-
-  2. x402-gated seller — hand it a seller URL (a storefront base like
-     "https://inference.v1337.org" or a specific offer ".../services/aeon")
-     and the CLI walks /api/services.json, picks the inference offer, and
-     pre-signs payment authorizations via the agent's remote signer. With no
-     argument, the public ` + x402verifier.DefaultBuySellerURL + ` storefront is used.
-
-In a TTY the seller flow prompts for auto-refill, request count, and
-confirmation. Pass --yes / -y for non-interactive runs (--count required).
+For hosted BYOK providers (Venice, OpenRouter, …) use ` + "`obol model setup`" + `
+instead — that path takes the API key and wires LiteLLM directly, no x402.
 
 Examples:
-    obol buy inference venice
-    obol buy inference openrouter --free
+    obol buy inference
     obol buy inference https://inference.v1337.org/services/aeon
     obol buy inference https://seller.example/services/foo --yes --count 100`,
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "api-key",
-				Usage:   "API key for a hosted provider (BYOK). Also read from the provider's env var when set.",
-				Sources: cli.EnvVars("LLM_API_KEY"),
-			},
-			&cli.BoolFlag{
-				Name:  "free",
-				Usage: "For a hosted provider that has them, seed only the curated free-tier models (OpenRouter)",
-			},
 			&cli.StringFlag{
 				Name:  "seller",
 				Usage: "Seller URL (alternative to positional). When neither is set the default storefront is used.",
@@ -177,49 +159,6 @@ Examples:
 	}
 }
 
-// runBuyInferenceProvider is the BYOK front door: open the provider's
-// API-key page (hermes-style openurl), take the key (--api-key → env →
-// prompt), then wire the LiteLLM gateway via the shared model-setup
-// engine. No wallet, no x402 — this is hosted inference with the user's
-// own key, the easiest way to get an agent talking to a model.
-func runBuyInferenceProvider(cfg *config.Config, cmd *cli.Command, prof model.ProviderInfo) error {
-	u := getUI(cmd)
-	u.Infof("Connecting %s for your agents (bring-your-own-key)", prof.Name)
-
-	apiKey := strings.TrimSpace(cmd.String("api-key"))
-	if apiKey == "" {
-		if key, envVar := model.ResolveAPIKey(prof.ID); key != "" {
-			apiKey = key
-			u.Infof("Using %s API key from %s", prof.Name, envVar)
-		}
-	}
-
-	// openurl: send the operator to the provider's onboarding page before
-	// we prompt for the key (skipped when a key is already in hand or
-	// non-TTY). Prefer JoinURL (the new-user landing page, possibly
-	// referral-tagged) when set; fall back to SignupURL (keys dashboard).
-	onboardURL := prof.JoinURL
-	if onboardURL == "" {
-		onboardURL = prof.SignupURL
-	}
-	if apiKey == "" && onboardURL != "" && u.IsTTY() && !u.IsJSON() {
-		u.Infof("Opening %s to sign up / create an API key …", onboardURL)
-		if err := openBrowser(onboardURL); err != nil {
-			u.Dim(fmt.Sprintf("(couldn't open a browser — visit %s)", onboardURL))
-		}
-	}
-
-	var models []string
-	if m := strings.TrimSpace(cmd.String("model")); m != "" {
-		models = []string{m}
-	}
-
-	// Shared engine: prompts for the key if still empty, seeds --free,
-	// resolves a model (registry default or live /v1/models), patches
-	// LiteLLM, and promotes + syncs the agents to use it.
-	return setupCloudProvider(cfg, u, prof, apiKey, models, cmd.Bool("free"))
-}
-
 // runBuyInference is the orchestrator for the new flow. Kept separate from
 // the cli.Command literal so the steps stay scannable: resolve agent →
 // resolve seller URL → pick catalog entry → resolve token+count+budget →
@@ -227,16 +166,17 @@ func runBuyInferenceProvider(cfg *config.Config, cmd *cli.Command, prof model.Pr
 func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) error {
 	u := getUI(cmd)
 
-	// Front door: if the argument names a hosted provider in the registry
-	// (venice, openrouter, …) rather than a seller URL, run BYOK onboarding
-	// — open the provider's key page and wire the LiteLLM gateway. Ollama is
-	// local and free, so it's not a "buy" target.
+	// If the argument names a hosted provider in the registry (venice,
+	// openrouter, …) rather than a seller URL, the user wants BYOK setup,
+	// not an x402 purchase. Redirect to `obol model setup`. The command
+	// name stays reserved for future credit top-up flows against the same
+	// remote providers.
 	arg := strings.TrimSpace(cmd.String("seller"))
 	if arg == "" {
 		arg = strings.TrimSpace(cmd.Args().First())
 	}
 	if prof, ok := model.ProviderByID(arg); ok && prof.ID != model.ProviderOllama {
-		return runBuyInferenceProvider(cfg, cmd, prof)
+		return fmt.Errorf("BYOK provider setup moved — run: obol model setup --provider %s", prof.ID)
 	}
 
 	u.Info("Purchasing remote inference for running Obol Agents")

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -66,28 +66,45 @@ func buyCommand(cfg *config.Config) *cli.Command {
 func buyInferenceCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:      "inference",
-		Usage:     "Buy paid inference from an x402-gated seller via the obol-agent",
-		ArgsUsage: "[<seller-url>]",
-		Description: `Pre-authorizes an x402-gated inference seller through an obol-agent's wallet.
+		Usage:     "Buy inference for your agents — a hosted BYOK provider (Venice, OpenRouter, …) or an x402-gated seller",
+		ArgsUsage: "[<provider>|<seller-url>]",
+		Description: `Two ways to give your agents inference:
 
-Hand the command a seller URL — either a storefront base
-("https://inference.v1337.org") or a specific offer
-("https://inference.v1337.org/services/aeon") — and the CLI will walk
-/api/services.json, pick the inference offer, and pre-sign authorizations
-via the agent's remote signer.
+  1. Hosted provider (BYOK) — hand the command a provider id and it opens
+     that provider's API-key page in your browser, takes the key, and wires
+     your agents' LiteLLM gateway to it:
 
-With no URL, the public ` + x402verifier.DefaultBuySellerURL + ` storefront is used.
+         obol buy inference venice
+         obol buy inference openrouter --free
 
-In a TTY, the CLI prompts for auto-refill, request count, and
-confirmation. Pass --yes / -y for non-interactive runs (CI, scripts) —
---count is required in that mode.
+     Built-in providers: venice, openrouter, nvidia, gmi, novita,
+     huggingface (plus anthropic, openai). The key is read from the
+     provider's env var when already set, so this stays non-interactive in CI.
+
+  2. x402-gated seller — hand it a seller URL (a storefront base like
+     "https://inference.v1337.org" or a specific offer ".../services/aeon")
+     and the CLI walks /api/services.json, picks the inference offer, and
+     pre-signs payment authorizations via the agent's remote signer. With no
+     argument, the public ` + x402verifier.DefaultBuySellerURL + ` storefront is used.
+
+In a TTY the seller flow prompts for auto-refill, request count, and
+confirmation. Pass --yes / -y for non-interactive runs (--count required).
 
 Examples:
-    obol buy inference
+    obol buy inference venice
+    obol buy inference openrouter --free
     obol buy inference https://inference.v1337.org/services/aeon
-    obol buy inference https://seller.example/services/foo --yes --count 100
-    obol buy inference https://seller.example/services/foo --auto-refill --refill-threshold 5 --refill-count 25`,
+    obol buy inference https://seller.example/services/foo --yes --count 100`,
 		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "api-key",
+				Usage:   "API key for a hosted provider (BYOK). Also read from the provider's env var when set.",
+				Sources: cli.EnvVars("LLM_API_KEY"),
+			},
+			&cli.BoolFlag{
+				Name:  "free",
+				Usage: "For a hosted provider that has them, seed only the curated free-tier models (OpenRouter)",
+			},
 			&cli.StringFlag{
 				Name:  "seller",
 				Usage: "Seller URL (alternative to positional). When neither is set the default storefront is used.",
@@ -160,12 +177,61 @@ Examples:
 	}
 }
 
+// runBuyInferenceProvider is the BYOK front door: open the provider's
+// API-key page (hermes-style openurl), take the key (--api-key → env →
+// prompt), then wire the LiteLLM gateway via the shared model-setup
+// engine. No wallet, no x402 — this is hosted inference with the user's
+// own key, the easiest way to get an agent talking to a model.
+func runBuyInferenceProvider(cfg *config.Config, cmd *cli.Command, prof model.ProviderInfo) error {
+	u := getUI(cmd)
+	u.Infof("Connecting %s for your agents (bring-your-own-key)", prof.Name)
+
+	apiKey := strings.TrimSpace(cmd.String("api-key"))
+	if apiKey == "" {
+		if key, envVar := model.ResolveAPIKey(prof.ID); key != "" {
+			apiKey = key
+			u.Infof("Using %s API key from %s", prof.Name, envVar)
+		}
+	}
+
+	// openurl: send the operator to the provider's key page before we
+	// prompt for the key (skipped when a key is already in hand or non-TTY).
+	if apiKey == "" && prof.SignupURL != "" && u.IsTTY() && !u.IsJSON() {
+		u.Infof("Opening %s to create an API key …", prof.SignupURL)
+		if err := openBrowser(prof.SignupURL); err != nil {
+			u.Dim(fmt.Sprintf("(couldn't open a browser — visit %s)", prof.SignupURL))
+		}
+	}
+
+	var models []string
+	if m := strings.TrimSpace(cmd.String("model")); m != "" {
+		models = []string{m}
+	}
+
+	// Shared engine: prompts for the key if still empty, seeds --free,
+	// resolves a model (registry default or live /v1/models), patches
+	// LiteLLM, and promotes + syncs the agents to use it.
+	return setupCloudProvider(cfg, u, prof, apiKey, models, cmd.Bool("free"))
+}
+
 // runBuyInference is the orchestrator for the new flow. Kept separate from
 // the cli.Command literal so the steps stay scannable: resolve agent →
 // resolve seller URL → pick catalog entry → resolve token+count+budget →
 // confirm → exec buy.py → optional model prefer + agent sync.
 func runBuyInference(ctx context.Context, cfg *config.Config, cmd *cli.Command) error {
 	u := getUI(cmd)
+
+	// Front door: if the argument names a hosted provider in the registry
+	// (venice, openrouter, …) rather than a seller URL, run BYOK onboarding
+	// — open the provider's key page and wire the LiteLLM gateway. Ollama is
+	// local and free, so it's not a "buy" target.
+	arg := strings.TrimSpace(cmd.String("seller"))
+	if arg == "" {
+		arg = strings.TrimSpace(cmd.Args().First())
+	}
+	if prof, ok := model.ProviderByID(arg); ok && prof.ID != model.ProviderOllama {
+		return runBuyInferenceProvider(cfg, cmd, prof)
+	}
 
 	u.Info("Purchasing remote inference for running Obol Agents")
 

--- a/cmd/obol/buy.go
+++ b/cmd/obol/buy.go
@@ -194,12 +194,18 @@ func runBuyInferenceProvider(cfg *config.Config, cmd *cli.Command, prof model.Pr
 		}
 	}
 
-	// openurl: send the operator to the provider's key page before we
-	// prompt for the key (skipped when a key is already in hand or non-TTY).
-	if apiKey == "" && prof.SignupURL != "" && u.IsTTY() && !u.IsJSON() {
-		u.Infof("Opening %s to create an API key …", prof.SignupURL)
-		if err := openBrowser(prof.SignupURL); err != nil {
-			u.Dim(fmt.Sprintf("(couldn't open a browser — visit %s)", prof.SignupURL))
+	// openurl: send the operator to the provider's onboarding page before
+	// we prompt for the key (skipped when a key is already in hand or
+	// non-TTY). Prefer JoinURL (the new-user landing page, possibly
+	// referral-tagged) when set; fall back to SignupURL (keys dashboard).
+	onboardURL := prof.JoinURL
+	if onboardURL == "" {
+		onboardURL = prof.SignupURL
+	}
+	if apiKey == "" && onboardURL != "" && u.IsTTY() && !u.IsJSON() {
+		u.Infof("Opening %s to sign up / create an API key …", onboardURL)
+		if err := openBrowser(onboardURL); err != nil {
+			u.Dim(fmt.Sprintf("(couldn't open a browser — visit %s)", onboardURL))
 		}
 	}
 

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
 	"github.com/ObolNetwork/obol-stack/internal/buy"
+	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/schemas"
 )
 
@@ -598,5 +600,38 @@ func TestLooksLikeURL(t *testing.T) {
 		if got := looksLikeURL(in); got != want {
 			t.Errorf("looksLikeURL(%q) = %v, want %v", in, got, want)
 		}
+	}
+}
+
+// TestBuyInference_BYOKFrontDoor pins the BYOK onboarding surface on
+// `obol buy inference`: the command exposes --api-key/--free/--model, and
+// every registry provider that isn't local Ollama is recognized as a
+// hosted-provider argument (the dispatch the Action keys on).
+func TestBuyInference_BYOKFrontDoor(t *testing.T) {
+	cmd := buyInferenceCommand(&config.Config{})
+
+	want := map[string]bool{"api-key": false, "free": false, "model": false, "seller": false}
+	for _, f := range cmd.Flags {
+		for _, n := range f.Names() {
+			if _, ok := want[n]; ok {
+				want[n] = true
+			}
+		}
+	}
+	for n, found := range want {
+		if !found {
+			t.Errorf("buy inference missing --%s flag", n)
+		}
+	}
+
+	// Hosted providers route to BYOK onboarding; ollama does not (local).
+	for _, id := range []string{"venice", "openrouter", "nvidia", "gmi", "novita", "huggingface"} {
+		p, ok := model.ProviderByID(id)
+		if !ok || p.ID == model.ProviderOllama {
+			t.Errorf("provider %q should be a BYOK buy-inference target", id)
+		}
+	}
+	if p, ok := model.ProviderByID("ollama"); !ok || p.ID != model.ProviderOllama {
+		t.Errorf("ollama must remain a local (non-buy) provider")
 	}
 }

--- a/cmd/obol/buy_test.go
+++ b/cmd/obol/buy_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/agentruntime"
 	"github.com/ObolNetwork/obol-stack/internal/buy"
 	"github.com/ObolNetwork/obol-stack/internal/config"
-	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/schemas"
 )
 
@@ -603,35 +602,35 @@ func TestLooksLikeURL(t *testing.T) {
 	}
 }
 
-// TestBuyInference_BYOKFrontDoor pins the BYOK onboarding surface on
-// `obol buy inference`: the command exposes --api-key/--free/--model, and
-// every registry provider that isn't local Ollama is recognized as a
-// hosted-provider argument (the dispatch the Action keys on).
-func TestBuyInference_BYOKFrontDoor(t *testing.T) {
+// TestBuyInference_NoBYOKArm pins that `obol buy inference` is x402-only:
+// the BYOK provider arm (which previously dispatched to setupCloudProvider
+// when a provider id was passed) has been removed in favour of
+// `obol model setup`. The `--api-key` and `--free` flags went with it.
+// The command name stays reserved for future remote-credit top-ups.
+func TestBuyInference_NoBYOKArm(t *testing.T) {
 	cmd := buyInferenceCommand(&config.Config{})
 
-	want := map[string]bool{"api-key": false, "free": false, "model": false, "seller": false}
+	// BYOK-only flags must be gone; the x402 surface keeps --seller.
+	gone := map[string]bool{"api-key": false, "free": false}
+	stillHere := map[string]bool{"seller": false}
 	for _, f := range cmd.Flags {
 		for _, n := range f.Names() {
-			if _, ok := want[n]; ok {
-				want[n] = true
+			if _, ok := gone[n]; ok {
+				gone[n] = true
+			}
+			if _, ok := stillHere[n]; ok {
+				stillHere[n] = true
 			}
 		}
 	}
-	for n, found := range want {
+	for n, found := range gone {
+		if found {
+			t.Errorf("buy inference must not expose --%s (BYOK arm removed; use `obol model setup`)", n)
+		}
+	}
+	for n, found := range stillHere {
 		if !found {
 			t.Errorf("buy inference missing --%s flag", n)
 		}
-	}
-
-	// Hosted providers route to BYOK onboarding; ollama does not (local).
-	for _, id := range []string{"venice", "openrouter", "nvidia", "gmi", "novita", "huggingface"} {
-		p, ok := model.ProviderByID(id)
-		if !ok || p.ID == model.ProviderOllama {
-			t.Errorf("provider %q should be a BYOK buy-inference target", id)
-		}
-	}
-	if p, ok := model.ProviderByID("ollama"); !ok || p.ID != model.ProviderOllama {
-		t.Errorf("ollama must remain a local (non-buy) provider")
 	}
 }

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -97,17 +97,17 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 				providers, _ := model.GetAvailableProviders(cfg)
 
 				options := make([]string, len(providers))
-				// Default to Venice — the friendliest BYOK on-ramp (cheap,
-				// no credit card to start, referral link in the JoinURL).
-				// Falls back to index 0 if Venice is ever removed from the
-				// registry.
+				// Default to OpenRouter — free roster auto-seeds when no
+				// --model is passed, so a new user gets a working remote
+				// model with zero credit-card friction. Falls back to
+				// index 0 if OpenRouter is ever removed from the registry.
 				defaultIdx := 0
 				for i, p := range providers {
 					label := fmt.Sprintf("%s (%s)", p.Name, p.ID)
 					if det, ok := creds[p.ID]; ok {
 						label += " — detected: " + det.source
 					}
-					if p.ID == "venice" {
+					if p.ID == "openrouter" {
 						defaultIdx = i
 					}
 
@@ -202,11 +202,25 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 
 func setupCloudProvider(cfg *config.Config, u *ui.UI, prof model.ProviderInfo, apiKey string, models []string, free bool) error {
 	if apiKey == "" {
+		// Prefer JoinURL (new-user landing, possibly referral-tagged) for
+		// the browser open; fall back to KeyURL (keys dashboard). Always
+		// print both as Dim hints so the URLs are visible whether the
+		// browser opened or not.
+		onboardURL := prof.JoinURL
+		if onboardURL == "" {
+			onboardURL = prof.KeyURL
+		}
+		if onboardURL != "" && u.IsTTY() && !u.IsJSON() {
+			u.Infof("Opening %s to sign up / create an API key …", onboardURL)
+			if err := openBrowser(onboardURL); err != nil {
+				u.Dim(fmt.Sprintf("(couldn't open a browser — visit %s)", onboardURL))
+			}
+		}
 		if prof.JoinURL != "" {
 			u.Dim(fmt.Sprintf("New to %s? Sign up: %s", prof.Name, prof.JoinURL))
 		}
-		if prof.SignupURL != "" {
-			u.Dim(fmt.Sprintf("Get a %s API key: %s", prof.Name, prof.SignupURL))
+		if prof.KeyURL != "" {
+			u.Dim(fmt.Sprintf("Get a %s API key: %s", prof.Name, prof.KeyURL))
 		}
 
 		var err error
@@ -220,14 +234,24 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, prof model.ProviderInfo, a
 		}
 	}
 
+	// OpenRouter zero-friction default: when no explicit --model and no
+	// explicit --free, auto-seed the curated free roster. The Dim hint
+	// surfaces openrouter/auto as the paid upgrade for users with balance.
+	if !free && len(models) == 0 && prof.ID == "openrouter" && len(prof.Free) > 0 {
+		free = true
+		u.Dim("Seeding OpenRouter's curated free models. With account balance, use: obol model setup --provider openrouter --model openrouter/auto")
+	}
+
 	// --free: seed the provider's curated free-tier models (unless the
-	// operator already named explicit --model values).
+	// operator already named explicit --model values). The static roster
+	// is intersected against the live /v1/models response so removed or
+	// renamed ids drop out without breaking the install.
 	if free {
 		if len(prof.Free) == 0 {
 			return fmt.Errorf("--free is not available for %s (no curated free models); pass --model instead", prof.Name)
 		}
 		if len(models) == 0 {
-			models = append([]string(nil), prof.Free...)
+			models = filterFreeAgainstLive(u, prof, apiKey)
 			u.Infof("Seeding %d curated free %s model(s)", len(models), prof.Name)
 		}
 	}
@@ -260,6 +284,41 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, prof model.ProviderInfo, a
 	return promoteAndSync(cfg, u, models)
 }
 
+// filterFreeAgainstLive intersects the registry's curated Free model list
+// with the provider's live /v1/models response so removed or renamed ids
+// drop out before they hit LiteLLM. On any fetch failure (network down,
+// auth error, unparseable body) it falls back to the full static list —
+// a slightly stale roster is better than a zero-model install.
+func filterFreeAgainstLive(u *ui.UI, prof model.ProviderInfo, apiKey string) []string {
+	static := append([]string(nil), prof.Free...)
+	live, err := model.FetchOpenAICompatibleModels(prof.BaseURL, apiKey)
+	if err != nil || len(live) == 0 {
+		return static
+	}
+	liveSet := make(map[string]bool, len(live))
+	for _, id := range live {
+		liveSet[id] = true
+	}
+	filtered := make([]string, 0, len(static))
+	dropped := make([]string, 0)
+	for _, id := range static {
+		if liveSet[id] {
+			filtered = append(filtered, id)
+		} else {
+			dropped = append(dropped, id)
+		}
+	}
+	if len(filtered) == 0 {
+		// All curated ids missing from live list — likely a major rotation;
+		// fall back rather than seed nothing.
+		return static
+	}
+	if len(dropped) > 0 {
+		u.Dim(fmt.Sprintf("(%d curated free model(s) no longer listed by %s: %s)", len(dropped), prof.Name, strings.Join(dropped, ", ")))
+	}
+	return filtered
+}
+
 // resolveSetupModel picks a model when the operator passed none. A registry
 // Default wins (overridable in a TTY). With no static default — BYOK
 // aggregators whose catalog rotates — it lists the live /v1/models endpoint:
@@ -290,7 +349,7 @@ func resolveSetupModel(u *ui.UI, prof model.ProviderInfo, apiKey string) (string
 		if u.IsTTY() && !u.IsJSON() {
 			return u.Input(fmt.Sprintf("Model id for %s", prof.Name), "")
 		}
-		return "", fmt.Errorf("could not resolve a model for %s: pass --model <id> (keys/models at %s)", prof.Name, prof.SignupURL)
+		return "", fmt.Errorf("could not resolve a model for %s: pass --model <id> (keys/models at %s)", prof.Name, prof.KeyURL)
 	}
 
 	if u.IsTTY() && !u.IsJSON() {

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -97,16 +97,24 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 				providers, _ := model.GetAvailableProviders(cfg)
 
 				options := make([]string, len(providers))
+				// Default to Venice — the friendliest BYOK on-ramp (cheap,
+				// no credit card to start, referral link in the JoinURL).
+				// Falls back to index 0 if Venice is ever removed from the
+				// registry.
+				defaultIdx := 0
 				for i, p := range providers {
 					label := fmt.Sprintf("%s (%s)", p.Name, p.ID)
 					if det, ok := creds[p.ID]; ok {
 						label += " — detected: " + det.source
 					}
+					if p.ID == "venice" {
+						defaultIdx = i
+					}
 
 					options[i] = label
 				}
 
-				idx, err := u.Select("Select a provider:", options, 0)
+				idx, err := u.Select("Select a provider:", options, defaultIdx)
 				if err != nil {
 					return err
 				}
@@ -194,6 +202,9 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 
 func setupCloudProvider(cfg *config.Config, u *ui.UI, prof model.ProviderInfo, apiKey string, models []string, free bool) error {
 	if apiKey == "" {
+		if prof.JoinURL != "" {
+			u.Dim(fmt.Sprintf("New to %s? Sign up: %s", prof.Name, prof.JoinURL))
+		}
 		if prof.SignupURL != "" {
 			u.Dim(fmt.Sprintf("Get a %s API key: %s", prof.Name, prof.SignupURL))
 		}

--- a/cmd/obol/model.go
+++ b/cmd/obol/model.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -67,16 +66,20 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "provider",
-				Usage: "Provider name: anthropic, openai, or ollama",
+				Usage: "Provider id (anthropic, openai, ollama, venice, openrouter, nvidia, gmi, novita, huggingface). Run with no flags to pick interactively.",
 			},
 			&cli.StringFlag{
 				Name:    "api-key",
-				Usage:   "API key for the provider",
+				Usage:   "API key for the provider (BYOK; also read from the provider's env var if set)",
 				Sources: cli.EnvVars("LLM_API_KEY"),
 			},
 			&cli.StringSliceFlag{
 				Name:  "model",
-				Usage: "Model(s) to configure (e.g. claude-sonnet-4-5-20250929, gpt-4o)",
+				Usage: "Model(s) to configure (e.g. claude-sonnet-4-6, gpt-5.5, or an aggregator model id)",
+			},
+			&cli.BoolFlag{
+				Name:  "free",
+				Usage: "Seed only the provider's curated free-tier models (OpenRouter)",
 			},
 		},
 		Commands: []*cli.Command{
@@ -120,15 +123,17 @@ func modelSetupCommand(cfg *config.Config) *cli.Command {
 				}
 			}
 
-			// Provider-specific flow
-			switch provider {
-			case "ollama":
-				return setupOllama(cfg, u, models)
-			case "anthropic", "openai":
-				return setupCloudProvider(cfg, u, provider, apiKey, models)
-			default:
-				return fmt.Errorf("unknown provider %q — use anthropic, openai, or ollama", provider)
+			// Provider-specific flow — dispatch off the registry, not a
+			// hardcoded switch. Ollama is local; everything else is a
+			// key-based cloud/BYOK provider handled by one generic path.
+			prof, ok := model.ProviderByID(provider)
+			if !ok {
+				return fmt.Errorf("unknown provider %q — run `obol model setup` (no flags) to pick from the list, or `obol model setup custom --endpoint … --model …` for an unlisted OpenAI-compatible endpoint", provider)
 			}
+			if prof.ID == model.ProviderOllama {
+				return setupOllama(cfg, u, models)
+			}
+			return setupCloudProvider(cfg, u, prof, apiKey, models, cmd.Bool("free"))
 		},
 	}
 }
@@ -187,13 +192,14 @@ func setupOllama(cfg *config.Config, u *ui.UI, models []string) error {
 	return promoteAndSync(cfg, u, explicit)
 }
 
-func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, models []string) error {
+func setupCloudProvider(cfg *config.Config, u *ui.UI, prof model.ProviderInfo, apiKey string, models []string, free bool) error {
 	if apiKey == "" {
+		if prof.SignupURL != "" {
+			u.Dim(fmt.Sprintf("Get a %s API key: %s", prof.Name, prof.SignupURL))
+		}
+
 		var err error
-
-		info := providerInfo(provider)
-
-		apiKey, err = u.SecretInput(fmt.Sprintf("%s API key (%s)", info.Name, info.EnvVar))
+		apiKey, err = u.SecretInput(fmt.Sprintf("%s API key (%s)", prof.Name, prof.EnvVar))
 		if err != nil {
 			return err
 		}
@@ -203,38 +209,34 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 		}
 	}
 
-	if len(models) == 0 {
-		// Per-provider defaults — kept in sync with what the providers
-		// document as their current chat-tuned flagship. Bumping these is a
-		// small follow-up PR when frontier models drop, and it isolates the
-		// "what's good today" maintenance to one place.
-		var defaultModel string
-		switch provider {
-		case "anthropic":
-			defaultModel = "claude-sonnet-4-6"
-		case "openai":
-			defaultModel = "gpt-5.5"
+	// --free: seed the provider's curated free-tier models (unless the
+	// operator already named explicit --model values).
+	if free {
+		if len(prof.Free) == 0 {
+			return fmt.Errorf("--free is not available for %s (no curated free models); pass --model instead", prof.Name)
 		}
+		if len(models) == 0 {
+			models = append([]string(nil), prof.Free...)
+			u.Infof("Seeding %d curated free %s model(s)", len(models), prof.Name)
+		}
+	}
 
-		// Interactive: let the user override the default with a free-text
-		// entry. Non-interactive (no TTY): silently use the default — the
-		// caller can always pass --model to be explicit.
-		chosen := defaultModel
-		if defaultModel != "" && u.IsTTY() && !u.IsJSON() {
-			input, err := u.Input(fmt.Sprintf("Model for %s", provider), defaultModel)
-			if err != nil {
-				return err
-			}
-			if strings.TrimSpace(input) != "" {
-				chosen = strings.TrimSpace(input)
-			}
+	// Resolve a model when none was given: the registry Default, else (for
+	// BYOK aggregators with a rotating catalog) the live /v1/models list.
+	if len(models) == 0 {
+		chosen, err := resolveSetupModel(u, prof, apiKey)
+		if err != nil {
+			return err
 		}
 		if chosen != "" {
 			models = []string{chosen}
 		}
 	}
+	if len(models) == 0 {
+		return fmt.Errorf("no model selected for %s — pass --model <id>", prof.Name)
+	}
 
-	if err := model.ConfigureLiteLLM(cfg, u, provider, apiKey, models); err != nil {
+	if err := model.ConfigureLiteLLM(cfg, u, prof.ID, apiKey, models); err != nil {
 		u.Print("")
 		u.Print("  Hint: Configuration stored in: litellm-config ConfigMap (llm namespace)")
 
@@ -245,6 +247,58 @@ func setupCloudProvider(cfg *config.Config, u *ui.UI, provider, apiKey string, m
 	u.Successf("Model configured. To change later, run: obol model setup (or obol model remove <name>)")
 
 	return promoteAndSync(cfg, u, models)
+}
+
+// resolveSetupModel picks a model when the operator passed none. A registry
+// Default wins (overridable in a TTY). With no static default — BYOK
+// aggregators whose catalog rotates — it lists the live /v1/models endpoint:
+// a picker in a TTY, otherwise an error naming real ids so the operator can
+// re-run with --model. Returns "" only when there is genuinely nothing to
+// pick (the caller then errors).
+func resolveSetupModel(u *ui.UI, prof model.ProviderInfo, apiKey string) (string, error) {
+	if prof.Default != "" {
+		if u.IsTTY() && !u.IsJSON() {
+			input, err := u.Input(fmt.Sprintf("Model for %s", prof.ID), prof.Default)
+			if err != nil {
+				return "", err
+			}
+			if strings.TrimSpace(input) != "" {
+				return strings.TrimSpace(input), nil
+			}
+		}
+		return prof.Default, nil
+	}
+
+	if !prof.IsBYOK() {
+		return "", nil
+	}
+
+	ids, err := model.FetchOpenAICompatibleModels(prof.BaseURL, apiKey)
+	if err != nil {
+		u.Dim(fmt.Sprintf("Couldn't list %s models (%v)", prof.Name, err))
+		if u.IsTTY() && !u.IsJSON() {
+			return u.Input(fmt.Sprintf("Model id for %s", prof.Name), "")
+		}
+		return "", fmt.Errorf("could not resolve a model for %s: pass --model <id> (keys/models at %s)", prof.Name, prof.SignupURL)
+	}
+
+	if u.IsTTY() && !u.IsJSON() {
+		shown := ids
+		if len(shown) > 30 {
+			shown = shown[:30]
+		}
+		idx, err := u.Select(fmt.Sprintf("Select a %s model:", prof.Name), shown, 0)
+		if err != nil {
+			return "", err
+		}
+		return shown[idx], nil
+	}
+
+	sample := ids
+	if len(sample) > 8 {
+		sample = sample[:8]
+	}
+	return "", fmt.Errorf("pass --model <id> for %s; available include: %s", prof.Name, strings.Join(sample, ", "))
 }
 
 // syncAgentModels re-renders the stack-managed Hermes default agent from the
@@ -852,17 +906,6 @@ func modelRemoveCommand(cfg *config.Config) *cli.Command {
 	}
 }
 
-func providerInfo(id string) model.ProviderInfo {
-	providers, _ := model.GetAvailableProviders(nil)
-	for _, p := range providers {
-		if p.ID == id {
-			return p
-		}
-	}
-
-	return model.ProviderInfo{ID: id, Name: id}
-}
-
 // detectedCredential describes a credential found in the environment.
 type detectedCredential struct {
 	key    string // the actual API key value (empty for Ollama)
@@ -875,22 +918,22 @@ type detectedCredential struct {
 func detectCredentials() map[string]detectedCredential {
 	creds := make(map[string]detectedCredential)
 
-	// Anthropic: check ANTHROPIC_API_KEY, then CLAUDE_CODE_OAUTH_TOKEN
-	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
-		creds["anthropic"] = detectedCredential{key: key, source: "ANTHROPIC_API_KEY"}
-	} else if key := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); key != "" {
-		creds["anthropic"] = detectedCredential{key: key, source: "CLAUDE_CODE_OAUTH_TOKEN"}
-	}
+	// Registry-driven: every provider's primary + alternate env vars are
+	// checked via model.ResolveAPIKey, so a new provider row auto-detects
+	// without editing this function. Ollama has no key — probe reachability.
+	providers, _ := model.GetAvailableProviders(nil)
+	for _, p := range providers {
+		if p.ID == model.ProviderOllama {
+			if ollamaModels, err := model.ListOllamaModels(); err == nil && len(ollamaModels) > 0 {
+				creds[p.ID] = detectedCredential{
+					source: fmt.Sprintf("%d model(s) available", len(ollamaModels)),
+				}
+			}
+			continue
+		}
 
-	// OpenAI: check OPENAI_API_KEY
-	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
-		creds["openai"] = detectedCredential{key: key, source: "OPENAI_API_KEY"}
-	}
-
-	// Ollama: check if reachable with models
-	if ollamaModels, err := model.ListOllamaModels(); err == nil && len(ollamaModels) > 0 {
-		creds["ollama"] = detectedCredential{
-			source: fmt.Sprintf("%d model(s) available", len(ollamaModels)),
+		if key, envVar := model.ResolveAPIKey(p.ID); key != "" {
+			creds[p.ID] = detectedCredential{key: key, source: envVar}
 		}
 	}
 

--- a/cmd/obol/model_test.go
+++ b/cmd/obol/model_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"testing"
 
+	"github.com/ObolNetwork/obol-stack/internal/model"
+	"github.com/urfave/cli/v3"
+
 	"github.com/ObolNetwork/obol-stack/internal/config"
 )
 
@@ -68,4 +71,47 @@ func TestSetupPromoteList(t *testing.T) {
 			t.Fatalf("setupPromoteList aliased its input: mutating the result changed in[0] to %q", in[0])
 		}
 	})
+}
+
+// TestModelSetup_BYOKFlags pins the BYOK onboarding surface: the setup
+// command exposes --provider/--api-key/--model/--free, and every BYOK
+// aggregator in the registry dispatches through the generic cloud path
+// (only Ollama is special-cased).
+func TestModelSetup_BYOKFlags(t *testing.T) {
+	cfg := &config.Config{}
+	var setup *cli.Command
+	for _, sub := range modelCommand(cfg).Commands {
+		if sub.Name == "setup" {
+			setup = sub
+		}
+	}
+	if setup == nil {
+		t.Fatal("model setup command missing")
+	}
+
+	want := map[string]bool{"provider": false, "api-key": false, "model": false, "free": false}
+	for _, f := range setup.Flags {
+		for _, n := range f.Names() {
+			if _, ok := want[n]; ok {
+				want[n] = true
+			}
+		}
+	}
+	for n, found := range want {
+		if !found {
+			t.Errorf("model setup missing --%s flag", n)
+		}
+	}
+
+	// The registry must carry the BYOK providers this PR adds.
+	for _, id := range []string{"venice", "openrouter", "nvidia", "gmi", "novita", "huggingface"} {
+		p, ok := model.ProviderByID(id)
+		if !ok {
+			t.Errorf("provider %q missing from registry", id)
+			continue
+		}
+		if p.BaseURL == "" {
+			t.Errorf("provider %q has no BaseURL", id)
+		}
+	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -37,19 +37,171 @@ const (
 	ProviderOpenAI    = "openai"
 )
 
-// Known provider definitions — no need to query the running pod.
-var knownProviders = []ProviderInfo{
-	{ID: ProviderAnthropic, Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY", AltEnvVars: []string{"CLAUDE_CODE_OAUTH_TOKEN"}},
-	{ID: ProviderOpenAI, Name: "OpenAI", EnvVar: "OPENAI_API_KEY"},
-	{ID: ProviderOllama, Name: "Ollama (local)", EnvVar: ""},
-}
+// apiMode selects how a provider's LiteLLM model_list entries are shaped.
+type apiMode string
 
-// ProviderInfo describes an LLM provider.
+const (
+	// modeAnthropic: native LiteLLM anthropic routing + prompt-cache markers
+	// + an anthropic/* wildcard. Key read from EnvVar.
+	modeAnthropic apiMode = "anthropic"
+	// modeOpenAI: native LiteLLM openai/ routing + an openai/* wildcard.
+	modeOpenAI apiMode = "openai"
+	// modeOllama: local ollama_chat/ entries pointed at the in-cluster Ollama.
+	modeOllama apiMode = "ollama"
+	// modeOpenAICompatible: any OpenAI-compatible BYOK aggregator (OpenRouter,
+	// Venice, NVIDIA, …). Explicit entries only, Model="openai/<id>" with an
+	// explicit api_base = BaseURL and key read from EnvVar. No wildcard:
+	// aggregator namespaces are huge and overlapping, so we register only the
+	// models the operator asked for.
+	modeOpenAICompatible apiMode = "openai-compatible"
+)
+
+// ProviderInfo describes an LLM provider. knownProviders is the single
+// source of truth: adding a provider is one row here, and every layer (the
+// setup CLI, default-model selection, LiteLLM entry shaping, status, and
+// the persisted record) reads from this struct instead of a per-provider
+// switch.
 type ProviderInfo struct {
-	ID         string   // provider id (e.g. "anthropic", "openai", "ollama")
+	ID         string   // provider id (e.g. "anthropic", "openai", "venice")
 	Name       string   // display name
 	EnvVar     string   // primary env var for API key (empty for Ollama)
 	AltEnvVars []string // fallback env vars checked in order (e.g. CLAUDE_CODE_OAUTH_TOKEN)
+	Mode       apiMode  // how model_list entries are shaped
+	BaseURL    string   // OpenAI-compatible base_url (modeOpenAICompatible only)
+	Default    string   // default chat model when --model is omitted ("" = ask/require)
+	SignupURL  string   // where to obtain an API key (shown as a hint)
+	Free       []string // curated zero-marginal-cost model ids (seeded by --free)
+}
+
+// IsBYOK reports whether the provider is a BYOK OpenAI-compatible
+// aggregator reached over the public internet (as opposed to a native
+// provider or the local Ollama).
+func (p ProviderInfo) IsBYOK() bool { return p.Mode == modeOpenAICompatible }
+
+// knownProviders is the registry of supported LLM providers. The first
+// three are native/local; the rest are BYOK OpenAI-compatible aggregators —
+// each is pure data, no bespoke wiring. base_url values are intentionally
+// without a trailing /v1 where LiteLLM appends it; aggregator paths that
+// already include /v1 keep it (LiteLLM only auto-appends for bare hosts).
+var knownProviders = []ProviderInfo{
+	{
+		ID: ProviderAnthropic, Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY",
+		AltEnvVars: []string{"CLAUDE_CODE_OAUTH_TOKEN"}, Mode: modeAnthropic,
+		Default: "claude-sonnet-4-6", SignupURL: "https://console.anthropic.com/settings/keys",
+	},
+	{
+		ID: ProviderOpenAI, Name: "OpenAI", EnvVar: "OPENAI_API_KEY", Mode: modeOpenAI,
+		Default: "gpt-5.5", SignupURL: "https://platform.openai.com/api-keys",
+	},
+	{
+		ID: ProviderOllama, Name: "Ollama (local)", EnvVar: "", Mode: modeOllama,
+	},
+	// ── BYOK OpenAI-compatible aggregators (the easy getting-started path) ──
+	// model_list entries are pure data: Model="openai/<id>", api_base=BaseURL,
+	// key from EnvVar. Default models that can't be statically pinned (the
+	// aggregator's catalog rotates) are left blank — setup then resolves a
+	// model from the live /v1/models list or --model.
+	{
+		ID: "venice", Name: "Venice", EnvVar: "VENICE_API_KEY", Mode: modeOpenAICompatible,
+		BaseURL: "https://api.venice.ai/api/v1", SignupURL: "https://venice.ai/settings/api",
+	},
+	{
+		ID: "openrouter", Name: "OpenRouter", EnvVar: "OPENROUTER_API_KEY", Mode: modeOpenAICompatible,
+		BaseURL: "https://openrouter.ai/api/v1", Default: "openrouter/auto",
+		SignupURL: "https://openrouter.ai/keys",
+		// Curated zero-cost models (snapshot — OpenRouter's free roster
+		// rotates; pass --model for any other). Seeded by `--free`.
+		Free: []string{
+			"openrouter/elephant-alpha",
+			"openrouter/owl-alpha",
+			"poolside/laguna-m.1:free",
+			"tencent/hy3-preview:free",
+			"nvidia/nemotron-3-super-120b-a12b:free",
+			"nvidia/nemotron-3-ultra-550b-a55b:free",
+			"inclusionai/ring-2.6-1t:free",
+		},
+	},
+	{
+		ID: "nvidia", Name: "NVIDIA NIM", EnvVar: "NVIDIA_API_KEY", Mode: modeOpenAICompatible,
+		BaseURL: "https://integrate.api.nvidia.com/v1", SignupURL: "https://build.nvidia.com",
+	},
+	{
+		ID: "gmi", Name: "GMI Cloud", EnvVar: "GMI_API_KEY", Mode: modeOpenAICompatible,
+		BaseURL: "https://api.gmi-serving.com/v1", SignupURL: "https://console.gmicloud.ai",
+	},
+	{
+		ID: "novita", Name: "Novita", EnvVar: "NOVITA_API_KEY", Mode: modeOpenAICompatible,
+		BaseURL: "https://api.novita.ai/openai/v1", SignupURL: "https://novita.ai/settings/key-management",
+	},
+	{
+		ID: "huggingface", Name: "Hugging Face Router", EnvVar: "HF_TOKEN", Mode: modeOpenAICompatible,
+		BaseURL: "https://router.huggingface.co/v1", SignupURL: "https://huggingface.co/settings/tokens",
+	},
+}
+
+// ProviderByID returns the registry entry for id and whether it was found.
+func ProviderByID(id string) (ProviderInfo, bool) {
+	for _, p := range knownProviders {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return ProviderInfo{}, false
+}
+
+// FetchOpenAICompatibleModels lists model ids from a provider's
+// OpenAI-compatible GET <baseURL>/models endpoint. Used at setup time to
+// resolve a real model id when an aggregator has no statically-pinnable
+// default (its catalog rotates). Best-effort: a non-200, a network error,
+// or an unparseable body returns an error the caller falls back from
+// (prompt for / require --model). The just-entered apiKey authenticates
+// the call from the host.
+func FetchOpenAICompatibleModels(baseURL, apiKey string) ([]string, error) {
+	endpoint := strings.TrimRight(baseURL, "/") + "/models"
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("models endpoint returned %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("parse models response: %w", err)
+	}
+
+	ids := make([]string, 0, len(parsed.Data))
+	for _, m := range parsed.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, errors.New("models endpoint returned no models")
+	}
+	return ids, nil
 }
 
 // ProviderStatus captures effective global LiteLLM provider state.
@@ -1308,16 +1460,42 @@ var WellKnownModels = map[string][]string{
 	},
 }
 
-// buildModelEntries creates LiteLLM model_list entries for a provider.
-// Cloud providers (anthropic, openai) get a wildcard entry plus explicit
-// entries for the requested models. Ollama gets explicit entries only
-// (wildcards are broken for ollama_chat/).
+// buildModelEntries creates LiteLLM model_list entries for a provider,
+// shaped by its registry Mode:
+//   - anthropic/openai: explicit entries (so the chosen model wins Rank's
+//     "first chat-capable" rule) followed by a <provider>/* wildcard.
+//   - ollama: explicit ollama_chat/ entries only (wildcards are broken).
+//   - openai-compatible: explicit openai/<id> entries with an explicit
+//     api_base = BaseURL and key from EnvVar — no wildcard.
+//
+// A provider not in the registry falls back to the generic openai/<id>
+// shape keyed on <PROVIDER>_API_KEY (legacy `setup custom` behavior).
 func buildModelEntries(provider string, models []string) []ModelEntry {
-	var entries []ModelEntry
+	p, ok := ProviderByID(provider)
+	if !ok {
+		// Unknown provider: legacy generic shape (no api_base).
+		var entries []ModelEntry
+		for _, m := range models {
+			entries = append(entries, ModelEntry{
+				ModelName: m,
+				LiteLLMParams: LiteLLMParams{
+					Model:  provider + "/" + m,
+					APIKey: fmt.Sprintf("os.environ/%s_API_KEY", strings.ToUpper(provider)),
+				},
+			})
+		}
+		return entries
+	}
 
-	switch provider {
-	case ProviderOllama:
-		// Explicit entries — ollama_chat/* wildcards are broken in LiteLLM
+	keyRef := ""
+	if p.EnvVar != "" {
+		keyRef = "os.environ/" + p.EnvVar
+	}
+
+	var entries []ModelEntry
+	switch p.Mode {
+	case modeOllama:
+		// Explicit entries — ollama_chat/* wildcards are broken in LiteLLM.
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
 				ModelName: m,
@@ -1327,7 +1505,7 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 				},
 			})
 		}
-	case ProviderAnthropic:
+	case modeAnthropic:
 		cachePoints := anthropicCacheControlPoints()
 		// Explicit entries first so the user-selected model is the primary
 		// under model.Rank's "first chat-capable wins" rule. Hermes cannot
@@ -1338,39 +1516,41 @@ func buildModelEntries(provider string, models []string) []ModelEntry {
 				ModelName: m,
 				LiteLLMParams: LiteLLMParams{
 					Model:                       m,
-					APIKey:                      "os.environ/ANTHROPIC_API_KEY",
+					APIKey:                      keyRef,
 					CacheControlInjectionPoints: cachePoints,
 				},
 			})
 		}
-		// Wildcard: routes any anthropic model without explicit registration.
 		entries = append(entries, ModelEntry{
 			ModelName: "anthropic/*",
 			LiteLLMParams: LiteLLMParams{
 				Model:                       "anthropic/*",
-				APIKey:                      "os.environ/ANTHROPIC_API_KEY",
+				APIKey:                      keyRef,
 				CacheControlInjectionPoints: cachePoints,
 			},
 		})
-	case ProviderOpenAI:
+	case modeOpenAI:
 		// Explicit-before-wildcard, same rationale as Anthropic above.
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
 				ModelName:     m,
-				LiteLLMParams: LiteLLMParams{Model: "openai/" + m, APIKey: "os.environ/OPENAI_API_KEY"},
+				LiteLLMParams: LiteLLMParams{Model: "openai/" + m, APIKey: keyRef},
 			})
 		}
 		entries = append(entries, ModelEntry{
 			ModelName:     "openai/*",
-			LiteLLMParams: LiteLLMParams{Model: "openai/*", APIKey: "os.environ/OPENAI_API_KEY"},
+			LiteLLMParams: LiteLLMParams{Model: "openai/*", APIKey: keyRef},
 		})
-	default:
+	case modeOpenAICompatible:
+		// Explicit openai-shaped entries with an explicit api_base. No
+		// wildcard — the aggregator's catalog is huge and overlaps others.
 		for _, m := range models {
 			entries = append(entries, ModelEntry{
 				ModelName: m,
 				LiteLLMParams: LiteLLMParams{
-					Model:  provider + "/" + m,
-					APIKey: fmt.Sprintf("os.environ/%s_API_KEY", strings.ToUpper(provider)),
+					Model:   "openai/" + m,
+					APIBase: p.BaseURL,
+					APIKey:  keyRef,
 				},
 			})
 		}
@@ -1464,6 +1644,18 @@ func detectProvider(entry ModelEntry) string {
 	}
 
 	model := entry.LiteLLMParams.Model
+	// BYOK aggregator entries are openai-shaped (openai/<id>) but carry an
+	// explicit api_base — match it back to the registry so status groups
+	// them under their real provider (venice, openrouter, …) rather than
+	// "openai". Checked before the bare openai/ prefix below.
+	if base := entry.LiteLLMParams.APIBase; base != "" && strings.HasPrefix(model, ProviderOpenAI+"/") {
+		for _, p := range knownProviders {
+			if p.Mode == modeOpenAICompatible && p.BaseURL == base {
+				return p.ID
+			}
+		}
+	}
+
 	// Wildcard entries
 	if strings.HasPrefix(model, ProviderAnthropic+"/") {
 		return ProviderAnthropic

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,11 +69,10 @@ type ProviderInfo struct {
 	Mode       apiMode  // how model_list entries are shaped
 	BaseURL    string   // OpenAI-compatible base_url (modeOpenAICompatible only)
 	Default    string   // default chat model when --model is omitted ("" = ask/require)
-	SignupURL  string   // where to obtain an API key (assumes existing account)
-	JoinURL    string   // optional landing page for users without an account yet
-	// (may carry a referral tag). When set, `obol buy inference <provider>`
-	// opens this in preference to SignupURL, and `obol model setup`'s
-	// missing-key Dim hint surfaces it as a "new to X? sign up" line above
+	KeyURL     string   // where to create an API key (assumes existing account)
+	JoinURL    string   // optional new-user landing page (may carry a referral
+	// tag). When set, `obol model setup` opens this in preference to KeyURL
+	// (browser open) and surfaces it as a "new to X? sign up" Dim hint above
 	// the keys-dashboard hint.
 	Free []string // curated zero-marginal-cost model ids (seeded by --free)
 }
@@ -92,11 +91,11 @@ var knownProviders = []ProviderInfo{
 	{
 		ID: ProviderAnthropic, Name: "Anthropic", EnvVar: "ANTHROPIC_API_KEY",
 		AltEnvVars: []string{"CLAUDE_CODE_OAUTH_TOKEN"}, Mode: modeAnthropic,
-		Default: "claude-sonnet-4-6", SignupURL: "https://console.anthropic.com/settings/keys",
+		Default: "claude-sonnet-4-6", KeyURL: "https://console.anthropic.com/settings/keys",
 	},
 	{
 		ID: ProviderOpenAI, Name: "OpenAI", EnvVar: "OPENAI_API_KEY", Mode: modeOpenAI,
-		Default: "gpt-5.5", SignupURL: "https://platform.openai.com/api-keys",
+		Default: "gpt-5.5", KeyURL: "https://platform.openai.com/api-keys",
 	},
 	{
 		ID: ProviderOllama, Name: "Ollama (local)", EnvVar: "", Mode: modeOllama,
@@ -108,14 +107,14 @@ var knownProviders = []ProviderInfo{
 	// model from the live /v1/models list or --model.
 	{
 		ID: "venice", Name: "Venice", EnvVar: "VENICE_API_KEY", Mode: modeOpenAICompatible,
-		BaseURL:   "https://api.venice.ai/api/v1",
-		SignupURL: "https://venice.ai/settings/api",
-		JoinURL:   "https://venice.ai/chat?ref=ZynMuD",
+		BaseURL: "https://api.venice.ai/api/v1",
+		KeyURL:  "https://venice.ai/settings/api",
+		JoinURL: "https://venice.ai/chat?ref=ZynMuD",
 	},
 	{
 		ID: "openrouter", Name: "OpenRouter", EnvVar: "OPENROUTER_API_KEY", Mode: modeOpenAICompatible,
 		BaseURL: "https://openrouter.ai/api/v1", Default: "openrouter/auto",
-		SignupURL: "https://openrouter.ai/keys",
+		KeyURL: "https://openrouter.ai/keys",
 		// Curated zero-cost models (snapshot — OpenRouter's free roster
 		// rotates; pass --model for any other). Seeded by `--free`.
 		Free: []string{
@@ -130,19 +129,19 @@ var knownProviders = []ProviderInfo{
 	},
 	{
 		ID: "nvidia", Name: "NVIDIA NIM", EnvVar: "NVIDIA_API_KEY", Mode: modeOpenAICompatible,
-		BaseURL: "https://integrate.api.nvidia.com/v1", SignupURL: "https://build.nvidia.com",
+		BaseURL: "https://integrate.api.nvidia.com/v1", KeyURL: "https://build.nvidia.com",
 	},
 	{
 		ID: "gmi", Name: "GMI Cloud", EnvVar: "GMI_API_KEY", Mode: modeOpenAICompatible,
-		BaseURL: "https://api.gmi-serving.com/v1", SignupURL: "https://console.gmicloud.ai",
+		BaseURL: "https://api.gmi-serving.com/v1", KeyURL: "https://console.gmicloud.ai",
 	},
 	{
 		ID: "novita", Name: "Novita", EnvVar: "NOVITA_API_KEY", Mode: modeOpenAICompatible,
-		BaseURL: "https://api.novita.ai/openai/v1", SignupURL: "https://novita.ai/settings/key-management",
+		BaseURL: "https://api.novita.ai/openai/v1", KeyURL: "https://novita.ai/settings/key-management",
 	},
 	{
 		ID: "huggingface", Name: "Hugging Face Router", EnvVar: "HF_TOKEN", Mode: modeOpenAICompatible,
-		BaseURL: "https://router.huggingface.co/v1", SignupURL: "https://huggingface.co/settings/tokens",
+		BaseURL: "https://router.huggingface.co/v1", KeyURL: "https://huggingface.co/settings/tokens",
 	},
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,8 +69,13 @@ type ProviderInfo struct {
 	Mode       apiMode  // how model_list entries are shaped
 	BaseURL    string   // OpenAI-compatible base_url (modeOpenAICompatible only)
 	Default    string   // default chat model when --model is omitted ("" = ask/require)
-	SignupURL  string   // where to obtain an API key (shown as a hint)
-	Free       []string // curated zero-marginal-cost model ids (seeded by --free)
+	SignupURL  string   // where to obtain an API key (assumes existing account)
+	JoinURL    string   // optional landing page for users without an account yet
+	// (may carry a referral tag). When set, `obol buy inference <provider>`
+	// opens this in preference to SignupURL, and `obol model setup`'s
+	// missing-key Dim hint surfaces it as a "new to X? sign up" line above
+	// the keys-dashboard hint.
+	Free []string // curated zero-marginal-cost model ids (seeded by --free)
 }
 
 // IsBYOK reports whether the provider is a BYOK OpenAI-compatible
@@ -103,7 +108,9 @@ var knownProviders = []ProviderInfo{
 	// model from the live /v1/models list or --model.
 	{
 		ID: "venice", Name: "Venice", EnvVar: "VENICE_API_KEY", Mode: modeOpenAICompatible,
-		BaseURL: "https://api.venice.ai/api/v1", SignupURL: "https://venice.ai/settings/api",
+		BaseURL:   "https://api.venice.ai/api/v1",
+		SignupURL: "https://venice.ai/settings/api",
+		JoinURL:   "https://venice.ai/chat?ref=ZynMuD",
 	},
 	{
 		ID: "openrouter", Name: "OpenRouter", EnvVar: "OPENROUTER_API_KEY", Mode: modeOpenAICompatible,

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1166,3 +1166,82 @@ func modelNames(entries []ModelEntry) []string {
 	}
 	return out
 }
+
+func TestBuildModelEntries_OpenAICompatible(t *testing.T) {
+	entries := buildModelEntries("venice", []string{"venice-uncensored"})
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (aggregators get no wildcard)", len(entries))
+	}
+	e := entries[0]
+	if e.ModelName != "venice-uncensored" {
+		t.Errorf("model_name = %q", e.ModelName)
+	}
+	if e.LiteLLMParams.Model != "openai/venice-uncensored" {
+		t.Errorf("model = %q, want openai/venice-uncensored", e.LiteLLMParams.Model)
+	}
+	if e.LiteLLMParams.APIBase != "https://api.venice.ai/api/v1" {
+		t.Errorf("api_base = %q, want venice base_url", e.LiteLLMParams.APIBase)
+	}
+	if e.LiteLLMParams.APIKey != "os.environ/VENICE_API_KEY" {
+		t.Errorf("api_key = %q, want os.environ/VENICE_API_KEY", e.LiteLLMParams.APIKey)
+	}
+}
+
+func TestBuildModelEntries_UnknownProviderLegacyShape(t *testing.T) {
+	// Providers not in the registry keep the legacy generic shape (no api_base).
+	entries := buildModelEntries("somevendor", []string{"m1"})
+	if len(entries) != 1 || entries[0].LiteLLMParams.Model != "somevendor/m1" {
+		t.Fatalf("unexpected legacy entries: %+v", entries)
+	}
+	if entries[0].LiteLLMParams.APIBase != "" {
+		t.Errorf("legacy shape must not set api_base, got %q", entries[0].LiteLLMParams.APIBase)
+	}
+}
+
+func TestProviderByID(t *testing.T) {
+	p, ok := ProviderByID("openrouter")
+	if !ok {
+		t.Fatal("openrouter must be in the registry")
+	}
+	if p.BaseURL == "" || p.EnvVar != "OPENROUTER_API_KEY" || len(p.Free) == 0 {
+		t.Errorf("openrouter row incomplete: %+v", p)
+	}
+	if _, ok := ProviderByID("nope"); ok {
+		t.Error("unknown provider must not be found")
+	}
+}
+
+func TestDetectProvider_AggregatorByAPIBase(t *testing.T) {
+	venice := ModelEntry{ModelName: "x", LiteLLMParams: LiteLLMParams{
+		Model: "openai/x", APIBase: "https://api.venice.ai/api/v1",
+	}}
+	if got := detectProvider(venice); got != "venice" {
+		t.Errorf("venice entry detected as %q, want venice", got)
+	}
+	// A native OpenAI entry (no api_base) must still read as openai.
+	oai := ModelEntry{ModelName: "gpt-5.5", LiteLLMParams: LiteLLMParams{Model: "openai/gpt-5.5"}}
+	if got := detectProvider(oai); got != ProviderOpenAI {
+		t.Errorf("openai entry detected as %q, want openai", got)
+	}
+}
+
+func TestProviderRegistry_Invariants(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range knownProviders {
+		if seen[p.ID] {
+			t.Errorf("duplicate provider id %q", p.ID)
+		}
+		seen[p.ID] = true
+		if p.Mode == modeOpenAICompatible && (p.BaseURL == "" || p.EnvVar == "") {
+			t.Errorf("BYOK provider %q must set BaseURL and EnvVar", p.ID)
+		}
+		if len(p.Free) > 0 && p.Mode != modeOpenAICompatible {
+			t.Errorf("provider %q has Free models but is not openai-compatible", p.ID)
+		}
+	}
+	for _, id := range []string{ProviderAnthropic, ProviderOpenAI, ProviderOllama} {
+		if _, ok := ProviderByID(id); !ok {
+			t.Errorf("native provider %q missing from registry", id)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Give a new user the shortest path to a working agent: bring an OpenRouter or Venice key and go. The headline command is the requested verb —

```bash
obol buy inference venice
obol buy inference openrouter --free
```

— which opens the provider's API-key page in the browser (hermes-agent-style), takes the key, and wires the agent's LiteLLM gateway to it. `obol buy inference <seller-url>` (or no arg) is **unchanged** — still the x402 crypto-paid seller flow. Dispatch keys on whether the positional argument matches a known provider id, so the two doors coexist behind one verb.

## Two front doors, one engine

- **`obol buy inference <provider>`** — friendly onboarding. Resolves the key (`--api-key` → provider env var → prompt), opens `SignupURL` via `openBrowser` (skipped when a key is already in hand or non-TTY), then wires LiteLLM and syncs agents.
- **`obol model setup <provider> --api-key <key>`** — the scriptable, no-browser equivalent (CI/automation).

Both call the same `setupCloudProvider` engine, so behavior can't drift.

## The registry refactor (the DB smell)

Provider knowledge was smeared across five sites — adding one provider meant editing all of them: `knownProviders`, the setup dispatch `switch`, a default-model `switch`, `detectCredentials`, and `buildModelEntries`. This PR collapses them into **one source of truth**: a richer `ProviderInfo` row (`id`, `EnvVar`/`AltEnvVars`, `Mode`, `BaseURL`, `Default`, `SignupURL`, `Free`) + `ProviderByID`. Every layer — buy/setup dispatch, default-model selection, credential auto-detection, LiteLLM entry shaping, and `model status` labelling — reads the registry. **Adding a provider is one row, no switch edits.**

## What's added

| provider | base_url | env var |
|---|---|---|
| `venice` | `https://api.venice.ai/api/v1` | `VENICE_API_KEY` |
| `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
| `nvidia` | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
| `gmi` | `https://api.gmi-serving.com/v1` | `GMI_API_KEY` |
| `novita` | `https://api.novita.ai/openai/v1` | `NOVITA_API_KEY` |
| `huggingface` | `https://router.huggingface.co/v1` | `HF_TOKEN` |

All `Mode=openai-compatible`: entries are `openai/<id>` + explicit `api_base` + key from env, no wildcard. `litellm-secrets` is `envFrom`-mounted and `record.go` persists `model_list` verbatim, so new providers authenticate and survive `obol stack up` with **zero changes to the secret/record layers**.

## Model resolution (no guessed ids)

Aggregator catalogs rotate, so hardcoding model ids would ship 404s. With `--model` omitted: the registry `Default` is used if set (`openrouter/auto`; native flagships for anthropic/openai), otherwise setup lists the live `GET <base>/v1/models` — a picker in a TTY, or a non-TTY error naming real ids. `--free` seeds OpenRouter's curated free snapshot (mapped from our hermes-agent free list), documented as rotating.

## Tests

`buildModelEntries` openai-compatible shape + legacy fallback; `ProviderByID`; `detectProvider` labelling aggregators by `api_base`; registry invariants; the `model setup` and `buy inference` flag surfaces (incl. `--free`/`--api-key`) and the provider-vs-ollama dispatch gate. Existing anthropic/openai/ollama entry tests pass unchanged. Full `go build` + `vet` + `test ./...` green.

## Follow-ups (not here)

- OAuth PKCE for OpenRouter (hermes uses api-key today, so this matches; PKCE is a nice-to-have).
- Cache `/v1/models`; live free-tier discovery (filter `pricing==0`) instead of a static snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)