### PR TITLE
fix(hermes): edge-redirect dashboard root to password-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ obol agent list
 obol agent auth obol-agent
 ```
 
+Open the Hermes dashboard (root edge-redirects to the password form):
+
+```
+http://obol-agent.obol.stack
+```
+
+- **Username:** `obol`
+- **Password:** the agent API token from `obol agent auth obol-agent`
+
+Details: [Hermes dashboard login](docs/guides/hermes-dashboard-login.md).
+
 `obol stack up` provisions the cluster, auto-detects your local Ollama models into the LiteLLM gateway, deploys the default Hermes agent (with its own wallet behind a remote signer), and starts a Cloudflare quick-tunnel. From here you can chat with your agent locally at `http://obol.stack:8080` — or go straight to selling.
 
 ## Sell: Your First Paid Service

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,16 @@ All pods should show `Running` or `Completed` within ~2 minutes:
 
 Open the frontend: http://obol.stack/
 
+The Hermes agent dashboard is separate from the frontend. Open the pretty host
+(edge-redirects to the password form — see
+[Hermes dashboard login](guides/hermes-dashboard-login.md)):
+
+```
+http://obol-agent.obol.stack
+```
+
+Username `obol`, password from `obol agent auth obol-agent`.
+
 ## Step 3 -- Test LLM Inference
 
 The stack routes all LLM requests through LiteLLM, an OpenAI-compatible gateway that forwards to your host Ollama.

--- a/docs/guides/hermes-dashboard-login.md
+++ b/docs/guides/hermes-dashboard-login.md
@@ -1,0 +1,56 @@
+# Hermes dashboard login (basic-auth)
+
+Local Hermes dashboards are gated with password basic-auth after hermes-agent
+v2026.7.x.
+
+## Working URL (pretty host)
+
+```
+http://obol-agent.obol.stack
+```
+
+Named instances use `http://hermes-<id>-ui.obol.stack`.
+
+Obol’s dashboard `HTTPRoute` **edge-redirects** Exact `/` → `/auth/password-login`
+(302) so you never have to type the form path. The agent API host
+(`hermes-obol-agent.obol.stack`) is unchanged.
+
+| Field | Value |
+|-------|--------|
+| Username | `obol` |
+| Password | Agent API token from `obol agent auth <id>` |
+
+The password is the same secret Obol wires as `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`
+(and `API_SERVER_KEY`). It never leaves your machine (`obol.stack` → loopback).
+
+CLI alternative (no browser): `obol hermes chat`.
+
+## Why the redirect exists
+
+Hermes’s own root handling is broken for password-only basic-auth:
+
+```
+GET /  (if proxied straight to Hermes)
+  → Hermes redirects to /auth/login?provider=basic
+  → NotImplementedError: BasicAuthProvider is password-only
+  → HTTP 500
+```
+
+The real form lives at `/auth/password-login`. Obol intercepts Exact `/` on the
+**dashboard hostname only** and issues:
+
+```
+302 Location: /auth/password-login
+```
+
+So operators open the pretty host; Traefik never forwards bare `/` into Hermes’s
+broken auto-login path.
+
+| Layer | Ownership |
+|-------|-----------|
+| Upstream Hermes (`nousresearch/hermes-agent`) | Ideally fix `/` (and login CTAs) to land on `/auth/password-login` when basic-auth is password-only |
+| Obol Stack | Edge-redirect dashboard `/` → password form; print pretty URL + credentials after install/sync; smoke-test root + password-login non-500 in flow-04 |
+
+Fallback if the edge rule is missing (old install before re-sync): open
+`http://obol-agent.obol.stack/auth/password-login` directly, then
+`obol agent sync` / re-install to pick up the redirect.

--- a/flows/flow-04-agent.sh
+++ b/flows/flow-04-agent.sh
@@ -231,20 +231,43 @@ fi
 # stack configures basic-auth. Assert the dashboard container is UP (public
 # /api/status → 200) and ENFORCES auth (protected /api/sessions → 401 for an
 # unauthenticated caller; /api routes gate on the session token, not basic-auth).
+#
+# Also probe /auth/password-login (working form) and Exact "/" on the
+# dashboard host. Obol edge-redirects "/" → /auth/password-login so operators
+# can open the pretty host; Hermes's own /auth/login?provider=basic still 500s.
+# See docs/guides/hermes-dashboard-login.md.
 dash_code() { curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
     -s -o /dev/null -w "%{http_code}" --max-time 10 "$@" 2>/dev/null; }
-dash_status="" dash_protected=""
+# -L follows redirect once so we can assert the pretty root lands on a non-500 page.
+dash_code_follow() { curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
+    -s -o /dev/null -w "%{http_code}" --max-time 10 -L --max-redirs 3 "$@" 2>/dev/null; }
+dash_status="" dash_protected="" dash_login="" dash_root="" dash_root_final=""
 for i in $(seq 1 15); do
     dash_status=$(dash_code "$HERMES_DASHBOARD_URL/api/status")
     dash_protected=$(dash_code "$HERMES_DASHBOARD_URL/api/sessions")
-    if [ "$dash_status" = "200" ] && [ "$dash_protected" = "401" ]; then
-        pass "Hermes dashboard up + auth-gated (status=$dash_status protected=$dash_protected)"
+    dash_login=$(dash_code "$HERMES_DASHBOARD_URL/auth/password-login")
+    dash_root=$(dash_code "$HERMES_DASHBOARD_URL/")
+    dash_root_final=$(dash_code_follow "$HERMES_DASHBOARD_URL/")
+    if [ "$dash_status" = "200" ] && [ "$dash_protected" = "401" ] && \
+       [ "$dash_login" != "500" ] && [ -n "$dash_login" ] && [ "$dash_login" != "000" ] && \
+       [ "$dash_root" != "500" ] && [ -n "$dash_root" ] && [ "$dash_root" != "000" ] && \
+       [ "$dash_root_final" != "500" ] && [ -n "$dash_root_final" ] && [ "$dash_root_final" != "000" ]; then
+        pass "Hermes dashboard up + auth-gated + root/login ok (status=$dash_status protected=$dash_protected login=$dash_login root=$dash_root final=$dash_root_final)"
         break
     fi
     sleep 2
 done
 if [ "$dash_status" != "200" ] || [ "$dash_protected" != "401" ]; then
     fail "Hermes dashboard check failed — status=$dash_status protected=$dash_protected"
