### PR TITLE
fix(sell): stop defaulting agent offer description to the internal objective

### DIFF
--- a/cmd/obol/sell_agent.go
+++ b/cmd/obol/sell_agent.go
@@ -82,7 +82,7 @@ Examples:
 			&cli.StringFlag{
 				Name:    "description",
 				Aliases: []string{"register-description"},
-				Usage:   "Human-readable description of the service. Surfaced on the 402 payment page, in the storefront catalog, and (when registration is enabled) on the ERC-8004 registration document. Defaults to the agent's objective.",
+				Usage:   "Human-readable description of the service. Surfaced on the 402 payment page, in the storefront catalog, and (when registration is enabled) on the ERC-8004 registration document. Defaults to a generic service description.",
 			},
 		}, acceptFlags()...),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -228,9 +228,9 @@ Examples:
 			if regName == "" {
 				regName = name
 			}
-			regDesc := strings.TrimSpace(cmd.String("description"))
-			if regDesc == "" {
-				regDesc = agent.Objective
+			regDesc := resolveAgentOfferDescription(cmd.String("description"), agent.Objective)
+			if regDesc == "" && register {
+				u.Warnf("No --description set; the storefront listing will use a generic description. Pass --description to customize it.")
 			}
 
 			// Build the ServiceOffer manifest. type=agent + agent.ref tells
@@ -694,6 +694,18 @@ func agentOfferRegistrationMetadata(agent *agentRefForSale, price, symbol, chain
 		metadata["model"] = strings.TrimSpace(agent.Model)
 	}
 	return metadata
+}
+
+// resolveAgentOfferDescription returns the value to write to
+// spec.registration.description given the --description flag and the
+// agent's Objective. It deliberately ignores objective: that field is
+// operator-authored system-prompt text (tool addresses, wallet details,
+// operational instructions) and must never default onto the public
+// storefront listing. An operator who wants a description must pass
+// --description explicitly; otherwise the controller's own generic
+// fallback applies.
+func resolveAgentOfferDescription(flagValue, objective string) string {
+	return strings.TrimSpace(flagValue)
 }
 
 // agentOfferBundle wraps an agent-typed ServiceOffer manifest together

--- a/cmd/obol/sell_agent_test.go
+++ b/cmd/obol/sell_agent_test.go
@@ -179,6 +179,27 @@ func TestAgentOfferRegistrationMetadata_DefaultsRuntimeHermes(t *testing.T) {
 	}
 }
 
+func TestResolveAgentOfferDescription_NoDescriptionFlagStaysEmpty(t *testing.T) {
+	// Regression: sell_agent.go used to default an omitted --description to
+	// agent.Objective — leaking operator-authored system-prompt text (tool
+	// addresses, wallet details, operational instructions) into the public
+	// storefront/registration description. resolveAgentOfferDescription must
+	// never manufacture a non-empty description; it stays empty and the
+	// controller's own generic fallback applies.
+	objective := "You are a focused sub-agent. Trade using wallet 0xDEADBEEF via tool http://internal.example/mcp"
+	got := resolveAgentOfferDescription("", objective)
+	if got != "" {
+		t.Fatalf("resolveAgentOfferDescription(\"\", objective) = %q, want empty (must not fall back to the objective)", got)
+	}
+}
+
+func TestResolveAgentOfferDescription_PassesThroughExplicitFlag(t *testing.T) {
+	got := resolveAgentOfferDescription("  Quant trading agent  ", "unrelated objective text")
+	if got != "Quant trading agent" {
+		t.Errorf("resolveAgentOfferDescription = %q, want trimmed explicit value", got)
+	}
+}
+
 func TestSellAgentCommand_FlagShape(t *testing.T) {
 	cfg := newTestConfig(t)
 	cmd := sellCommand(cfg)
@@ -186,6 +207,12 @@ func TestSellAgentCommand_FlagShape(t *testing.T) {
 	flags := flagMap(agent)
 
 	requireFlags(t, flags, "pay-to", "wallet", "chain", "token", "price", "per-request", "path", "max-timeout", "no-register")
+
+	// The --description Usage text used to advertise the leaky
+	// objective-fallback default; it must not document that anymore.
+	if desc, ok := flags["description"].(*cli.StringFlag); ok && strings.Contains(desc.Usage, "objective") {
+		t.Errorf("description usage still documents the objective fallback: %q", desc.Usage)
+	}
 
 	if chain, ok := flags["chain"].(*cli.StringFlag); ok && chain.Value != "base" {
 		t.Errorf("chain default = %q, want base", chain.Value)


### PR DESCRIPTION
## Canary402 field report — issue 9 (⚠️ agent objectives leak into public descriptions)

`obol sell agent` defaulted `spec.registration.description` — published to the storefront catalog, skill.md and registration documents, **regardless of `--no-register`** — to the entire internal Agent objective, potentially exposing tool addresses and operational instructions.

### Fix
The objective fallback is removed: an omitted `--description` now falls through to the controller's existing safe generic defaults (same behavior as `sell http`/`sell mcp`). The flag's usage text no longer documents the leaky default, and the CLI warns when registering without an explicit description. Description resolution is extracted into a small pure function so the non-propagation is directly unit-tested.

`go build ./... && go test ./cmd/obol/...` green.

Part of the Canary402 field-report sweep (6 PRs). Commit unsigned — batch re-sign before merge if required.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk
