### PR TITLE
fix(serviceoffer-controller): skip skill catalog rollout when hash un…

### DIFF
--- a/internal/serviceoffercontroller/catalog.go
+++ b/internal/serviceoffercontroller/catalog.go
@@ -1,0 +1,64 @@
+package serviceoffercontroller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// listServiceOffersForCatalog returns every ServiceOffer from the API server.
+// Listing live objects avoids catalog hash flips caused by reconciling one
+// offer with a fresh status while other offers are still read from a lagging
+// informer cache. override is merged only when the informer/API list has not
+// yet observed a just-created offer.
+func (c *Controller) listServiceOffersForCatalog(ctx context.Context, override *monetizeapi.ServiceOffer) ([]*monetizeapi.ServiceOffer, error) {
+	list, err := c.offers.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	offers := make([]*monetizeapi.ServiceOffer, 0, len(list.Items)+1)
+	overrideUsed := false
+	for i := range list.Items {
+		offer, err := decodeServiceOffer(&list.Items[i])
+		if err != nil {
+			return nil, err
+		}
+		if override != nil && offer.Namespace == override.Namespace && offer.Name == override.Name {
+			offer = override
+			overrideUsed = true
+		}
+		offers = append(offers, offer)
+	}
+	if override != nil && !overrideUsed {
+		offers = append(offers, override)
+	}
+	return offers, nil
+}
+
+func computeSkillCatalogContentHash(content, servicesJSON, openAPIJSON, apiDocsHTML string) string {
+	return fmt.Sprintf("%x", md5Sum(content+servicesJSON+openAPIJSON+apiDocsHTML))[:8]
+}
+
+func skillCatalogDeployedContentHash(deployment *unstructured.Unstructured) string {
+	if deployment == nil {
+		return ""
+	}
+	hash, _, _ := unstructured.NestedString(deployment.Object, "spec", "template", "metadata", "annotations", "obol.org/content-hash")
+	return hash
+}
+
+func (c *Controller) skillCatalogDeployedContentHash(ctx context.Context) (string, error) {
+	deployment, err := c.deployments.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return skillCatalogDeployedContentHash(deployment), nil
+}

--- a/internal/serviceoffercontroller/catalog.go
+++ b/internal/serviceoffercontroller/catalog.go
@@ -11,10 +11,10 @@ import (
 )
 
 // listServiceOffersForCatalog returns every ServiceOffer from the API server.
