### PR TITLE
chore(renovate): enable gomod + OSV vuln alerts; automerge patches (not aztec)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,14 @@
   ],
   "enabledManagers": [
     "custom.regex",
-    "github-actions"
+    "github-actions",
+    "gomod"
   ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "renovate/security"]
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -434,6 +440,21 @@
       ],
       "groupName": "Aztec node updates",
       "groupSlug": "aztec-node"
+    },
+    {
+      "description": "Auto-merge patch-level updates (low risk) once CI passes. Platform auto-merge waits for required checks; aztec is excluded by the rule below.",
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Never auto-merge Aztec — fast-moving testnet (nightly tags, frequent majors). Always review, even patches.",
+      "matchFileNames": [
+        "internal/embed/networks/aztec/**"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Why

Auditing why image pins drift (reth was a minor behind) showed **Renovate is
working** — it opens grouped PRs (#604 clients, #642 cloudflared, #603 tools,
#575/#576 aztec) — but two gaps let updates rot and security bumps slip:

1. **`gomod` was never enabled.** `enabledManagers` listed only `custom.regex` +
   `github-actions`, so ~121 direct Go deps got **no** Renovate updates. This is
   almost certainly the source of the open Dependabot vulnerabilities on `main`.
2. **No `automerge`.** Every update waited on a manual merge, so low-risk bumps
   piled up for weeks.

## What

- **Enable `gomod`** in `enabledManagers`.
- **Vulnerability-driven PRs:** `osvVulnerabilityAlerts: true` (OSV database — works
  *without* the GitHub Dependabot-alerts permission the dependency dashboard
  reports as missing) + an explicit `vulnerabilityAlerts` block with `security`
  labels.
- **Auto-merge `patch` updates** once required checks pass (`automerge` +
  `platformAutomerge`), with **Aztec explicitly excluded** (fast-moving testnet —
  nightly tags / frequent majors; always reviewed).

Existing custom managers and the major-update approval gates (frontend / hermes /
remote-signer remain dashboard-gated) are unchanged.

## Follow-ups (not in this PR — repo settings / org)

- Grant Renovate the **Dependabot alerts** read permission (dashboard #545 warns
  it can't access them) to also get GitHub-native vuln alerts alongside OSV.
- Fix the `aquasecurity/trivy-action` lookup failure in the 3 `docker-publish-*`
  workflows (dashboard #545).
- The main-branch **ruleset** currently blocks even approved + green Renovate PRs
  from merging (e.g. #604) — worth reviewing so `automerge` can actually land.

## Validation

`renovate.json` is valid JSON; all keys are standard Renovate schema.
