### PR TITLE
chore(network): bump ethereum reth image to v2.3.0

### DIFF
--- a/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
@@ -63,7 +63,7 @@ releases:
                     - --full
                     {{- else if eq (index .Values "pruneKind" | default "") "before" }}
                     # Partial archive: keep state, receipts and bodies from
-                    # the requested block forward. Reth v2.2.0 and current
+                    # the requested block forward. Reth v2.3.0 and current
                     # main both support exact .before cutoffs for these
                     # segments, so avoid the coarser pre-merge preset.
                     - --prune.account-history.before={{ .Values.pruneBlock }}


### PR DESCRIPTION
## What

Bump the **reth** execution-client image tag for `obol network install ethereum`
from `v2.2.0` → **`v2.3.0`** (latest reth release), and update the matching
partial-archive comment.

## Why

Keep the bundled execution client current. `v2.3.0` is the latest reth release;
it brings payload/engine/trie/transaction-pool performance improvements. The
existing partial-archive prune wiring (`--prune.<segment>.before`) is unchanged —
both `v2.2.0` and `v2.3.0` support exact `.before` cutoffs, so `--mode archive
--since <block>` behaves identically.

## Scope

- `internal/embed/networks/ethereum/helmfile.yaml.gotmpl` — one tag line + one
  comment line. Renovate-tracked (`datasource=github-releases depName=paradigmxyz/reth`).
- No behavior change; no API/flag change.

## Verification

- `go build ./...` — clean.
- `go test ./internal/network/` — pass.

Generic, provider-agnostic version bump.
