### PR TITLE
chore: bump frontend image to v0.1.28-rc0 (draft — digest pending)

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,10 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.26 (linux/amd64 + linux/arm64).
-  tag: "v0.1.26@sha256:7a6109e43e3fd7461818f172b4c78fc0fb5a124a7c266cf68bd5bc08fff10858"
+  # review. TODO(v0.1.28-rc0): re-pin with the multi-arch index digest once the
+  # v0.1.28-rc0 image is published (front-end PR #417 merged + v0.1.28-rc0 tag
+  # pushed). This PR stays a DRAFT until the @sha256 digest is appended below.
+  tag: "v0.1.28-rc0" # DRAFT — append @sha256:<multi-arch index digest> before merge
 
 service:
   type: ClusterIP

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ dev-frontend-reset:
     set -e
     echo "→ Resetting frontend to released image"
     obol kubectl set image deployment/obol-frontend-obol-app \
-        obol-app=obolnetwork/obol-stack-front-end:v0.1.25 -n obol-frontend
+        obol-app=obolnetwork/obol-stack-front-end:v0.1.28-rc0 -n obol-frontend
     obol kubectl rollout restart deployment/obol-frontend-obol-app -n obol-frontend
     obol kubectl rollout status deployment/obol-frontend-obol-app -n obol-frontend --timeout=120s
     echo "✓ Frontend reset to released image"


### PR DESCRIPTION
> ⚠️ **DRAFT — do not merge yet.** The image pin is intentionally un-digested until the `v0.1.28-rc0` front-end image is published.

## Summary

Bumps the front-end Docker image consumed by obol-stack to **v0.1.28-rc0**, the RC cut in [ObolNetwork/obol-stack-front-end#417](https://github.com/ObolNetwork/obol-stack-front-end/pull/417) (bundled dependency bumps + removal of the dead x402 probe surface).

Changes:
- `internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl` — `image.tag` `v0.1.26@sha256:7a61…` → `v0.1.28-rc0` (digest TODO)
- `justfile` `dev-frontend-reset` — `…front-end:v0.1.25` → `…front-end:v0.1.28-rc0`

## Why this is a draft

The Helm pin is **digest-pinned** (`tag: "vX.Y.Z@sha256:…"`) by the v0.10.0-rc2 supply-chain hardening, so the authoritative `sha256` can only be computed **after** the multi-arch image is published. That happens once front-end #417 merges, the `v0.1.28-rc0` tag is pushed, and `build-push-deploy.yml` publishes `linux/amd64 + linux/arm64`.

**Before marking ready:** re-pin to `tag: "v0.1.28-rc0@sha256:<multi-arch index digest>"` (and optionally add the digest to the justfile recipe to match). Renovate's `obol-stack-front-end` image rule may also raise this automatically once the image is live.

## Notes

- Supersedes the version target of open PR **#617** (`v0.1.27-rc0`); base is current `main` (still on `v0.1.26`). Close/redirect #617 as you prefer.
- Touches only the two image-pin sites — no controller/CLI/storefront changes.

https://claude.ai/code/session_01QXX79ZAedwYzBegvhkgjDV
