### PR TITLE
fix(defaults): rewrite :latest image pins to the dev tag (job-broker ImagePullBackOff)

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -158,18 +158,28 @@ func rewriteDevDigestPins(defaultsDir, devTag string) error {
 	patterns := make([]*regexp.Regexp, 0, len(devLocallyBuiltImageBases))
 	replaceWith := make([]string, 0, len(devLocallyBuiltImageBases))
 	for _, base := range devLocallyBuiltImageBases {
-		// Match all three pin styles we ship across the infrastructure
-		// templates and rewrite to `:latest` so the local-dev build wins.
+		// Match all four pin styles we ship across the infrastructure
+		// templates and rewrite to the dev tag so the local-dev build wins.
 		// Patterns covered (single regex, left-to-right alternation):
 		//   <base>:<7-40 hex>@sha256:<64 hex>   tag + digest combo
 		//   <base>@sha256:<64 hex>              digest-only pin
 		//   <base>:<7-40 hex>                   short-SHA tag pin (e.g. b13254e)
+		//   <base>:latest                       unpinned (e.g. job-broker, an
+		//                                       image not yet published to ghcr,
+		//                                       so it ships as :latest and has
+		//                                       no digest for the release
+		//                                       pipeline to stamp)
 		// The combo form MUST come first so the engine doesn't stop at the
 		// shorter `:<hex>` match and leave a stray `@sha256:<digest>` suffix,
 		// which Docker still resolves to the immutable registry image and
 		// silently bypasses the local build (root cause of the no-debug-logs
-		// regression in flow-11 step 43 chase, May 2026).
-		patterns = append(patterns, regexp.MustCompile(regexp.QuoteMeta(base)+"(:[a-f0-9]{7,40}@sha256:[a-f0-9]{64}|@sha256:[a-f0-9]{64}|:[a-f0-9]{7,40})"))
+		// regression in flow-11 step 43 chase, May 2026). :latest is matched
+		// last because a locally-built base always resolves to the dev build,
+		// so an unpinned ref must point at it too — without this the :latest
+		// deployment stays :latest, the image isn't present under that tag
+		// (the build imports :dev-<sha>), and the pod ImagePullBackOffs against
+		// the unpublished registry ref.
+		patterns = append(patterns, regexp.MustCompile(regexp.QuoteMeta(base)+"(:[a-f0-9]{7,40}@sha256:[a-f0-9]{64}|@sha256:[a-f0-9]{64}|:[a-f0-9]{7,40}|:latest)"))
 		replaceWith = append(replaceWith, base+":"+devTag)
 	}
 

--- a/internal/defaults/defaults_test.go
+++ b/internal/defaults/defaults_test.go
@@ -41,10 +41,20 @@ func TestCopyInfrastructure_DevModeRewritesDigestPins(t *testing.T) {
 	for _, base := range []string{
 		"ghcr.io/obolnetwork/x402-verifier",
 		"ghcr.io/obolnetwork/serviceoffer-controller",
+		// job-broker ships as :latest (unpublished to ghcr, so no digest for
+		// the release pipeline to stamp). The dev rewrite must still repoint
+		// it at the local build's :dev-<sha> tag, or the pod ImagePullBackOffs
+		// on the missing :latest ref. Regression guard for the smoke-surfaced
+		// bug where the pin regex matched only digest/short-SHA forms.
+		"ghcr.io/obolnetwork/job-broker",
 	} {
 		want := base + ":" + devTag
 		if !strings.Contains(out, want) {
 			t.Errorf("dev mode did not rewrite to %q in %s", want, x402Path)
+		}
+		// And no stale :latest ref for a locally-built base must survive.
+		if strings.Contains(out, base+":latest") {
+			t.Errorf("dev mode left an unrewritten %s:latest in %s", base, x402Path)
 		}
 	}
 


### PR DESCRIPTION
## What
Under `OBOL_DEVELOPMENT=true`, `rewriteDevDigestPins` repoints component image refs at the freshly-built local `:dev-<sha>` tag. It matched digest and short-SHA pins but **not `:latest`**. `job-broker` ships as `:latest` (no published ghcr image → no digest for the release pipeline to stamp), so its Deployment ref survived the rewrite → the local build imports `:dev-<sha>`, no `:latest` image exists → pod **ImagePullBackOff**, blocking `flow-02`.

Fix: add `:latest` to the rewrite alternation (a locally-built base always resolves to the dev build, so an unpinned ref must point at it too). Regression test asserts `job-broker` is rewritten and no `:latest` survives for any locally-built base.

## How found
Surfaced by the **v0.13.0-rc1 release smoke on a real k3d cluster (spark1)** — job-broker was the only pod stuck in ImagePullBackOff while the digest-pinned verifier/controller/buyer came up fine.

## Follow-up (flagged, not in this PR)
`job-broker` is **absent from `.github/workflows/docker-publish-x402.yml`**, so `:latest` never resolves in a **production** install either. This dev fix unblocks rc smoke; adding job-broker to the publish matrix is required before a GA tag.

https://claude.ai/code/session_01VquWN9UMaSHH7MHGcG8bw1