### PR TITLE
fix(serviceoffer): gate RoutePublished on Traefik acceptance, sweep legacy ReferenceGrant

### DIFF
--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -833,12 +833,17 @@ func (c *Controller) reconcileRoute(ctx context.Context, status *monetizeapi.Ser
 			return err
 		}
 	}
-	// Delete the legacy (pre-4726dcfe) non-namespace-qualified ReferenceGrant
-	// name every reconcile so grants orphaned by that rename don't linger and
-	// collide with a same-named offer in another namespace.
-	err := c.referenceGrants.Namespace("x402").Delete(ctx, legacyBackendReferenceGrantName(offer.Name), metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+	// Delete both superseded ReferenceGrant names every reconcile so grants
+	// orphaned by a rename don't linger and collide with another offer: the
+	// pre-4726dcfe non-namespaced name, and the 4726dcfe dash-joined name that
+	// the injective hash suffix replaced.
+	for _, staleGrant := range []string{
+		legacyBackendReferenceGrantName(offer.Name),
+		intermediateBackendReferenceGrantName(offer.Namespace, offer.Name),
+	} {
+		if err := c.referenceGrants.Namespace("x402").Delete(ctx, staleGrant, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 	if err := c.applyObject(ctx, c.httpRoutes.Namespace(offer.Namespace), buildHTTPRoute(offer)); err != nil {
 		setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
@@ -1396,6 +1401,7 @@ func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi
 	}{
 		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Namespace, offer.Name)},
 		{resource: c.referenceGrants.Namespace("x402"), name: legacyBackendReferenceGrantName(offer.Name)},
+		{resource: c.referenceGrants.Namespace("x402"), name: intermediateBackendReferenceGrantName(offer.Namespace, offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: childName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: hostChildName(offer.Name)},
 		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsInFlightMiddlewareName(offer.Name)},

--- a/internal/serviceoffercontroller/controller.go
+++ b/internal/serviceoffercontroller/controller.go
@@ -833,14 +833,39 @@ func (c *Controller) reconcileRoute(ctx context.Context, status *monetizeapi.Ser
 			return err
 		}
 	}
+	// Delete the legacy (pre-4726dcfe) non-namespace-qualified ReferenceGrant
+	// name every reconcile so grants orphaned by that rename don't linger and
+	// collide with a same-named offer in another namespace.
+	err := c.referenceGrants.Namespace("x402").Delete(ctx, legacyBackendReferenceGrantName(offer.Name), metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
 	if err := c.applyObject(ctx, c.httpRoutes.Namespace(offer.Namespace), buildHTTPRoute(offer)); err != nil {
 		setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
 		return err
+	}
+	route, err := c.httpRoutes.Namespace(offer.Namespace).Get(ctx, childName(offer.Name), metav1.GetOptions{})
+	if err != nil {
+		setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
+		return err
+	}
+	if !httpRouteAccepted(route) {
+		setCondition(status, "RoutePublished", "False", "WaitingForTraefikAcceptance", "HTTPRoute applied but not yet accepted by Traefik")
+		return nil
 	}
 	if offer.Spec.Hostname != "" {
 		if err := c.applyObject(ctx, c.httpRoutes.Namespace(offer.Namespace), buildHostHTTPRoute(offer)); err != nil {
 			setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
 			return err
+		}
+		hostRoute, err := c.httpRoutes.Namespace(offer.Namespace).Get(ctx, hostChildName(offer.Name), metav1.GetOptions{})
+		if err != nil {
+			setCondition(status, "RoutePublished", "False", "ApplyFailed", err.Error())
+			return err
+		}
+		if !httpRouteAccepted(hostRoute) {
+			setCondition(status, "RoutePublished", "False", "WaitingForTraefikAcceptance", "Host HTTPRoute applied but not yet accepted by Traefik")
+			return nil
 		}
 	} else {
 		// Hostname removed from the spec: tear the host route down so the
@@ -1370,6 +1395,7 @@ func (c *Controller) deleteRouteChildren(ctx context.Context, offer *monetizeapi
 		name     string
 	}{
 		{resource: c.referenceGrants.Namespace("x402"), name: backendReferenceGrantName(offer.Namespace, offer.Name)},
+		{resource: c.referenceGrants.Namespace("x402"), name: legacyBackendReferenceGrantName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: childName(offer.Name)},
 		{resource: c.httpRoutes.Namespace(offer.Namespace), name: hostChildName(offer.Name)},
 		{resource: c.middlewares.Namespace(offer.Namespace), name: limitsInFlightMiddlewareName(offer.Name)},

--- a/internal/serviceoffercontroller/name_injectivity_test.go
+++ b/internal/serviceoffercontroller/name_injectivity_test.go
@@ -1,0 +1,88 @@
+package serviceoffercontroller
+
+import "testing"
+
+// Invariant oracle: every child resource created in a namespace SHARED across
+// offers must have a name that is injective over the full identity of the
+// offer that owns it. A collision means two live offers fight over one object
+// — the exact HTTP-500 failure mode of the original Canary402 ReferenceGrant
+// report (offers Ready, requests 500).
+//
+// The ReferenceGrant is the only child the controller creates in the shared
+// "x402" namespace (every other child — Middleware, HTTPRoute,
+// RegistrationRequest — lives in the offer's own namespace, where the offer
+// name is already unique). So its name must be injective over the pair
+// (offer.Namespace, offer.Name).
+//
+// This is a property test, not an example test: it enumerates a space of
+// identity pairs and asserts no two distinct pairs map to the same name. It is
+// written to be reused for any future shared-namespace child by adding its
+// builder to sharedNamespaceNameBuilders.
+
+// sharedNamespaceNameBuilders lists every name builder for a child resource
+// that lives in a namespace shared across offers, keyed by (namespace, name).
+var sharedNamespaceNameBuilders = map[string]func(namespace, name string) string{
+	"backendReferenceGrant": backendReferenceGrantName,
+}
+
+// labelFragments are pieces that appear in real Kubernetes namespaces and
+// object names. Both namespaces and object names are DNS subdomains that may
+// contain internal dashes, so any pair-join that leans on a dash separator is
+// where injectivity breaks. These fragments are deliberately chosen so several
+// distinct (namespace, name) pairs share the same dash-joined string.
+var labelFragments = []string{"foo", "bar", "baz", "foo-bar", "bar-baz", "a", "a-b", "b", "team-a", "team", "a-team"}
+
+func TestSharedNamespaceNames_Injective(t *testing.T) {
+	for builderName, build := range sharedNamespaceNameBuilders {
+		t.Run(builderName, func(t *testing.T) {
+			seen := map[string][2]string{} // generated name -> (namespace, name) that first produced it
+			for _, ns := range labelFragments {
+				for _, name := range labelFragments {
+					got := build(ns, name)
+					if prev, clash := seen[got]; clash && prev != [2]string{ns, name} {
+						t.Errorf("collision: (ns=%q, name=%q) and (ns=%q, name=%q) both map to %q",
+							prev[0], prev[1], ns, name, got)
+					}
+					seen[got] = [2]string{ns, name}
+				}
+			}
+		})
+	}
+}
+
+// TestBackendReferenceGrantName_KnownCollision pins the exact adversarial pair
+// from the injectivity property so a regression is unambiguous, not just a
+// probabilistic property failure.
+func TestBackendReferenceGrantName_KnownCollision(t *testing.T) {
+	a := backendReferenceGrantName("foo-bar", "baz")
+	b := backendReferenceGrantName("foo", "bar-baz")
+	if a == b {
+		t.Fatalf("(ns=foo-bar, name=baz) and (ns=foo, name=bar-baz) collide on grant name %q — "+
+			"two live offers in different namespaces share one ReferenceGrant in x402 (HTTP 500)", a)
+	}
+}
+
+// TestBackendReferenceGrantName_StableForSameOffer guards the other direction:
+// the disambiguation must be deterministic, so the same offer always resolves
+// to the same grant (server-side apply is by name — a nondeterministic name
+// would orphan the previous grant on every reconcile).
+func TestBackendReferenceGrantName_StableForSameOffer(t *testing.T) {
+	for i := 0; i < 4; i++ {
+		if got := backendReferenceGrantName("prod", "hyperliquid-analyst"); got != backendReferenceGrantName("prod", "hyperliquid-analyst") {
+			t.Fatalf("grant name not stable across calls: %q", got)
+		}
+	}
+	// And distinct offers that happen to dash-collide on the readable prefix
+	// still resolve to distinct, stable names.
+	seen := map[string]bool{}
+	for _, p := range [][2]string{{"foo-bar", "baz"}, {"foo", "bar-baz"}, {"foo-bar-baz", ""}} {
+		if p[1] == "" {
+			continue // empty name is not a real offer; skip
+		}
+		n := backendReferenceGrantName(p[0], p[1])
+		if seen[n] {
+			t.Fatalf("stable-but-colliding name %q for %v", n, p)
+		}
+		seen[n] = true
+	}
+}

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -1054,9 +1054,16 @@ func childName(name string) string {
 }
 
 func backendReferenceGrantName(namespace, name string) string {
-	// Prefix with namespace so cluster-scoped-looking names in x402 stay unique
-	// per (namespace, offer). safeName still truncates+hashes long names.
-	return safeName("so-", namespace+"-"+name, "-backend-grant")
+	// All grants share the x402 namespace, so this name must be injective over
+	// (namespace, name). namespace and name are DNS subdomains that may both
+	// contain internal dashes, so NO literal separator between them is
+	// injective — (ns "foo-bar", name "baz") and (ns "foo", name "bar-baz")
+	// would both dash-join to "foo-bar-baz" and fight over one ReferenceGrant
+	// (the HTTP-500 collision the namespace-qualification was meant to end).
+	// Disambiguate with a hash of the exact tuple: "/" is illegal in a DNS
+	// label, so namespace+"/"+name is a collision-free encoding of the pair.
+	tuple := md5.Sum([]byte(namespace + "/" + name))
+	return safeName("so-", namespace+"-"+name, "-"+fmt.Sprintf("%x", tuple)[:8]+"-backend-grant")
 }
 
 // legacyBackendReferenceGrantName is the pre-4726dcfe non-namespaced grant
@@ -1064,6 +1071,14 @@ func backendReferenceGrantName(namespace, name string) string {
 // (grants created before the rename are never touched by the new name).
 func legacyBackendReferenceGrantName(offerName string) string {
 	return safeName("so-", offerName, "-backend-grant")
+}
+
+// intermediateBackendReferenceGrantName is the dash-joined 4726dcfe grant name
+// (never released, but live on integration deployments) that the hash suffix
+// superseded. Swept alongside the pre-4726dcfe name so an upgrade tears down
+// both stale forms.
+func intermediateBackendReferenceGrantName(namespace, name string) string {
+	return safeName("so-", namespace+"-"+name, "-backend-grant")
 }
 
 func registrationRequestName(name string) string {

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -1059,6 +1059,13 @@ func backendReferenceGrantName(namespace, name string) string {
 	return safeName("so-", namespace+"-"+name, "-backend-grant")
 }
 
+// legacyBackendReferenceGrantName is the pre-4726dcfe non-namespaced grant
+// name; still deleted on reconcile so upgrades tear down the orphaned object
+// (grants created before the rename are never touched by the new name).
+func legacyBackendReferenceGrantName(offerName string) string {
+	return safeName("so-", offerName, "-backend-grant")
+}
+
 func registrationRequestName(name string) string {
 	return safeName("so-", name, "-registration")
 }

--- a/internal/serviceoffercontroller/route_accept_test.go
+++ b/internal/serviceoffercontroller/route_accept_test.go
@@ -1,0 +1,211 @@
+package serviceoffercontroller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// fake.FakeDynamicClient's ObjectTracker doesn't implement server-side-apply
+// merge semantics for pure unstructured objects, so applyObject's
+// types.ApplyPatchType Patch fails against it. Reactor turns an apply patch
+// into create-or-update, leaving any existing .status untouched — matching
+// real SSA, which never touches a subresource it doesn't target. Goes
+// straight to the Tracker (not back through the client) — routing through
+// dynClient itself would re-enter the Fake's non-reentrant action lock and
+// deadlock.
+func withApplyPatchSupport(dynClient *fake.FakeDynamicClient) *fake.FakeDynamicClient {
+	tracker := dynClient.Tracker()
+	dynClient.PrependReactor("patch", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(ktesting.PatchAction)
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		var patched map[string]any
+		if err := json.Unmarshal(patchAction.GetPatch(), &patched); err != nil {
+			return true, nil, err
+		}
+		gvr := patchAction.GetResource()
+		ns := patchAction.GetNamespace()
+
+		existing, err := tracker.Get(gvr, ns, patchAction.GetName())
+		if apierrors.IsNotFound(err) {
+			obj := &unstructured.Unstructured{Object: patched}
+			if err := tracker.Create(gvr, obj, ns); err != nil {
+				return true, nil, err
+			}
+			return true, obj, nil
+		}
+		if err != nil {
+			return true, nil, err
+		}
+		merged := existing.(*unstructured.Unstructured).DeepCopy()
+		for k, v := range patched {
+			merged.Object[k] = v
+		}
+		if err := tracker.Update(gvr, merged, ns); err != nil {
+			return true, nil, err
+		}
+		return true, merged, nil
+	})
+	return dynClient
+}
+
+func controllerForRouteTest(dynClient *fake.FakeDynamicClient) *Controller {
+	dynClient = withApplyPatchSupport(dynClient)
+	return &Controller{
+		dynClient:       dynClient,
+		client:          dynClient,
+		middlewares:     dynClient.Resource(monetizeapi.MiddlewareGVR),
+		httpRoutes:      dynClient.Resource(monetizeapi.HTTPRouteGVR),
+		referenceGrants: dynClient.Resource(monetizeapi.ReferenceGrantGVR),
+	}
+}
+
+func routeListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		monetizeapi.MiddlewareGVR:     "MiddlewareList",
+		monetizeapi.HTTPRouteGVR:      "HTTPRouteList",
+		monetizeapi.ReferenceGrantGVR: "ReferenceGrantList",
+	}
+}
+
+// acceptedHTTPRoute seeds an HTTPRoute that Traefik has already reported as
+// programmed (status.parents Accepted=True, ResolvedRefs=True).
+func acceptedHTTPRoute(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"status": map[string]any{
+			"parents": []any{
+				map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Accepted", "status": "True"},
+						map[string]any{"type": "ResolvedRefs", "status": "True"},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func conditionReason(status *monetizeapi.ServiceOfferStatus, conditionType string) string {
+	for _, c := range status.Conditions {
+		if c.Type == conditionType {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+// --- RoutePublished gating on Traefik acceptance ----------------------------
+
+func TestReconcileRoute_WaitsForTraefikAcceptance(t *testing.T) {
+	offer := readyOffer("svc")
+	offer.Namespace = "pending"
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), routeListKinds())
+	c := controllerForRouteTest(dynClient)
+	status := &monetizeapi.ServiceOfferStatus{}
+
+	// applyObject creates the HTTPRoute with no status yet — Traefik hasn't
+	// reconciled it, so RoutePublished must stay False, not flip True on
+	// apply success alone.
+	if err := c.reconcileRoute(context.Background(), status, offer); err != nil {
+		t.Fatalf("reconcileRoute: %v", err)
+	}
+	if isConditionTrue(*status, "RoutePublished") {
+		t.Fatalf("RoutePublished should stay False until Traefik accepts the route: %+v", status.Conditions)
+	}
+	if reason := conditionReason(status, "RoutePublished"); reason != "WaitingForTraefikAcceptance" {
+		t.Fatalf("RoutePublished reason = %q, want WaitingForTraefikAcceptance", reason)
+	}
+}
+
+func TestReconcileRoute_PublishesWhenAccepted(t *testing.T) {
+	offer := readyOffer("svc")
+	offer.Namespace = "accepted"
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		routeListKinds(),
+		acceptedHTTPRoute(offer.Namespace, childName(offer.Name)),
+	)
+	c := controllerForRouteTest(dynClient)
+	status := &monetizeapi.ServiceOfferStatus{}
+
+	if err := c.reconcileRoute(context.Background(), status, offer); err != nil {
+		t.Fatalf("reconcileRoute: %v", err)
+	}
+	if !isConditionTrue(*status, "RoutePublished") {
+		t.Fatalf("RoutePublished should be True once Traefik has accepted the route: %+v", status.Conditions)
+	}
+}
+
+func TestReconcileRoute_WaitsForHostRouteAcceptance(t *testing.T) {
+	offer := readyOffer("svc")
+	offer.Namespace = "hostpending"
+	offer.Spec.Hostname = "svc.example.test"
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		routeListKinds(),
+		// Main route is accepted, but the dedicated host route is not.
+		acceptedHTTPRoute(offer.Namespace, childName(offer.Name)),
+	)
+	c := controllerForRouteTest(dynClient)
+	status := &monetizeapi.ServiceOfferStatus{}
+
+	if err := c.reconcileRoute(context.Background(), status, offer); err != nil {
+		t.Fatalf("reconcileRoute: %v", err)
+	}
+	if isConditionTrue(*status, "RoutePublished") {
+		t.Fatalf("RoutePublished should stay False until the host HTTPRoute is accepted too: %+v", status.Conditions)
+	}
+	if reason := conditionReason(status, "RoutePublished"); reason != "WaitingForTraefikAcceptance" {
+		t.Fatalf("RoutePublished reason = %q, want WaitingForTraefikAcceptance", reason)
+	}
+}
+
+// --- legacy ReferenceGrant sweep --------------------------------------------
+
+func TestReconcileRoute_DeletesLegacyReferenceGrant(t *testing.T) {
+	offer := readyOffer("svc")
+	offer.Namespace = "legacygrant"
+	legacyGrant := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1beta1",
+		"kind":       "ReferenceGrant",
+		"metadata": map[string]any{
+			"name":      legacyBackendReferenceGrantName(offer.Name),
+			"namespace": "x402",
+		},
+	}}
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		routeListKinds(),
+		legacyGrant,
+		acceptedHTTPRoute(offer.Namespace, childName(offer.Name)),
+	)
+	c := controllerForRouteTest(dynClient)
+	status := &monetizeapi.ServiceOfferStatus{}
+
+	if err := c.reconcileRoute(context.Background(), status, offer); err != nil {
+		t.Fatalf("reconcileRoute: %v", err)
+	}
+
+	_, err := c.referenceGrants.Namespace("x402").Get(context.Background(), legacyBackendReferenceGrantName(offer.Name), metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("legacy ReferenceGrant should be deleted on reconcile, got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Canary402 field report — issues 3b/6b (⚠️ offers stay Ready while Traefik rejects their routers) + residual gap in 4726dcfe

**A) Traefik acceptance → status:** `reconcileRoute` set `RoutePublished=True` purely on apply success — a route Traefik rejected (e.g. invalid Middleware ref) still showed Ready, and only Traefik logs revealed the failure (the reporter's exact experience with the combined rate-limit middleware). The controller now Gets each applied HTTPRoute back and gates `RoutePublished` on the existing `httpRouteAccepted()` (Accepted + ResolvedRefs), mirroring `identityRegistrationResourcesReady`'s proven pattern, for both the main and hostname routes. Not-yet-accepted → `RoutePublished=False/WaitingForTraefikAcceptance`, re-checked by the existing 5s requeue. No RBAC change needed.

**B) Legacy ReferenceGrant sweep:** 4726dcfe namespace-qualified ReferenceGrant names but left old-named grants orphaned forever — live colliding deployments would never self-heal. This mirrors the `legacyLimitsMiddlewareName` pattern exactly: the legacy name is deleted in both the per-reconcile teardown loop and `deleteRouteChildren`.

Tests: RoutePublished gating on unaccepted route status (with an apply-patch reactor for the fake dynamic client, test-only scaffolding), legacy grant deletion during reconcile. `go test ./internal/serviceoffercontroller/...` green.

Part of the Canary402 field-report sweep (6 PRs). Commit unsigned — batch re-sign before merge if required.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk

---

### Follow-up commit: injective ReferenceGrant name (proactive-hunt finding)

A property-based **name-injectivity oracle** (`name_injectivity_test.go`, added here) found that 4726dcfe's namespace-qualified grant name — `safeName("so-", namespace+"-"+name, "-backend-grant")` — is still **not injective**. Namespace and name are both DNS subdomains that may contain internal dashes, so `(ns=foo-bar, name=baz)` and `(ns=foo, name=bar-baz)` both collapse to `so-foo-bar-baz-backend-grant`. Since every grant shares the `x402` namespace, that's the *same HTTP-500 collision the original field report described*, merely narrowed instead of closed (the oracle found 4 colliding pairs in an 11-element fragment set).

Fixed by disambiguating with a hash of the exact `(namespace, name)` tuple (encoded with the DNS-illegal `/` so the hash input is collision-free); the superseded dash-joined name is swept alongside the pre-4726dcfe name so upgrades tear down both stale forms. The oracle is written to generalize — any future shared-namespace child resource is covered by adding its builder to `sharedNamespaceNameBuilders`.