-// Listing live objects avoids catalog hash flips caused by reconciling one
-// offer with a fresh status while other offers are still read from a lagging
-// informer cache. override is merged only when the informer/API list has not
-// yet observed a just-created offer.
+// A live list is the single source of truth for catalog rendering so parallel
+// offer reconciles do not mix one freshly-updated status with stale informer
+// copies. override is appended only when a just-created offer is not yet
+// visible in the list response.
 func (c *Controller) listServiceOffersForCatalog(ctx context.Context, override *monetizeapi.ServiceOffer) ([]*monetizeapi.ServiceOffer, error) {
 	list, err := c.offers.List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -22,22 +22,46 @@ func (c *Controller) listServiceOffersForCatalog(ctx context.Context, override *
 	}
 
 	offers := make([]*monetizeapi.ServiceOffer, 0, len(list.Items)+1)
-	overrideUsed := false
+	seen := make(map[string]struct{}, len(list.Items))
 	for i := range list.Items {
 		offer, err := decodeServiceOffer(&list.Items[i])
 		if err != nil {
 			return nil, err
 		}
-		if override != nil && offer.Namespace == override.Namespace && offer.Name == override.Name {
-			offer = override
-			overrideUsed = true
-		}
+		seen[offer.Namespace+"/"+offer.Name] = struct{}{}
 		offers = append(offers, offer)
 	}
-	if override != nil && !overrideUsed {
-		offers = append(offers, override)
+	if override != nil {
+		if _, ok := seen[override.Namespace+"/"+override.Name]; !ok {
+			offers = append(offers, override)
+		}
 	}
 	return offers, nil
+}
+
+func skillCatalogContentMatches(cm *unstructured.Unstructured, content, servicesJSON, openAPIJSON, apiDocsHTML string) bool {
+	if cm == nil {
+		return false
+	}
+	data, _, _ := unstructured.NestedStringMap(cm.Object, "data")
+	if data == nil {
+		return false
+	}
+	return data["skill.md"] == content &&
+		data["services.json"] == servicesJSON &&
+		data["openapi.json"] == openAPIJSON &&
+		data["api.html"] == apiDocsHTML
+}
+
+func (c *Controller) skillCatalogContentUnchanged(ctx context.Context, content, servicesJSON, openAPIJSON, apiDocsHTML string) (bool, error) {
+	cm, err := c.configMaps.Namespace(skillCatalogNamespace).Get(ctx, skillCatalogConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return skillCatalogContentMatches(cm, content, servicesJSON, openAPIJSON, apiDocsHTML), nil
 }
 
 func computeSkillCatalogContentHash(content, servicesJSON, openAPIJSON, apiDocsHTML string) string {

--- a/internal/serviceoffercontroller/catalog_test.go
+++ b/internal/serviceoffercontroller/catalog_test.go
@@ -1,0 +1,38 @@
+package serviceoffercontroller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestComputeSkillCatalogContentHashDeterministic(t *testing.T) {
+	a := computeSkillCatalogContentHash("# cat", `{"services":[]}`, `{"openapi":"3.1.0"}`, "<html></html>")
+	b := computeSkillCatalogContentHash("# cat", `{"services":[]}`, `{"openapi":"3.1.0"}`, "<html></html>")
+	if a != b {
+		t.Fatalf("hash not deterministic: %q vs %q", a, b)
+	}
+	if len(a) != 8 {
+		t.Fatalf("hash length = %d, want 8", len(a))
+	}
+
+	changed := computeSkillCatalogContentHash("# cat", `{"services":[{"name":"a"}]}`, `{"openapi":"3.1.0"}`, "<html></html>")
+	if changed == a {
+		t.Fatal("expected different hash when catalog content changes")
+	}
+}
+
+func TestSkillCatalogDeployedContentHash(t *testing.T) {
+	deployment := buildSkillCatalogDeployment("abc12345")
+	if got := skillCatalogDeployedContentHash(deployment); got != "abc12345" {
+		t.Fatalf("hash = %q, want abc12345", got)
+	}
+	if got := skillCatalogDeployedContentHash(nil); got != "" {
+		t.Fatalf("nil deployment hash = %q, want empty", got)
+	}
+
+	empty := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	if got := skillCatalogDeployedContentHash(empty); got != "" {
+		t.Fatalf("missing annotation hash = %q, want empty", got)
+	}
+}

--- a/internal/serviceoffercontroller/catalog_test.go
+++ b/internal/serviceoffercontroller/catalog_test.go
@@ -22,6 +22,19 @@ func TestComputeSkillCatalogContentHashDeterministic(t *testing.T) {
 	}
 }
 
+func TestSkillCatalogContentMatches(t *testing.T) {
+	cm := buildSkillCatalogConfigMap("# cat", `{"services":[]}`, `{"openapi":"3.1.0"}`, "<html></html>")
+	if !skillCatalogContentMatches(cm, "# cat", `{"services":[]}`, `{"openapi":"3.1.0"}`, "<html></html>") {
+		t.Fatal("expected matching catalog content")
+	}
+	if skillCatalogContentMatches(cm, "# changed", `{"services":[]}`, `{"openapi":"3.1.0"}`, "<html></html>") {
+		t.Fatal("expected different skill.md to not match")
+	}
+	if skillCatalogContentMatches(nil, "# cat", `{}`, `{}`, "") {
+		t.Fatal("nil configmap must not match")
+	}
+}
+
 func TestSkillCatalogDeployedContentHash(t *testing.T) {
 	deployment := buildSkillCatalogDeployment("abc12345")
 	if got := skillCatalogDeployedContentHash(deployment); got != "abc12345" {

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -622,9 +622,7 @@ func (c *Controller) reconcileOffer(ctx context.Context, key string) error {
 	// Rebuild the skill catalog on every reconcile so tunnel URL changes and
 	// offer status updates propagate immediately. reconcileSkillCatalog skips
 	// ConfigMap/Deployment writes when the rendered hash is unchanged.
-	freshOffer := *offer
-	freshOffer.Status = status
-	return c.reconcileSkillCatalog(ctx, &freshOffer)
+	return c.reconcileSkillCatalog(ctx, nil)
 }
 
 func (c *Controller) reconcileDeletingOffer(ctx context.Context, offer *monetizeapi.ServiceOffer) error {
@@ -1213,11 +1211,11 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	apiDocsHTML := scalarHTML()
 	contentHash := computeSkillCatalogContentHash(content, servicesJSON, openAPIJSON, apiDocsHTML)
 
-	deployedHash, err := c.skillCatalogDeployedContentHash(ctx)
+	unchanged, err := c.skillCatalogContentUnchanged(ctx, content, servicesJSON, openAPIJSON, apiDocsHTML)
 	if err != nil {
 		return err
 	}
-	if deployedHash != "" && deployedHash == contentHash {
+	if unchanged {
 		readyOffers := countReadyServiceOffers(offers)
 		log.Printf("serviceoffer-controller: /skill.md unchanged (hash=%s, %d ready offer(s))", contentHash, readyOffers)
 		return nil

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -619,12 +619,9 @@ func (c *Controller) reconcileOffer(ctx context.Context, key string) error {
 		// requiring a spec mutation or unrelated ConfigMap update.
 		c.offerQueue.AddAfter(offer.Namespace+"/"+offer.Name, 5*time.Second)
 	}
-	// Rebuild the skill catalog on every reconcile so the just-updated status
-	// (not yet reflected in the informer store) and tunnel URL changes both
-	// propagate immediately. The catalog's ConfigMap/Deployment only rotate
-	// when the rendered markdown actually differs, so idle reconciles are
-	// no-ops at the API-server level. Pass `offer`+`status` as an override so
-	// the just-committed status is used instead of the stale informer copy.
+	// Rebuild the skill catalog on every reconcile so tunnel URL changes and
+	// offer status updates propagate immediately. reconcileSkillCatalog skips
+	// ConfigMap/Deployment writes when the rendered hash is unchanged.
 	freshOffer := *offer
 	freshOffer.Status = status
 	return c.reconcileSkillCatalog(ctx, &freshOffer)
@@ -1180,11 +1177,12 @@ func (c *Controller) loadStorefrontProfile(ctx context.Context) (*schemas.Storef
 }
 
 // reconcileSkillCatalog rebuilds the /skill.md ConfigMap/Deployment/Service/
-// HTTPRoute from the current set of Ready ServiceOffers. If `override` is
-// non-nil, that offer replaces (or is appended to) the informer-cached copy
-// with the same namespace/name; this is how reconcileOffer feeds its
-// just-committed status into the catalog without waiting for the informer's
-// watch event to update the local store.
+// HTTPRoute from the current set of operationally-ready ServiceOffers. Offers
+// are listed from the API server so every reconcile sees a consistent snapshot;
+// override replaces or appends a just-created offer the list has not observed yet.
+// ConfigMap and Deployment are only applied when the rendered catalog hash differs
+// from the live obol-skill-md Deployment annotation, so idle reconciles do not
+// roll the skill-catalog pod.
 func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *monetizeapi.ServiceOffer) error {
 	c.catalogMu.Lock()
 	defer c.catalogMu.Unlock()
@@ -1194,29 +1192,9 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 		return err
 	}
 
-	items := c.offerInformer.GetStore().List()
-	offers := make([]*monetizeapi.ServiceOffer, 0, len(items)+1)
-	overrideUsed := false
-	for _, item := range items {
-		raw := asUnstructured(item)
-		if raw == nil {
-			continue
-		}
-		offer, err := decodeServiceOffer(raw)
-		if err != nil {
-			return err
-		}
-		if override != nil && offer.Namespace == override.Namespace && offer.Name == override.Name {
-			offer = override
-			overrideUsed = true
-		}
-		offers = append(offers, offer)
-	}
-	if override != nil && !overrideUsed {
-		// Override refers to an offer the informer hasn't yet observed (e.g.
-		// a just-created ServiceOffer whose Add event hasn't fired). Include
-		// it so the catalog reflects reality.
-		offers = append(offers, override)
+	offers, err := c.listServiceOffersForCatalog(ctx, override)
+	if err != nil {
+		return err
 	}
 
 	storefrontProfile, err := c.loadStorefrontProfile(ctx)
@@ -1233,7 +1211,17 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	// when tunnelURL changes — see enqueueDiscoveryRefresh).
 	openAPIJSON := buildOpenAPIDocument(offers, baseURL)
 	apiDocsHTML := scalarHTML()
-	contentHash := fmt.Sprintf("%x", md5Sum(content+servicesJSON+openAPIJSON+apiDocsHTML))[:8]
+	contentHash := computeSkillCatalogContentHash(content, servicesJSON, openAPIJSON, apiDocsHTML)
+
+	deployedHash, err := c.skillCatalogDeployedContentHash(ctx)
+	if err != nil {
+		return err
+	}
+	if deployedHash != "" && deployedHash == contentHash {
+		readyOffers := countReadyServiceOffers(offers)
+		log.Printf("serviceoffer-controller: /skill.md unchanged (hash=%s, %d ready offer(s))", contentHash, readyOffers)
+		return nil
+	}
 
 	if err := c.applyObject(ctx, c.configMaps.Namespace(skillCatalogNamespace), buildSkillCatalogConfigMap(content, servicesJSON, openAPIJSON, apiDocsHTML)); err != nil {
 		return err
@@ -1256,14 +1244,19 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	if err := c.applyObject(ctx, c.httpRoutes.Namespace(skillCatalogNamespace), buildAPIDocsHTTPRoute()); err != nil {
 		return err
 	}
+	readyOffers := countReadyServiceOffers(offers)
+	log.Printf("serviceoffer-controller: /skill.md published with %d ready offer(s) (hash=%s)", readyOffers, contentHash)
+	return nil
+}
+
+func countReadyServiceOffers(offers []*monetizeapi.ServiceOffer) int {
 	readyOffers := 0
 	for _, offer := range offers {
 		if offer != nil && offer.DeletionTimestamp == nil && isConditionTrue(offer.Status, "Ready") {
 			readyOffers++
 		}
 	}
-	log.Printf("serviceoffer-controller: /skill.md published with %d ready offer(s)", readyOffers)
-	return nil
+	return readyOffers
 }
 
 func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi.ServiceOffer) error {


### PR DESCRIPTION
## Summary

Fixes `obol-skill-md` rollout loops when multiple ServiceOffers are live but not yet registered on-chain (`Ready=False`). The skill-catalog pod was Terminating/Creating every ~10s even though x402 and paid routes were fine.

**Root cause:** Each offer reconcile rebuilt the catalog from mixed sources (one offer with freshly-written status, others from a lagging informer cache or override). That produced slightly different `services.json` / `skill.md` on every pass → `obol.org/content-hash` flipped → Kubernetes rolled the Deployment on every reconcile.

**Reproduced on a live cluster:** 1 offer = stable; 2+ unregistered offers = hash alternation (`661249ae` ↔ `671e60f0`) and generation climbing every few seconds.

## What changed

1. **Stable catalog input** — `reconcileSkillCatalog` lists ServiceOffers from the **API server** instead of the informer store. Parallel reconciles now see the same etcd snapshot. The per-offer status override is no longer substituted into the list (only appended when a just-created offer is not yet visible in the list).

2. **Skip writes when catalog is unchanged** — After rendering, compare the full catalog payload (`skill.md`, `services.json`, `openapi.json`, `api.html`) against the **live `obol-skill-md` ConfigMap**. If they match, skip ConfigMap and Deployment applies entirely — no pod churn. HTTPRoutes/Services are unchanged once published.

3. **Offer reconcile no longer passes override into catalog** — Status is written to the API first; catalog rebuild reads it back via the live list.

## Evidence

After deploying `dev-263ae190047d` on a cluster with `bounty-radar` + `loop-test`:

| Before | After |
|--------|-------|
| Deployment generation climbing every ~5s | One rollout, then stable |
| Hash flipping between two values | Fixed at `597ab64f` |
| Controller logs: `/skill.md published` every few seconds | `/skill.md unchanged (hash=…)` on idle reconciles |

## Test plan

- [x] `go test ./internal/serviceoffercontroller/...`
- [x] Manual: 2+ unregistered offers → `obol-skill-md` generation/hash stable for 60s+
- [x] Controller logs show `unchanged` on idle reconciles
- [ ] Add a new offer → catalog updates once (hash changes, single rollout)
- [ ] `obol sell register` → `Ready=True` → catalog updates if registration affects published content
- [ ] Tunnel URL / storefront profile change → catalog still updates

## Notes

- `Ready=False` from pending ERC-8004 registration is expected; offers remain in the catalog when operationally ready.
- Dev clusters with stale `~/.config/obol/defaults` may still pin the production controller digest after `obol stack up`; rebuild + `kubectl set image` (or refresh defaults) may be needed to pick up this controller change locally before release.
<img width="1117" height="456" alt="Screenshot 2026-07-03 at 4 16 52 PM" src="https://github.com/user-attachments/assets/23f12c7e-36f8-4d43-95ba-fa01ba341154" />

