### PR TITLE
fix(serviceoffer): namespace-disambiguate ReferenceGrant names

### DIFF
--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -1341,7 +1341,7 @@ func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi
 		resource dynamic.ResourceInterface
 		name     string
 	}{
-		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Name)},
+		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Namespace, offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: childName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: hostChildName(offer.Name)},
 		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsMiddlewareName(offer.Name)},

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -875,7 +875,11 @@ func buildReferenceGrant(offer *monetizeapi.ServiceOffer) *unstructured.Unstruct
 			"apiVersion": "gateway.networking.k8s.io/v1beta1",
 			"kind":       "ReferenceGrant",
 			"metadata": map[string]any{
-				"name":      backendReferenceGrantName(offer.Name),
+				// Name must include the offer namespace: grants live in x402 and
+				// two offers with the same name in different namespaces would
+				// otherwise overwrite each other's ReferenceGrant (HTTP 500 /
+				// flapping backendRefs for one of the two).
+				"name":      backendReferenceGrantName(offer.Namespace, offer.Name),
 				"namespace": "x402",
 				"labels": map[string]any{
 					"obol.org/serviceoffer-namespace": offer.Namespace,
@@ -934,8 +938,10 @@ func childName(name string) string {
 	return safeName("so-", name, "")
 }
 
-func backendReferenceGrantName(name string) string {
-	return safeName("so-", name, "-backend-grant")
+func backendReferenceGrantName(namespace, name string) string {
+	// Prefix with namespace so cluster-scoped-looking names in x402 stay unique
+	// per (namespace, offer). safeName still truncates+hashes long names.
+	return safeName("so-", namespace+"-"+name, "-backend-grant")
 }
 
 func registrationRequestName(name string) string {

--- a/internal/serviceoffercontroller/render_test.go
+++ b/internal/serviceoffercontroller/render_test.go
@@ -103,6 +103,12 @@ func TestBuildReferenceGrant(t *testing.T) {
 	if grant.GetNamespace() != "x402" {
 		t.Fatalf("grant namespace = %q, want x402", grant.GetNamespace())
 	}
+	if grant.GetName() != backendReferenceGrantName("llm", "demo") {
+		t.Fatalf("grant name = %q, want namespaced unique name", grant.GetName())
+	}
+	if !strings.Contains(grant.GetName(), "llm") || !strings.Contains(grant.GetName(), "demo") {
+		t.Fatalf("grant name %q must include offer namespace and name", grant.GetName())
+	}
 	spec := grant.Object["spec"].(map[string]any)
 	from := spec["from"].([]any)[0].(map[string]any)
 	to := spec["to"].([]any)[0].(map[string]any)
@@ -111,6 +117,26 @@ func TestBuildReferenceGrant(t *testing.T) {
 	}
 	if to["name"] != "x402-verifier" {
 		t.Fatalf("grant to.name = %v, want x402-verifier", to["name"])
+	}
+}
+
+// Two offers with the same name in different namespaces must not share a
+// ReferenceGrant object name in x402 (overwrite / flapping 500s).
+func TestBuildReferenceGrant_DisambiguatesByNamespace(t *testing.T) {
+	a := buildReferenceGrant(&monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "canary402", Namespace: "ns-a"},
+	})
+	b := buildReferenceGrant(&monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "canary402", Namespace: "ns-b"},
+	})
+	if a.GetName() == b.GetName() {
+		t.Fatalf("same-named offers in different namespaces must get distinct grant names; both = %q", a.GetName())
+	}
+	if a.Object["spec"].(map[string]any)["from"].([]any)[0].(map[string]any)["namespace"] != "ns-a" {
+		t.Fatal("grant A from.namespace must be ns-a")
+	}
+	if b.Object["spec"].(map[string]any)["from"].([]any)[0].(map[string]any)["namespace"] != "ns-b" {
+		t.Fatal("grant B from.namespace must be ns-b")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes cross-namespace ReferenceGrant collision: two ServiceOffers with the same name in different namespaces both targeted `x402/so-<name>-backend-grant`, overwriting each other and causing HTTP 500 flapping.

Grant names now include the offer namespace: `so-<ns>-<name>-backend-grant`.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/ -run TestBuildReferenceGrant`
- [ ] Reconcile two same-named offers in different namespaces; both grants exist under x402

Part of v0.14.0-rc0 hackathon bugfix train (stacked onto integration/v0.14.0-rc0).