### PR TITLE
chore(deps): integration/v0.13.0-rc4 — collected Renovate bumps

### DIFF
--- a/internal/embed/infrastructure/cloudflared/values.yaml
+++ b/internal/embed/infrastructure/cloudflared/values.yaml
@@ -5,7 +5,7 @@ transport:
 
 image:
   repository: cloudflare/cloudflared
-  tag: "2026.6.1@sha256:6d91c121b803126f7a5344005d17a9324788fc09d305b6e2560ec6040a7ae283"
+  tag: "2026.7.1@sha256:188bb03589a32affed3cf4d0590565ffe67b78866e6b5582574afab2b705bafe"
 
 metrics:
   address: "0.0.0.0:2000"

--- a/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
@@ -97,13 +97,13 @@ releases:
             tag: v1.17.4
             {{- else if eq .Values.executionClient "nethermind" }}
             # renovate: datasource=github-releases depName=NethermindEth/nethermind
-            tag: "1.38.1"
+            tag: "1.39.0"
             {{- else if eq .Values.executionClient "besu" }}
             # renovate: datasource=github-releases depName=hyperledger/besu
-            tag: "26.6.1"
+            tag: "26.7.0"
             {{- else if eq .Values.executionClient "erigon" }}
             # renovate: datasource=github-releases depName=erigontech/erigon
-            tag: v3.5.0
+            tag: v3.5.1
             {{- end }}
           persistence:
             enabled: true
@@ -123,7 +123,7 @@ releases:
             tag: v7.1.6
             {{- else if eq .Values.consensusClient "teku" }}
             # renovate: datasource=github-releases depName=Consensys/teku
-            tag: "26.7.0"
+            tag: "26.7.1"
             {{- else if eq .Values.consensusClient "nimbus" }}
             # renovate: datasource=docker depName=statusim/nimbus-eth2
             tag: multiarch-v26.5.0

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -35,7 +35,7 @@ const (
 	rawChartVersion = "2.0.2"
 
 	// renovate: datasource=docker depName=nousresearch/hermes-agent
-	defaultImage = "nousresearch/hermes-agent:v2026.7.1"
+	defaultImage = "nousresearch/hermes-agent:v2026.7.7.2"
 	// Use the upstream image venv instead of cloning Hermes into the PVC on
 	// every cold start. The init container below validates the required extras
 	// are present so image regressions fail before the gateway starts.

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -27,7 +27,7 @@ const (
 	hermesDataPVC      = "hermes-data"
 	hermesAPIPath      = "/health"
 	// renovate: datasource=docker depName=nousresearch/hermes-agent
-	defaultHermesImage = "nousresearch/hermes-agent:v2026.7.1"
+	defaultHermesImage = "nousresearch/hermes-agent:v2026.7.7.2"
 )
 
 // agentLabels returns the standard label set we attach to every primitive

--- a/internal/serviceoffercontroller/scalar_html.go
+++ b/internal/serviceoffercontroller/scalar_html.go
@@ -6,7 +6,7 @@ package serviceoffercontroller
 // payload never drifts silently. After a bump, refresh the SRI hash below
 // with scripts/update-scalar-sri.sh (the renovate PR body links it too).
 // renovate: datasource=npm depName=@scalar/api-reference
-const scalarBundleVersion = "1.62.4"
+const scalarBundleVersion = "1.62.5"
 
 // scalarBundleSRI is the Subresource Integrity hash for the pinned bundle.
 // The /api page is served over the public tunnel, so the third-party Scalar
@@ -16,7 +16,7 @@ const scalarBundleVersion = "1.62.4"
 // bundle and rewrites this constant). The hash is taken over the exact
 // (jsdelivr-minified) bytes that the pinned URL serves; it must be refreshed
 // in lockstep with scalarBundleVersion or the browser will block the script.
-const scalarBundleSRI = "sha384-8krtlmjW90KNKDXFfcFls2ueiU+9/jzPmL/C2r7Y2NPh9KWCau8HyweAvBvm/y0y"
+const scalarBundleSRI = "sha384-jVBCKhcCfx34USN27x4iQK1SBNdL/HxKq3KuBAxTS4WPaP5w80K4fjpwB+DezJL5"
 
 // scalarHTML returns the static HTML shell served at /api. It loads the
 // pinned @scalar/api-reference bundle from jsdelivr, points it at the

--- a/obolup.sh
+++ b/obolup.sh
@@ -57,7 +57,7 @@ fi
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 readonly KUBECTL_VERSION="1.36.2"
 # renovate: datasource=github-releases depName=helm/helm
-readonly HELM_VERSION="3.21.2"
+readonly HELM_VERSION="3.21.3"
 # renovate: datasource=github-releases depName=k3d-io/k3d
 readonly K3D_VERSION="5.9.0"
 # renovate: datasource=github-releases depName=helmfile/helmfile
@@ -67,7 +67,7 @@ readonly K9S_VERSION="0.51.0"
 # renovate: datasource=github-releases depName=databus23/helm-diff
 readonly HELM_DIFF_VERSION="3.15.10"
 # renovate: datasource=github-releases depName=ollama/ollama
-readonly OLLAMA_VERSION="0.31.1"
+readonly OLLAMA_VERSION="0.31.2"
 # Must match internal/openclaw/OPENCLAW_VERSION (without "v" prefix).
 # Tested by TestOpenClawVersionConsistency.
 readonly OPENCLAW_VERSION="2026.4.21"


### PR DESCRIPTION
Collects all open Renovate dependency bumps into one integration branch for the next RC (**v0.13.0-rc4**). Branched off `main`; each Renovate branch merged in cleanly (no conflicts); `go build ./...` passes.

## Bundled Renovate PRs

| PR | Bump | File(s) |
|----|------|---------|
| #739 | `cloudflare/cloudflared` → v2026.7.1 | `internal/embed/infrastructure/cloudflared/values.yaml` |
| #737 | `nousresearch/hermes-agent` → v2026.7.7.2 | `internal/hermes/hermes.go`, `internal/serviceoffercontroller/agent_render.go` |
| #736 | ethereum el/cl client updates | `internal/embed/networks/ethereum/helmfile.yaml.gotmpl` |
| #738 | obolup.sh dependency updates | `obolup.sh` |
| #735 | `@scalar/api-reference` → v1.62.5 | `internal/serviceoffercontroller/scalar_html.go` |

6 files changed, +11/−11 — dependency bumps only, no logic changes.

## Notes
- **Base check:** `v0.13.0-rc3` is not an ancestor of `main` (RCs appear to be cut from a line that has diverged). This branch is based on `main`, where the Renovate PRs target and merge cleanly. If rc4 is cut from a separate release branch, rebase this collector accordingly before tagging.
- Merging this closes/supersedes the five individual Renovate PRs above.

https://claude.ai/code/session_01VquWN9UMaSHH7MHGcG8bw1