+fi
+if [ -z "$dash_login" ] || [ "$dash_login" = "000" ] || [ "$dash_login" = "500" ]; then
+    fail "Hermes dashboard password-login path failed — expected non-500 HTML login page, got HTTP $dash_login"
+fi
+if [ -z "$dash_root" ] || [ "$dash_root" = "000" ] || [ "$dash_root" = "500" ]; then
+    fail "Hermes dashboard root failed — expected edge 302 (or non-500) to password-login, got HTTP $dash_root"
+fi
+if [ -z "$dash_root_final" ] || [ "$dash_root_final" = "000" ] || [ "$dash_root_final" = "500" ]; then
+    fail "Hermes dashboard root follow failed — expected non-500 after redirect, got HTTP $dash_root_final"
 fi
 
 # §4: Verify Hermes config still has the expected model/provider wiring.

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -45,6 +45,18 @@ const (
 	containerUID  = 1000
 	containerGID  = 1000
 	dashboardPort = 9119
+
+	// DashboardPasswordLoginPath is the browser entry that works with Hermes
+	// basic-auth. Hermes root "/" auto-redirects to
+	// /auth/login?provider=basic, which raises
+	// NotImplementedError: BasicAuthProvider is password-only (HTTP 500).
+	// See docs/guides/hermes-dashboard-login.md.
+	DashboardPasswordLoginPath = "/auth/password-login"
+
+	// DashboardBasicAuthUsername is the fixed username Obol wires into
+	// HERMES_DASHBOARD_BASIC_AUTH_USERNAME. The password is the agent API
+	// token (same value as HERMES_DASHBOARD_BASIC_AUTH_PASSWORD / API_SERVER_KEY).
+	DashboardBasicAuthUsername = "obol"
 )
 
 type OnboardOptions struct {
@@ -266,10 +278,7 @@ func Sync(cfg *config.Config, id string, u *ui.UI) error {
 	u.Success("Hermes installed successfully!")
 	u.Detail("Namespace", agentruntime.Namespace(agentruntime.Hermes, id))
 	u.Detail("URL", "http://"+agentruntime.Hostname(agentruntime.Hermes, id))
-	u.Detail("Dashboard", "http://"+dashboardHostname(id))
-	u.Blank()
-	u.Dim("[Optional] Retrieve an API server token:")
-	u.Printf("  obol agent auth %s", id)
+	printDashboardAccessGuidance(u, id)
 	u.Blank()
 	u.Dim("[Optional] Port-forward fallback:")
 	u.Printf("  obol kubectl -n %s port-forward svc/%s %d:%d",
@@ -718,6 +727,48 @@ func dashboardHostname(id string) string {
 	return agentruntime.DashboardHostname(agentruntime.Hermes, id)
 }
 
+// dashboardURL is the pretty operator URL for the Hermes dashboard host.
+// An HTTPRoute RequestRedirect on Exact "/" rewrites to the password form
+// so operators never need to type /auth/password-login.
+func dashboardURL(id string) string {
+	return "http://" + dashboardHostname(id)
+}
+
+// dashboardPasswordLoginURL is the form path Hermes actually serves (and the
+// target of the edge redirect from "/").
+func dashboardPasswordLoginURL(id string) string {
+	return dashboardURL(id) + DashboardPasswordLoginPath
+}
+
+// dashboardAccessGuidance returns operator-facing lines that name the pretty
+// dashboard URL and how credentials map to the agent API token.
+// Pure for unit tests; printDashboardAccessGuidance is the Sync success path.
+func dashboardAccessGuidance(id string) []string {
+	return []string{
+		"Dashboard: " + dashboardURL(id),
+		"  Username: " + DashboardBasicAuthUsername,
+		"  Password: agent API token from `obol agent auth " + id + "`",
+		"  (root edge-redirects to " + DashboardPasswordLoginPath + ")",
+	}
+}
+
+func printDashboardAccessGuidance(u *ui.UI, id string) {
+	// Drive UI from the pure guidance lines so unit tests cover the shipped path.
+	for i, line := range dashboardAccessGuidance(id) {
+		if i == 0 {
+			const prefix = "Dashboard: "
+			if strings.HasPrefix(line, prefix) {
+				u.Detail("Dashboard", strings.TrimPrefix(line, prefix))
+				continue
+			}
+		}
+		u.Dim(line)
+	}
+	u.Blank()
+	u.Dim("[Optional] Retrieve the dashboard password (API token):")
+	u.Printf("  obol agent auth %s", id)
+}
+
 func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token, primary string, configData []byte) string {
 	desc := agentruntime.Describe(agentruntime.Hermes)
 	configChecksum := sha256.Sum256(configData)
@@ -963,7 +1014,7 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
                 # existing API token as the password (already surfaced to the
                 # operator). Probe path /api/status stays auth-exempt.
                 - name: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
-                  value: obol
+                  value: %s
                 - name: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
                   value: %s
               readinessProbe:
@@ -1041,15 +1092,33 @@ func generateValues(namespace, hostname, dashboardHostname, agentBaseURL, token,
           namespace: traefik
           sectionName: web
       rules:
+        # Hermes root "/" auto-redirects to /auth/login?provider=basic which
+        # 500s for password-only basic-auth. Edge-redirect Exact "/" to the
+        # working password form so operators can open the pretty dashboard
+        # host. Dashboard hostname only — agent API host is untouched.
+        - matches:
+            - path:
+                type: Exact
+                value: /
+          filters:
+            - type: RequestRedirect
+              requestRedirect:
+                path:
+                  type: ReplaceFullPath
+                  replaceFullPath: %s
+                statusCode: 302
         - backendRefs:
             - name: %s
               port: %d
 `, desc.DefaultPort, desc.DefaultPort, desc.DefaultPort,
-		quoteYAML(image()), quoteYAML(hermesBinary), dashboardPort, dashboardPort, desc.DefaultPort, quoteYAML(token), dashboardPort, dashboardPort, dashboardPort,
+		quoteYAML(image()), quoteYAML(hermesBinary), dashboardPort, dashboardPort, desc.DefaultPort,
+		quoteYAML(DashboardBasicAuthUsername), quoteYAML(token),
+		dashboardPort, dashboardPort, dashboardPort,
 		desc.DataPVCName,
 		desc.ServiceName, namespace, desc.ServiceName, desc.ServiceName, desc.DefaultPort, dashboardPort,
 		desc.ServiceName, namespace, quoteYAML(hostname), desc.ServiceName, desc.DefaultPort,
-		desc.ServiceName, namespace, quoteYAML(dashboardHostname), desc.ServiceName, dashboardPort)
+		desc.ServiceName, namespace, quoteYAML(dashboardHostname),
+		DashboardPasswordLoginPath, desc.ServiceName, dashboardPort)
 
 	return strings.ReplaceAll(b.String(), "\t", "")
 }

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -303,6 +303,9 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		"name: GATEWAY_HEALTH_URL",
 		"HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
 		"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+		// Username is fixed; password is the agent API token (API_SERVER_KEY).
+		`value: "obol"`,
+		`value: "secret-token"`,
 		// Must track HERMES_HOME: v2026.7.x images bake
 		// HERMES_WRITE_SAFE_ROOT=/opt/data and deny all file-tool
 		// writes outside the safe root.
@@ -312,6 +315,58 @@ func TestGenerateValues_UsesHermesNativeNames(t *testing.T) {
 		if !strings.Contains(values, needle) {
 			t.Fatalf("generateValues() missing %q:\n%s", needle, values)
 		}
+	}
+
+	// Basic-auth must stay wired: non-loopback dashboard bind requires it,
+	// and the password must equal the agent API token already in the Secret.
+	if !strings.Contains(values, "HERMES_DASHBOARD_BASIC_AUTH_USERNAME") ||
+		!strings.Contains(values, "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD") {
+		t.Fatalf("generateValues() missing dashboard basic-auth env wiring:\n%s", values)
+	}
+	// Password env must carry the same token as API_SERVER_KEY (secret-token in this fixture).
+	if idx := strings.Index(values, "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"); idx < 0 {
+		t.Fatal("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD missing")
+	} else {
+		window := values[idx:]
+		if len(window) > 120 {
+			window = window[:120]
+		}
+		if !strings.Contains(window, `value: "secret-token"`) {
+			t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD must use agent API token; nearby:\n%s", window)
+		}
+	}
+
+	// Dashboard HTTPRoute must edge-redirect Exact "/" → password-login so
+	// operators can open the pretty host without hitting Hermes's broken
+	// /auth/login?provider=basic path.
+	for _, needle := range []string{
+		"type: RequestRedirect",
+		"replaceFullPath: " + DashboardPasswordLoginPath,
+		"type: Exact",
+		"value: /",
+	} {
+		if !strings.Contains(values, needle) {
+			t.Fatalf("generateValues() dashboard root redirect missing %q:\n%s", needle, values)
+		}
+	}
+	// Redirect must only live on the dashboard HTTPRoute, not the agent API route.
+	firstHTTPRoute := strings.Index(values, "kind: HTTPRoute")
+	if firstHTTPRoute < 0 {
+		t.Fatal("expected HTTPRoute resources in generateValues()")
+	}
+	secondHTTPRouteRel := strings.Index(values[firstHTTPRoute+1:], "kind: HTTPRoute")
+	if secondHTTPRouteRel < 0 {
+		t.Fatal("expected two HTTPRoutes (agent + dashboard)")
+	}
+	secondHTTPRoute := firstHTTPRoute + 1 + secondHTTPRouteRel
+	agentRouteYAML := values[firstHTTPRoute:secondHTTPRoute]
+	if strings.Contains(agentRouteYAML, "RequestRedirect") {
+		t.Fatalf("agent API HTTPRoute must not edge-redirect root:\n%s", agentRouteYAML)
+	}
+	dashRouteYAML := values[secondHTTPRoute:]
+	if !strings.Contains(dashRouteYAML, "RequestRedirect") ||
+		!strings.Contains(dashRouteYAML, "replaceFullPath: "+DashboardPasswordLoginPath) {
+		t.Fatalf("dashboard HTTPRoute missing root→password-login redirect:\n%s", dashRouteYAML)
 	}
 
 	for _, banned := range []string{
@@ -389,6 +444,46 @@ func TestDashboardHostname_UsesDefaultAgentHostAndHermesUIHostForNamedInstances(
 				t.Fatalf("dashboardHostname(%q) = %q, want %q", tt.id, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDashboardPasswordLoginURL_UsesPasswordLoginPath(t *testing.T) {
+	got := dashboardPasswordLoginURL("obol-agent")
+	want := "http://obol-agent.obol.stack" + DashboardPasswordLoginPath
+	if got != want {
+		t.Fatalf("dashboardPasswordLoginURL(obol-agent) = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(got, "/auth/password-login") {
+		t.Fatalf("login URL must end with /auth/password-login, got %q", got)
+	}
+	if gotRoot := dashboardURL("obol-agent"); gotRoot != "http://obol-agent.obol.stack" {
+		t.Fatalf("dashboardURL(obol-agent) = %q, want pretty host root", gotRoot)
+	}
+}
+
+func TestDashboardAccessGuidance_NamesPrettyURLAndTokenPassword(t *testing.T) {
+	id := "obol-agent"
+	lines := dashboardAccessGuidance(id)
+	joined := strings.Join(lines, "\n")
+
+	for _, needle := range []string{
+		"Dashboard: http://obol-agent.obol.stack",
+		DashboardPasswordLoginPath,
+		"Username: " + DashboardBasicAuthUsername,
+		"obol agent auth " + id,
+		"Password:",
+	} {
+		if !strings.Contains(joined, needle) {
+			t.Fatalf("dashboardAccessGuidance missing %q:\n%s", needle, joined)
+		}
+	}
+
+	// Primary line is the pretty host (edge-redirected), not only the form path.
+	if !strings.HasPrefix(lines[0], "Dashboard: http://obol-agent.obol.stack") {
+		t.Fatalf("first guidance line should be pretty Dashboard URL, got %q", lines[0])
+	}
+	if strings.HasPrefix(lines[0], "Dashboard: http://obol-agent.obol.stack/auth/") {
+		t.Fatalf("primary Dashboard URL should be host root, not form path: %q", lines[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Hermes password-only basic-auth makes bare dashboard `/` 500 via `/auth/login?provider=basic` (`NotImplementedError: BasicAuthProvider is password-only`).
- Edge-redirect Exact `/` → `/auth/password-login` on the **dashboard** HTTPRoute only (agent API host unchanged).
- Post-install/sync prints pretty `Dashboard: http://…` plus username `obol` and password = `obol agent auth <id>`.
- flow-04 asserts root + password-login are non-500 (alongside existing `/api/status` 200 and protected API 401).
- Docs: `docs/guides/hermes-dashboard-login.md`, README + getting-started.

## Test plan

- [x] `go test ./internal/hermes/ -count=1`
- [x] `bash -n flows/flow-04-agent.sh`
- [ ] `obol agent sync` (or stack up) applies dashboard HTTPRoute redirect
- [ ] `curl -I http://obol-agent.obol.stack/` → 302 to `/auth/password-login`
- [ ] Follow redirect lands on login form; login with `obol` + `obol agent auth`