### PR TITLE
feat(sell): add OpenAPI contact email for x402scan discovery

### DIFF
--- a/cmd/obol/sell_info.go
+++ b/cmd/obol/sell_info.go
@@ -47,6 +47,7 @@ Manage the storefront's own branding (independent of individual services):
   obol sell info set             Interactive when no flags are passed;
   obol sell info set --tagline … updates only the fields you pass, leaving
                                  the rest untouched.
+  obol sell info set --contact-email … publishes info.contact.email in /openapi.json
   obol sell info reset           Clears all branding back to defaults;
   obol sell info reset --tagline resets only the fields you pass.
 
@@ -105,6 +106,7 @@ the fields you pass change; everything else is left untouched.`,
 			&cli.StringFlag{Name: "display-name", Usage: "Seller title shown in the storefront header"},
 			&cli.StringFlag{Name: "tagline", Usage: "Short subtitle under the storefront hero"},
 			&cli.StringFlag{Name: "logo-url", Usage: "Logo image URL (https://... or /path on this host)"},
+			&cli.StringFlag{Name: "contact-email", Usage: "Operator contact email published in /openapi.json (x402scan)"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
@@ -118,7 +120,7 @@ the fields you pass change; everything else is left untouched.`,
 			}
 
 			patch := schemas.StorefrontProfile{}
