### PR TITLE
fix(x402scan): detect testnet-only origins and surface per-endpoint 422 detail

### DIFF
--- a/cmd/obol/sell_register_x402scan.go
+++ b/cmd/obol/sell_register_x402scan.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/hermes"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
+	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	"github.com/ObolNetwork/obol-stack/internal/x402scan"
 	"github.com/urfave/cli/v3"
 )
@@ -72,8 +74,10 @@ Examples:
 			// Non-fatal preflight: x402scan discovers services from the
 			// origin's /openapi.json, so a missing/empty doc means the
 			// registration will come back "no discovery" or "no valid
-			// resources". Warn early with the local fix.
-			preflightOpenAPI(ctx, u, origin)
+			// resources". Warn early with the local fix. allTestnet feeds
+			// the ErrNoValidResources message below with the accurate cause
+			// when every advertised offer prices on a testnet.
+			allTestnet := preflightOpenAPI(ctx, u, origin)
 
 			// Same signer posture as ERC-8004 registration: all signing via
 			// the agent's remote-signer, no key material in the CLI.
@@ -114,8 +118,13 @@ Examples:
 					u.Dim(fmt.Sprintf("  Check that %s/openapi.json is publicly reachable and the tunnel is up (obol tunnel status).", origin))
 				case errors.Is(err, x402scan.ErrNoValidResources):
 					u.Error(err.Error())
-					u.Dim("  A discovery document was found, but no endpoint answered with a live x402 402 challenge.")
-					u.Dim("  Check offers are Ready (obol sell status) and publicly reachable through the tunnel.")
+					if allTestnet {
+						u.Dim("  This origin's offers price on a testnet — x402scan indexes mainnet resources only.")
+						u.Dim("  Switch the payment network to base (mainnet) and re-register.")
+					} else {
+						u.Dim("  A discovery document was found, but no endpoint answered with a live x402 402 challenge.")
+						u.Dim("  Check offers are Ready (obol sell status) and publicly reachable through the tunnel.")
+					}
 				}
 				return err
 			}
@@ -181,33 +190,36 @@ func resolveX402scanOrigin(cfg *config.Config, explicit string) (string, error) 
 
 // preflightOpenAPI warns (never fails) when the origin's /openapi.json is
 // unreachable or advertises no operations — the two states that make the
-// remote registration a guaranteed no-op.
-func preflightOpenAPI(ctx context.Context, u *ui.UI, origin string) {
+// remote registration a guaranteed no-op. It returns true when every paid
+// operation it found prices exclusively on testnet networks — x402scan
+// indexes mainnet resources only, so that's a third guaranteed no-op the
+// caller can use to explain an ErrNoValidResources accurately.
+func preflightOpenAPI(ctx context.Context, u *ui.UI, origin string) bool {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/openapi.json", nil)
 	if err != nil {
-		return
+		return false
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		u.Warnf("could not fetch %s/openapi.json (%v) — x402scan discovers services from it; check the tunnel is up", origin, err)
-		return
+		return false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		u.Warnf("%s/openapi.json returned HTTP %d — x402scan discovers services from it; check the tunnel is up", origin, resp.StatusCode)
-		return
+		return false
 	}
 	var doc struct {
 		Paths map[string]json.RawMessage `json:"paths"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-		return
+		return false
 	}
 	if len(doc.Paths) == 0 {
 		u.Warn("the published /openapi.json advertises no operations — put at least one offer on sale (obol sell inference|http|agent) before registering")
-		return
+		return false
 	}
 	// x402scan indexes per ORIGIN — it crawls this one /openapi.json and
 	// lists everything it finds under the origin we submit. On the shared
@@ -224,6 +236,60 @@ func preflightOpenAPI(ctx context.Context, u *ui.UI, origin string) {
 	if len(offers) > 1 {
 		u.Warnf("this origin advertises %d offers in one /openapi.json — x402scan indexes per origin, so all of them will be listed together under %s rather than as distinct products. For clean discovery, give each offer its own subdomain (obol tunnel hostname add <host>) and register that origin.", len(offers), origin)
 	}
+
+	networks := paidNetworksFromOpenAPI(doc.Paths)
+	if len(networks) == 0 {
+		return false
+	}
+	allTestnet := true
+	for net := range networks {
+		if !x402verifier.IsTestnetCAIP2(net) {
+			allTestnet = false
+			break
+		}
+	}
+	if allTestnet {
+		list := make([]string, 0, len(networks))
+		for net := range networks {
+			list = append(list, net)
+		}
+		sort.Strings(list)
+		u.Warnf("this origin's offers price on %s (testnet) — x402scan indexes mainnet resources only; switch payment network to base (mainnet) and re-register", strings.Join(list, ", "))
+	}
+	return allTestnet
+}
+
+// paidNetworksFromOpenAPI collects the distinct CAIP-2 network ids
+// advertised across every paid operation's `x-payment-info.accepts[]`
+// (published by internal/serviceoffercontroller/openapi.go's
+// paymentInfoAccept). Operations without x-payment-info (free/auth-gated
+// routes) contribute nothing.
+func paidNetworksFromOpenAPI(paths map[string]json.RawMessage) map[string]struct{} {
+	networks := map[string]struct{}{}
+	for _, pathRaw := range paths {
+		var methods map[string]json.RawMessage
+		if err := json.Unmarshal(pathRaw, &methods); err != nil {
+			continue
+		}
+		for _, opRaw := range methods {
+			var op struct {
+				PaymentInfo *struct {
+					Accepts []struct {
+						Network string `json:"network"`
+					} `json:"accepts"`
+				} `json:"x-payment-info"`
+			}
+			if err := json.Unmarshal(opRaw, &op); err != nil || op.PaymentInfo == nil {
+				continue
+			}
+			for _, accept := range op.PaymentInfo.Accepts {
+				if accept.Network != "" {
+					networks[accept.Network] = struct{}{}
+				}
+			}
+		}
+	}
+	return networks
 }
 
 // servicesOfferName extracts the offer name from a shared-origin OpenAPI path

--- a/cmd/obol/sell_register_x402scan_preflight_test.go
+++ b/cmd/obol/sell_register_x402scan_preflight_test.go
@@ -51,6 +51,55 @@ func TestPreflightOpenAPI_MultiOfferSharedOrigin(t *testing.T) {
 	}
 }
 
+func TestPreflightOpenAPI_AllTestnet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"paths":{
+			"/services/foo/v1/chat/completions": {
+				"post": {"x-payment-info": {"accepts": [{"network": "eip155:84532"}]}}
+			}
+		}}`))
+	}))
+	defer srv.Close()
+
+	var stderr bytes.Buffer
+	u := ui.NewForTest(&bytes.Buffer{}, &stderr)
+	allTestnet := preflightOpenAPI(context.Background(), u, srv.URL)
+
+	if !allTestnet {
+		t.Fatal("expected allTestnet=true for an origin whose only accepted network is base-sepolia")
+	}
+	if got := stderr.String(); !strings.Contains(got, "eip155:84532 (testnet)") {
+		t.Fatalf("expected testnet warning, got: %q", got)
+	}
+}
+
+func TestPreflightOpenAPI_MixedMainnetAndTestnetIsNotAllTestnet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"paths":{
+			"/services/foo/v1/chat/completions": {
+				"post": {"x-payment-info": {"accepts": [
+					{"network": "eip155:84532"},
+					{"network": "eip155:8453"}
+				]}}
+			}
+		}}`))
+	}))
+	defer srv.Close()
+
+	var stderr bytes.Buffer
+	u := ui.NewForTest(&bytes.Buffer{}, &stderr)
+	allTestnet := preflightOpenAPI(context.Background(), u, srv.URL)
+
+	if allTestnet {
+		t.Fatal("expected allTestnet=false when a mainnet network is also accepted")
+	}
+	if got := stderr.String(); strings.Contains(got, "testnet") {
+		t.Fatalf("did not expect a testnet warning when base mainnet is accepted, got: %q", got)
+	}
+}
+
 func TestPreflightOpenAPI_UnreachableOrNon200(t *testing.T) {
 	// Non-200: server up but returns an error status.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/x402/chains.go
+++ b/internal/x402/chains.go
@@ -33,6 +33,12 @@ type ChainInfo struct {
 
 	// EIP3009Version is the EIP-712 domain version.
 	EIP3009Version string
+
+	// Testnet marks a chain as a test network rather than a production
+	// mainnet. Consumers that only care about "real money" chains (e.g. the
+	// x402scan registry preflight, which indexes mainnet resources only)
+	// key off this instead of pattern-matching chain names.
+	Testnet bool
 }
 
 // AssetInfo describes the token and EIP-712 metadata used for x402 settlement.
@@ -71,6 +77,7 @@ var (
 		CAIP2Network: "eip155:84532",
 		USDCAddress:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
 		Decimals:     6,
+		Testnet:      true,
 		// Base-Sepolia USDC is FiatTokenV2_2 whose EIP-712 domain name is
 		// "USDC", NOT the mainnet "USD Coin". Advertising "USD Coin" makes a
 		// real facilitator reject otherwise-valid signatures — the recurring
@@ -107,6 +114,7 @@ var (
 		Decimals:       6,
 		EIP3009Name:    "USD Coin",
 		EIP3009Version: "2",
+		Testnet:        true,
 	}
 
 	ChainAvalancheMainnet = ChainInfo{
@@ -127,6 +135,7 @@ var (
 		Decimals:       6,
 		EIP3009Name:    "USD Coin",
 		EIP3009Version: "2",
+		Testnet:        true,
 	}
 
 	ChainArbitrumOne = ChainInfo{
@@ -147,8 +156,32 @@ var (
 		Decimals:       6,
 		EIP3009Name:    "USD Coin",
 		EIP3009Version: "2",
+		Testnet:        true,
+	}
+
+	// allChains lists every chain the registry knows about, used to answer
+	// "is this CAIP-2 id a testnet" without a second hardcoded id list.
+	allChains = []ChainInfo{
+		ChainBaseMainnet, ChainBaseSepolia,
+		ChainEthereumMainnet,
+		ChainPolygonMainnet, ChainPolygonAmoy,
+		ChainAvalancheMainnet, ChainAvalancheFuji,
+		ChainArbitrumOne, ChainArbitrumSepolia,
 	}
 )
+
+// IsTestnetCAIP2 reports whether caip2 (e.g. "eip155:84532") identifies a
+// known testnet chain. Unknown ids return false — callers that need to
+// distinguish "known mainnet" from "unrecognized" should check membership
+// separately.
+func IsTestnetCAIP2(caip2 string) bool {
+	for _, c := range allChains {
+		if c.CAIP2Network == caip2 {
+			return c.Testnet
+		}
+	}
+	return false
+}
 
 // NormalizeNetworkID maps a human-friendly chain name to its CAIP-2 network
 // identifier. Already-normalized CAIP-2 values are returned as-is.

--- a/internal/x402/chains_test.go
+++ b/internal/x402/chains_test.go
@@ -41,6 +41,32 @@ func TestResolveChainInfo(t *testing.T) {
 	}
 }
 
+func TestIsTestnetCAIP2(t *testing.T) {
+	tests := []struct {
+		caip2 string
+		want  bool
+	}{
+		{ChainBaseSepolia.CAIP2Network, true},
+		{ChainPolygonAmoy.CAIP2Network, true},
+		{ChainAvalancheFuji.CAIP2Network, true},
+		{ChainArbitrumSepolia.CAIP2Network, true},
+		{ChainBaseMainnet.CAIP2Network, false},
+		{ChainEthereumMainnet.CAIP2Network, false},
+		{ChainPolygonMainnet.CAIP2Network, false},
+		{ChainAvalancheMainnet.CAIP2Network, false},
+		{ChainArbitrumOne.CAIP2Network, false},
+		{"eip155:999999", false}, // unknown chain — not a known testnet
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.caip2, func(t *testing.T) {
+			if got := IsTestnetCAIP2(tt.caip2); got != tt.want {
+				t.Errorf("IsTestnetCAIP2(%q) = %v, want %v", tt.caip2, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestChainUSDCAddresses(t *testing.T) {
 	// Verify USDC addresses are non-empty and start with 0x.
 	chains := []ChainInfo{

--- a/internal/x402scan/client.go
+++ b/internal/x402scan/client.go
@@ -91,12 +91,17 @@ type SIWXResource struct {
 }
 
 // registryError is the {"success":false,"error":{...}} failure envelope.
+// FailedDetails mirrors RegisterResult.FailedList: the registry may carry
+// the same per-endpoint probe diagnostics on a 422 rejection as it does on
+// a 200-with-partial-failures response, so a genuinely-no-402 origin can be
+// told apart from a per-endpoint reason (wrong network, timeout, ...).
 type registryError struct {
 	Success bool `json:"success"`
 	Error   struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
 	} `json:"error"`
+	FailedDetails []FailedResource `json:"failedDetails,omitempty"`
 }
 
 // challengeBody is the subset of the 402 response we need: the SIWX
@@ -229,7 +234,18 @@ func parseRegisterResponse(status int, body []byte) (*RegisterResult, error) {
 func registryErrorMessage(body []byte) string {
 	var e registryError
 	if err := json.Unmarshal(body, &e); err == nil && e.Error.Message != "" {
-		return e.Error.Message
+		if len(e.FailedDetails) == 0 {
+			return e.Error.Message
+		}
+		var b strings.Builder
+		b.WriteString(e.Error.Message)
+		for _, f := range e.FailedDetails {
+			fmt.Fprintf(&b, "\n  - %s — %s", f.URL, f.Error)
+			if f.Status != 0 {
+				fmt.Fprintf(&b, " (status %d)", f.Status)
+			}
+		}
+		return b.String()
 	}
 	return strings.TrimSpace(fmt.Sprintf("%.300s", body))
 }

--- a/internal/x402scan/client_test.go
+++ b/internal/x402scan/client_test.go
@@ -187,6 +187,26 @@ func TestRegisterOrigin_NoValidResources(t *testing.T) {
 	}
 }
 
+func TestRegisterOrigin_NoValidResources_FailedDetails(t *testing.T) {
+	// Mirrors the 200-partial-failure golden fixture's failedDetails shape,
+	// but on the 422 rejection path — the asymmetry that dropped per-endpoint
+	// diagnostics before registryError grew a FailedDetails field.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"type":"no_valid_resources","message":"0 of 2 endpoints answered a 402"},"failedDetails":[{"url":"https://s.example/services/x","error":"wrong network: eip155:84532 not indexed","status":402}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	key, _ := crypto.GenerateKey()
+	_, err := NewClient(srv.URL).RegisterOrigin(context.Background(), "https://seller.example", crypto.PubkeyToAddress(key.PublicKey), localSigner{key})
+	if !errors.Is(err, ErrNoValidResources) {
+		t.Fatalf("expected ErrNoValidResources, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "https://s.example/services/x") || !strings.Contains(err.Error(), "wrong network: eip155:84532 not indexed") || !strings.Contains(err.Error(), "status 402") {
+		t.Fatalf("expected per-endpoint failure detail in error, got %v", err)
+	}
+}
+
 func TestFormatSIWEMessage_Golden(t *testing.T) {
 	info := SIWXInfo{
 		Domain:         "x402scan.com",


### PR DESCRIPTION
## Canary402 field report — issues 0/10 (x402scan rejects testnet resources with a misleading generic message)

x402scan indexes mainnet resources only; registering an origin whose offers price on Base Sepolia failed with x402scan's generic "no valid paid resources", which obol relayed as "no endpoint answered with a live x402 402 challenge" — factually wrong (the endpoints answered 402 fine) and pointing the operator away from the real cause. Per-endpoint failure detail returned by the registry on the 422 path was also silently dropped.

### Fix
- `internal/x402/chains.go`: `Testnet` flag on the existing chain registry + `IsTestnetCAIP2` helper (single source of truth, no second hardcoded list).
- Preflight (same non-fatal pattern as `preflightOpenAPI`) decodes `x-payment-info.accepts[].network` across paid paths; when every network is a testnet it warns before submitting, and the `ErrNoValidResources` failure message becomes an accurate "offers price on <network> (testnet) — x402scan indexes mainnet resources only; switch payment network to a mainnet and re-register" (generic text kept as fallback for genuinely-no-402 cases).
- `internal/x402scan/client.go`: the 422 error path now carries `failedDetails` (per-endpoint url/error/status), symmetric with the 200 partial-failure path.

Tests: golden-fixture 422-with-failedDetails, testnet-detection preflight test, chains table test. `go test ./cmd/obol/... ./internal/x402/... ./internal/x402scan/...` green.

Part of the Canary402 field-report sweep (6 PRs). Commit unsigned — batch re-sign before merge if required.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk
