### PR TITLE
fix(x402): public path + https in 402 resource.URL

### DIFF
--- a/internal/x402/authgate.go
+++ b/internal/x402/authgate.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
@@ -10,6 +11,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -81,10 +83,38 @@ func requestHost(r *http.Request) string {
 // public URLs must not leak the internal prefix; on the shared origin the
 // prefix is the offer path itself.
 func publicPrefix(rule *RouteRule, host string) string {
-	if rule.Hostname != "" && strings.EqualFold(host, rule.Hostname) {
+	if rule == nil {
+		return ""
+	}
+	h := host
+	if hh, _, err := net.SplitHostPort(host); err == nil {
+		h = hh
+	}
+	rh := rule.Hostname
+	if rhH, _, err := net.SplitHostPort(rule.Hostname); err == nil {
+		rh = rhH
+	}
+	if rule.Hostname != "" && strings.EqualFold(h, rh) {
 		return ""
 	}
 	return strings.TrimSuffix(rule.StripPrefix, "/")
+}
+
+// routeRuleContextKey carries the matched RouteRule on the request context
+// so 402 resource.URL builders can recover the public path-world after
+// Traefik rewrote a dedicated-origin request into /services/<name>/….
+type routeRuleContextKey struct{}
+
+func withRouteRule(ctx context.Context, rule *RouteRule) context.Context {
+	if rule == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, routeRuleContextKey{}, rule)
+}
+
+func routeRuleFrom(ctx context.Context) *RouteRule {
+	rule, _ := ctx.Value(routeRuleContextKey{}).(*RouteRule)
+	return rule
 }
 
 // Broker contract headers (mirrors internal/jobbroker — see the comment on

--- a/internal/x402/forwardauth.go
+++ b/internal/x402/forwardauth.go
@@ -598,19 +598,70 @@ func facilitatorSettle(ctx context.Context, client *http.Client, facilitatorURL 
 }
 
 func buildResourceURL(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	}
+	// Scheme matches resolveSiteURL: default https for public hosts so a
+	// Cloudflare-terminated tunnel that forwards plaintext (X-Forwarded-Proto
+	// often "http") still advertises https:// resource URLs that match what
+	// discovery and x402scan probe.
 	host := r.Host
 	if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
 		host = forwardedHost
 	}
-	uri := r.RequestURI
-	if forwardedURI := r.Header.Get("X-Forwarded-Uri"); forwardedURI != "" {
-		uri = forwardedURI
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && isLocalHost(host) {
+		scheme = "http"
 	}
-	return scheme + "://" + host + uri
+
+	path := r.URL.Path
+	if r.URL.RawQuery != "" {
+		path = path + "?" + r.URL.RawQuery
+	}
+	if forwardedURI := r.Header.Get("X-Forwarded-Uri"); forwardedURI != "" {
+		path = forwardedURI
+	}
+
+	// Dedicated-origin offers rewrite /public → /services/<name>/public before
+	// the verifier matches. Challenge resource.URL must use the public path
+	// the buyer/discovery saw, not the internal rewritten path.
+	if rule := routeRuleFrom(r.Context()); rule != nil && rule.Hostname != "" {
+		if strings.EqualFold(stripHostPort(host), stripHostPort(rule.Hostname)) {
+			rawPath := r.URL.Path
+			if forwardedURI := r.Header.Get("X-Forwarded-Uri"); forwardedURI != "" {
+				if u, err := parsePathOnly(forwardedURI); err == nil {
+					rawPath = u
+				}
+			}
+			pub := publicPrefix(rule, host) + stripRoutePrefix(rule.StripPrefix, rawPath)
+			if r.URL.RawQuery != "" && !strings.Contains(pub, "?") {
+				pub += "?" + r.URL.RawQuery
+			}
+			path = pub
+		}
+	}
+
+	return scheme + "://" + host + path
+}
+
+func stripHostPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+// parsePathOnly returns the path (and optional query) from a URI that may be
+// path-only (/foo) or absolute (https://h/foo?q=1).
+func parsePathOnly(uri string) (string, error) {
+	if strings.HasPrefix(uri, "/") {
+		return uri, nil
+	}
+	// Absolute form — rare for X-Forwarded-Uri; fall back to as-is path parse.
+	if i := strings.Index(uri, "://"); i >= 0 {
+		rest := uri[i+3:]
+		if j := strings.Index(rest, "/"); j >= 0 {
+			return rest[j:], nil
+		}
+	}
+	return uri, nil
 }
 
 // settlementInterceptor wraps a ResponseWriter to intercept the status code.

--- a/internal/x402/forwardauth_resource_url_test.go
+++ b/internal/x402/forwardauth_resource_url_test.go
@@ -1,0 +1,48 @@
+package x402
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildResourceURL_PublicHostDefaultsHTTPS(t *testing.T) {
+	r := httptest.NewRequest("GET", "/services/demo/v1", nil)
+	r.Host = "store.example.com"
+	// Tunnel edge often forwards X-Forwarded-Proto: http after TLS termination.
+	r.Header.Set("X-Forwarded-Proto", "http")
+	got := buildResourceURL(r)
+	want := "https://store.example.com/services/demo/v1"
+	if got != want {
+		t.Fatalf("buildResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestBuildResourceURL_HostnameOfferStripsInternalPrefix(t *testing.T) {
+	rule := &RouteRule{
+		Hostname:    "audit.example.com",
+		StripPrefix: "/services/canary402",
+		OfferName:   "canary402",
+	}
+	// Traefik rewrote /audit → /services/canary402/audit before the verifier.
+	r := httptest.NewRequest("GET", "/services/canary402/audit", nil)
+	r.Host = "audit.example.com"
+	r.Header.Set("X-Forwarded-Host", "audit.example.com")
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r = r.WithContext(withRouteRule(r.Context(), rule))
+
+	got := buildResourceURL(r)
+	want := "https://audit.example.com/audit"
+	if got != want {
+		t.Fatalf("buildResourceURL = %q, want public path %q", got, want)
+	}
+}
+
+func TestBuildResourceURL_LocalHostStaysHTTP(t *testing.T) {
+	r := httptest.NewRequest("GET", "/services/x", nil)
+	r.Host = "obol.stack:8080"
+	got := buildResourceURL(r)
+	want := "http://obol.stack:8080/services/x"
+	if got != want {
+		t.Fatalf("buildResourceURL = %q, want %q", got, want)
+	}
+}

--- a/internal/x402/verifier.go
+++ b/internal/x402/verifier.go
@@ -352,6 +352,9 @@ func (v *Verifier) HandleProxy(w http.ResponseWriter, r *http.Request) {
 			"This path is not part of any published service. The operator's catalog lists every live endpoint.")
 		return
 	}
+	// Carry the matched rule so 402 resource.URL builders can map the
+	// Traefik-rewritten internal path back to the public dedicated-origin path.
+	r = r.WithContext(withRouteRule(r.Context(), rule))
 
 	// Declared free carve-out: proxy straight to the upstream, no payment
 	// middleware. buildUpstreamProxy still injects upstream auth and strips


### PR DESCRIPTION
## Summary

1. **Dedicated hostname path rewrite:** Traefik rewrites `/audit` → `/services/<name>/audit` before the verifier; 402 `resource.URL` still used the rewritten path while discovery advertised the public URL. Challenges now strip the internal prefix when the request host matches the offer hostname (same logic as SIWX).

2. **HTTPS for public hosts:** `buildResourceURL` defaulted to `http` unless `X-Forwarded-Proto: https`. Tunnel TLS termination often leaves proto as http → x402scan saw http challenges for https discovery. Align with `resolveSiteURL` (default https for non-local hosts).

## Test plan

- [x] `go test ./internal/x402/ -run TestBuildResourceURL`
- [x] Full `go test ./internal/x402/`

Part of v0.14.0-rc0 hackathon bugfix train.