### PR TITLE
fix(serviceoffer): split inFlightReq and rateLimit middlewares

### DIFF
--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -793,14 +793,32 @@ func (c *Controller) reconcilePaymentGate(ctx context.Context, status *monetizea
 
 func (c *Controller) reconcileRoute(ctx context.Context, status *monetizeapi.ServiceOfferStatus, offer *monetizeapi.ServiceOffer) error {
 	// Protection middleware must exist before the routes that reference it
-	// (Traefik drops routes with a dangling ExtensionRef).
-	if hasLimits(offer) {
-		if err := c.applyObject(ctx, c.middlewares.Namespace(offer.Namespace), buildLimitsMiddleware(offer)); err != nil {
+	// (Traefik drops routes with a dangling ExtensionRef). inFlightReq and
+	// rateLimit are separate Middleware CRs — a combined CR is rejected by
+	// Traefik while the ServiceOffer still looked Ready.
+	for _, mw := range buildLimitsMiddlewares(offer) {
+		if err := c.applyObject(ctx, c.middlewares.Namespace(offer.Namespace), mw); err != nil {
 			setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
 			return err
 		}
-	} else {
-		err := c.middlewares.Namespace(offer.Namespace).Delete(ctx, limitsMiddlewareName(offer.Name), metav1.DeleteOptions{})
+	}
+	// Tear down unused limit CRs (including the legacy combined -limits name).
+	for _, name := range []string{
+		limitsInFlightMiddlewareName(offer.Name),
+		limitsRPSMiddlewareName(offer.Name),
+		legacyLimitsMiddlewareName(offer.Name),
+	} {
+		wanted := false
+		for _, mw := range buildLimitsMiddlewares(offer) {
+			if mw.GetName() == name {
+				wanted = true
+				break
+			}
+		}
+		if wanted {
+			continue
+		}
+		err := c.middlewares.Namespace(offer.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -1344,7 +1362,9 @@ func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi
 		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: childName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: hostChildName(offer.Name)},
-		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsMiddlewareName(offer.Name)},
+		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsInFlightMiddlewareName(offer.Name)},
+		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsRPSMiddlewareName(offer.Name)},
+		{resource: c.middlewares.Namespace(offer.Namespace), name: legacyLimitsMiddlewareName(offer.Name)},
 	} {
 		err := deletion.resource.Delete(ctx, deletion.name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -670,50 +670,91 @@ func hasLimits(offer *monetizeapi.ServiceOffer) bool {
 	return offer.Spec.Limits.MaxInFlight > 0 || offer.Spec.Limits.RPS > 0
 }
 
-// buildLimitsMiddleware renders the Traefik protection middleware for
-// spec.limits: inFlightReq (concurrency cap — the unbounded-concurrency
-// hole on paid agents is pentest-proven) and/or rateLimit. Lives in the
-// offer's namespace because Gateway API ExtensionRef resolves there.
-func buildLimitsMiddleware(offer *monetizeapi.ServiceOffer) *unstructured.Unstructured {
-	spec := map[string]any{}
+// buildLimitsMiddlewares renders one Traefik Middleware CR per limit type.
+// Traefik rejects a single Middleware CR that declares both inFlightReq and
+// rateLimit ("invalid middleware type" / incompatible types). Combining
+// --max-in-flight and --rps therefore must produce two CRs and two
+// ExtensionRef filters. Lives in the offer's namespace because Gateway API
+// ExtensionRef resolves there.
+func buildLimitsMiddlewares(offer *monetizeapi.ServiceOffer) []*unstructured.Unstructured {
+	var out []*unstructured.Unstructured
 	if offer.Spec.Limits.MaxInFlight > 0 {
-		spec["inFlightReq"] = map[string]any{"amount": offer.Spec.Limits.MaxInFlight}
+		out = append(out, &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "traefik.io/v1alpha1",
+				"kind":       "Middleware",
+				"metadata": map[string]any{
+					"name":            limitsInFlightMiddlewareName(offer.Name),
+					"namespace":       offer.Namespace,
+					"ownerReferences": []any{ownerRefMap(offer)},
+				},
+				"spec": map[string]any{
+					"inFlightReq": map[string]any{"amount": offer.Spec.Limits.MaxInFlight},
+				},
+			},
+		})
 	}
 	if offer.Spec.Limits.RPS > 0 {
-		spec["rateLimit"] = map[string]any{
-			"average": offer.Spec.Limits.RPS,
-			"burst":   offer.Spec.Limits.RPS * 2,
-		}
-	}
-	return &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "traefik.io/v1alpha1",
-			"kind":       "Middleware",
-			"metadata": map[string]any{
-				"name":            limitsMiddlewareName(offer.Name),
-				"namespace":       offer.Namespace,
-				"ownerReferences": []any{ownerRefMap(offer)},
+		out = append(out, &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "traefik.io/v1alpha1",
+				"kind":       "Middleware",
+				"metadata": map[string]any{
+					"name":            limitsRPSMiddlewareName(offer.Name),
+					"namespace":       offer.Namespace,
+					"ownerReferences": []any{ownerRefMap(offer)},
+				},
+				"spec": map[string]any{
+					"rateLimit": map[string]any{
+						"average": offer.Spec.Limits.RPS,
+						"burst":   offer.Spec.Limits.RPS * 2,
+					},
+				},
 			},
-			"spec": spec,
-		},
+		})
 	}
+	return out
 }
 
-func limitsMiddlewareName(offerName string) string {
+func limitsInFlightMiddlewareName(offerName string) string {
+	return safeName("so-", offerName, "-inflight")
+}
+
+func limitsRPSMiddlewareName(offerName string) string {
+	return safeName("so-", offerName, "-ratelimit")
+}
+
+// legacyLimitsMiddlewareName is the pre-split combined CR name; still deleted
+// on reconcile so upgrades tear down the broken object.
+func legacyLimitsMiddlewareName(offerName string) string {
 	return safeName("so-", offerName, "-limits")
 }
 
-// limitsFilter is the ExtensionRef filter attached to gated rules when
-// spec.limits is set.
-func limitsFilter(offer *monetizeapi.ServiceOffer) map[string]any {
-	return map[string]any{
-		"type": "ExtensionRef",
-		"extensionRef": map[string]any{
-			"group": "traefik.io",
-			"kind":  "Middleware",
-			"name":  limitsMiddlewareName(offer.Name),
-		},
+// limitsFilters returns ExtensionRef filters for every configured limit
+// middleware (zero, one, or both).
+func limitsFilters(offer *monetizeapi.ServiceOffer) []any {
+	var filters []any
+	if offer.Spec.Limits.MaxInFlight > 0 {
+		filters = append(filters, map[string]any{
+			"type": "ExtensionRef",
+			"extensionRef": map[string]any{
+				"group": "traefik.io",
+				"kind":  "Middleware",
+				"name":  limitsInFlightMiddlewareName(offer.Name),
+			},
+		})
 	}
+	if offer.Spec.Limits.RPS > 0 {
+		filters = append(filters, map[string]any{
+			"type": "ExtensionRef",
+			"extensionRef": map[string]any{
+				"group": "traefik.io",
+				"kind":  "Middleware",
+				"name":  limitsRPSMiddlewareName(offer.Name),
+			},
+		})
+	}
+	return filters
 }
 
 func buildHTTPRoute(offer *monetizeapi.ServiceOffer) *unstructured.Unstructured {
@@ -799,7 +840,7 @@ func buildHostHTTPRoute(offer *monetizeapi.ServiceOffer) *unstructured.Unstructu
 		},
 	}
 	if hasLimits(offer) {
-		catchallFilters = append(catchallFilters, limitsFilter(offer))
+		catchallFilters = append(catchallFilters, limitsFilters(offer)...)
 	}
 
 	return &unstructured.Unstructured{
@@ -860,7 +901,7 @@ func sharedOriginRule(offer *monetizeapi.ServiceOffer) map[string]any {
 		},
 	}
 	if hasLimits(offer) {
-		rule["filters"] = []any{limitsFilter(offer)}
+		rule["filters"] = limitsFilters(offer)
 	}
 	return rule
 }

--- a/internal/serviceoffercontroller/render_test.go
+++ b/internal/serviceoffercontroller/render_test.go
@@ -90,6 +90,55 @@ func TestBuildHTTPRoute(t *testing.T) {
 	}
 }
 
+func TestBuildLimitsMiddlewares_SplitsInFlightAndRPS(t *testing.T) {
+	offer := &monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "gated", Namespace: "llm"},
+		Spec: monetizeapi.ServiceOfferSpec{
+			Limits: monetizeapi.ServiceOfferLimits{MaxInFlight: 4, RPS: 10},
+		},
+	}
+	mws := buildLimitsMiddlewares(offer)
+	if len(mws) != 2 {
+		t.Fatalf("len(middlewares) = %d, want 2 (one per Traefik type)", len(mws))
+	}
+	names := map[string]map[string]any{}
+	for _, mw := range mws {
+		spec, _ := mw.Object["spec"].(map[string]any)
+		names[mw.GetName()] = spec
+		// Each CR must carry exactly one middleware type key.
+		if len(spec) != 1 {
+			t.Fatalf("middleware %q has %d spec keys; Traefik requires one type per CR: %v", mw.GetName(), len(spec), spec)
+		}
+	}
+	if _, ok := names[limitsInFlightMiddlewareName("gated")]["inFlightReq"]; !ok {
+		t.Fatal("missing inFlightReq middleware")
+	}
+	if _, ok := names[limitsRPSMiddlewareName("gated")]["rateLimit"]; !ok {
+		t.Fatal("missing rateLimit middleware")
+	}
+	filters := limitsFilters(offer)
+	if len(filters) != 2 {
+		t.Fatalf("len(filters) = %d, want 2 ExtensionRefs", len(filters))
+	}
+}
+
+func TestBuildLimitsMiddlewares_SingleType(t *testing.T) {
+	onlyInFlight := buildLimitsMiddlewares(&monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "llm"},
+		Spec:       monetizeapi.ServiceOfferSpec{Limits: monetizeapi.ServiceOfferLimits{MaxInFlight: 2}},
+	})
+	if len(onlyInFlight) != 1 {
+		t.Fatalf("maxInFlight only: len = %d", len(onlyInFlight))
+	}
+	onlyRPS := buildLimitsMiddlewares(&monetizeapi.ServiceOffer{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "llm"},
+		Spec:       monetizeapi.ServiceOfferSpec{Limits: monetizeapi.ServiceOfferLimits{RPS: 5}},
+	})
+	if len(onlyRPS) != 1 {
+		t.Fatalf("rps only: len = %d", len(onlyRPS))
+	}
+}
+
 func TestBuildReferenceGrant(t *testing.T) {
 	offer := &monetizeapi.ServiceOffer{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

`--max-in-flight` + `--rps` generated a single Traefik Middleware with both `inFlightReq` and `rateLimit`. Traefik rejects that combination, but the ServiceOffer still reached Ready.

Now each limit is its own Middleware CR (+ ExtensionRef). Legacy `so-*-limits` CRs are deleted on reconcile.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/ -run TestBuildLimits`
- [ ] Live: `obol sell http … --max-in-flight 4 --rps 10` and confirm two Middleware CRs accepted by Traefik

Part of v0.14.0-rc0 hackathon bugfix train.