-			anyFlag := cmd.IsSet("display-name") || cmd.IsSet("tagline") || cmd.IsSet("logo-url")
+			anyFlag := cmd.IsSet("display-name") || cmd.IsSet("tagline") || cmd.IsSet("logo-url") || cmd.IsSet("contact-email")
 			if anyFlag {
 				// Flag mode: patch only the fields the operator passed.
 				if cmd.IsSet("display-name") {
@@ -130,10 +132,13 @@ the fields you pass change; everything else is left untouched.`,
 				if cmd.IsSet("logo-url") {
 					patch.LogoURL = strings.TrimSpace(cmd.String("logo-url"))
 				}
+				if cmd.IsSet("contact-email") {
+					patch.ContactEmail = strings.TrimSpace(cmd.String("contact-email"))
+				}
 			} else {
 				// No flags: prompt interactively (pre-filled with effective values).
 				if !u.IsTTY() {
-					return errors.New("no flags given and not a TTY: pass --display-name, --tagline, and/or --logo-url")
+					return errors.New("no flags given and not a TTY: pass --display-name, --tagline, --logo-url, and/or --contact-email")
 				}
 				effective := storefront.ResolvePublished(&current, mustSellerBaseURL(cfg))
 				if v, err := u.Input("Display name", effective.DisplayName); err == nil {
@@ -145,12 +150,18 @@ the fields you pass change; everything else is left untouched.`,
 				if v, err := u.Input("Logo URL", effective.LogoURL); err == nil {
 					patch.LogoURL = strings.TrimSpace(v)
 				}
+				if v, err := u.Input("Contact email (OpenAPI)", effective.ContactEmail); err == nil {
+					patch.ContactEmail = strings.TrimSpace(v)
+				}
 			}
 
-			if patch.DisplayName == "" && patch.Tagline == "" && patch.LogoURL == "" {
+			if patch.DisplayName == "" && patch.Tagline == "" && patch.LogoURL == "" && patch.ContactEmail == "" {
 				return errors.New("nothing to set")
 			}
 			if err := storefront.ValidateLogoURL(patch.LogoURL); err != nil {
+				return err
+			}
+			if err := storefront.ValidateContactEmail(patch.ContactEmail); err != nil {
 				return err
 			}
 
@@ -183,6 +194,7 @@ more field flags to reset only those fields, leaving the rest untouched.`,
 			&cli.BoolFlag{Name: "display-name", Usage: "Reset only the display name"},
 			&cli.BoolFlag{Name: "tagline", Usage: "Reset only the tagline"},
 			&cli.BoolFlag{Name: "logo-url", Usage: "Reset only the logo URL"},
+			&cli.BoolFlag{Name: "contact-email", Usage: "Reset only the OpenAPI contact email"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			u := getUI(cmd)
@@ -190,7 +202,7 @@ more field flags to reset only those fields, leaving the rest untouched.`,
 				return err
 			}
 
-			partial := cmd.Bool("display-name") || cmd.Bool("tagline") || cmd.Bool("logo-url")
+			partial := cmd.Bool("display-name") || cmd.Bool("tagline") || cmd.Bool("logo-url") || cmd.Bool("contact-email")
 
 			var explicit *schemas.StorefrontProfile
 			if partial {
@@ -198,7 +210,7 @@ more field flags to reset only those fields, leaving the rest untouched.`,
 				if err != nil {
 					return err
 				}
-				cleared := clearProfileFields(current, cmd.Bool("display-name"), cmd.Bool("tagline"), cmd.Bool("logo-url"))
+				cleared := clearProfileFields(current, cmd.Bool("display-name"), cmd.Bool("tagline"), cmd.Bool("logo-url"), cmd.Bool("contact-email"))
 				if cleared == (schemas.StorefrontProfile{}) {
 					// Everything is back to default — remove the override entirely.
 					if err := deleteSellerProfile(cfg); err != nil {
@@ -231,7 +243,7 @@ more field flags to reset only those fields, leaving the rest untouched.`,
 // clearProfileFields returns a copy of p with the flagged fields emptied, so
 // they fall back to stack defaults while the rest of the operator override is
 // preserved.
-func clearProfileFields(p schemas.StorefrontProfile, displayName, tagline, logoURL bool) schemas.StorefrontProfile {
+func clearProfileFields(p schemas.StorefrontProfile, displayName, tagline, logoURL, contactEmail bool) schemas.StorefrontProfile {
 	if displayName {
 		p.DisplayName = ""
 	}
@@ -240,6 +252,9 @@ func clearProfileFields(p schemas.StorefrontProfile, displayName, tagline, logoU
 	}
 	if logoURL {
 		p.LogoURL = ""
+	}
+	if contactEmail {
+		p.ContactEmail = ""
 	}
 	return p
 }
@@ -436,11 +451,7 @@ func waitForPublishedCatalog(cfg *config.Config, explicit *schemas.StorefrontPro
 		if err == nil && strings.TrimSpace(raw) != "" {
 			var got schemas.ServiceCatalog
 			if err := json.Unmarshal([]byte(raw), &got); err == nil && sellerProfilesEqual(got, want) {
-				return schemas.StorefrontProfile{
-					DisplayName: got.DisplayName,
-					Tagline:     got.Tagline,
-					LogoURL:     got.LogoURL,
-				}, nil
+				return want, nil
 			}
 		}
 		time.Sleep(2 * time.Second)
@@ -477,9 +488,14 @@ func mustSellerBaseURL(cfg *config.Config) string {
 }
 
 func printSellerProfile(u *ui.UI, profile schemas.StorefrontProfile) {
-	u.Printf("  Display name: %s", profile.DisplayName)
-	u.Printf("  Tagline:      %s", profile.Tagline)
-	u.Printf("  Logo URL:     %s", profile.LogoURL)
+	u.Printf("  Display name:   %s", profile.DisplayName)
+	u.Printf("  Tagline:        %s", profile.Tagline)
+	u.Printf("  Logo URL:       %s", profile.LogoURL)
+	if email := strings.TrimSpace(profile.ContactEmail); email != "" {
+		u.Printf("  Contact email:  %s", email)
+	} else {
+		u.Printf("  Contact email:  (not set — x402scan may reject /openapi.json)")
+	}
 }
 
 // endpointBase returns the origin (scheme://host[:port]) of a service endpoint,

--- a/cmd/obol/sell_info_test.go
+++ b/cmd/obol/sell_info_test.go
@@ -8,21 +8,28 @@ import (
 )
 
 func TestClearProfileFields(t *testing.T) {
-	base := schemas.StorefrontProfile{DisplayName: "Acme", Tagline: "Paid APIs.", LogoURL: "https://acme/logo.png"}
+	base := schemas.StorefrontProfile{
+		DisplayName:  "Acme",
+		Tagline:      "Paid APIs.",
+		LogoURL:      "https://acme/logo.png",
+		ContactEmail: "ops@acme.example",
+	}
 
 	tests := []struct {
 		name       string
 		dn, tl, lu bool
+		ce         bool
 		want       schemas.StorefrontProfile
 	}{
-		{"none", false, false, false, base},
-		{"tagline only", false, true, false, schemas.StorefrontProfile{DisplayName: "Acme", LogoURL: "https://acme/logo.png"}},
-		{"display+logo", true, false, true, schemas.StorefrontProfile{Tagline: "Paid APIs."}},
-		{"all", true, true, true, schemas.StorefrontProfile{}},
+		{"none", false, false, false, false, base},
+		{"tagline only", false, true, false, false, schemas.StorefrontProfile{DisplayName: "Acme", LogoURL: "https://acme/logo.png", ContactEmail: "ops@acme.example"}},
+		{"display+logo", true, false, true, false, schemas.StorefrontProfile{Tagline: "Paid APIs.", ContactEmail: "ops@acme.example"}},
+		{"contact only", false, false, false, true, schemas.StorefrontProfile{DisplayName: "Acme", Tagline: "Paid APIs.", LogoURL: "https://acme/logo.png"}},
+		{"all", true, true, true, true, schemas.StorefrontProfile{}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := clearProfileFields(base, tc.dn, tc.tl, tc.lu)
+			got := clearProfileFields(base, tc.dn, tc.tl, tc.lu, tc.ce)
 			if got != tc.want {
 				t.Fatalf("clearProfileFields = %+v, want %+v", got, tc.want)
 			}

--- a/internal/schemas/service_catalog.go
+++ b/internal/schemas/service_catalog.go
@@ -131,9 +131,10 @@ type ServiceCatalogEIP712Domain struct {
 // StorefrontProfile is operator-set seller branding merged into
 // /api/services.json by the controller.
 type StorefrontProfile struct {
-	DisplayName string `json:"displayName"`
-	Tagline     string `json:"tagline"`
-	LogoURL     string `json:"logoUrl"`
+	DisplayName  string `json:"displayName"`
+	Tagline      string `json:"tagline"`
+	LogoURL      string `json:"logoUrl"`
+	ContactEmail string `json:"contactEmail,omitempty"`
 }
 
 // ServiceCatalog is the public /api/services.json envelope.

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -1201,13 +1201,14 @@ func (c *Controller) reconcileSkillCatalog(ctx context.Context, override *moneti
 	}
 	content := buildSkillCatalogMarkdown(offers, baseURL, storefrontProfile)
 	servicesJSON := buildServiceCatalogJSON(offers, baseURL, storefrontProfile)
+	resolvedProfile := storefront.ResolvePublished(storefrontProfile, baseURL)
 	// buildOpenAPIDocument prefers the tunnel URL for the public `servers[0]`
 	// entry; baseURL is sourced from obol-stack-config.tunnelURL via
 	// registrationBaseURL, which is also what /skill.md and services.json
 	// use as their public-facing prefix, so the three surfaces stay in sync
 	// on tunnel restarts (the configMap informer re-enqueues every offer
 	// when tunnelURL changes — see enqueueDiscoveryRefresh).
-	openAPIJSON := buildOpenAPIDocument(offers, baseURL)
+	openAPIJSON := buildOpenAPIDocument(offers, baseURL, resolvedProfile)
 	apiDocsHTML := scalarHTML()
 	contentHash := computeSkillCatalogContentHash(content, servicesJSON, openAPIJSON, apiDocsHTML)
 

--- a/internal/serviceoffercontroller/openapi.go
+++ b/internal/serviceoffercontroller/openapi.go
@@ -30,7 +30,7 @@ const localBaseURL = "http://obol.stack:8080"
 //
 // The output is JSON, deterministically ordered, indented with two spaces
 // so manual `curl /openapi.json` is readable.
-func buildOpenAPIDocument(offers []*monetizeapi.ServiceOffer, tunnelURL string) string {
+func buildOpenAPIDocument(offers []*monetizeapi.ServiceOffer, tunnelURL string, profile schemas.StorefrontProfile) string {
 	tunnelURL = strings.TrimRight(tunnelURL, "/")
 
 	now := time.Now()
@@ -55,7 +55,7 @@ func buildOpenAPIDocument(offers []*monetizeapi.ServiceOffer, tunnelURL string) 
 
 	doc := map[string]any{
 		"openapi": openAPISpecVersion,
-		"info":    buildOpenAPIInfo(len(ready)),
+		"info":    buildOpenAPIInfo(profile, len(ready)),
 		"servers": buildOpenAPIServers(tunnelURL),
 		"tags":    buildOpenAPITags(ready),
 		"paths":   buildOpenAPIPaths(ready),
@@ -82,7 +82,7 @@ func buildOpenAPIDocument(offers []*monetizeapi.ServiceOffer, tunnelURL string) 
 	return string(encoded)
 }
 
-func buildOpenAPIInfo(readyCount int) map[string]any {
+func buildOpenAPIInfo(profile schemas.StorefrontProfile, readyCount int) map[string]any {
 	description := "x402 payment-gated services advertised by this Obol Stack operator. " +
 		"Every operation expects an `X-PAYMENT` header carrying a signed x402 v2 payment payload; " +
 		"unpaid requests receive a 402 with `accepts[]` describing the prices the operator will honour. " +
@@ -94,14 +94,22 @@ func buildOpenAPIInfo(readyCount int) map[string]any {
 	if readyCount == 0 {
 		description = "This operator currently advertises no live services. " + description
 	}
+	contactName := strings.TrimSpace(profile.DisplayName)
+	if contactName == "" || contactName == "Obol Stack" {
+		contactName = "Obol Stack"
+	}
+	contact := map[string]any{
+		"name": contactName,
+		"url":  "https://github.com/ObolNetwork/obol-stack",
+	}
+	if email := strings.TrimSpace(profile.ContactEmail); email != "" {
+		contact["email"] = email
+	}
 	return map[string]any{
 		"title":       "Obol Stack — paid services",
 		"version":     "1",
 		"description": description,
-		"contact": map[string]any{
-			"name": "Obol Stack",
-			"url":  "https://github.com/ObolNetwork/obol-stack",
-		},
+		"contact":     contact,
 		// x-guidance is the agent-facing usage overview read by discovery
 		// indexers (x402scan L4 audit). Keep it answer-shaped: what an agent
 		// must do to call any operation in this document.

--- a/internal/serviceoffercontroller/openapi_test.go
+++ b/internal/serviceoffercontroller/openapi_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	"github.com/ObolNetwork/obol-stack/internal/schemas"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,7 +56,7 @@ func dig(t *testing.T, m map[string]any, keys ...string) any {
 }
 
 func TestBuildOpenAPIDocument_EmptyCluster(t *testing.T) {
-	out := buildOpenAPIDocument(nil, "https://tunnel.example")
+	out := buildOpenAPIDocument(nil, "https://tunnel.example", schemas.StorefrontProfile{})
 	doc := parseOpenAPI(t, out)
 
 	if got := doc["openapi"]; got != openAPISpecVersion {
@@ -99,10 +100,27 @@ func TestBuildOpenAPIDocument_EmptyCluster(t *testing.T) {
 	if c := dig(t, doc, "info", "contact", "url"); c != "https://github.com/ObolNetwork/obol-stack" {
 		t.Errorf("info.contact.url = %v, want obol-stack repo", c)
 	}
+	if dig(t, doc, "info", "contact", "email") != nil {
+		t.Error("info.contact.email should be omitted when unset")
+	}
+}
+
+func TestBuildOpenAPIDocument_ContactEmail(t *testing.T) {
+	profile := schemas.StorefrontProfile{
+		DisplayName:  "Acme Labs",
+		ContactEmail: "ops@acme.example",
+	}
+	doc := parseOpenAPI(t, buildOpenAPIDocument(nil, "https://tunnel.example", profile))
+	if e := dig(t, doc, "info", "contact", "email"); e != "ops@acme.example" {
+		t.Errorf("info.contact.email = %v, want ops@acme.example", e)
+	}
+	if n := dig(t, doc, "info", "contact", "name"); n != "Acme Labs" {
+		t.Errorf("info.contact.name = %v, want Acme Labs", n)
+	}
 }
 
 func TestBuildOpenAPIDocument_NoTunnelOmitsTunnelServer(t *testing.T) {
-	doc := parseOpenAPI(t, buildOpenAPIDocument(nil, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument(nil, "", schemas.StorefrontProfile{}))
 	servers, _ := doc["servers"].([]any)
 	if len(servers) != 1 {
 		t.Fatalf("servers = %d entries, want only local fallback", len(servers))
@@ -130,7 +148,7 @@ func TestBuildOpenAPIDocument_InferenceOffer(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "https://tunnel.example"))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "https://tunnel.example", schemas.StorefrontProfile{}))
 
 	want := "/services/llama-3/v1/chat/completions"
 	op := dig(t, doc, "paths", want, "post")
@@ -218,7 +236,7 @@ func TestBuildOpenAPIDocument_AcceptsCarrySigningMetadata(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "https://tunnel.example"))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "https://tunnel.example", schemas.StorefrontProfile{}))
 	op := dig(t, doc, "paths", "/services/solo/v1/chat/completions", "post")
 	info, _ := op.(map[string]any)["x-payment-info"].(map[string]any)
 	if info == nil {
@@ -272,7 +290,7 @@ func TestBuildOpenAPIDocument_MultiPaymentAdvertisesAllOptions(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "", schemas.StorefrontProfile{}))
 	op := dig(t, doc, "paths", "/services/dual/v1/chat/completions", "post")
 	xpay, _ := op.(map[string]any)["x-payment-info"].(map[string]any)
 	if xpay == nil {
@@ -311,7 +329,7 @@ func TestBuildOpenAPIDocument_AgentOfferSameShapeAsInference(t *testing.T) {
 	})
 	offer.Status.AgentResolution = &monetizeapi.ServiceOfferAgentResolution{Model: "qwen3.5:9b"}
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "", schemas.StorefrontProfile{}))
 
 	if op := dig(t, doc, "paths", "/services/hermes-agent/v1/chat/completions", "post"); op == nil {
 		t.Fatalf("agent offer missing /v1/chat/completions endpoint, paths = %v", doc["paths"])
@@ -334,7 +352,7 @@ func TestBuildOpenAPIDocument_HTTPOffer(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "", schemas.StorefrontProfile{}))
 
 	op := dig(t, doc, "paths", "/services/echo", "post")
 	if op == nil {
@@ -361,7 +379,7 @@ func TestBuildOpenAPIDocument_FineTuningOffer(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{offer}, "", schemas.StorefrontProfile{}))
 
 	op := dig(t, doc, "paths", "/services/train", "post")
 	if op == nil {
@@ -383,7 +401,7 @@ func TestBuildOpenAPIDocument_ExcludesNotReadyAndDrained(t *testing.T) {
 		Status:     monetizeapi.ServiceOfferStatus{Conditions: []monetizeapi.Condition{{Type: "Ready", Status: "False"}}},
 	}
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{ready, notReady}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{ready, notReady}, "", schemas.StorefrontProfile{}))
 	paths, _ := doc["paths"].(map[string]any)
 	if len(paths) != 1 {
 		t.Fatalf("paths = %d entries, want only the ready offer: %v", len(paths), paths)
@@ -397,7 +415,7 @@ func TestBuildOpenAPIDocument_ExcludesNotReadyAndDrained(t *testing.T) {
 // safety check buildServiceCatalogJSON has — a stray trailing slash on
 // the configmap value should not produce a `//` in the spec servers[].
 func TestBuildOpenAPIDocument_TunnelURLTrailingSlash(t *testing.T) {
-	doc := parseOpenAPI(t, buildOpenAPIDocument(nil, "https://tunnel.example/"))
+	doc := parseOpenAPI(t, buildOpenAPIDocument(nil, "https://tunnel.example/", schemas.StorefrontProfile{}))
 	servers, _ := doc["servers"].([]any)
 	first := servers[0].(map[string]any)
 	if first["url"] != "https://tunnel.example" {
@@ -420,7 +438,7 @@ func TestBuildOpenAPIDocument_MultipleOffersPathsDistinct(t *testing.T) {
 		Payment: monetizeapi.ServiceOfferPayment{Network: "base", PayTo: "0xbb", Price: monetizeapi.ServiceOfferPriceTable{PerRequest: "0.001"}},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{a, b}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{a, b}, "", schemas.StorefrontProfile{}))
 	paths, _ := doc["paths"].(map[string]any)
 	if _, ok := paths["/services/a/v1/chat/completions"]; !ok {
 		t.Errorf("offer a missing")
@@ -450,7 +468,7 @@ func TestBuildOpenAPIDocument_AggregateTags(t *testing.T) {
 		},
 	})
 
-	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{a, b}, ""))
+	doc := parseOpenAPI(t, buildOpenAPIDocument([]*monetizeapi.ServiceOffer{a, b}, "", schemas.StorefrontProfile{}))
 	tags, _ := doc["tags"].([]any)
 	names := map[string]struct{}{}
 	for _, t := range tags {

--- a/internal/storefront/profile.go
+++ b/internal/storefront/profile.go
@@ -3,6 +3,7 @@ package storefront
 import (
 	"encoding/json"
 	"fmt"
+	"net/mail"
 	"path/filepath"
 	"strings"
 
@@ -37,6 +38,9 @@ func ResolvePublished(explicit *schemas.StorefrontProfile, baseURL string) schem
 	}
 	if v := strings.TrimSpace(explicit.LogoURL); v != "" {
 		profile.LogoURL = v
+	}
+	if v := strings.TrimSpace(explicit.ContactEmail); v != "" {
+		profile.ContactEmail = v
 	}
 	return profile
 }
@@ -75,6 +79,9 @@ func MergeProfile(base, patch schemas.StorefrontProfile) schemas.StorefrontProfi
 	if v := strings.TrimSpace(patch.LogoURL); v != "" {
 		out.LogoURL = v
 	}
+	if v := strings.TrimSpace(patch.ContactEmail); v != "" {
+		out.ContactEmail = v
+	}
 	return out
 }
 
@@ -96,6 +103,23 @@ func ValidateLogoURL(raw string) error {
 		return nil
 	}
 	return fmt.Errorf("logo URL must be https://..., http://..., or a path starting with /")
+}
+
+// ValidateContactEmail accepts a bare operator contact address for OpenAPI
+// info.contact.email (required by x402scan discovery audits).
+func ValidateContactEmail(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	addr, err := mail.ParseAddress(raw)
+	if err != nil {
+		return fmt.Errorf("contact email: %w", err)
+	}
+	if addr.Address == "" {
+		return fmt.Errorf("contact email: address is empty")
+	}
+	return nil
 }
 
 // IsDefaultLogoURL reports whether url is the stack default wordmark (relative or absolute).

--- a/internal/storefront/profile_test.go
+++ b/internal/storefront/profile_test.go
@@ -46,6 +46,25 @@ func TestValidateLogoURL(t *testing.T) {
 	}
 }
 
+func TestValidateContactEmail(t *testing.T) {
+	for _, tc := range []struct {
+		raw string
+		ok  bool
+	}{
+		{"ops@acme.example", true},
+		{"", true},
+		{"not-an-email", false},
+	} {
+		err := storefront.ValidateContactEmail(tc.raw)
+		if tc.ok && err != nil {
+			t.Fatalf("%q: %v", tc.raw, err)
+		}
+		if !tc.ok && err == nil {
+			t.Fatalf("%q: expected error", tc.raw)
+		}
+	}
+}
+
 func TestIsDefaultLogoURL(t *testing.T) {
 	for _, tc := range []struct {
 		raw   string


### PR DESCRIPTION
Let operators set contactEmail on the storefront profile and publish it as info.contact.email in /openapi.json while keeping the services catalog envelope unchanged.

## Summary

What changed:

Why it matters:

Risk level: <!-- low / medium / high -->

Commit under test:

Base branch:

## Scope

- [ ] Code
- [ ] Charts / manifests
- [ ] Flows / QA scripts
- [ ] Docs / skills
- [ ] Images / dependencies
- [ ] Other:

## Validation

CI checks:

| Check | Status | Link |
|-------|--------|------|
|       |        |      |

Unit tests:

```text
<!-- command, result, commit/SHA -->
```

Integration tests:

```text
<!-- command, result, commit/SHA -->
```

Flow tests:

| Flow | Network | QA machine label | Worktree | Result | Artifacts |
|------|---------|------------------|----------|--------|-----------|
|      |         |                  |          |        |           |

Release smoke:

```text
<!-- command, flags, result -->
```

## Live Chain Evidence

Do not include private keys, seed phrases, passwords, hostnames, personal paths, or raw bearer tokens.

Network:

RPC/provider:

Facilitator:

Contracts and tokens:

| Name | Address | Version / notes |
|------|---------|-----------------|
|      |         |                 |

Wallet roles:

| Role | Address | Source |
|------|---------|--------|
| Alice / seller / register | | |
| Bob / buyer / payer | | |
| Facilitator / receiver | | |

Balances:

| Token | Address | Before | After | Expected delta | Actual delta |
|-------|---------|--------|-------|----------------|--------------|
|       |         |        |       |                |              |

Transaction receipts:

| Purpose | Tx hash | From | To | Amount / event | Status |
|---------|---------|------|----|----------------|--------|
| ERC-8004 registration | | | | | |
| Metadata / service offer | | | | | |
| Approval / permit | | | | | |
| Purchase request | | | | | |
| Settlement transfer | | | | | |

## Runtime Evidence

QA environment:

| Item | Value |
|------|-------|
| OS / arch | |
| Backend | |
| Tool versions | |
| QA agent/model | |

Images:

| Component | Image | Tag / digest | Source |
|-----------|-------|--------------|--------|
|           |       |              |        |

Kubernetes / stack:

| Item | Value |
|------|-------|
| Stack IDs | |
| Namespaces | |
| Pod readiness | |
| Cleanup result | |

Model and routing:

| Item | Value |
|------|-------|
| Agent/model used | |
| LiteLLM route | |
| Paid endpoint status | |
| Auth token source | |

Artifacts and logs:

| Artifact | Location / link | Notes |
|----------|-----------------|-------|
|          |                 |       |

Demo readiness:

| Item | Status | Notes |
|------|--------|-------|
| Seller visible / registered | | |
| Buyer discovery works | | |
| Paid route works | | |
| Settlement visible on-chain | | |

## Review Notes

Known gaps:

Follow-ups:

Reviewer focus:
