### PR TITLE
fix(x402): never settle for a disconnected buyer + expose agent maxConcurrentRuns

### DIFF
--- a/internal/embed/infrastructure/base/templates/agent-crd.yaml
+++ b/internal/embed/infrastructure/base/templates/agent-crd.yaml
@@ -73,6 +73,14 @@ spec:
                   type: string
                 maxItems: 32
                 type: array
+              maxConcurrentRuns:
+                description: |-
+                  Hermes gateway.api_server.max_concurrent_runs. Nil = omit the
+                  gateway block (Hermes internal default, 10). 0 disables the
+                  in-process cap — edge concurrency middleware governs instead.
+                maximum: 10000
+                minimum: 0
+                type: integer
               maxTurns:
                 description: Hermes agent.max_turns. Nil = 30 (historical sub-agent
                   default).

--- a/internal/monetizeapi/types.go
+++ b/internal/monetizeapi/types.go
@@ -980,6 +980,12 @@ type AgentSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=10000
 	MaxTurns *int `json:"maxTurns,omitempty"`
+	// Hermes gateway.api_server.max_concurrent_runs. Nil = omit the
+	// gateway block (Hermes internal default, 10). 0 disables the
+	// in-process cap — edge concurrency middleware governs instead.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=10000
+	MaxConcurrentRuns *int `json:"maxConcurrentRuns,omitempty"`
 	// Hermes agent.disabled_toolsets. Nil = ["memory","web"] (historical
 	// default). Explicit empty list disables none.
 	// +kubebuilder:validation:MaxItems=32

--- a/internal/monetizeapi/zz_generated.deepcopy.go
+++ b/internal/monetizeapi/zz_generated.deepcopy.go
@@ -199,6 +199,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.MaxConcurrentRuns != nil {
+		in, out := &in.MaxConcurrentRuns, &out.MaxConcurrentRuns
+		*out = new(int)
+		**out = **in
+	}
 	if in.DisabledToolsets != nil {
 		in, out := &in.DisabledToolsets, &out.DisabledToolsets
 		*out = make([]string, len(*in))

--- a/internal/serviceoffercontroller/agent_render.go
+++ b/internal/serviceoffercontroller/agent_render.go
@@ -175,6 +175,15 @@ skills:
     - /data/.hermes/obol-skills
 `)
 
+	// gateway block only when the operator set maxConcurrentRuns; nil =>
+	// omit entirely so existing agents stay byte-identical.
+	if agent.Spec.MaxConcurrentRuns != nil {
+		fmt.Fprintf(&b, `gateway:
+  api_server:
+    max_concurrent_runs: %d
+`, *agent.Spec.MaxConcurrentRuns)
+	}
+
 	// mcp_servers only when the operator listed servers; empty => omit entirely
 	// so existing agents stay byte-identical to the pre-field template.
 	if len(agent.Spec.MCPServers) > 0 {

--- a/internal/serviceoffercontroller/agent_render_test.go
+++ b/internal/serviceoffercontroller/agent_render_test.go
@@ -446,11 +446,32 @@ func TestRenderHermesConfig_UnsetFieldsByteIdentical(t *testing.T) {
 	agent.Spec.ModelProvider = ""
 	agent.Spec.MCPServers = nil
 	agent.Spec.MaxTurns = nil
+	agent.Spec.MaxConcurrentRuns = nil
 	agent.Spec.DisabledToolsets = nil
 
 	got := renderHermesConfig(agent, "lit-key")
 	if got != preChangeHermesConfigGolden {
 		t.Errorf("unset-fields config not byte-identical to pre-change golden\n--- got ---\n%q\n--- want ---\n%q", got, preChangeHermesConfigGolden)
+	}
+}
+
+func TestRenderHermesConfig_MaxConcurrentRunsZero(t *testing.T) {
+	agent := testAgentForHermesConfig("qwen3.5:9b")
+	agent.Spec.MaxConcurrentRuns = ptrInt(0)
+
+	got := renderHermesConfig(agent, "lit-key")
+	want := "gateway:\n  api_server:\n    max_concurrent_runs: 0\n"
+	if !strings.Contains(got, want) {
+		t.Errorf("config missing max_concurrent_runs: 0 block\n---\n%s", got)
+	}
+}
+
+func TestRenderHermesConfig_MaxConcurrentRunsNilOmitsGateway(t *testing.T) {
+	agent := testAgentForHermesConfig("qwen3.5:9b")
+	// MaxConcurrentRuns left nil (default/unset).
+	got := renderHermesConfig(agent, "lit-key")
+	if strings.Contains(got, "gateway:") {
+		t.Errorf("nil MaxConcurrentRuns must omit gateway block entirely; got:\n%s", got)
 	}
 }
 

--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -316,6 +316,14 @@ func NewForwardAuthMiddleware(cfg ForwardAuthConfig, requirements []x402types.Pa
 						return true
 					}
 
+					// Buyer already gone (client disconnect propagated) —
+					// don't take their money for a response nobody receives.
+					if err := r.Context().Err(); err != nil {
+						log.Printf("x402: buyer disconnected before settlement, skipping settlement: %v", err)
+						reportFailure("client_disconnected")
+						return false
+					}
+
 					settleResp, err := facilitatorSettle(r.Context(), settleClient, cfg.FacilitatorURL, payloadBytes, matchedReq)
 					if err != nil {
 						log.Printf("x402: settlement failed: %v", err)

--- a/internal/x402/forwardauth_test.go
+++ b/internal/x402/forwardauth_test.go
@@ -2,6 +2,7 @@ package x402
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -568,6 +569,42 @@ func TestForwardAuth_NoSettleOnHandlerError(t *testing.T) {
 	}
 	if settleCalled.Load() != 0 {
 		t.Errorf("settle called %d times, want 0 (handler failed)", settleCalled.Load())
+	}
+}
+
+func TestForwardAuth_NoSettleOnClientDisconnect(t *testing.T) {
+	var verifyCalled, settleCalled atomic.Int32
+	fac := mockFacilitatorV1(true, true, &verifyCalled, &settleCalled)
+	defer fac.Close()
+
+	mw := NewForwardAuthMiddleware(ForwardAuthConfig{
+		FacilitatorURL: fac.URL,
+		VerifyOnly:     false,
+	}, testRequirements())
+
+	// Cancel after verify succeeds but before WriteHeader triggers
+	// settlement. Cancelling before ServeHTTP aborts facilitator verify
+	// (same r.Context()) so settleFunc never runs and verifyCalled stays 0.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel() // buyer disconnects after verify, before response commits
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	})
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("X-PAYMENT", validPaymentHeader())
+	rec := httptest.NewRecorder()
+	mw(inner).ServeHTTP(rec, req)
+
+	if verifyCalled.Load() != 1 {
+		t.Errorf("verify called %d times, want 1", verifyCalled.Load())
+	}
+	if settleCalled.Load() != 0 {
+		t.Errorf("settle called %d times, want 0 (client disconnected)", settleCalled.Load())
 	}
 }
 


### PR DESCRIPTION
Closes #742.

## What

Two config/verifier-side fixes for the paid-agent path (no hermes upstream changes), root-caused from the Bankr bot's failed paid calls and validated live on base mainnet:

1. **`Agent.spec.maxConcurrentRuns`** — rendered as `gateway.api_server.max_concurrent_runs` in the agent's config.yaml. Nil omits the block (Hermes internal default, 10); `0` disables the in-process cap so edge concurrency middleware is the single gate. Existing agents render byte-identical (confighash suite untouched and green).
2. **x402 verifier settle-guard** — skip settlement when the buyer's request context is already canceled at settle time. A disconnected buyer must never be debited for a response nobody receives. Reason `client_disconnected`; the interceptor hijacks the write path so nothing is written to the dead socket.

## Why (see #742 for the full trace)

- The buyer-charged-for-nothing case was proven on-chain: a client abort that doesn't propagate past cloudflared leaves the agent run completing "successfully" → verifier settles → buyer debited, response undelivered. This is exactly Bankr's "payment made but no completion" report.
- The agent's in-process cap (default 10) was not settable from the CR at all, while the Traefik `inFlightReq` middleware was the actually-binding external gate — two inconsistent numbers on the same path.

## Validation

- `go build ./...` + full test run: `internal/monetizeapi`, `internal/serviceoffercontroller`, `internal/x402`, `internal/embed` all green (493 PASS); new tests: `TestRenderHermesConfig_MaxConcurrentRunsZero`, `...NilOmitsGateway`, `TestForwardAuth_NoSettleOnClientDisconnect` (guard fires: `verifyCalled=1, settleCalled=0`).
- Live A/B on silvernuc3 (mainnet wallet, real settlements): pre-fix 12 concurrent paid requests → 4×200 + 8×429; post-fix (maxTurns 12 + cap 0 + edge 24) → 12×200, wallet −$0.12 exactly, zero spurious charges.

Note: until the controller image carrying this lands, the live hyperliquid-analyst cap-off is a hash-gated manual ConfigMap edit (flagged ConfigDrift) — any Agent CR spec change wipes it. After merge + controller roll: set `spec.maxConcurrentRuns: 0` on the CR to make it durable.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk
