### PR TITLE
feat(claude): nudge to update plugin version if a newer one exists

### DIFF
--- a/internal/stack/claudetip_test.go
+++ b/internal/stack/claudetip_test.go
@@ -1,0 +1,138 @@
+package stack
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writePluginsFixture materializes a fake ~/.claude/plugins dir. Shapes
+// mirror real Claude Code files (installed_plugins.json v2 maps each
+// "<plugin>@<marketplace>" key to an ARRAY of per-scope install records).
+func writePluginsFixture(t *testing.T, marketplaces, installed string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if marketplaces != "" {
+		if err := os.WriteFile(filepath.Join(dir, "known_marketplaces.json"), []byte(marketplaces), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if installed != "" {
+		if err := os.WriteFile(filepath.Join(dir, "installed_plugins.json"), []byte(installed), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const marketplacesFixture = `{
+  "claude-plugins-official": {"source": {"source": "github", "repo": "anthropics/claude-plugins-official"}},
+  "obol": {"source": {"source": "github", "repo": "ObolNetwork/skills"}}
+}`
+
+func TestObolMarketplaceName(t *testing.T) {
+	dir := writePluginsFixture(t, marketplacesFixture, "")
+	name, ok := obolMarketplaceName(dir)
+	if !ok || name != "obol" {
+		t.Fatalf("obolMarketplaceName = %q, %v; want obol, true", name, ok)
+	}
+
+	// Renamed marketplace still resolves by repo.
+	dir = writePluginsFixture(t, `{"my-skills": {"source": {"source": "github", "repo": "obolnetwork/SKILLS"}}}`, "")
+	name, ok = obolMarketplaceName(dir)
+	if !ok || name != "my-skills" {
+		t.Fatalf("case-insensitive repo match = %q, %v", name, ok)
+	}
+
+	// Missing file / no matching repo → not registered.
+	if _, ok := obolMarketplaceName(t.TempDir()); ok {
+		t.Fatal("empty dir must report unregistered")
+	}
+	dir = writePluginsFixture(t, `{"other": {"source": {"source": "github", "repo": "someone/else"}}}`, "")
+	if _, ok := obolMarketplaceName(dir); ok {
+		t.Fatal("unrelated marketplace must report unregistered")
+	}
+}
+
+func TestObolInstalledPlugin(t *testing.T) {
+	// v2 shape: array of install records, version present.
+	dir := writePluginsFixture(t, "", `{
+  "version": 2,
+  "plugins": {
+    "ralph-loop@claude-plugins-official": [{"scope": "project", "version": "1.0.0"}],
+    "obol@obol": [{"scope": "user", "version": "1.3.0"}, {"scope": "project", "version": "1.4.0"}]
+  }
+}`)
+	key, version, ok := obolInstalledPlugin(dir, "obol")
+	if !ok || key != "obol@obol" || version != "1.4.0" {
+		t.Fatalf("obolInstalledPlugin = %q, %q, %v; want obol@obol, 1.4.0, true", key, version, ok)
+	}
+
+	// "unknown" version → installed but version unknowable (no update nag).
+	dir = writePluginsFixture(t, "", `{"plugins": {"obol@obol": [{"version": "unknown"}]}}`)
+	key, version, ok = obolInstalledPlugin(dir, "obol")
+	if !ok || key != "obol@obol" || version != "" {
+		t.Fatalf("unknown version: got %q, %q, %v; want obol@obol, \"\", true", key, version, ok)
+	}
+
+	// Pre-v2 single-object shape tolerated.
+	dir = writePluginsFixture(t, "", `{"plugins": {"obol@obol": {"version": "1.1.0"}}}`)
+	if _, version, ok = obolInstalledPlugin(dir, "obol"); !ok || version != "1.1.0" {
+		t.Fatalf("legacy shape: version = %q, ok = %v", version, ok)
+	}
+
+	// Not installed / different marketplace.
+	dir = writePluginsFixture(t, "", `{"plugins": {"obol@other-mp": [{"version": "9.9.9"}]}}`)
+	if _, _, ok = obolInstalledPlugin(dir, "obol"); ok {
+		t.Fatal("plugin from another marketplace must not count as installed")
+	}
+	if _, _, ok = obolInstalledPlugin(t.TempDir(), "obol"); ok {
+		t.Fatal("missing installed_plugins.json must report not installed")
+	}
+}
+
+func TestLatestObolPluginVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name": "obol", "version": "1.5.2"}`))
+	}))
+	defer srv.Close()
+	orig := obolPluginManifestURL
+	obolPluginManifestURL = srv.URL
+	t.Cleanup(func() { obolPluginManifestURL = orig })
+
+	if got := latestObolPluginVersion(); got != "1.5.2" {
+		t.Fatalf("latestObolPluginVersion = %q, want 1.5.2", got)
+	}
+
+	// Failure modes stay silent (empty), never error.
+	obolPluginManifestURL = srv.URL + "/missing"
+	srv404 := httptest.NewServer(http.NotFoundHandler())
+	defer srv404.Close()
+	obolPluginManifestURL = srv404.URL
+	if got := latestObolPluginVersion(); got != "" {
+		t.Fatalf("404 must yield empty version, got %q", got)
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"1.3.0", "1.4.0", true},
+		{"1.4.0", "1.3.0", false},
+		{"1.4.0", "1.4.0", false},
+		{"1.4", "1.4.1", true},
+		{"v1.3.0", "1.10.0", true}, // numeric, not lexicographic
+		{"1.9.9", "2.0.0", true},
+		{"2.0.0", "1.9.9", false},
+		{"", "1.0.0", true}, // "" splits to [""] → non-numeric fallback
+	}
+	for _, tc := range tests {
+		if got := versionLess(tc.a, tc.b); got != tc.want {
+			t.Errorf("versionLess(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -640,48 +641,66 @@ func preflightHelmRepos(cfg *config.Config, u *ui.UI, helmBinary, helmfilePath s
 }
 
 // claudeTipIfRelevant prints a hint when the user has Claude Code installed
-// but the Obol skills plugin is not yet usable in their setup. Best-effort
-// and silent on any error — a missing or malformed Claude config must never
-// block stack up.
+// but the Obol skills plugin is not yet usable — or is out of date — in
+// their setup. Best-effort and silent on any error — a missing or malformed
+// Claude config (or an unreachable GitHub) must never block stack up.
 //
-// Three states the user can be in:
-//   - plugin already installed → silent (nothing to suggest)
+// States the user can be in:
+//   - marketplace not registered at all → suggest the marketplace add and install
 //   - marketplace registered but plugin not installed → suggest the install step
-//   - marketplace not registered at all → suggest both the marketplace add and install
+//   - plugin installed, newer version released → suggest the update step
+//   - plugin installed and current (or version unknowable) → silent
 func claudeTipIfRelevant(u *ui.UI) {
 	if _, err := exec.LookPath("claude"); err != nil {
 		return
 	}
-	mpName, mpRegistered := obolMarketplaceName()
-	if mpRegistered && obolPluginInstalled(mpName) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	pluginsDir := filepath.Join(home, ".claude", "plugins")
+
+	mpName, mpRegistered := obolMarketplaceName(pluginsDir)
+	if !mpRegistered {
+		u.Blank()
+		u.Dim("Tip: let your Claude Code instance manage your Obol Stack for you.")
+		u.Dim("  Add the Obol skills marketplace, then install the plugin:")
+		u.Dim("    claude plugin marketplace add ObolNetwork/skills")
+		u.Dim("    claude plugin install obol@obol")
+		return
+	}
+	pluginKey, installedVersion, installed := obolInstalledPlugin(pluginsDir, mpName)
+	if !installed {
+		u.Blank()
+		u.Dim("Tip: let your Claude Code instance manage your Obol Stack for you.")
+		u.Dim("  The Obol marketplace is registered. Install the plugin to enable it:")
+		u.Dim(fmt.Sprintf("    claude plugin install obol@%s", mpName))
+		return
+	}
+
+	// Installed: nudge only when a newer release is visible. Both sides are
+	// best-effort — an unknowable local version or an unreachable GitHub
+	// stays silent rather than nagging on guesswork.
+	latest := latestObolPluginVersion()
+	if installedVersion == "" || latest == "" || !versionLess(installedVersion, latest) {
 		return
 	}
 	u.Blank()
-	u.Dim("Tip: let your Claude Code instance manage your Obol Stack for you.")
-	if !mpRegistered {
-		u.Dim("  Add the Obol skills marketplace, then install the plugin:")
-		u.Dim("    claude plugin marketplace add ObolNetwork/skills")
-		u.Dim("    /plugin install obol@obol")
-	} else {
-		u.Dim("  The Obol marketplace is registered. Install the plugin to enable it:")
-		u.Dim(fmt.Sprintf("    /plugin install obol@%s", mpName))
-	}
+	u.Dim(fmt.Sprintf("Tip: Obol skills plugin %s is available (you have %s). Update with:", latest, installedVersion))
+	u.Dim(fmt.Sprintf("    claude plugin marketplace update %s", mpName))
+	u.Dim(fmt.Sprintf("    claude plugin update %s", pluginKey))
 }
 
 // obolMarketplaceName returns the local marketplace name that points at
 // ObolNetwork/skills (typically "obol") and a bool indicating whether it was
-// found in ~/.claude/plugins/known_marketplaces.json. The file is shaped as
-// an object keyed by marketplace name, e.g.:
+// found in <pluginsDir>/known_marketplaces.json. The file is shaped as an
+// object keyed by marketplace name, e.g.:
 //
 //	{
 //	  "obol": {"source": {"source": "github", "repo": "ObolNetwork/skills"}, ...}
 //	}
-func obolMarketplaceName() (string, bool) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", false
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"))
+func obolMarketplaceName(pluginsDir string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(pluginsDir, "known_marketplaces.json"))
 	if err != nil {
 		return "", false
 	}
@@ -703,32 +722,126 @@ func obolMarketplaceName() (string, bool) {
 	return "", false
 }
 
-// obolPluginInstalled reports whether any plugin from the given local
-// marketplace name is recorded in ~/.claude/plugins/installed_plugins.json.
-// Plugin keys are stored as "<plugin>@<marketplace>"; we match on the suffix
-// so we don't have to hardcode every plugin the marketplace ever publishes.
-func obolPluginInstalled(marketplaceName string) bool {
+// obolInstalledPlugin looks for a plugin from the given local marketplace in
+// <pluginsDir>/installed_plugins.json and returns its full key
+// ("<plugin>@<marketplace>"), its installed version ("" when unknowable),
+// and whether it was found at all. Plugin keys are stored as
+// "<plugin>@<marketplace>"; we match on the suffix so we don't have to
+// hardcode every plugin the marketplace ever publishes.
+//
+// The v2 file maps each key to an ARRAY of install records (one per scope —
+// user, project, ...), each carrying a "version" field that may be the
+// literal "unknown". Older shapes mapped keys to a single object; both are
+// tolerated, and any parse trouble degrades to "installed, version unknown"
+// (presence of the key is enough for the install check).
+func obolInstalledPlugin(pluginsDir, marketplaceName string) (key, version string, installed bool) {
 	if marketplaceName == "" {
-		return false
+		return "", "", false
 	}
-	home, err := os.UserHomeDir()
+	data, err := os.ReadFile(filepath.Join(pluginsDir, "installed_plugins.json"))
 	if err != nil {
-		return false
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
-	if err != nil {
-		return false
+		return "", "", false
 	}
 	var doc struct {
-		Plugins map[string]any `json:"plugins"`
+		Plugins map[string]json.RawMessage `json:"plugins"`
 	}
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return false
+		return "", "", false
 	}
 	suffix := "@" + marketplaceName
-	for key := range doc.Plugins {
-		if strings.HasSuffix(key, suffix) {
-			return true
+	for k, raw := range doc.Plugins {
+		if !strings.HasSuffix(k, suffix) {
+			continue
+		}
+		return k, installedPluginVersion(raw), true
+	}
+	return "", "", false
+}
+
+// installedPluginVersion extracts the best (highest) version from one
+// installed_plugins.json entry. "" when no usable version is recorded.
+func installedPluginVersion(raw json.RawMessage) string {
+	type record struct {
+		Version string `json:"version"`
+	}
+	var records []record
+	if err := json.Unmarshal(raw, &records); err != nil {
+		// Pre-v2 shape: a single object.
+		var one record
+		if err := json.Unmarshal(raw, &one); err != nil {
+			return ""
+		}
+		records = []record{one}
+	}
+	best := ""
+	for _, r := range records {
+		v := strings.TrimSpace(r.Version)
+		if v == "" || strings.EqualFold(v, "unknown") {
+			continue
+		}
+		if best == "" || versionLess(best, v) {
+			best = v
+		}
+	}
+	return best
+}
+
+// obolPluginManifestURL is the released plugin manifest on the marketplace
+// repo's default branch — the source of truth for "what's the latest
+// version". Package var so tests can point it at a local server.
+var obolPluginManifestURL = "https://raw.githubusercontent.com/ObolNetwork/skills/main/.claude-plugin/plugin.json"
+
+// latestObolPluginVersion fetches the released plugin version. Best-effort
+// with a tight timeout: "" on any failure — stack up output must never hang
+// or warn because GitHub is slow.
+func latestObolPluginVersion() string {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(obolPluginManifestURL)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return ""
+	}
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Version)
+}
+
+// versionLess reports whether version a is older than version b. Handles
+// dotted numeric versions ("1.4.0", optionally "v"-prefixed); missing
+// segments count as zero and non-numeric segments fall back to string
+// comparison. Unparseable inputs compare as not-less (never nag on noise).
+func versionLess(a, b string) bool {
+	as := strings.Split(strings.TrimPrefix(strings.TrimSpace(a), "v"), ".")
+	bs := strings.Split(strings.TrimPrefix(strings.TrimSpace(b), "v"), ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		av, bv := "0", "0"
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		an, aerr := strconv.Atoi(av)
+		bn, berr := strconv.Atoi(bv)
+		if aerr != nil || berr != nil {
+			if av != bv {
+				return av < bv
+			}
+			continue
+		}
+		if an != bn {
+			return an < bn
 		}
 	}
 	return false


### PR DESCRIPTION
# feat(claude): nudge to update the Obol skills plugin when a newer version is released

`obol stack up` already tips Claude Code users toward installing the Obol skills plugin, but went permanently silent once it was installed — and its nudges mixed CLI and in-REPL syntax. This PR fixes the wording and adds a staleness check.

## What's here

- **Consistent CLI nudges**: both the "marketplace not registered" and "plugin not installed" tips now use `claude plugin marketplace add ObolNetwork/skills` / `claude plugin install obol@<marketplace>` (previously one line was the in-REPL `/plugin install …` form).
- **Update nudge**: when the plugin *is* installed, the installed version (from `~/.claude/plugins/installed_plugins.json` — v2 maps each `plugin@marketplace` key to an array of per-scope install records; the legacy single-object shape and the literal `"unknown"` version are tolerated) is compared against the released version (`.claude-plugin/plugin.json` on ObolNetwork/skills' default branch, fetched with a 2-second timeout and capped body read). A newer release prints:

  ```
  Tip: Obol skills plugin 1.4.0 is available (you have 1.3.0). Update with:
      claude plugin marketplace update obol
      claude plugin update obol@obol
  ```

- **Never blocks, never nags on guesswork**: any failure — no `claude` in PATH, malformed config, unreachable GitHub, unknowable local version — stays silent. Timing unchanged: the tip remains the final output of a successful `stack up`.

## Testing

Unit tests with fixtures mirroring the real Claude Code file shapes (marketplace lookup incl. a renamed marketplace resolving by repo, both installed-plugins formats, `"unknown"` handling), a local test server for the manifest fetch (including 404-stays-silent), and a numeric version-compare table (`1.9.0 < 1.10.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
