### PR TITLE
fix(serviceoffer-controller): advertise stream:false on generated chat openapi

### DIFF
--- a/internal/serviceoffercontroller/openapi_components.go
+++ b/internal/serviceoffercontroller/openapi_components.go
@@ -158,8 +158,19 @@ func openAIChatCompletionsRequestSchema() map[string]any {
 			"temperature": map[string]any{"type": "number", "minimum": 0, "maximum": 2},
 			"top_p":       map[string]any{"type": "number", "minimum": 0, "maximum": 1},
 			"n":           map[string]any{"type": "integer", "minimum": 1},
-			"stream":      map[string]any{"type": "boolean"},
-			"max_tokens":  map[string]any{"type": "integer", "minimum": 1},
+			// Paid chat runs through the x402 paywall, which settles at
+			// status-commit time and returns the settlement receipt with a
+			// single buffered application/json body. A streamed (SSE) response
+			// commits its status before the body exists, so the receipt can't
+			// ride it and pay-and-confirm clients can't parse an event stream
+			// as a completion. Advertise stream:false as the default + required
+			// value until streaming-aware settlement lands (obol-stack#671).
+			"stream": map[string]any{
+				"type":        "boolean",
+				"default":     false,
+				"description": "Must be false. Streaming (text/event-stream / SSE) is not supported over the x402 payment path — the settlement receipt ships with one buffered application/json completion, so stream:true breaks payment confirmation in x402 clients.",
+			},
+			"max_tokens": map[string]any{"type": "integer", "minimum": 1},
 			"stop": map[string]any{
 				"oneOf": []any{
 					map[string]any{"type": "string"},
@@ -169,6 +180,13 @@ func openAIChatCompletionsRequestSchema() map[string]any {
 			"presence_penalty":  map[string]any{"type": "number", "minimum": -2, "maximum": 2},
 			"frequency_penalty": map[string]any{"type": "number", "minimum": -2, "maximum": 2},
 			"user":              map[string]any{"type": "string"},
+		},
+		// Example steers discovery clients (agentcash/poncho/CDP) to the
+		// non-streaming shape the x402 pay path requires.
+		"example": map[string]any{
+			"model":    "<model-id from /api/services.json>",
+			"stream":   false,
+			"messages": []any{map[string]any{"role": "user", "content": "Hello"}},
 		},
 	}
 }


### PR DESCRIPTION
## Problem

Paid chat offers (`sell agent`, `sell inference`) are gated by the x402 paywall. The verifier settles at status-commit time and delivers the settlement receipt (`X-PAYMENT-RESPONSE` / `PAYMENT-RESPONSE`) alongside a single buffered `application/json` completion.

A streamed response (`stream: true` → `text/event-stream`) commits its `200` status **before** any token exists, so:

- the receipt can't ride the response in a way pay-and-confirm clients consume, and
- x402 clients (agentcash, poncho / tryponcho.com, CDP) read the body as one JSON completion — an SSE event stream isn't a JSON object, so the parse **and** the payment confirmation fail.

Observed live: a paid chat endpoint completes the x402 transaction only when the caller sends `stream: false`.

## Change

Advertise the constraint in the generated `OpenAIChatCompletionsRequest` schema (`internal/serviceoffercontroller/openapi_components.go`) so discovery indexers and agent clients pick it up:

- `stream` → `default: false` + a description explaining the x402 pay-path constraint
- a schema-level `example` with `stream: false`

The `200` response is already `application/json`-only, so no change there. Applies to every `agent` and `inference` offer via the shared component.

## Scope / follow-up

This is the **interim** advertisement so today's clients transact correctly. The durable fix is streaming-aware settlement in the verifier — buffer-and-settle, or an in-band SSE settlement frame the way streaming x402 chat endpoints deliver it — tracked with the paid-chat settlement work in #671. Once that lands, the `stream:false` default can be relaxed.

## Test

- `go build ./internal/serviceoffercontroller/...`
- `go test ./internal/serviceoffercontroller/...` — green
- Rendered `openAIChatCompletionsRequestSchema()` and confirmed `stream.default:false` + the `example` appear in the emitted schema.

https://claude.ai/code/session_01VquWN9UMaSHH7MHGcG8bw1
