### PR TITLE
fix(sell): enable offers after CLI ERC-8004 register

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -3332,11 +3332,49 @@ Examples:
 				return fmt.Errorf("registration failed on all networks")
 			}
 
+			// Offers created with --no-register stay registration.enabled=false
+			// and never flip to Registered/Active even after a successful CLI
+			// register. Enable them so the controller attaches them to the
+			// shared AgentIdentity and discovery surfaces services.
+			if n, err := enableRegistrationOnOffers(cfg, u); err != nil {
+				u.Warnf("could not enable registration on existing ServiceOffers: %v", err)
+				u.Dim("  Manually set registration.enabled=true on offers created with --no-register.")
+			} else if n > 0 {
+				u.Infof("Enabled registration on %d ServiceOffer(s) previously created with --no-register", n)
+			}
+
 			u.Blank()
 			u.Successf("Agent registered on %d/%d networks.", successes, len(networks))
 			return nil
 		},
 	}
+}
+
+// enableRegistrationOnOffers patches every ServiceOffer that still has
+// registration.enabled=false to true so post-hoc `obol sell register` activates
+// existing offers instead of leaving them Disabled while the AgentIdentity
+// is already on-chain.
+func enableRegistrationOnOffers(cfg *config.Config, u *ui.UI) (int, error) {
+	offers, err := listServiceOffers(cfg)
+	if err != nil {
+		return 0, err
+	}
+	enabled := 0
+	for _, o := range offers {
+		if o.Spec.Registration.Enabled {
+			continue
+		}
+		// Merge-patch only the enabled flag; leave name/description/skills alone.
+		patch := `{"spec":{"registration":{"enabled":true}}}`
+		if _, err := kubectlOutput(cfg, "patch", "serviceoffer.obol.org", o.Name,
+			"-n", o.Namespace, "--type", "merge", "-p", patch); err != nil {
+			u.Warnf("  %s/%s: %v", o.Namespace, o.Name, err)
+			continue
+		}
+		u.Dim(fmt.Sprintf("  %s/%s: registration.enabled → true", o.Namespace, o.Name))
+		enabled++
+	}
+	return enabled, nil
 }
 
 // registerAgentOnNetworks runs the per-network ERC-8004 registration loop used

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -1413,8 +1413,16 @@ func applySharedRegistrationStatus(status *monetizeapi.ServiceOfferStatus, offer
 		return
 	}
 
-	if requestPhaseReady(request.Status.Phase) {
+	// Prefer a completed RegistrationRequest phase. Also treat a non-empty
+	// agentId (including one filled from AgentIdentity after CLI register)
+	// as Registered=True so non-owner offers and post-hoc enables leave
+	// Pending once the on-chain id is known — even when RegistrationTxHash
+	// is still empty (CLI path does not always populate the request tx).
+	if requestPhaseReady(request.Status.Phase) || strings.TrimSpace(request.Status.AgentID) != "" {
 		message := defaultString(request.Status.Message, "Registration reconciled")
+		if request.Status.AgentID != "" {
+			message = defaultString(request.Status.Message, fmt.Sprintf("Recorded agent %s", request.Status.AgentID))
+		}
 		if owner != nil && (owner.Namespace != offer.Namespace || owner.Name != offer.Name) {
 			if request.Status.AgentID != "" {
 				message = fmt.Sprintf("Shared registration via %s/%s recorded agent %s", owner.Namespace, owner.Name, request.Status.AgentID)
@@ -1422,7 +1430,11 @@ func applySharedRegistrationStatus(status *monetizeapi.ServiceOfferStatus, offer
 				message = fmt.Sprintf("Shared registration via %s/%s is active", owner.Namespace, owner.Name)
 			}
 		}
-		setCondition(status, "Registered", "True", request.Status.Phase, message)
+		reason := defaultString(request.Status.Phase, "Active")
+		if !requestPhaseReady(request.Status.Phase) && request.Status.AgentID != "" {
+			reason = "Active"
+		}
+		setCondition(status, "Registered", "True", reason, message)
 		return
 	}
 

--- a/internal/serviceoffercontroller/controller_test.go
+++ b/internal/serviceoffercontroller/controller_test.go
@@ -142,3 +142,29 @@ func TestApplySharedRegistrationStatus_WaitsForRoute(t *testing.T) {
 		t.Fatalf("registered should remain false until route is published: %+v", status.Conditions)
 	}
 }
+
+// CLI `obol sell register` may leave RegistrationRequest phase empty while
+// AgentIdentity already has the agentId — non-owner offers must still flip
+// Registered=True so status/checkmarks agree.
+func TestApplySharedRegistrationStatus_AgentIDWithoutPhase(t *testing.T) {
+	status := &monetizeapi.ServiceOfferStatus{
+		Conditions: []monetizeapi.Condition{{Type: "RoutePublished", Status: "True"}},
+	}
+	owner := &monetizeapi.ServiceOffer{ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "demo"}}
+	offer := &monetizeapi.ServiceOffer{ObjectMeta: metav1.ObjectMeta{Name: "beta", Namespace: "other"}}
+	request := &monetizeapi.RegistrationRequest{
+		Status: monetizeapi.RegistrationRequestStatus{
+			AgentID: "8104",
+			// Phase empty / Pending — common after CLI-only registration path
+		},
+	}
+
+	applySharedRegistrationStatus(status, offer, owner, request)
+
+	if status.AgentID != "8104" {
+		t.Fatalf("AgentID = %q, want 8104", status.AgentID)
+	}
+	if !isConditionTrue(*status, "Registered") {
+		t.Fatalf("Registered should be True when agentId is known: %+v", status.Conditions)
+	}
+}


### PR DESCRIPTION
## Summary

1. After successful `obol sell register`, patch every ServiceOffer with `registration.enabled=false` → `true` so post-hoc registration activates existing `--no-register` offers.
2. Controller: when a shared RegistrationRequest carries an **agentId** (including after CLI mint), set `Registered=True` even if phase is empty — fixes non-owner offers stuck Pending and status/checkmarks disagreeing.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/ -run TestApplyShared`
- [x] `go test ./cmd/obol/ -run TestSell`

Part of v0.14.0-rc0 hackathon bugfix train.