### PR TITLE
fix(x402): default 402 challenge resource.url to https on public hosts

### DIFF
--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -598,14 +598,18 @@ func facilitatorSettle(ctx context.Context, client *http.Client, facilitatorURL 
 }
 
 func buildResourceURL(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	}
 	host := r.Host
 	if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
 		host = forwardedHost
 	}
+	// resolveScheme, not X-Forwarded-Proto alone: behind the Cloudflare
+	// tunnel the ForwardAuth hop sees plaintext (XFP=http), which rendered
+	// http:// resource URLs in 402 challenges on public hostnames whenever a
+	// route lacked the X-Forwarded-Proto:https RequestHeaderModifier — the
+	// shared-origin so-<name> routes don't carry it (#679). Public hosts
+	// default to https; only local plain-HTTP hosts (obol.stack, loopback,
+	// *.localhost/*.local) stay http.
+	scheme := resolveScheme(r, host)
 	uri := r.RequestURI
 	if forwardedURI := r.Header.Get("X-Forwarded-Uri"); forwardedURI != "" {
 		uri = forwardedURI

--- a/internal/x402/forwardauth_test.go
+++ b/internal/x402/forwardauth_test.go
@@ -949,3 +949,43 @@ func TestForwardAuth_402CarriesCatalogLinkHeader(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildResourceURL_Scheme(t *testing.T) {
+	cases := []struct {
+		name   string
+		host   string
+		xfHost string
+		xfp    string
+		xfURI  string
+		want   string
+	}{
+		// Public hosts default to https even when the TLS-terminating tunnel
+		// forwards plaintext (XFP=http) and the route carries no
+		// X-Forwarded-Proto filter — the shared-origin so-<name> case (#679).
+		{"public host, no forwarded proto", "svc.example.org", "", "", "", "https://svc.example.org/services/x"},
+		{"public host, xfp http from tunnel", "svc.example.org", "", "http", "", "https://svc.example.org/services/x"},
+		{"forwarded public host", "10.42.0.5:8000", "svc.example.org", "", "", "https://svc.example.org/services/x"},
+		{"local obol.stack stays http", "obol.stack:8080", "", "", "", "http://obol.stack:8080/services/x"},
+		{"localhost stays http", "localhost:3000", "", "", "", "http://localhost:3000/services/x"},
+		{"local host, explicit https honored", "obol.stack:8080", "", "https", "", "https://obol.stack:8080/services/x"},
+		{"forwarded uri used", "svc.example.org", "", "", "/services/x/v1/chat", "https://svc.example.org/services/x/v1/chat"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", "/services/x", nil)
+			r.Host = tc.host
+			if tc.xfHost != "" {
+				r.Header.Set("X-Forwarded-Host", tc.xfHost)
+			}
+			if tc.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", tc.xfp)
+			}
+			if tc.xfURI != "" {
+				r.Header.Set("X-Forwarded-Uri", tc.xfURI)
+			}
+			if got := buildResourceURL(r); got != tc.want {
+				t.Errorf("buildResourceURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/x402/paymentrequired.go
+++ b/internal/x402/paymentrequired.go
@@ -190,11 +190,20 @@ func resolveSiteURL(r *http.Request) string {
 	if forwarded := r.Header.Get("X-Forwarded-Host"); forwarded != "" {
 		host = forwarded
 	}
-	scheme := "https"
+	return resolveScheme(r, host) + "://" + host
+}
+
+// resolveScheme is the single source of truth for the public scheme of a
+// request that may have crossed a TLS-terminating tunnel. Default https;
+// downgrade to http only for hosts the stack serves locally over plain HTTP.
+// An explicit https signal (direct TLS or X-Forwarded-Proto: https) still
+// forces https for any host. Shared by resolveSiteURL (402 page links) and
+// buildResourceURL (challenge resource.url) so both stay consistent.
+func resolveScheme(r *http.Request, host string) string {
 	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && isLocalHost(host) {
-		scheme = "http"
+		return "http"
 	}
-	return scheme + "://" + host
+	return "https"
 }
 
 // isLocalHost reports whether host (optionally with :port) is one the stack


### PR DESCRIPTION
## Summary

What changed: `buildResourceURL` (the 402 challenge `resource.url` builder in the verifier's ForwardAuth path) now uses the same scheme resolution as `resolveSiteURL`: **default https, downgrade to http only for hosts the stack serves locally over plain HTTP** (`obol.stack`, loopback, `*.localhost`/`*.local`); an explicit https signal (direct TLS or `X-Forwarded-Proto: https`) still wins for any host. The resolution is extracted into a shared `resolveScheme` so challenge URLs and 402-page links can never disagree again.

Why it matters: behind a TLS-terminating tunnel the ForwardAuth hop sees plaintext, so the scheme keyed off `X-Forwarded-Proto` alone renders `http://` resource URLs whenever a route lacks the `X-Forwarded-Proto: https` RequestHeaderModifier. The controller's host-bound `so-<name>-host` routes carry that filter, but the shared-origin `so-<name>` routes do not — and being more path-specific for `/services/<name>`, they win the match even on dedicated-hostname origins. Observed live: 5 of 8 host-bound offers advertised `http://` resources in their 402 challenges on https endpoints — a scheme mismatch visible to strict x402 v2 clients and discovery crawlers.

This is the verifier-side half of the correctness gap discussed in #679. It deliberately does NOT force `X-Forwarded-Proto: https` on shared-origin routes: those also serve genuine local plaintext traffic on `obol.stack`, where claiming https would be wrong in the other direction.

Risk level: low

Base branch: main

## Scope

- [x] Code

## Validation

Unit tests:
```text
go build ./... && go test ./internal/x402/ -count=1 — ok
New TestBuildResourceURL_Scheme: public host no-XFP -> https; public host
XFP=http (tunnel case) -> https; forwarded host honored; obol.stack/localhost
stay http; explicit XFP=https on local host honored; X-Forwarded-Uri preserved.
```

Live evidence (v0.13.0 deployment behind a Cloudflare tunnel): all 8 host-bound offers' `/services/<name>` challenges advertised `http://` or `https://` depending solely on whether a hand-authored route with the header filter happened to match; with trusted forwarded headers (the operator-side workaround) all emit https and a real x402 payment settled end-to-end ($0.01 USDC on Base, exact ledger delta). This patch makes the correct scheme the default with no per-route filters or Traefik trust configuration required.

Refs #679

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk