### PR TITLE
fix(route-surface): security + correctness + x402 hardening for #717 (F1,F1-HMAC,F3,F3+,F4,F5,F6,F7,F8,P1b)

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -4903,12 +4903,51 @@ func preflightOfferPathCollision(cfg *config.Config, manifest map[string]any) er
 	if root := monetizeapi.ReservedPathConflict(path); root != "" {
 		return fmt.Errorf("path %s collides with the reserved platform path %s (discovery/routing surface) — pass --path to pick a different public path", path, root)
 	}
+	// F8: same static check, but over each declared spec.routes[].path
+	// entry rather than just the offer root. A route landing on "/auth" (or
+	// nested under it) would shadow the verifier's SIWX sign-in endpoints.
+	if routePath, root := reservedRoutePathCollision(spec); root != "" {
+		return fmt.Errorf("route path %s collides with the reserved platform path %s (discovery/routing surface) — pick a different route path", routePath, root)
+	}
 	bin, kubeconfig := kubectl.Paths(cfg)
 	out, err := kubectl.Output(bin, kubeconfig, "get", "serviceoffers.obol.org", "-A", "-o", "json")
 	if err != nil {
 		return nil //nolint:nilerr // best-effort preflight; the apply surfaces real errors
 	}
 	return offerPathCollisionInList([]byte(out), ns, name, path, hostname)
+}
+
+// reservedRoutePathCollision checks spec["routes"] against the route-level
+// reserved-path denylist and returns the first colliding route's path and
+// the reserved root it hit, or ("", "") when none collide. spec["routes"]
+// takes two shapes depending on how the manifest was built: []map[string]any
+// from parseRouteFlags (the --route flag path) or []any of
+// map[string]interface{} from json.Unmarshal (the --from-json path) — any
+// is an alias for interface{}, so both element types assert the same way.
+func reservedRoutePathCollision(spec map[string]any) (routePath, root string) {
+	var routes []any
+	switch rs := spec["routes"].(type) {
+	case []map[string]any:
+		for _, r := range rs {
+			routes = append(routes, r)
+		}
+	case []any:
+		routes = rs
+	}
+	for _, item := range routes {
+		rm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		p, _ := rm["path"].(string)
+		if p == "" {
+			continue
+		}
+		if r := monetizeapi.ReservedRoutePathConflict(p); r != "" {
+			return p, r
+		}
+	}
+	return "", ""
 }
 
 // offerPathCollisionInList is the pure core of preflightOfferPathCollision.

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
@@ -97,6 +98,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
+	github.com/signinwithethereum/siwe-go v1.0.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/supranational/blst v0.3.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
+github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -301,6 +303,8 @@ github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/signinwithethereum/siwe-go v1.0.0 h1:NhGba4ov9Eq+5kDU6APGTfCzbLsjZPPkvrxcgwd8CEM=
+github.com/signinwithethereum/siwe-go v1.0.0/go.mod h1:/4nSXYCSkf+o3kZQV7uSrISK9/1Nw4yoUKd98cayPhQ=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -553,3 +553,31 @@ spec:
     - name: http
       port: 8090
       targetPort: 8090
+---
+# job-broker trusts the X-Obol-Upstream-* headers on every request it
+# receives to know where to replay it — it is not itself capable of
+# re-verifying payment. Without this policy any in-cluster pod could POST
+# straight to job-broker.x402.svc with forged upstream headers (SSRF /
+# free-compute against whatever upstream it names). Restrict ingress to
+# only the x402-verifier pods, which are the sole intended caller (F1).
+# Egress is intentionally left unrestricted: the broker must be able to
+# reach arbitrary seller upstreams by design.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: job-broker
+  namespace: x402
+spec:
+  podSelector:
+    matchLabels:
+      app: job-broker
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: x402-verifier
+      ports:
+        - protocol: TCP
+          port: 8090

--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -57,6 +57,10 @@ metadata:
 type: Opaque
 stringData:
   WALLET_ADDRESS: ""
+  # Shared secret for the verifier→broker HMAC (F1 defense in depth over the
+  # NetworkPolicy). Empty = disabled on both sides; set the same non-empty
+  # value to require a valid X-Obol-Broker-Sig on every async submit.
+  JOB_BROKER_HMAC_SECRET: ""
 
 ---
 apiVersion: v1
@@ -279,6 +283,16 @@ spec:
             - --config=/config/pricing.yaml
             - --listen=:8080
             - --route-source=kube
+          env:
+            # F1 defense in depth: sign async broker-contract headers so a
+            # NetworkPolicy-allowed pod still can't forge a submit. optional
+            # so an install without the key runs (HMAC off, NetworkPolicy on).
+            - name: JOB_BROKER_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: x402-secrets
+                  key: JOB_BROKER_HMAC_SECRET
+                  optional: true
           volumeMounts:
             - name: pricing-config
               mountPath: /config
@@ -514,6 +528,15 @@ spec:
           args:
             - --listen=:8090
             - --db=/data/jobs.db
+          env:
+            # Same shared secret the verifier signs with (F1). When set, the
+            # broker requires a valid X-Obol-Broker-Sig on every submit.
+            - name: JOB_BROKER_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: x402-secrets
+                  key: JOB_BROKER_HMAC_SECRET
+                  optional: true
           ports:
             - name: http
               containerPort: 8090

--- a/internal/jobbroker/server.go
+++ b/internal/jobbroker/server.go
@@ -2,12 +2,16 @@ package jobbroker
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -44,15 +48,40 @@ const upstreamTimeout = 2 * time.Hour
 type Server struct {
 	store  *Store
 	client *http.Client
+	// hmacSecret, when non-empty, requires every submit to carry a valid
+	// X-Obol-Broker-Sig computed by the verifier over the contract headers.
+	// Empty = disabled (the NetworkPolicy is then the only guard). Sourced
+	// from JOB_BROKER_HMAC_SECRET, the same value the verifier signs with.
+	hmacSecret string
 	// now is swappable for tests.
 	now func() time.Time
 }
 
+// HeaderBrokerSig carries the verifier's HMAC over the contract headers, so
+// the broker can reject forged submits even from a pod the NetworkPolicy
+// allows (defense in depth with the F1 NetworkPolicy). Mirrored in
+// internal/x402 (see authgate.go) — the two packages don't share code.
+const HeaderBrokerSig = "X-Obol-Broker-Sig"
+
+// brokerSignature is the HMAC the verifier and broker both compute over the
+// security-critical contract fields: the replay URL, the offer identity, and
+// the injected upstream credential. Keep byte-identical to the x402 copy.
+func brokerSignature(secret, upstreamURL, offer, upstreamAuth string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(upstreamURL + "\n" + offer + "\n" + upstreamAuth))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
 func NewServer(store *Store) *Server {
+	secret := os.Getenv("JOB_BROKER_HMAC_SECRET")
+	if secret == "" {
+		log.Printf("job-broker: JOB_BROKER_HMAC_SECRET unset — verifier→broker HMAC disabled; relying on the NetworkPolicy alone")
+	}
 	return &Server{
-		store:  store,
-		client: &http.Client{Timeout: upstreamTimeout},
-		now:    time.Now,
+		store:      store,
+		client:     &http.Client{Timeout: upstreamTimeout},
+		hmacSecret: secret,
+		now:        time.Now,
 	}
 }
 
@@ -122,6 +151,18 @@ func (s *Server) handleSubmit(w http.ResponseWriter, r *http.Request) {
 		// come through the payment gate.
 		http.Error(w, "not a gated async submit (missing broker contract headers)", http.StatusBadRequest)
 		return
+	}
+	// Defense in depth over the NetworkPolicy: when a shared secret is
+	// provisioned, header *presence* is not enough — the verifier's HMAC
+	// over (upstreamURL, offer, upstreamAuth) must check out, so a pod that
+	// slips past the network layer still can't forge an arbitrary-URL,
+	// attacker-credentialed submit.
+	if s.hmacSecret != "" {
+		want := brokerSignature(s.hmacSecret, upstream, offer, r.Header.Get(HeaderUpstreamAuth))
+		if !hmac.Equal([]byte(r.Header.Get(HeaderBrokerSig)), []byte(want)) {
+			http.Error(w, "invalid or missing broker signature", http.StatusForbidden)
+			return
+		}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxSubmitBody+1))

--- a/internal/jobbroker/server_test.go
+++ b/internal/jobbroker/server_test.go
@@ -272,3 +272,50 @@ func TestBroker_SubmitWithoutContractHeaders(t *testing.T) {
 		t.Errorf("ungated submit = %d, want 400", w.Code)
 	}
 }
+
+// TestBroker_HMAC_RejectsForgedSubmit pins F1 defense-in-depth: with a shared
+// secret set, a submit whose X-Obol-Broker-Sig doesn't match the contract
+// headers is refused (403) — so a NetworkPolicy-allowed pod still can't forge
+// an arbitrary-URL, attacker-credentialed job. A correctly-signed submit passes.
+func TestBroker_HMAC_RejectsForgedSubmit(t *testing.T) {
+	t.Setenv("JOB_BROKER_HMAC_SECRET", "test-shared-secret")
+	dir := t.TempDir()
+	store, err := OpenStore(dir + "/jobs.db")
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+	srv := NewServer(store)
+
+	upstream := "http://upstream.internal/work"
+	offer := "sec/audit"
+	newReq := func(sig string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/jobs", strings.NewReader(`{}`))
+		req.Header.Set(HeaderUpstreamURL, upstream)
+		req.Header.Set(HeaderOffer, offer)
+		if sig != "" {
+			req.Header.Set(HeaderBrokerSig, sig)
+		}
+		return req
+	}
+
+	// Forged / missing signature → 403.
+	w := httptest.NewRecorder()
+	srv.handleSubmit(w, newReq("deadbeef"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("forged-sig submit = %d, want 403", w.Code)
+	}
+	w = httptest.NewRecorder()
+	srv.handleSubmit(w, newReq(""))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("missing-sig submit = %d, want 403", w.Code)
+	}
+
+	// Correct signature (matching the verifier's computation) → accepted (202).
+	good := brokerSignature("test-shared-secret", upstream, offer, "")
+	w = httptest.NewRecorder()
+	srv.handleSubmit(w, newReq(good))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("correctly-signed submit = %d (%s), want 202", w.Code, w.Body.String())
+	}
+}

--- a/internal/monetizeapi/types.go
+++ b/internal/monetizeapi/types.go
@@ -623,6 +623,27 @@ func ReservedPathConflict(path string) string {
 	return ""
 }
 
+// routeReservedPathRoots extends reservedPathRoots with the verifier's own
+// sign-in surface for gate:auth offers. A route declared at "/auth" or
+// "/auth/verify" would shadow the SIWX challenge/verify endpoints the
+// verifier serves at those paths.
+var routeReservedPathRoots = append(append([]string{}, reservedPathRoots...), "/auth")
+
+// ReservedRoutePathConflict returns the reserved root a route's
+// offer-relative path (spec.routes[].path) collides with, or "". Unlike
+// ReservedPathConflict this does not special-case "/" or "/services" — "/"
+// is a normal, meaningful relative route path (the offer's own root route)
+// — it only guards the shared verifier surfaces plus "/auth".
+func ReservedRoutePathConflict(path string) string {
+	p := strings.TrimSuffix(path, "/")
+	for _, root := range routeReservedPathRoots {
+		if p == root || strings.HasPrefix(p, root+"/") {
+			return root
+		}
+	}
+	return ""
+}
+
 // EffectiveOrigin returns the offer's dedicated public origin
 // ("https://<hostname>") when spec.hostname is set, else "". Discovery
 // surfaces use it to advertise hostname-bound offers at their own origin

--- a/internal/monetizeapi/types_test.go
+++ b/internal/monetizeapi/types_test.go
@@ -197,3 +197,28 @@ func TestReservedPathConflict(t *testing.T) {
 		}
 	}
 }
+
+// TestReservedRoutePathConflict pins the route-level denylist (F8): a
+// spec.routes[].path may not land on "/auth" or "/auth/verify" (the
+// verifier's SIWX sign-in endpoints for gate:auth offers) or nest under any
+// of the shared reservedPathRoots. Unlike the offer-root check, "/" is a
+// legitimate relative route path and must stay unreserved.
+func TestReservedRoutePathConflict(t *testing.T) {
+	tests := []struct{ path, wantRoot string }{
+		{"/", ""},
+		{"/v1/*", ""},
+		{"/healthz", ""},
+		{"/auth", "/auth"},
+		{"/auth/", "/auth"},
+		{"/auth/verify", "/auth"},
+		{"/authorize", ""}, // prefix must respect segment boundaries
+		{"/api", "/api"},
+		{"/api/services.json", "/api"},
+		{"/.well-known/x402", "/.well-known"},
+	}
+	for _, tt := range tests {
+		if got := ReservedRoutePathConflict(tt.path); got != tt.wantRoot {
+			t.Errorf("ReservedRoutePathConflict(%q) = %q, want %q", tt.path, got, tt.wantRoot)
+		}
+	}
+}

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -526,6 +526,19 @@ func (c *Controller) reconcileOffer(ctx context.Context, key string) error {
 		setCondition(&status, "Draining", "False", "Active", "Offer is active")
 		setCondition(&status, "PaymentGateReady", "False", "ReservedPath", msg)
 		setCondition(&status, "RoutePublished", "False", "ReservedPath", msg)
+	} else if routePath, root := reservedRouteConflict(offer); root != "" {
+		// Same reserved-surface treatment as above, but for an individual
+		// spec.routes[].path entry (F8) — e.g. a route declared at "/auth"
+		// would shadow the verifier's own SIWX sign-in endpoints for
+		// gate:auth offers.
+		msg := fmt.Sprintf("route path %s collides with the reserved platform path %s — set a different spec.routes[].path", routePath, root)
+		log.Printf("serviceoffer-controller: %s/%s reserved route path: %s", offer.Namespace, offer.Name, msg)
+		if err := c.deleteRouteChildren(ctx, offer); err != nil {
+			return err
+		}
+		setCondition(&status, "Draining", "False", "Active", "Offer is active")
+		setCondition(&status, "PaymentGateReady", "False", "ReservedPath", msg)
+		setCondition(&status, "RoutePublished", "False", "ReservedPath", msg)
 	} else if conflict := c.findHostnameConflict(offer); conflict != "" {
 		// One offer per public origin — same first-claimant-wins treatment
 		// as a path conflict.

--- a/internal/serviceoffercontroller/openapi.go
+++ b/internal/serviceoffercontroller/openapi.go
@@ -427,9 +427,21 @@ func annotateAsyncPaths(offer *monetizeapi.ServiceOffer, paths map[string]map[st
 // payments). Free routes carry neither — they are advertised as plainly
 // callable, marked with x-gate: free so indexers don't misread the absence
 // of payment metadata as an omission.
+//
+// openAPIRelPathForRoute collapses an exact path and its own "/*" wildcard
+// sibling onto the same {key, method} slot (e.g. "/jobs" and "/jobs/*" both
+// key as "/jobs"). The verifier resolves that overlap by specificity, not
+// declaration order (sortRoutesBySpecificity in internal/x402/matcher.go) —
+// exact beats wildcard. We sort a copy of the route table the same way
+// before rendering, and skip a method that a more specific route already
+// wrote, so the collapsed operation always reflects the route the verifier
+// will actually select instead of whichever was declared last.
 func openAPIPathsForRouteTable(offer *monetizeapi.ServiceOffer) map[string]map[string]any {
+	routes := append([]monetizeapi.ServiceOfferRoute(nil), offer.EffectiveRoutes()...)
+	sortRouteTableBySpecificity(routes)
+
 	paths := map[string]map[string]any{}
-	for _, rt := range offer.EffectiveRoutes() {
+	for _, rt := range routes {
 		rel := openAPIRelPathForRoute(rt.Path)
 		item := paths[rel]
 		if item == nil {
@@ -464,6 +476,12 @@ func openAPIPathsForRouteTable(offer *monetizeapi.ServiceOffer) map[string]map[s
 		}
 
 		for _, method := range methods {
+			// routes is sorted most-specific-first: if a more specific
+			// route already claimed this method at this collapsed key,
+			// it wins — matching the verifier's resolution.
+			if _, claimed := item[strings.ToLower(method)]; claimed {
+				continue
+			}
 			op := map[string]any{
 				"summary":     summary,
 				"description": description,
@@ -509,6 +527,41 @@ func openAPIPathsForRouteTable(offer *monetizeapi.ServiceOffer) map[string]map[s
 		}
 	}
 	return paths
+}
+
+// sortRouteTableBySpecificity orders a copy of the route table
+// most-specific-first: exact patterns before wildcards, then longer literal
+// prefix, then deeper (more path segments) — the same rule
+// sortRoutesBySpecificity (internal/x402/matcher.go) applies to the
+// verifier's RouteRules. All routes in a table share the offer's prefix, so
+// comparing the relative rt.Path is equivalent to comparing the full
+// verifier pattern. sort.SliceStable so equally-specific routes keep their
+// declared order.
+func sortRouteTableBySpecificity(routes []monetizeapi.ServiceOfferRoute) {
+	sort.SliceStable(routes, func(i, j int) bool {
+		ei, li := routePatternSpecificity(routes[i].Path)
+		ej, lj := routePatternSpecificity(routes[j].Path)
+		if ei != ej {
+			return ei // exact before wildcard
+		}
+		if li != lj {
+			return li > lj // longer literal prefix first
+		}
+		si := strings.Count(routes[i].Path, "/")
+		sj := strings.Count(routes[j].Path, "/")
+		return si > sj // deeper pattern first
+	})
+}
+
+// routePatternSpecificity mirrors patternSpecificity in
+// internal/x402/matcher.go: whether the path is an exact match (no
+// wildcards) and the length of its literal prefix before the first "*".
+func routePatternSpecificity(routePath string) (exact bool, literalLen int) {
+	i := strings.IndexByte(routePath, '*')
+	if i < 0 {
+		return true, len(routePath)
+	}
+	return false, i
 }
 
 // openAPIRelPathForRoute converts a route-table path into an OpenAPI paths

--- a/internal/serviceoffercontroller/pathconflict.go
+++ b/internal/serviceoffercontroller/pathconflict.go
@@ -115,6 +115,20 @@ func pickHostnameConflict(offer *monetizeapi.ServiceOffer, others []*monetizeapi
 	return ""
 }
 
+// reservedRouteConflict returns the offer-relative route path and reserved
+// root of the first declared spec.routes[] entry that collides with a
+// reserved verifier surface (F8), or ("", "") when none do. The offer's
+// root path is checked separately via monetizeapi.ReservedPathConflict —
+// this only walks the route table.
+func reservedRouteConflict(offer *monetizeapi.ServiceOffer) (routePath, root string) {
+	for _, route := range offer.EffectiveRoutes() {
+		if r := monetizeapi.ReservedRoutePathConflict(route.Path); r != "" {
+			return route.Path, r
+		}
+	}
+	return "", ""
+}
+
 // claimPrecedes reports whether a's claim on a path beats b's: older
 // creationTimestamp wins; equal timestamps fall back to namespace/name
 // ordering so the outcome is deterministic on both sides.

--- a/internal/serviceoffercontroller/routesurface_golden_test.go
+++ b/internal/serviceoffercontroller/routesurface_golden_test.go
@@ -153,6 +153,97 @@ func TestRouteSurface_Golden_SkillMDListsEveryRoute(t *testing.T) {
 	}
 }
 
+// TestRouteSurface_Golden_ExactBeatsWildcardRegardlessOfDeclarationOrder is
+// the regression test for finding F6: an exact PAID route and a free
+// wildcard route can collapse onto the same OpenAPI {path, method} slot
+// (openAPIRelPathForRoute strips "/jobs/*" down to "/jobs", same as the
+// exact "/jobs"). The verifier always resolves that overlap by specificity
+// — exact beats wildcard — regardless of spec.routes declaration order
+// (sortRoutesBySpecificity, internal/x402/matcher.go). The OpenAPI builder
+// must resolve the same way, or discovery can advertise a route as free
+// while the verifier charges it. Here the exact PAID route is declared
+// FIRST, free wildcard SECOND: a buggy "last route in spec.routes wins"
+// render lets the later free wildcard clobber the paid route's operation
+// at the collapsed "/jobs" key.
+func TestRouteSurface_Golden_ExactBeatsWildcardRegardlessOfDeclarationOrder(t *testing.T) {
+	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit", Namespace: "sec"},
+		Spec: monetizeapi.ServiceOfferSpec{
+			Type:     "http",
+			Upstream: monetizeapi.ServiceOfferUpstream{Service: "auditd", Namespace: "sec", Port: 8080},
+			Payment: monetizeapi.ServiceOfferPayment{
+				Network: "base-sepolia",
+				PayTo:   "0x1111111111111111111111111111111111111111",
+				Price:   monetizeapi.ServiceOfferPriceTable{PerRequest: "0.1"},
+			},
+			Routes: []monetizeapi.ServiceOfferRoute{
+				// Exact PAID route declared FIRST, free wildcard SECOND.
+				{Path: "/jobs", Methods: []string{"GET"}, Gate: monetizeapi.GatePaid,
+					Price: monetizeapi.ServiceOfferPriceTable{PerRequest: "0.5"}},
+				{Path: "/jobs/*", Methods: []string{"GET"}, Gate: monetizeapi.GateFree},
+			},
+		},
+		Status: monetizeapi.ServiceOfferStatus{
+			Conditions: []monetizeapi.Condition{
+				{Type: "ModelReady", Status: "True"},
+				{Type: "UpstreamHealthy", Status: "True"},
+				{Type: "PaymentGateReady", Status: "True"},
+				{Type: "RoutePublished", Status: "True"},
+			},
+		},
+	}
+
+	rules, err := x402.RouteRulesForOffer(offer, "")
+	if err != nil {
+		t.Fatalf("RouteRulesForOffer: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("len(rules) = %d, want 2", len(rules))
+	}
+	// The verifier resolves the "/jobs" vs "/jobs/*" overlap by specificity
+	// (sortRoutesBySpecificity, internal/x402/matcher.go:63-93): exact
+	// beats wildcard, regardless of spec.routes declaration order. Find the
+	// exact rule directly rather than re-deriving the verifier's matching —
+	// this test only needs to know what that rule enforces.
+	var exactRule *x402.RouteRule
+	for i := range rules {
+		if !strings.HasSuffix(rules[i].Pattern, "/*") {
+			exactRule = &rules[i]
+		}
+	}
+	if exactRule == nil {
+		t.Fatalf("no exact rule among %v — fixture no longer reproduces F6", rules)
+	}
+	if exactRule.IsFree() {
+		t.Fatalf("exact rule %q is free — fixture no longer reproduces F6 (expected the paid override)", exactRule.Pattern)
+	}
+	if exactRule.Price != "0.5" {
+		t.Fatalf("exact rule %q price = %q, want \"0.5\"", exactRule.Pattern, exactRule.Price)
+	}
+
+	paths := buildOpenAPIPaths([]*monetizeapi.ServiceOffer{offer})
+	const key = "/services/audit/jobs"
+	item, ok := paths[key].(map[string]any)
+	if !ok {
+		t.Fatalf("OpenAPI has no %s path (keys: %v)", key, mapKeys(paths))
+	}
+	op, ok := item["get"].(map[string]any)
+	if !ok {
+		t.Fatalf("OpenAPI %s has no GET operation: %v", key, item)
+	}
+	if op["x-gate"] == "free" {
+		t.Errorf("OpenAPI advertises GET %s as free, but the verifier charges it (per-route price override 0.5): %v", key, op)
+	}
+	info, hasPayment := op["x-payment-info"].(map[string]any)
+	if !hasPayment {
+		t.Fatalf("OpenAPI GET %s is missing x-payment-info; the verifier gates it paid at the override price", key)
+	}
+	price, _ := info["price"].(map[string]any)
+	if got := price["amount"]; got != exactRule.Price {
+		t.Errorf("GET %s: advertised amount %v != enforced price %q", key, got, exactRule.Price)
+	}
+}
+
 func mapKeys(m map[string]any) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1227,9 +1227,14 @@ func storefrontHostnames(cfg *config.Config, tunnelURL string) []string {
 }
 
 // offerBoundHostnames returns the set of hostnames claimed by ServiceOffers
-// (spec.hostname), normalized. Best-effort: any error (cluster down, CRD
-// missing) returns nil and the caller keeps its historical behavior.
-func offerBoundHostnames(kubectlPath, kubeconfigPath string) map[string]bool {
+// (spec.hostname), normalized, and any error from the query itself (cluster
+// down, CRD missing, kubectl not found). A successful query with no offers
+// bound returns an empty, non-nil map with a nil error — callers must not
+// conflate that with a query failure (P1b): collapsing both into the same
+// "nil" previously made CreateStorefront treat "can't tell" as "zero
+// hostnames are bound" and reclaim every hostname, including live
+// per-offer origins, under the catch-all.
+func offerBoundHostnames(kubectlPath, kubeconfigPath string) (map[string]bool, error) {
 	cmd := exec.Command(kubectlPath,
 		"--kubeconfig", kubeconfigPath,
 		"get", "serviceoffers.obol.org", "-A",
@@ -1237,7 +1242,7 @@ func offerBoundHostnames(kubectlPath, kubeconfigPath string) map[string]bool {
 	)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	bound := map[string]bool{}
 	for _, line := range strings.Split(string(out), "\n") {
@@ -1245,10 +1250,7 @@ func offerBoundHostnames(kubectlPath, kubeconfigPath string) map[string]bool {
 			bound[h] = true
 		}
 	}
-	if len(bound) == 0 {
-		return nil
-	}
-	return bound
+	return bound, nil
 }
 
 // CreateStorefront creates (or updates) the public storefront landing page and
@@ -1268,9 +1270,18 @@ func CreateStorefront(cfg *config.Config, hostnames ...string) error {
 	// Hostnames claimed by a ServiceOffer (spec.hostname) belong to that
 	// offer's dedicated-origin route — the storefront catch-all must not
 	// contest their root (Gateway API breaks PathPrefix-/ ties on route
-	// age, i.e. silently). Best-effort: if the cluster can't be queried,
-	// keep the historical behavior.
-	if bound := offerBoundHostnames(kubectlPath, kubeconfigPath); len(bound) > 0 {
+	// age, i.e. silently).
+	bound, err := offerBoundHostnames(kubectlPath, kubeconfigPath)
+	if err != nil {
+		// ponytail: fail safe (P1b) — we can't tell which hostnames are
+		// offer-bound, so proceeding would risk the catch-all reclaiming a
+		// live per-offer origin on what may be a transient kubectl error.
+		// Leave the existing storefront route untouched instead of
+		// guessing "zero hostnames are bound".
+		fmt.Printf("   Storefront: could not query offer-bound hostnames (%v) — leaving existing storefront route unchanged\n", err)
+		return nil
+	}
+	if len(bound) > 0 {
 		kept := hosts[:0]
 		for _, h := range hosts {
 			if bound[h] {

--- a/internal/x402/authgate.go
+++ b/internal/x402/authgate.go
@@ -222,6 +222,22 @@ func (v *Verifier) handleAuthVerify(w http.ResponseWriter, r *http.Request, rule
 		http.Error(w, "POST {message, signature}", http.StatusMethodNotAllowed)
 		return
 	}
+	// Login-CSRF defense. Minting a session cookie from a cross-origin POST
+	// would let an attacker plant *their own* wallet's session in a victim's
+	// browser (session fixation). Two guards, either sufficient:
+	//   1. Require Content-Type: application/json. A cross-origin HTML form
+	//      can only send text/plain|form-encoded as a CORS "simple" request;
+	//      anything else triggers a preflight this endpoint never satisfies.
+	//   2. Reject a browser-declared cross-site fetch. Non-browser API
+	//      clients omit Sec-Fetch-Site, so this only ever blocks browsers.
+	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	if site := r.Header.Get("Sec-Fetch-Site"); site == "cross-site" {
+		http.Error(w, "cross-site sign-in is not allowed", http.StatusForbidden)
+		return
+	}
 	var body struct {
 		Message   string `json:"message"`
 		Signature string `json:"signature"`
@@ -249,7 +265,12 @@ func (v *Verifier) handleAuthVerify(w http.ResponseWriter, r *http.Request, rule
 		MaxAge:   int(DefaultSIWXSessionTTL.Seconds()),
 		HttpOnly: true,
 		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
+		// Strict, not Lax: the post-sign-in redirect is same-origin
+		// (sanitizeNextPath enforces same-origin paths), so Strict never
+		// blocks the legitimate flow, but it stops the session cookie from
+		// riding along on any cross-site request — a second layer under the
+		// Content-Type/Sec-Fetch-Site guards on the verify endpoint.
+		SameSite: http.SameSiteStrictMode,
 	})
 
 	if next := sanitizeNextPath(firstNonEmptyStr(body.Next, r.URL.Query().Get("next"))); next != "" {
@@ -296,9 +317,15 @@ func (v *Verifier) authRuleForPrefix(prefix string) *RouteRule {
 
 // sanitizeNextPath allows only same-origin absolute paths for post-auth
 // redirects — anything else (absolute URLs, scheme-relative //host, or
-// javascript:) is an open-redirect vector and is dropped.
+// javascript:) is an open-redirect vector and is dropped. A backslash is
+// rejected outright: Go's url.Parse treats "\" as a path byte, but WHATWG
+// browsers normalize it to "/", so "/\evil.com" would pass the checks here
+// yet resolve to "//evil.com" → https://evil.com in the browser.
 func sanitizeNextPath(next string) string {
 	if next == "" || !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return ""
+	}
+	if strings.Contains(next, "\\") {
 		return ""
 	}
 	if u, err := url.Parse(next); err != nil || u.Host != "" || u.Scheme != "" {

--- a/internal/x402/authgate.go
+++ b/internal/x402/authgate.go
@@ -1,7 +1,10 @@
 package x402
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -90,6 +93,10 @@ const (
 	headerBrokerVisibility   = "X-Obol-Result-Visibility"
 	headerBrokerPublicPrefix = "X-Obol-Public-Prefix"
 	headerBrokerUpstreamAuth = "X-Obol-Upstream-Auth"
+	// headerBrokerSig carries the verifier's HMAC over the contract fields,
+	// so the broker can reject forged submits even from a NetworkPolicy-
+	// allowed pod (F1 defense in depth). Verified in internal/jobbroker.
+	headerBrokerSig = "X-Obol-Broker-Sig"
 )
 
 // stripIdentityHeaders removes client-supplied identity and broker-contract
@@ -106,6 +113,17 @@ func stripIdentityHeaders(h http.Header) {
 	h.Del(headerBrokerVisibility)
 	h.Del(headerBrokerPublicPrefix)
 	h.Del(headerBrokerUpstreamAuth)
+	h.Del(headerBrokerSig)
+}
+
+// brokerSignature is the HMAC the verifier sets and the broker checks over
+// the security-critical contract fields (replay URL, offer, injected upstream
+// credential). Byte-identical to internal/jobbroker.brokerSignature — the two
+// packages deliberately don't share code (the broker pulls in SQLite).
+func brokerSignature(secret, upstreamURL, offer, upstreamAuth string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(upstreamURL + "\n" + offer + "\n" + upstreamAuth))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // authPageSuffix/authVerifySuffix are the verifier-served sign-in endpoints

--- a/internal/x402/authgate.go
+++ b/internal/x402/authgate.go
@@ -2,6 +2,7 @@ package x402
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
@@ -13,6 +14,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	signinwithx "github.com/x402-foundation/x402/go/v2/extensions/signinwithx"
 )
 
 // Identity propagation headers. Both are set by the verifier ONLY — any
@@ -163,6 +166,7 @@ func (v *Verifier) writeSIWXChallenge(w http.ResponseWriter, r *http.Request, ru
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
+	resourceURI := "https://" + host + publicPrefix(rule, host) + stripRoutePrefix(rule.StripPrefix, r.URL.Path)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error":  "authentication_required",
 		"detail": reason.Error(),
@@ -178,7 +182,56 @@ func (v *Verifier) writeSIWXChallenge(w http.ResponseWriter, r *http.Request, ru
 				"`Authorization: SIWX <base64 message>.<base64 signature>`. Or POST {message, signature} " +
 				"to verifyUrl to mint a reusable session token (also set as the obol_siwx cookie).",
 		},
+		// x402 sign-in-with-x extension block, so a cold stock client can
+		// construct the credential without prior knowledge of this server.
+		// The nonce is freshly minted per challenge; obol accepts client
+		// nonces, so advertising one is additive, not a tightening.
+		"extensions": siwxChallengeExtension(host, resourceURI, "Sign in to "+rule.OfferName, v.siwx.Window()),
 	})
+}
+
+// obolSIWXChains are the CAIP-2 chains obol advertises for SIWx. Signing is
+// domain-bound (EIP-191), so chainId is a client hint only — obol verifies
+// the same way regardless. eip191/EOA only.
+var obolSIWXChains = []string{"eip155:8453", "eip155:84532"}
+
+// siwxChallengeExtension builds the extensions["sign-in-with-x"] block for a
+// 401/402 challenge per docs.x402.org/extensions/sign-in-with-x: message
+// metadata (with a fresh server nonce), the supported chains, and the
+// canonical schema from the x402 SDK.
+func siwxChallengeExtension(domain, resourceURI, statement string, window time.Duration) map[string]any {
+	now := time.Now().UTC()
+	supported := make([]map[string]any, 0, len(obolSIWXChains))
+	for _, c := range obolSIWXChains {
+		supported = append(supported, map[string]any{"chainId": c, "type": "eip191"})
+	}
+	return map[string]any{
+		"sign-in-with-x": map[string]any{
+			"info": map[string]any{
+				"domain":         domain,
+				"uri":            resourceURI,
+				"version":        "1",
+				"nonce":          siwxNonce(),
+				"issuedAt":       now.Format(time.RFC3339),
+				"expirationTime": now.Add(window).Format(time.RFC3339),
+				"statement":      statement,
+				"resources":      []string{resourceURI},
+			},
+			"supportedChains": supported,
+			"schema":          signinwithx.Schema(),
+		},
+	}
+}
+
+// siwxNonce mints a fresh alphanumeric nonce (siwe requires >=8 alphanumeric
+// characters). 16 hex chars from crypto/rand; falls back to a timestamp-derived
+// value only if the RNG is unavailable, which never happens in practice.
+func siwxNonce() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%016x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // handleAuthEndpoints intercepts the verifier-served sign-in endpoints

--- a/internal/x402/authgate_test.go
+++ b/internal/x402/authgate_test.go
@@ -387,3 +387,56 @@ func TestVerifier_ForwardAuth_ExactOnlyTable_FailsClosed(t *testing.T) {
 		t.Fatalf("undeclared sibling of an exact-only table = %d, want 403 (fail closed)", w.Code)
 	}
 }
+
+// TestVerifier_AuthChallenge_AdvertisesSIWXExtension pins the F3 follow-up:
+// the machine (JSON) 401 challenge carries the x402 sign-in-with-x extension
+// block — fresh nonce, supported chains, canonical schema — so a cold stock
+// client can construct the credential without prior knowledge of the server.
+func TestVerifier_AuthChallenge_AdvertisesSIWXExtension(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	v, _, _ := authGateVerifier(t, fac.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/services/audit/reports/7", nil)
+	req.Host = "shop.example.com"
+	w := httptest.NewRecorder()
+	v.HandleProxy(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("challenge status = %d, want 401", w.Code)
+	}
+	var body struct {
+		Extensions map[string]struct {
+			Info struct {
+				Domain   string `json:"domain"`
+				Nonce    string `json:"nonce"`
+				IssuedAt string `json:"issuedAt"`
+				URI      string `json:"uri"`
+			} `json:"info"`
+			SupportedChains []struct {
+				ChainID string `json:"chainId"`
+				Type    string `json:"type"`
+			} `json:"supportedChains"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("challenge not JSON: %v\n%s", err, w.Body.String())
+	}
+	siwx, ok := body.Extensions["sign-in-with-x"]
+	if !ok {
+		t.Fatalf("challenge missing extensions[sign-in-with-x]: %s", w.Body.String())
+	}
+	if siwx.Info.Domain != "shop.example.com" || len(siwx.Info.Nonce) < 8 || siwx.Info.IssuedAt == "" {
+		t.Errorf("info incomplete: %+v", siwx.Info)
+	}
+	if len(siwx.SupportedChains) == 0 || siwx.SupportedChains[0].Type != "eip191" {
+		t.Errorf("supportedChains missing/wrong: %+v", siwx.SupportedChains)
+	}
+	// Two challenges must mint different nonces (freshness).
+	w2 := httptest.NewRecorder()
+	v.HandleProxy(w2, req)
+	var body2 map[string]any
+	_ = json.Unmarshal(w2.Body.Bytes(), &body2)
+	n2 := body2["extensions"].(map[string]any)["sign-in-with-x"].(map[string]any)["info"].(map[string]any)["nonce"]
+	if n2 == siwx.Info.Nonce {
+		t.Error("nonce not fresh across challenges")
+	}
+}

--- a/internal/x402/authgate_test.go
+++ b/internal/x402/authgate_test.go
@@ -147,6 +147,7 @@ func TestVerifier_AuthEndpoints_SignInFlow(t *testing.T) {
 	})
 	req = httptest.NewRequest(http.MethodPost, "/services/audit/auth/verify", bytes.NewReader(body))
 	req.Host = "shop.example.com"
+	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	v.HandleProxy(w, req)
 	if w.Code != http.StatusSeeOther {
@@ -161,6 +162,9 @@ func TestVerifier_AuthEndpoints_SignInFlow(t *testing.T) {
 			session = c.Value
 			if !c.HttpOnly || !c.Secure {
 				t.Error("session cookie must be HttpOnly + Secure")
+			}
+			if c.SameSite != http.SameSiteStrictMode {
+				t.Error("session cookie must be SameSite=Strict (login-CSRF defense)")
 			}
 		}
 	}
@@ -185,6 +189,7 @@ func TestVerifier_AuthEndpoints_SignInFlow(t *testing.T) {
 	body, _ = json.Marshal(map[string]string{"message": msg, "signature": sig, "next": "https://evil.example.com/"})
 	req = httptest.NewRequest(http.MethodPost, "/services/audit/auth/verify", bytes.NewReader(body))
 	req.Host = "shop.example.com"
+	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	v.HandleProxy(w, req)
 	if w.Code == http.StatusSeeOther {
@@ -321,5 +326,64 @@ func TestVerifier_AuthGate_HostnameOffer_PublicURLs(t *testing.T) {
 	}
 	if challenge.Auth.SignInURL != "https://shop.example.com/services/audit/auth" {
 		t.Errorf("shared-origin signInUrl = %q, want prefixed path", challenge.Auth.SignInURL)
+	}
+}
+
+// TestVerifier_AuthVerify_CSRFGuards pins the login-CSRF defenses on
+// /auth/verify (F4): a POST without an application/json Content-Type, or a
+// browser-declared cross-site fetch, must be refused before any session is
+// minted — otherwise an attacker could plant their own wallet's session in
+// a victim's browser via a cross-origin form.
+func TestVerifier_AuthVerify_CSRFGuards(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	v, _, _ := authGateVerifier(t, fac.URL)
+	msg, sig, _ := signSIWX(t, "shop.example.com", "csrf-1", time.Now())
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+
+	// (a) no Content-Type → 415, no cookie.
+	req := httptest.NewRequest(http.MethodPost, "/services/audit/auth/verify", bytes.NewReader(body))
+	req.Host = "shop.example.com"
+	w := httptest.NewRecorder()
+	v.HandleProxy(w, req)
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("verify without JSON Content-Type = %d, want 415", w.Code)
+	}
+	if len(w.Result().Cookies()) != 0 {
+		t.Error("no session cookie must be set on a rejected CSRF-shaped request")
+	}
+
+	// (b) cross-site fetch → 403, even with the right Content-Type.
+	req = httptest.NewRequest(http.MethodPost, "/services/audit/auth/verify", bytes.NewReader(body))
+	req.Host = "shop.example.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	w = httptest.NewRecorder()
+	v.HandleProxy(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("cross-site verify = %d, want 403", w.Code)
+	}
+}
+
+// TestVerifier_ForwardAuth_ExactOnlyTable_FailsClosed pins F7: an offer whose
+// route table is entirely exact paid routes must still fail closed for an
+// undeclared sibling in ForwardAuth mode — the offer base is registered as a
+// paid prefix so an unmatched path under it is refused (403), not 200-passed.
+func TestVerifier_ForwardAuth_ExactOnlyTable_FailsClosed(t *testing.T) {
+	fac := newMockFacilitator(t, mockFacilitatorOpts{})
+	v := newTestVerifier(t, fac.URL, []RouteRule{{
+		Pattern:        "/services/foo/submit", // exact, no trailing /*
+		Price:          "0.0001",
+		StripPrefix:    "/services/foo",
+		OfferNamespace: "f",
+		OfferName:      "foo",
+	}})
+
+	// Undeclared sibling under the offer base → fail closed.
+	req := httptest.NewRequest(http.MethodGet, "/verify", nil)
+	req.Header.Set("X-Forwarded-Uri", "/services/foo/other")
+	w := httptest.NewRecorder()
+	v.HandleVerify(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("undeclared sibling of an exact-only table = %d, want 403 (fail closed)", w.Code)
 	}
 }

--- a/internal/x402/siwx.go
+++ b/internal/x402/siwx.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	signinwithx "github.com/x402-foundation/x402/go/v2/extensions/signinwithx"
 )
 
 // SIWX (Sign-In With X, EIP-4361) authentication for gate:auth routes.
@@ -301,6 +302,16 @@ func (a *SIWXAuthenticator) signSession(body string) string {
 // carries. expectedDomain is the request's public host authority. Returns
 // the authenticated wallet (lowercase) or an error describing what to send.
 func (a *SIWXAuthenticator) Authenticate(r *http.Request, expectedDomain string, now time.Time) (string, error) {
+	// Spec transport (x402 sign-in-with-x): a base64-JSON payload in the
+	// SIGN-IN-WITH-X header, per docs.x402.org/extensions/sign-in-with-x.
+	// Accepted alongside the Authorization forms so stock x402 clients (e.g.
+	// the SDK's client extension) interoperate without an obol-specific
+	// credential shape. We borrow only the SDK's canonical EIP-4361
+	// serialization and run the result through the same domain-binding,
+	// freshness, nonce-replay, and EOA-recovery checks as the native form.
+	if hdr := r.Header.Get("SIGN-IN-WITH-X"); hdr != "" {
+		return a.verifySpecHeader(hdr, expectedDomain, now)
+	}
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		if cred, ok := strings.CutPrefix(auth, "SIWX "); ok {
 			msgB64, sigB64, found := strings.Cut(strings.TrimSpace(cred), ".")
@@ -324,7 +335,29 @@ func (a *SIWXAuthenticator) Authenticate(r *http.Request, expectedDomain string,
 	if c, err := r.Cookie(SIWXSessionCookie); err == nil && c.Value != "" {
 		return a.VerifySession(c.Value, now)
 	}
-	return "", fmt.Errorf("siwx: no credential — sign in at the offer's /auth page or send Authorization: SIWX <b64 message>.<b64 signature>")
+	return "", fmt.Errorf("siwx: no credential — sign in at the offer's /auth page, send the SIGN-IN-WITH-X header, or Authorization: SIWX <b64 message>.<b64 signature>")
+}
+
+// verifySpecHeader verifies an x402 sign-in-with-x credential carried in the
+// SIGN-IN-WITH-X header (base64-JSON payload). It decodes the payload with the
+// x402 SDK, rebuilds the canonical EIP-4361 message the client signed, then
+// runs it through VerifyMessage so the domain, freshness, nonce, and EOA
+// checks are identical to the native transport. EVM (eip155) EOA only — the
+// same limitation as the rest of this file; Solana/EIP-1271 payloads get a
+// clear error rather than a silent pass.
+func (a *SIWXAuthenticator) verifySpecHeader(header, expectedDomain string, now time.Time) (string, error) {
+	payload, err := signinwithx.ParseHeader(header)
+	if err != nil {
+		return "", fmt.Errorf("siwx: %w", err)
+	}
+	if !strings.HasPrefix(payload.ChainID, "eip155:") {
+		return "", fmt.Errorf("siwx: unsupported chain %q — this server verifies EVM (eip155) EOA signatures only", payload.ChainID)
+	}
+	message, err := signinwithx.CreateMessage(payload)
+	if err != nil {
+		return "", fmt.Errorf("siwx: %w", err)
+	}
+	return a.VerifyMessage(message, payload.Signature, expectedDomain, now)
 }
 
 func isHexAddress(s string) bool {

--- a/internal/x402/siwx_test.go
+++ b/internal/x402/siwx_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	signinwithx "github.com/x402-foundation/x402/go/v2/extensions/signinwithx"
 )
 
 // signSIWX builds and signs a valid EIP-4361 message with a fresh key,
@@ -154,5 +155,67 @@ func TestSIWX_Authenticate_HeaderAndCookieForms(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/x", nil)
 	if _, err := a.Authenticate(req, "shop.example.com", now); err == nil {
 		t.Error("credential-less request authenticated")
+	}
+}
+
+// TestSIWX_SpecHeader_RoundTrip pins the additive x402 sign-in-with-x
+// transport (F3): a base64-JSON payload in the SIGN-IN-WITH-X header, built
+// and signed exactly as a stock x402 SDK client would, authenticates through
+// the same checks as the native Authorization: SIWX form.
+func TestSIWX_SpecHeader_RoundTrip(t *testing.T) {
+	a, err := NewSIWXAuthenticator(0, 0)
+	if err != nil {
+		t.Fatalf("NewSIWXAuthenticator: %v", err)
+	}
+	now := time.Now()
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey).Hex()
+	payload := signinwithx.Payload{
+		Domain:   "shop.example.com",
+		Address:  addr,
+		URI:      "https://shop.example.com/services/audit/auth",
+		Version:  "1",
+		ChainID:  "eip155:8453",
+		Type:     "eip191",
+		Nonce:    "specnonce0001",
+		IssuedAt: now.UTC().Format(time.RFC3339),
+	}
+	// Sign the canonical EIP-4361 message the server will reconstruct.
+	message, err := signinwithx.CreateMessage(payload)
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	digest := crypto.Keccak256([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)))
+	raw, err := crypto.Sign(digest, key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw[64] += 27
+	payload.Signature = "0x" + hex.EncodeToString(raw)
+
+	header, err := signinwithx.EncodeHeader(payload)
+	if err != nil {
+		t.Fatalf("EncodeHeader: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/services/audit/reports/1", nil)
+	req.Header.Set("SIGN-IN-WITH-X", header)
+
+	got, err := a.Authenticate(req, "shop.example.com", now)
+	if err != nil {
+		t.Fatalf("Authenticate(SIGN-IN-WITH-X) = %v", err)
+	}
+	if got != strings.ToLower(addr) {
+		t.Fatalf("wallet = %s, want %s", got, strings.ToLower(addr))
+	}
+
+	// Wrong host must be rejected (domain binding still enforced).
+	req2 := httptest.NewRequest(http.MethodGet, "/services/audit/reports/1", nil)
+	req2.Header.Set("SIGN-IN-WITH-X", header)
+	if _, err := a.Authenticate(req2, "evil.example.com", now); err == nil {
+		t.Fatal("spec header authenticated against the wrong domain")
 	}
 }

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -109,6 +109,17 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 	// uses this to fail-closed when a URI is under a tracked prefix but
 	// no rule matches (see isUnderPaidPrefix for the rationale).
 	prefixes := make([]string, 0, len(cfg.Routes))
+	seenPrefix := make(map[string]struct{}, len(cfg.Routes))
+	addPrefix := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, ok := seenPrefix[p]; ok {
+			return
+		}
+		seenPrefix[p] = struct{}{}
+		prefixes = append(prefixes, p)
+	}
 	for _, r := range cfg.Routes {
 		// Free carve-outs never establish a paid prefix: a wildcard free
 		// route (e.g. /services/foo/jobs/*) must not make unmatched
@@ -116,9 +127,18 @@ func (v *Verifier) load(cfg *PricingConfig) error {
 		if r.IsFree() {
 			continue
 		}
-		prefix := patternToPrefix(r.Pattern)
-		if prefix != "" {
-			prefixes = append(prefixes, prefix)
+		addPrefix(patternToPrefix(r.Pattern))
+		// Fail-closed for exact-only route tables. A wildcard route yields
+		// a paid prefix above, but an offer whose non-free routes are ALL
+		// exact (e.g. only `/services/foo/submit`) would register none, so
+		// an undeclared sibling like `/services/foo/other` — which matched
+		// no rule — would 200-free-pass in ForwardAuth mode, contradicting
+		// the route-table contract that undeclared paths are refused once
+		// any route is declared. Register the offer base as a paid prefix
+		// so those siblings fail closed. Declared routes (free/auth/paid)
+		// still return from matchRoute before this prefix is ever consulted.
+		if base := strings.TrimSuffix(r.StripPrefix, "/"); base != "" {
+			addPrefix(base + "/")
 		}
 	}
 	sort.Slice(prefixes, func(i, j int) bool { return len(prefixes[i]) > len(prefixes[j]) })

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -790,6 +791,11 @@ func buildUpstreamProxy(rule *RouteRule) (http.Handler, error) {
 		return nil, fmt.Errorf("parse upstream URL %q: %w", targetURL, err)
 	}
 
+	// Shared secret for the verifier→broker HMAC (F1 defense in depth over
+	// the NetworkPolicy). Read once here; empty disables signing, and the
+	// broker likewise only enforces when its own copy is set.
+	brokerHMACSecret := os.Getenv("JOB_BROKER_HMAC_SECRET")
+
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
@@ -809,6 +815,11 @@ func buildUpstreamProxy(rule *RouteRule) (http.Handler, error) {
 				// the client's own Authorization (SIWX / jobToken bearer)
 				// must keep flowing through for result access.
 				pr.Out.Header.Set(headerBrokerUpstreamAuth, rule.UpstreamAuth)
+				if brokerHMACSecret != "" {
+					pr.Out.Header.Set(headerBrokerSig,
+						brokerSignature(brokerHMACSecret, rule.UpstreamURL,
+							rule.OfferNamespace+"/"+rule.OfferName, rule.UpstreamAuth))
+				}
 			} else if rule.UpstreamAuth != "" {
 				pr.Out.Header.Set("Authorization", rule.UpstreamAuth)
 			}


### PR DESCRIPTION
Hardening fixes for the findings in [#717's review](https://github.com/ObolNetwork/obol-stack/pull/717#issuecomment-4912252175), based on `feat/route-surface-gates`. Six commits, grouped by category — all touch **disjoint files** and are independently revertable, so this can merge whole or be split into per-category PRs on request. Every finding was verified against the x402 spec (`sign-in-with-x`, `offer-receipt`, core v2) and re-checked by a second model.

**Build + test:** `go build ./...` clean; `go test` green across `internal/x402`, `internal/serviceoffercontroller`, `internal/monetizeapi`, `internal/tunnel`, `internal/embed`. New tests fail-before / pass-after each fix.

## Security (the two merge-blockers + one more)

- **F1 — job-broker trust boundary.** `NetworkPolicy` pinning `job-broker` ingress to the `x402-verifier` pod (port 8090). The broker only checked header *presence*, and any in-cluster pod could POST forged `X-Obol-Upstream-*` for a free SSRF/arbitrary-fetch relay. *(HMAC on the verifier→broker hop is the recommended defense-in-depth follow-up — left out of this security fix as it touches both sides + a Secret; happy to add.)*
- **F4 — login-CSRF on `/auth/verify`.** Require `Content-Type: application/json`, reject cross-site `Sec-Fetch-Site`, and set the session cookie `SameSite=Strict`. Blocks the `text/plain`-form session-fixation vector; the browser sign-in page already sends JSON, so nothing legitimate breaks. Adds CSRF-guard tests.
- **F5 — open redirect via backslash.** `sanitizeNextPath` now rejects `\` (Go's `url.Parse` keeps it as a path byte; browsers normalize it to `/`, so `/\evil.com` escaped off-origin).

## Route-surface correctness

- **F6 — OpenAPI/verifier gate drift.** The OpenAPI builder now resolves collapsed path+method winners with the *same* exact-over-wildcard specificity the matcher uses, so discovery can no longer advertise a route free that the gate charges. Golden test with the adversarial ordering.
- **F7 — fail-closed for exact-only tables.** Register the offer base (`StripPrefix`) as a tracked paid prefix whenever the offer has a non-free rule, so undeclared siblings 403 instead of 200 in ForwardAuth. Declared routes still resolve first, so no behavior change for real routes.
- **F8 — reserved-path validation.** Run the reserved-path check over every declared `spec.routes[].path` (not just the offer root) and add the verifier-owned `/auth` suffixes, refusing shadowing offers at admission with a clear condition/CLI error.

## x402 spec-fidelity

- **F3 — accept the `sign-in-with-x` spec transport.** Additively accept the standard `SIGN-IN-WITH-X` base64-JSON header (CAIP-122 / EIP-4361) alongside the existing `Authorization: SIWX` and Bearer/cookie forms, so a stock x402 client interoperates. Uses the x402 Go SDK's `signinwithx.ParseHeader` + `CreateMessage` to rebuild the canonical EIP-4361 message, then runs it through the *same* `VerifyMessage` path (domain binding, freshness window, nonce-replay cache, EIP-191 EOA recovery) — no bespoke crypto. EVM/EOA only, matching the rest of the surface. Adds a signed round-trip test. *(Remaining for full interop: advertise the `sign-in-with-x` extension block in the 402 challenge — a larger change touching the challenge/nonce model, noted for a follow-up.)*

## Reconcile safety

- **P1b — `offerBoundHostnames` fails safe.** It returned `nil` on any kubectl error, so a transient failure during `stack up` re-seized bound per-offer origins under the storefront catch-all. Now distinguishes "query failed" from "zero bound" and leaves existing routes untouched on failure.

## Follow-ups now folded in

- **F1-HMAC — authenticate the verifier→broker hop.** Defense in depth over the NetworkPolicy: when `JOB_BROKER_HMAC_SECRET` is set, the verifier signs the security-critical contract fields (`upstreamURL`, `offer`, `upstreamAuth`) into `X-Obol-Broker-Sig` and the broker rejects any mismatched submit — so a pod that slips past the network layer still can't forge an arbitrary-URL, attacker-credentialed job. Empty secret = disabled on both sides (NetworkPolicy-only), so installs without the key are unaffected. Secret + `optional` env wired into both containers; forged/missing/valid-sig submits tested.
- **F3-followup — advertise `sign-in-with-x` in the challenge.** The machine 401 challenge now carries the `extensions[sign-in-with-x]` block (fresh server nonce, supported EVM chains, SDK canonical schema), so a cold stock client can build the credential without prior knowledge of obol. Completes the F3 intake — obol now both accepts the spec transport and tells clients how to construct it. Stateless (obol accepts client nonces), so additive.

## Not in this PR (genuine blockers / decisions for the author)

- **F2** — result retrieval is **already** SIWx-gated in the broker (`callerMayRead`: `X-Verified-Wallet == payer`), so that half is done. The remaining piece — an `offer-receipt` **signed receipt on successful delivery** — needs a receipt-signer-key decision (payTo signs / a stack service key / verifier-via-remote-signer) plus hand-rolled EIP-712 (no SDK package). Surfaced as a design decision rather than a guessed implementation.
- **F9** — the `job-broker` image isn't published to ghcr yet (no remote manifest), so there is **no digest to pin**. This is inherently a release-pipeline step, not a code change — pin when the image is first built and pushed.

https://claude.ai/code/session_01VquWN9UMaSHH7MHGcG8bw1
