### PR TITLE
chore: pin obol-frontend to v0.1.28-rc3

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -46,8 +46,8 @@ image:
   pullPolicy: IfNotPresent
   # Digest-pinned: tag is informational, sha256 is authoritative. Eliminates
   # the mutable-tag attack surface called out by the v0.10.0-rc2 supply-chain
-  # review. Multi-arch index digest for v0.1.28-rc1 (linux/amd64 + linux/arm64).
-  tag: "v0.1.28-rc1@sha256:6075170e7246eba583ca7504a9bf411ddb581ae9b26cba219c3d7b8c481265d5"
+  # review. Multi-arch index digest for v0.1.28-rc3 (linux/amd64 + linux/arm64).
+  tag: "v0.1.28-rc3@sha256:eaf7afc6242b480a873df8bd55d0076641ce5407278813eb9856c19274a15f17"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Bumps the digest-pinned `obol-frontend` image to the newly released frontend **v0.1.28-rc3**.

`internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl` (L50):
```
tag: "v0.1.28-rc3@sha256:eaf7afc6242b480a873df8bd55d0076641ce5407278813eb9856c19274a15f17"
```

- Frontend release: https://github.com/ObolNetwork/obol-stack-front-end/releases/tag/v0.1.28-rc3
- Multi-arch index digest from GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)