### PR TITLE
chore(ci): repin x402 images to 2e8a97e

### DIFF
--- a/internal/embed/infrastructure/base/templates/llm.yaml
+++ b/internal/embed/infrastructure/base/templates/llm.yaml
@@ -303,14 +303,14 @@ spec:
         - name: x402-buyer
           # Pinned by sha256 digest (multi-arch manifest list, amd64+arm64)
           # so the deployed sidecar is byte-for-byte identical across QA
-          # hosts. The :81a5c52 tag is preserved for human readability; the
+          # hosts. The :2e8a97e tag is preserved for human readability; the
           # digest is authoritative.
           # Previous tag-only pin allowed the local-build path to silently
           # reuse a 5-day-old `:latest` image and ate the release-smoke 503
           # investigation: stale buyer serialized X-PAYMENT with empty
           # authorization fields → facilitator /verify 400 → 503 cascade
           # across flow-08/11/14/13. See internal/embed/embed_image_pin_test.go.
-          image: ghcr.io/obolnetwork/x402-buyer:81a5c52@sha256:66ffab3d6089004f184699527138176df516fa27fe88684b2e744fa213c07206
+          image: ghcr.io/obolnetwork/x402-buyer:2e8a97e@sha256:9a5de078a65561c7aa53c0a0eea2d8b15d59f037bca574b19d27506e5016171a
           imagePullPolicy: IfNotPresent
           # PSS Restricted + writable PVC. On fresh clusters the StorageClass
           # asks local-path-provisioner for local PVs, so kubelet applies the

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -262,7 +262,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: verifier
-          image: ghcr.io/obolnetwork/x402-verifier:81a5c52@sha256:e8bb7a7b793e348879e8f09df76f6e43c5f2f32275fda16a220fcf75a871182e
+          image: ghcr.io/obolnetwork/x402-verifier:2e8a97e@sha256:cb827c358454fe2242602f3e2d78afde28b59bac747538d4b22cbabbf8e49c44
           imagePullPolicy: IfNotPresent
           # PSS Restricted: per-container hardening. Verifier is a Go binary
           # reading two RO ConfigMaps; no writeable rootfs paths required.
@@ -364,7 +364,7 @@ spec:
           # bug; b39bcaa (post-rc10 main) carries it, and also ships PR #590's
           # actionable pending-registration status message.
           # See TestServiceOfferControllerImage_CarriesSecretCreateOnlyFix.
-          image: ghcr.io/obolnetwork/serviceoffer-controller:81a5c52@sha256:23c8ec3d1693668fdc04967615e0040863f51c8eb6e8e80b2de7c9997f6afcb3
+          image: ghcr.io/obolnetwork/serviceoffer-controller:2e8a97e@sha256:b4809c6e132c6da27e97955e1e806341b5e03e0a2ff05840843c9e0ddfbfe218
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Repin the embedded x402 image pins from `81a5c52` → `2e8a97e` in:
- `internal/embed/infrastructure/base/templates/x402.yaml` (x402-verifier, serviceoffer-controller)
- `internal/embed/infrastructure/base/templates/llm.yaml` (x402-buyer)

## Why

`release.yml`'s `verify-image-pins` gate fails on current `main`: the pins point to
build `81a5c52`, but `df92a23` (frontend bump) later changed `internal/embed/...`,
marking the pins stale. This blocks tagging **v0.11.0** off latest main.

The automated `repin-embedded-pins` job in `docker-publish-x402.yml` was supposed to
land this bump, but it has failed on every `main` push with
`BRANCH_PROTECTION_RULE_VIOLATION` ("Changes must be made through a pull request.
Required status check 'lint-test' is expected.") — the github-actions bot can't
commit directly to protected `main`. Hence this manual PR.

## Validation

- Images for `2e8a97e` exist in ghcr (build job succeeded; only the repin step failed).
- `verify-x402-pins.sh HEAD` with these pins reports: *"embedded x402 image pins are
  fresh: 2e8a97e covers all verifier/controller/buyer source between the pin and HEAD."*
- Diff is the 3 pin lines only (digest-pinned to the ghcr `2e8a97e` index digests).

## Follow-up (separate)

Fix the auto-repin job so it doesn't need this manual step: either bypass-list the
github-actions bot for the two pin files in the `main` ruleset, or have the job open
a PR instead of committing to `main`.
