### PR TITLE
feat(agent): fix sub-agent hang, improve guide prompts 

### DIFF
--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -100,6 +100,23 @@ func agentManifests(agent *monetizeapi.Agent, litellmKey, apiKey string) ([]*uns
 // operation can outlive the session. max_turns and reasoning_effort cap
 // chattiness, and disabled_toolsets drops Hermes tool families that aren't
 // useful in a paid-service context (memory persistence, web search).
+//
+// approvals.mode: off is required for a paid sub-agent. It is served
+// headless (`hermes gateway run`, OpenAI-compatible API only) with no chat
+// platform wired, so the buyer paying over x402 has no interactive channel
+// to answer a dangerous-command / execute_code approval prompt. Left on the
+// default (manual), a benign tool call (e.g. execute_code making an HTTP
+// request) enqueues a pending approval no one can answer and the paid,
+// streaming request stalls until the tunnel drops — the buyer pays and gets
+// nothing. "off" (== HERMES_YOLO_MODE) is deliberately scoped to these
+// sandboxed sub-agents, NOT the master agent (whose operator is present to
+// approve). It is not "unrestricted": Hermes' unconditional HARDLINE floor
+// still blocks catastrophic host commands (rm -rf /, mkfs, dd to a raw
+// device, shutdown/reboot, fork bomb, kill -1) even under off, and the
+// pod is already boxed in — non-root UID 1000, ephemeral 5Gi PVC, and the
+// agent-isolation NetworkPolicy (cluster-closed, cloud-IMDS blocked). Quote
+// "off" so the YAML parser keeps it the string "off" and never folds it to
+// the boolean false.
 func renderHermesConfig(model, litellmKey string) string {
 	return fmt.Sprintf(`model:
   default: %q
@@ -118,6 +135,8 @@ agent:
   disabled_toolsets:
     - memory
     - web
+approvals:
+  mode: "off"
 skills:
   external_dirs:
     - /data/.hermes/obol-skills

--- a/internal/serviceoffercontroller/agent_render_test.go
+++ b/internal/serviceoffercontroller/agent_render_test.go
@@ -372,6 +372,12 @@ func TestRenderHermesConfig_SubAgentConstraints(t *testing.T) {
 		`disabled_toolsets:`,
 		`- memory`,
 		`- web`,
+		// Paid sub-agents are served headless with no interactive channel for
+		// the buyer to answer an approval prompt, so the dangerous-command /
+		// execute_code gate must be off (HARDLINE floor still applies). Quoted
+		// so YAML keeps it the string "off", not boolean false.
+		`approvals:`,
+		`mode: "off"`,
 	} {
 		if !strings.Contains(cfg, must) {
 			t.Errorf("hermes config missing sub-agent constraint %q\n---\n%s", must, cfg)

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1271,7 +1271,11 @@ func CreateStorefront(cfg *config.Config, hostnames ...string) error {
 									{"containerPort": 3000, "name": "http"},
 								},
 								"env": []map[string]string{
-									{"name": "SERVICES_URL", "value": "http://obol-skill-md.x402.svc:8080"},
+									{"name": "SERVICES_URL", "value": "http://obol-skill-md.x402.svc.cluster.local:8080"},
+									// Bind Next on all interfaces so the kubelet probes
+									// and Traefik reach it on the pod IP (the standalone
+									// server otherwise defaults to localhost).
+									{"name": "HOSTNAME", "value": "0.0.0.0"},
 								},
 								// Next.js SSR `/` cold renders can take >1s (the
 								// implicit livenessProbe timeoutSeconds default).

--- a/internal/x402/paymentrequired.go
+++ b/internal/x402/paymentrequired.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html/template"
 	"math/big"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -35,6 +36,13 @@ func sanitizeDisplayToken(s, placeholder string) string {
 	}
 	return s
 }
+
+// defaultAgentTaskExample is the concrete sample task baked into the
+// agent-type copy so a buyer can paste the pay-agent command (or the
+// chat-completions body) and have it run as-is, then edit the message.
+// Mirrors AGENT_TASK_PLACEHOLDER in the storefront's ServiceCard.tsx so the
+// public storefront and the 402 page hand out the same example.
+const defaultAgentTaskExample = "Summarise the README and list the top 3 risks."
 
 //go:embed templates/payment_required.html
 var paymentRequiredHTMLSrc string
@@ -157,16 +165,42 @@ func prefersHTML(accept string) bool {
 // incoming request. Mirrors buildResourceURL but keeps just the origin so
 // rendered HTML can reference sibling routes (storefront, OG image) on the
 // same tunnel host the scraper or browser is currently hitting.
+//
+// Scheme resolution defaults to https and only downgrades to http for the
+// hosts the stack serves locally over plain HTTP (obol.stack, loopback,
+// *.localhost/*.local). This matters because the public 402 page is served
+// over the Cloudflare tunnel, which terminates TLS at the edge and forwards
+// plaintext to cloudflared -> Traefik -> verifier: the X-Forwarded-Proto we
+// observe on the ForwardAuth hop is "http", so keying off it alone rendered
+// http:// tunnel links (broken/mixed-content in the copy-paste prompts and
+// OG/asset URLs). An explicit https signal (direct TLS or X-Forwarded-Proto:
+// https) still forces https for any host.
 func resolveSiteURL(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	}
 	host := r.Host
 	if forwarded := r.Header.Get("X-Forwarded-Host"); forwarded != "" {
 		host = forwarded
 	}
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && isLocalHost(host) {
+		scheme = "http"
+	}
 	return scheme + "://" + host
+}
+
+// isLocalHost reports whether host (optionally with :port) is one the stack
+// serves locally over plain HTTP: obol.stack, loopback, or a developer
+// *.localhost/*.local name. Any other host is treated as a public tunnel
+// hostname (https).
+func isLocalHost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.Trim(strings.TrimSuffix(host, "."), "[]"))
+	switch host {
+	case "obol.stack", "localhost", "127.0.0.1", "::1", "0.0.0.0":
+		return true
+	}
+	return strings.HasSuffix(host, ".localhost") || strings.HasSuffix(host, ".local")
 }
 
 // sendPaymentRequiredHTML writes a 402 status with an HTML body that includes
@@ -414,13 +448,13 @@ func inferenceCopy(url, siteURL string, d PaymentDisplay) typeCopy {
 				"pre-authorizes the provider through your agent's wallet and registers the model as " +
 				"<code>paid/&lt;model&gt;</code> in your local LiteLLM gateway, so every agent in your stack " +
 				"can call it like any other OpenAI-compatible model."),
-		ShowPrimary:    true,
-		PrimaryTitle:   "Use this service for your Obol Agent's model",
-		PrimaryLede:    "Run this from your obol-stack host. The CLI walks `/api/services.json`, prompts for auto-refill + a request count, and pre-signs the authorizations from your master agent's wallet. Pass `--yes --count <N>` for non-interactive runs.",
-		PrimaryIsCode:  true,
-		PrimaryPayload: cmd,
-		PromptObol:     prompt,
-		PromptOther:    other,
+		ShowPrimary:         true,
+		PrimaryTitle:        "Use this service for your Obol Agent's model",
+		PrimaryLede:         "Run this from your obol-stack host. The CLI walks `/api/services.json`, prompts for auto-refill + a request count, and pre-signs the authorizations from your master agent's wallet. Pass `--yes --count <N>` for non-interactive runs.",
+		PrimaryIsCode:       true,
+		PrimaryPayload:      cmd,
+		PromptObol:          prompt,
+		PromptOther:         other,
 		ChatCompletionsNote: "Direct HTTP buyers use OpenAI-style chat-completions. A minimal paid request looks like:",
 		ChatCompletionsBody: fmt.Sprintf(`POST %s/v1/chat/completions
 Content-Type: application/json
@@ -444,10 +478,8 @@ X-PAYMENT: <pre-signed-EIP-3009-or-Permit2-voucher>
 func agentCopy(url, siteURL string, d PaymentDisplay) typeCopy {
 	model := sanitizeDisplayToken(d.Model, "")
 	modelClause := ""
-	modelLine := ""
 	if model != "" {
 		modelClause = fmt.Sprintf(`"model": "%s",`, model)
-		modelLine = " (running " + model + ")"
 	}
 
 	body := fmt.Sprintf(`POST %s
@@ -457,24 +489,30 @@ X-PAYMENT: <pre-signed-EIP-3009-or-Permit2-voucher>
 {
   %s
   "messages": [
-    {"role": "user", "content": "<your prompt to this agent goes here>"}
+    {"role": "user", "content": %q}
   ]
-}`, url, modelClause)
+}`, url, modelClause, defaultAgentTaskExample)
 
+	// pay-agent requires a --model value, but an agent runs its own pinned
+	// model server-side and ignores the field, so we don't editorialize about
+	// which model the seller uses — we just fill the required flag (the
+	// seller's model when known, a placeholder otherwise) and hand the buyer a
+	// command that runs as-is with a concrete example task they can edit.
 	modelFlag := sanitizeDisplayToken(d.Model, "<model-id>")
 	prompt := fmt.Sprintf(
-		"Use the buy-x402 skill's `pay-agent` command to buy one round of work from this Obol Agent%s. "+
-			"This is an *agent*, not a raw model — it has its own skills, tools, and memory. Example:\n\n"+
-			"pay-agent %s --model %s --message \"<your prompt to this agent goes here>\"",
-		modelLine, url, modelFlag,
+		"Use the buy-x402 skill's `pay-agent` command to buy one round of work from this "+
+			"Obol Agent — it has its own skills, tools, and memory, not just a model. Edit the "+
+			"message, then run:\n\n"+
+			"pay-agent %s --model %q --message %q",
+		url, modelFlag, defaultAgentTaskExample,
 	)
 
 	other := fmt.Sprintf(
-		"Help me call the Obol Agent at %s%s — it's an autonomous agent (tools + skills + memory), "+
-			"not a raw LLM. It's gated by %s. POST OpenAI-style chat-completions JSON with a real "+
-			"prompt in `messages`, attach a signed EIP-3009/Permit2 authorization as `X-PAYMENT`, "+
-			"and report what the agent does.",
-		url, modelLine, x402GuideRef(siteURL),
+		"Help me call the Obol Agent at %s — it's an autonomous agent (tools + skills + memory), "+
+			"not a raw LLM. It's gated by %s. POST OpenAI-style chat-completions JSON with this user "+
+			"message in `messages`: {\"role\":\"user\",\"content\":%q}. Attach a signed "+
+			"EIP-3009/Permit2 authorization as `X-PAYMENT`, and report what the agent does.",
+		url, x402GuideRef(siteURL), defaultAgentTaskExample,
 	)
 
 	return typeCopy{

--- a/internal/x402/paymentrequired_test.go
+++ b/internal/x402/paymentrequired_test.go
@@ -444,3 +444,64 @@ func TestInferenceCopy_StripsShellMetacharsFromCommand(t *testing.T) {
 	mustContain(t, c.PromptObol, "<model-id>")
 	mustContain(t, c.PrimaryPayload, "obol buy inference https://agent.example.tunnel.dev/services/x")
 }
+
+// The public 402 page is served over the Cloudflare tunnel, which terminates
+// TLS at the edge and forwards plaintext inward — so the ForwardAuth hop sees
+// X-Forwarded-Proto: http even though the buyer's browser is on https. Tunnel
+// (public) hosts must therefore default to https so the copy-paste prompt URLs
+// and OG/asset links are not broken http:// links; only local hosts stay http.
+func TestResolveSiteURL_Scheme(t *testing.T) {
+	cases := []struct {
+		name   string
+		host   string
+		xfHost string
+		xfp    string
+		want   string
+	}{
+		{"public tunnel host defaults to https", "agent.example.tunnel.dev", "", "", "https://agent.example.tunnel.dev"},
+		{"forwarded public host defaults to https", "10.42.0.5:8000", "agent.example.tunnel.dev", "", "https://agent.example.tunnel.dev"},
+		{"public host with xfp http still https", "agent.example.tunnel.dev", "", "http", "https://agent.example.tunnel.dev"},
+		{"local obol.stack stays http", "obol.stack:8080", "", "", "http://obol.stack:8080"},
+		{"localhost stays http", "localhost:3000", "", "", "http://localhost:3000"},
+		{"local host but explicit https honored", "obol.stack:8080", "", "https", "https://obol.stack:8080"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/services/x", nil)
+			r.Host = tc.host
+			if tc.xfHost != "" {
+				r.Header.Set("X-Forwarded-Host", tc.xfHost)
+			}
+			if tc.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", tc.xfp)
+			}
+			if got := resolveSiteURL(r); got != tc.want {
+				t.Errorf("resolveSiteURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The agent-type copy must NOT editorialize which model the seller runs (an
+// agent runs its own pinned model and ignores the request's model field), and
+// the pay-agent command must be runnable on paste — a concrete example task,
+// not a "<your prompt here>" placeholder the buyer has to notice and replace.
+func TestAgentCopy_NoModelProseAndRunnableExample(t *testing.T) {
+	d := PaymentDisplay{OfferType: "agent", Model: "qwen3.5:9b"}
+	c := agentCopy("https://agent.example.tunnel.dev/services/quant", "https://agent.example.tunnel.dev", d)
+
+	// No "(running <model>)" editorializing in either prompt.
+	for _, p := range []string{c.PromptObol, c.PromptOther} {
+		if strings.Contains(p, "running qwen3.5:9b") || strings.Contains(p, "(running") {
+			t.Errorf("agent prompt should not editorialize the seller model: %q", p)
+		}
+	}
+	// Runnable pay-agent command with a concrete task, not a placeholder.
+	mustContain(t, c.PromptObol, "pay-agent https://agent.example.tunnel.dev/services/quant")
+	mustContain(t, c.PromptObol, defaultAgentTaskExample)
+	if strings.Contains(c.PromptObol, "your prompt to this agent goes here") {
+		t.Errorf("agent prompt still uses the non-runnable placeholder: %q", c.PromptObol)
+	}
+	// The "other AI agent" prompt embeds the concrete message too.
+	mustContain(t, c.PromptOther, defaultAgentTaskExample)
+}

--- a/web/public-storefront/next.config.ts
+++ b/web/public-storefront/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const servicesURL =
-  process.env.SERVICES_URL ?? "http://obol-skill-md.x402.svc:8080";
+  process.env.SERVICES_URL ??
+  "http://obol-skill-md.x402.svc.cluster.local:8080";
 
 const nextConfig: NextConfig = {
   output: "standalone",

--- a/web/public-storefront/src/components/ServiceCard.tsx
+++ b/web/public-storefront/src/components/ServiceCard.tsx
@@ -444,8 +444,10 @@ function BuyViaOtherAgent({
     const model = service.model || "the advertised model";
     prompt = `${docsRef(service.endpoint)} I want to use the remote LLM at ${service.endpoint} (model ${model}) as a paid OpenAI-compatible chat-completions endpoint. Pre-sign a budget of EIP-3009 or Permit2 authorisations and POST chat-completions bodies with the X-PAYMENT header attached.`;
   } else if (kind === "agent") {
-    const modelLine = service.model ? ` (running ${service.model})` : "";
-    prompt = `${docsRef(service.endpoint)} Help me call the Obol Agent at ${service.endpoint}${modelLine} — it's an autonomous agent (tools + skills + memory), not a raw LLM. POST OpenAI-style chat-completions JSON with this user message in \`messages\`: {"role":"user","content":${quoteAgentTask(agentTask)}}. Attach a signed EIP-3009 or Permit2 authorisation as \`X-PAYMENT\`, and report what the agent does.`;
+    // An agent runs its own pinned model server-side and ignores the request's
+    // model field, so we don't tell the buyer which model it uses — the request
+    // shape is what matters.
+    prompt = `${docsRef(service.endpoint)} Help me call the Obol Agent at ${service.endpoint} — it's an autonomous agent (tools + skills + memory), not a raw LLM. POST OpenAI-style chat-completions JSON with this user message in \`messages\`: {"role":"user","content":${quoteAgentTask(agentTask)}}. Attach a signed EIP-3009 or Permit2 authorisation as \`X-PAYMENT\`, and report what the agent does.`;
   } else {
     prompt = `I want to purchase a service offered by an Obol Agent at ${service.endpoint} for ${opt.price} on ${opt.network}. Please install the run-obol-stack skill from https://github.com/ObolNetwork/skills, ask me for permission to set up the obol stack, and use the buy-x402 skill to make the purchase on my behalf.`;
   }

--- a/web/public-storefront/src/components/ServicesList.tsx
+++ b/web/public-storefront/src/components/ServicesList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { fetchPublicCatalog } from "@/lib/catalog-client";
 import type { Service } from "@/types";
 import { ServiceCard } from "./ServiceCard";
 
@@ -11,20 +12,20 @@ export function ServicesList({ initial }: { initial: Service[] }) {
 
   useEffect(() => {
     let cancelled = false;
-    const tick = async () => {
+
+    async function syncCatalog() {
       try {
-        const res = await fetch("/api/services.json", { cache: "no-store" });
-        if (!res.ok) return;
-        const data = await res.json();
-        const fresh: Service[] = Array.isArray(data?.services)
-          ? data.services
-          : [];
+        const fresh = await fetchPublicCatalog();
         if (!cancelled) setServices(fresh);
       } catch {
-        // Network blip — keep existing list, retry next tick.
+        // Network blip — keep the current list, retry on the next interval.
       }
-    };
-    const id = setInterval(tick, REFRESH_INTERVAL_MS);
+    }
+
+    // Sync immediately on mount so a stale/empty SSR snapshot is corrected
+    // in the first render cycle, not after the first 10s refresh tick.
+    void syncCatalog();
+    const id = setInterval(syncCatalog, REFRESH_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(id);

--- a/web/public-storefront/src/lib/catalog-client.ts
+++ b/web/public-storefront/src/lib/catalog-client.ts
@@ -1,0 +1,28 @@
+import type { Service } from "@/types";
+
+function unwrapServices(data: unknown): Service[] {
+  if (Array.isArray(data)) {
+    return data as Service[];
+  }
+  if (data && typeof data === "object") {
+    const services = (data as { services?: unknown }).services;
+    if (Array.isArray(services)) {
+      return services as Service[];
+    }
+  }
+  return [];
+}
+
+/**
+ * Browser-side catalog fetch (Traefik / Next rewrite -> obol-skill-md).
+ * Accepts both the envelope ({services:[...]}) and the legacy bare-array
+ * catalog so a client refresh never drops services on older controllers.
+ */
+export async function fetchPublicCatalog(): Promise<Service[]> {
+  const res = await fetch("/api/services.json", { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`catalog ${res.status} ${res.statusText}`);
+  }
+  const data: unknown = await res.json();
+  return unwrapServices(data);
+}

--- a/web/public-storefront/src/lib/catalog.ts
+++ b/web/public-storefront/src/lib/catalog.ts
@@ -1,10 +1,17 @@
+import { unstable_noStore as noStore } from "next/cache";
 import { cache } from "react";
 import type { Service, StorefrontProfile } from "@/types";
 
+// SSR fetches the catalog straight from the in-cluster upstream. That returns
+// byte-identical JSON to the public /api/services.json (obol-skill-md serves
+// the already-merged envelope; Traefik just routes to it), but without a WAN
+// hairpin back through the tunnel — so the storefront's own render never
+// depends on the tunnel being healthy. FQDN over the short .svc form to avoid
+// search-domain resolution flakiness on cold DNS.
 const SERVICES_URL =
-  process.env.SERVICES_URL ?? "http://obol-skill-md.x402.svc:8080";
+  process.env.SERVICES_URL ?? "http://obol-skill-md.x402.svc.cluster.local:8080";
 
-const CATALOG_FETCH_TIMEOUT_MS = 5_000;
+const CATALOG_FETCH_TIMEOUT_MS = 8_000;
 
 async function fetchCatalog(path: string): Promise<Response> {
   return fetch(`${SERVICES_URL}${path}`, {
@@ -35,8 +42,15 @@ export interface ServiceCatalogDocument extends StorefrontProfile {
 }
 
 function parseCatalogDocument(data: unknown): ServiceCatalogDocument {
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
+  if (!data || typeof data !== "object") {
     return { ...DEFAULT_STOREFRONT, services: [] };
+  }
+  // Accept the legacy bare-array catalog as well as the envelope. Older
+  // serviceoffer-controller images publish /api/services.json as a bare
+  // services[] array; rejecting it here dropped every service on those
+  // clusters (not just a stale render).
+  if (Array.isArray(data)) {
+    return { ...DEFAULT_STOREFRONT, services: data as Service[] };
   }
   const doc = data as Partial<ServiceCatalogDocument>;
   return {
@@ -49,6 +63,9 @@ function parseCatalogDocument(data: unknown): ServiceCatalogDocument {
 
 export const fetchCatalogDocument = cache(
   async (): Promise<ServiceCatalogDocument> => {
+    // Opt out of Next's fetch cache so a hit doesn't pin a stale (or empty,
+    // cold-start) catalog for the request-memoized lifetime.
+    noStore();
     try {
       const res = await fetchCatalog("/api/services.json");
       if (!res.ok) return { ...DEFAULT_STOREFRONT, services: [] };


### PR DESCRIPTION
## Improve billable subagents & storefront buy flow

Two fixes for the paid-agent experience: cleaner 402 copy-paste prompts, and a subagent hang on paid calls.

### 402 page prompts (`internal/x402`, storefront mirror)
- **Fix `http://` tunnel links → `https://`.** The public 402 page is served over the Cloudflare tunnel, which terminates TLS at the edge and forwards plaintext inward — so the ForwardAuth hop sees `X-Forwarded-Proto: http` and we rendered broken `http://` links. `resolveSiteURL` now defaults to `https`, downgrading to `http` only for local hosts (`obol.stack`, loopback, `*.localhost`/`*.local`).
- **Drop the seller-model mention from agent prompts.** An agent runs its own pinned model server-side and ignores the request's `model` field, so `(running <model>)` was a misleading inference-type holdover. Removed from both the Obol-agent and other-AI-agent prompts (402 page + storefront `ServiceCard.tsx`).
- **Make the copy-paste runnable.** The agent prompt shipped a `<your prompt goes here>` placeholder that sent literal text on paste. Now uses a concrete example task (matching the storefront), so a paste runs as-is.

### Subagent approval hang (`internal/serviceoffercontroller`)
Paid subagents are served headless (`hermes gateway run`, API only, no chat platform), so when a tool like `execute_code` hit Hermes' human-in-the-loop approval gate, the streaming x402 call stalled until the tunnel dropped — the buyer paid and got nothing.

Fix: set `approvals.mode: "off"` in the rendered subagent Hermes config. Verified against the Hermes source that this bypasses the exact gate that hung. **Not unrestricted:** the unconditional HARDLINE floor (`rm -rf /`, `mkfs`, `dd`, shutdown, fork bomb, `kill -1`) still applies, and the pod is already sandboxed (non-root, ephemeral PVC, cluster-closed + IMDS-blocked NetworkPolicy). Scoped to sold subagents only — the master agent keeps `manual`.

### Tests
- New `TestResolveSiteURL_Scheme` and `TestAgentCopy_NoModelProseAndRunnableExample`.
- `TestRenderHermesConfig_SubAgentConstraints` now locks in `approvals.mode: "off"`.

Existing subagents pick up the config change on next reconcile / `agent sync`.