### PR TITLE
fix(hermes): latest version restricted write in our path

### DIFF
--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -935,6 +935,13 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
               env:
                 - name: HERMES_HOME
                   value: /data/.hermes
+                # v2026.7.x images bake HERMES_WRITE_SAFE_ROOT=/opt/data (their
+                # default HERMES_HOME). We relocate HERMES_HOME to the PVC, so
+                # the safe root must follow or every file-tool write is denied
+                # as a "protected system/credential file". /tmp allows scratch
+                # scripts; the static credential denylist still applies inside.
+                - name: HERMES_WRITE_SAFE_ROOT
+                  value: /data/.hermes:/tmp
                 - name: HOME
                   value: /data/.hermes/home
                 - name: API_SERVER_ENABLED

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -256,6 +256,11 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		"name: GATEWAY_HEALTH_URL",
 		"HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
 		"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+		// Must track HERMES_HOME: v2026.7.x images bake
+		// HERMES_WRITE_SAFE_ROOT=/opt/data and deny all file-tool
+		// writes outside the safe root.
+		"name: HERMES_WRITE_SAFE_ROOT",
+		"value: /data/.hermes:/tmp",
 	} {
 		if !strings.Contains(values, needle) {
 			t.Fatalf("generateValues() missing %q:\n%s", needle, values)

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -326,6 +326,10 @@ fi
 func agentPodSpec(agent *monetizeapi.Agent) map[string]any {
 	containerEnv := []any{
 		map[string]any{"name": "HERMES_HOME", "value": "/data/.hermes"},
+		// v2026.7.x images bake HERMES_WRITE_SAFE_ROOT=/opt/data (their default
+		// HERMES_HOME); with HERMES_HOME relocated to the PVC the safe root must
+		// follow or every file-tool write is denied.
+		map[string]any{"name": "HERMES_WRITE_SAFE_ROOT", "value": "/data/.hermes:/tmp"},
 		map[string]any{"name": "HOME", "value": "/data/.hermes/home"},
 		map[string]any{"name": "API_SERVER_ENABLED", "value": "true"},
 		map[string]any{"name": "API_SERVER_HOST", "value": "0.0.0.0"},

--- a/internal/serviceoffercontroller/agent_render_test.go
+++ b/internal/serviceoffercontroller/agent_render_test.go
@@ -113,6 +113,9 @@ func TestAgentManifests_DeploymentEnvCarriesContext(t *testing.T) {
 		"AGENT_NAMESPACE":       "agent-quant",
 		"AGENT_WALLET_ADDRESS":  agent.Status.WalletAddress,
 		"OBOL_SKILLS_DIR":       "/data/.hermes/obol-skills",
+		// Must track HERMES_HOME: the upstream image bakes /opt/data and
+		// denies all file-tool writes outside the safe root.
+		"HERMES_WRITE_SAFE_ROOT": "/data/.hermes:/tmp",
 	}
 	got := make(map[string]string)
 	for _, e := range envs {


### PR DESCRIPTION
## Summary

What was happening

Neither file moves nor permissions would have helped — this isn't a filesystem/chown issue. The nousresearch/hermes-agent:v2026.7.1 image (pinned in the recent "bump image pins" commit) newly bakes HERMES_WRITE_SAFE_ROOT=/opt/data into the image env — an allowlist: when set, Hermes' file tools deny every write outside that root, with the (misleading) "protected system/credential file" error. v2026.5.7 didn't have this; I confirmed by diffing the two images' env and reading agent/file_safety.py inside the pinned image.

Upstream that default is coherent because their HERMES_HOME is /opt/data. But obol-stack relocates HERMES_HOME to /data/.hermes on the PVC and never touches /opt/data — so the safe root pointed at a directory nothing uses, and every write the agent attempted (/data/.hermes/workspace/*.py, /tmp/*.sh) was outside it and denied.

The fix

Override the env var to follow the relocated home, in both places that render Hermes pods:

- internal/hermes/hermes.go — stack-managed agent deployment: added HERMES_WRITE_SAFE_ROOT=/data/.hermes:/tmp (the guard supports colon-separated multi-roots; /tmp covers scratch scripts, and the static credential denylist still applies inside the roots, so the defense-in-depth is kept rather than disabled).
- internal/serviceoffercontroller/agent_render.go — CRD sub-agents (obol agent new) get the same env.
- Regression guards added to TestGenerateValues_UsesHermesNativeNames and TestAgentManifests_DeploymentEnvCarriesContext so a future image bump or env refactor can't silently drop it.