### PR TITLE
fix(tunnel): tear down storefront route when every hostname is offer-bound

### DIFF
--- a/cmd/obol/sell.go
+++ b/cmd/obol/sell.go
@@ -1125,6 +1125,16 @@ Examples:
 			u.Infof("The agent will reconcile: health-check → payment gate → route")
 			u.Infof("Check status: obol sell status %s -n %s", name, ns)
 
+			if strings.TrimSpace(cmd.String("hostname")) != "" {
+				// The offer's spec.hostname binding just landed on the
+				// cluster; narrow (or tear down) the storefront's catch-all
+				// route for it now rather than waiting for some later,
+				// unrelated tunnel/sell invocation to notice.
+				if err := tunnel.RefreshStorefront(cfg); err != nil {
+					u.Warnf("could not refresh storefront: %v", err)
+				}
+			}
+
 			if !registerEnabled {
 				// Best-effort tunnel for --no-register: not fatal if it doesn't come up.
 				u.Blank()

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1042,6 +1042,19 @@ func EnsureTunnelForSell(cfg *config.Config, u *ui.UI) (string, error) {
 	return tunnelURL, nil
 }
 
+// RefreshStorefront re-applies the storefront's HTTPRoute against the
+// tunnel's currently tracked hostnames, narrowing or tearing it down for any
+// hostname that is now offer-bound. CreateStorefront only sees ServiceOffer
+// bindings that already exist on the cluster at call time, so a hostname
+// bound by a manifest applied AFTER the tunnel was last (re)created — e.g.
+// `obol sell ... --hostname X` — needs this explicit follow-up to be
+// reflected immediately, instead of shadowing the offer's route until some
+// later, unrelated tunnel/sell invocation happens to run CreateStorefront
+// again (Canary402).
+func RefreshStorefront(cfg *config.Config) error {
+	return CreateStorefront(cfg, storefrontHostnames(cfg, "")...)
+}
+
 // Stop scales the cloudflared deployment to 0 replicas.
 func Stop(cfg *config.Config, u *ui.UI) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
@@ -1292,9 +1305,14 @@ func CreateStorefront(cfg *config.Config, hostnames ...string) error {
 		}
 		hosts = kept
 		if len(hosts) == 0 {
-			// Every tracked hostname is offer-bound; nothing for the
-			// storefront to serve — a valid configuration.
-			return nil
+			// Every tracked hostname is offer-bound: the storefront has
+			// nothing left to serve at any hostname. Tear it down instead
+			// of leaving the previously-applied HTTPRoute (with the now-
+			// stale wider host list) on the cluster — Gateway API breaks
+			// the resulting PathPrefix-/ tie by route age, so that stale
+			// route would otherwise keep shadowing the offer's own
+			// dedicated-origin route.
+			return DeleteStorefront(cfg)
 		}
 	}
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,11 +1,14 @@
 package tunnel
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ObolNetwork/obol-stack/internal/config"
 )
 
 func TestWaitReadyTimeout(t *testing.T) {
@@ -152,6 +155,59 @@ func TestBuildLocalManagedConfigYAMLDeduplicates(t *testing.T) {
 	}
 	if !strings.Contains(out, "- hostname: a.example.com") {
 		t.Fatalf("expected normalized lowercase hostname:\n%s", out)
+	}
+}
+
+// writeFakeKubectl drops an executable kubectl stub into cfg.BinDir that logs
+// every invocation (argv) to logPath and, for a `get serviceoffers.obol.org`
+// query, prints boundHostname as the sole offer-bound hostname -- just enough
+// to drive offerBoundHostnames()/DeleteStorefront() without a real cluster.
+func writeFakeKubectl(t *testing.T, cfg *config.Config, logPath, boundHostname string) {
+	t.Helper()
+	if err := os.MkdirAll(cfg.BinDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+case "$*" in
+  *"get serviceoffers.obol.org"*) echo %q ;;
+esac
+exit 0
+`, logPath, boundHostname)
+	if err := os.WriteFile(filepath.Join(cfg.BinDir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake kubectl: %v", err)
+	}
+}
+
+// TestCreateStorefront_TearsDownWhenAllHostsOfferBound guards the Canary402
+// fix: when every hostname CreateStorefront was asked to serve turns out to
+// be offer-bound, it must tear down the previously-applied tunnel-storefront
+// HTTPRoute (via DeleteStorefront) instead of a no-op `return nil` that would
+// leave a stale, wider-hostname route on the cluster shadowing the offer's
+// own dedicated-origin route (equal PathPrefix-/ specificity, older route
+// wins the Gateway API tie).
+func TestCreateStorefront_TearsDownWhenAllHostsOfferBound(t *testing.T) {
+	cfg := newHostnameTestConfig(t)
+	writeFakeKubeconfig(t, cfg)
+
+	logPath := filepath.Join(cfg.ConfigDir, "kubectl.log")
+	writeFakeKubectl(t, cfg, logPath, "example.com")
+
+	if err := CreateStorefront(cfg, "example.com"); err != nil {
+		t.Fatalf("CreateStorefront: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read kubectl log: %v", err)
+	}
+	log := string(logBytes)
+
+	if !strings.Contains(log, "delete httproute/tunnel-storefront") {
+		t.Fatalf("CreateStorefront must tear down the stale tunnel-storefront HTTPRoute when every requested hostname is offer-bound; kubectl invocations:\n%s", log)
+	}
+	if strings.Contains(log, "apply") {
+		t.Fatalf("CreateStorefront must not re-apply the storefront HTTPRoute when every requested hostname is offer-bound; kubectl invocations:\n%s", log)
 	}
 }
 


### PR DESCRIPTION
## Canary402 field report — issue 5 (⚠️ stale tunnel storefront routes shadow published services)

A catch-all storefront HTTPRoute created before an offer bound the hostname kept shadowing the offer's route (Gateway API breaks equal `PathPrefix /` ties by route age), so requests hit the Next.js storefront and returned 404 instead of reaching the agent. The "skipping X (bound to a ServiceOffer)" message was cosmetic — nothing removed or narrowed the already-applied route.

### Fix
1. `CreateStorefront`: when every tracked hostname is offer-bound, tear the storefront down via the existing idempotent `DeleteStorefront` instead of `return nil` — the stale wider-host route no longer lingers.
2. Ordering: binding a hostname via `obol sell http --hostname X` never re-ran `CreateStorefront`, so the shadow would persist until some unrelated tunnel command ran. The sell path now calls a new thin `tunnel.RefreshStorefront(cfg)` right after applying the manifest (warn-only on error, like every existing caller).

Tests: `internal/tunnel` unit tests for the teardown branch; `go build ./... && go test ./internal/tunnel/... ./cmd/obol/...` green.

Part of the Canary402 field-report sweep (6 PRs). Commit unsigned — batch re-sign before merge if required.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk
