### PR TITLE
fix(network): stop reth liveness probe from killing consistency recovery

### DIFF
--- a/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
+++ b/internal/embed/networks/ethereum/helmfile.yaml.gotmpl
@@ -105,6 +105,20 @@ releases:
             # renovate: datasource=github-releases depName=erigontech/erigon
             tag: v3.5.1
             {{- end }}
+          {{- if eq .Values.executionClient "reth" }}
+          # reth keeps p2p (30303) closed while running post-crash consistency
+          # recovery, which can exceed any bounded probe window on a large
+          # datadir. The chart's default tcp liveness probe then SIGKILLs it
+          # mid-recovery, forcing a longer recovery on the next start — a
+          # permanent crash loop. A genuinely dead process exits the container
+          # on its own, so make the probe effectively never fire.
+          livenessProbe:
+            tcpSocket:
+              port: p2p-tcp
+            initialDelaySeconds: 60
+            periodSeconds: 120
+            failureThreshold: 10000
+          {{- end }}
           persistence:
             enabled: true
             size: {{ if (index .Values "executionStorageSize" | default "") }}{{ index .Values "executionStorageSize" }}{{ else }}{{ if eq .Values.network "mainnet" }}{{ if eq .Values.mode "archive" }}4500Gi{{ else }}500Gi{{ end }}{{ else }}{{ if eq .Values.mode "archive" }}300Gi{{ else }}100Gi{{ end }}{{ end }}{{ end }}


### PR DESCRIPTION
## Problem

`obol network install ethereum` (reth) can enter a permanent crash loop after any unclean shutdown. Observed live: **637 restarts** on a mainnet full node.

The upstream `ethereum-node` chart's reth subchart defaults to a TCP liveness probe on the p2p port (30303) with `failureThreshold: 3` / `periodSeconds: 120` — ~12 minutes of grace. Reth keeps that port **closed** while running post-crash `check_consistency` recovery, which routinely takes longer than that on a large datadir. So:

1. kubelet SIGKILLs reth mid-recovery (exit 137)
2. the kill adds more inconsistency to heal on the next start (drift observed growing to ~129k blocks of StoragesHistory)
3. goto 1, forever

## Fix

Override the reth liveness probe in the ethereum helmfile with `failureThreshold: 10000` (effectively never fires). A genuinely dead reth exits the container on its own, so the probe adds nothing. The upstream chart has no `startupProbe` support, so a values override is the only lever.

Scoped to reth only: geth/nethermind/besu probe `http-rpc` and erigon probes `metrics`, none of which close during recovery.

## Verification

- `helmfile template` render of the ethereum helmfile with `executionClient: reth`: reth StatefulSet gets `livenessProbe: {tcpSocket: p2p-tcp, failureThreshold: 10000}`; lighthouse StatefulSet untouched.
- Equivalent live patch applied to the crash-looping node: recovery completed in ~20 min and the node is now 2/2 Ready, syncing, 0 restarts.

https://claude.ai/code/session_01VLQSsnH9WdAsnVYGTd2omr
