### PR TITLE
fix(agent): validate --id as a DNS label to stop /etc/hosts injection

### DIFF
--- a/internal/dns/resolver.go
+++ b/internal/dns/resolver.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -120,6 +121,19 @@ const (
 	hostsFile        = "/etc/hosts"
 )
 
+// validHostnameRegex matches DNS-safe hostnames: labels of lowercase/uppercase
+// alphanumerics and hyphens, joined by dots. No spaces, newlines, or other
+// characters that could inject extra lines into /etc/hosts.
+var validHostnameRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$`)
+
+// isValidHostname reports whether h is safe to write as an /etc/hosts entry.
+// Belt-and-suspenders check: callers are expected to validate ids before
+// they ever become a hostname, but this guards the file write regardless of
+// how a malformed hostname got here.
+func isValidHostname(h string) bool {
+	return validHostnameRegex.MatchString(h)
+}
+
 // EnsureHostsEntries adds /etc/hosts entries for the given hostnames.
 // Always includes "obol.stack" plus any additional hostnames (e.g. openclaw subdomains).
 // Entries are idempotent — existing managed block is replaced.
@@ -129,7 +143,7 @@ func EnsureHostsEntries(hostnames []string) error {
 
 	seen := map[string]bool{domain: true}
 	for _, h := range hostnames {
-		if h != "" && !seen[h] {
+		if h != "" && !seen[h] && isValidHostname(h) {
 			all = append(all, h)
 			seen[h] = true
 		}

--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -40,6 +40,30 @@ func TestGetNMDNSMode(t *testing.T) {
 	_ = mode
 }
 
+func TestIsValidHostname(t *testing.T) {
+	valid := []string{"obol.stack", "hermes-abc.obol.stack", "openclaw-my-agent.obol.stack", "a"}
+	for _, h := range valid {
+		if !isValidHostname(h) {
+			t.Errorf("isValidHostname(%q) = false, want true", h)
+		}
+	}
+
+	// Belt-and-suspenders guard for the Canary402 audit finding: a hostname
+	// carrying a newline (e.g. from an unsanitized agent --id) must never be
+	// written to /etc/hosts, even if it slipped past upstream validation.
+	invalid := []string{
+		"",
+		"evil\n127.0.0.1 attacker.com",
+		"has space",
+		"has/slash",
+	}
+	for _, h := range invalid {
+		if isValidHostname(h) {
+			t.Errorf("isValidHostname(%q) = true, want false", h)
+		}
+	}
+}
+
 func TestHasNMDnsmasqConfig(t *testing.T) {
 	// On a clean system without obol config, this should return false
 	// unless the test system has it installed

--- a/internal/hermes/hermes.go
+++ b/internal/hermes/hermes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
+	"github.com/ObolNetwork/obol-stack/internal/validate"
 	petname "github.com/dustinkirkland/golang-petname"
 	"gopkg.in/yaml.v3"
 )
@@ -104,6 +105,13 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 		u.Infof("Generated deployment ID: %s", id)
 	} else {
 		u.Infof("Using deployment ID: %s", id)
+	}
+
+	// id becomes a DNS label (hostname, namespace) below, so it must be
+	// restricted to a safe charset — an unsanitized id (e.g. containing a
+	// newline) could otherwise inject arbitrary /etc/hosts entries.
+	if err := validate.Name(id); err != nil {
+		return fmt.Errorf("invalid agent id: %w", err)
 	}
 
 	deploymentDir := DeploymentPath(cfg, id)

--- a/internal/hermes/hermes_test.go
+++ b/internal/hermes/hermes_test.go
@@ -117,6 +117,27 @@ func TestOnboardDefaultAlreadyInstalledIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestOnboardRejectsUnsafeID guards against the Canary402 full-surface audit
+// finding: an unsanitized --id becomes a DNS label (hostname, namespace) and
+// was written verbatim into /etc/hosts, so a newline in --id could inject
+// arbitrary /etc/hosts lines via "sudo tee". Onboard must reject any id that
+// isn't a safe DNS label before it reaches deployment/hostname construction.
+func TestOnboardRejectsUnsafeID(t *testing.T) {
+	invalid := []string{
+		"evil\n127.0.0.1 attacker.com", // /etc/hosts line injection
+		"has space",
+		"has/slash",
+		"-leading-dash",
+	}
+	for _, id := range invalid {
+		cfg := testConfig(t)
+		err := Onboard(cfg, OnboardOptions{ID: id}, newTestUI())
+		if err == nil {
+			t.Errorf("Onboard(ID=%q) = nil, want error", id)
+		}
+	}
+}
+
 // TestGenerateConfig_PrimaryIsRoundTrippable guards the LiteLLM model_name
 // contract end-to-end: whatever string the agent's `model.default` is set to
 // MUST match a `model_name` entry in the LiteLLM ConfigMap byte-for-byte,

--- a/internal/openclaw/onboard_test.go
+++ b/internal/openclaw/onboard_test.go
@@ -1,0 +1,28 @@
+package openclaw
+
+import (
+	"testing"
+
+	"github.com/ObolNetwork/obol-stack/internal/ui"
+)
+
+// TestOnboardRejectsUnsafeID guards against the Canary402 full-surface audit
+// finding: an unsanitized --id becomes a DNS label (hostname, namespace) and
+// was written verbatim into /etc/hosts, so a newline in --id could inject
+// arbitrary /etc/hosts lines via "sudo tee". Onboard must reject any id that
+// isn't a safe DNS label before it reaches deployment/hostname construction.
+func TestOnboardRejectsUnsafeID(t *testing.T) {
+	invalid := []string{
+		"evil\n127.0.0.1 attacker.com", // /etc/hosts line injection
+		"has space",
+		"has/slash",
+		"-leading-dash",
+	}
+	for _, id := range invalid {
+		cfg := testConfig(t)
+		err := Onboard(cfg, OnboardOptions{ID: id}, ui.New(false))
+		if err == nil {
+			t.Errorf("Onboard(ID=%q) = nil, want error", id)
+		}
+	}
+}

--- a/internal/openclaw/openclaw.go
+++ b/internal/openclaw/openclaw.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/model"
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
+	"github.com/ObolNetwork/obol-stack/internal/validate"
 	petname "github.com/dustinkirkland/golang-petname"
 )
 
@@ -166,6 +167,13 @@ func Onboard(cfg *config.Config, opts OnboardOptions, u *ui.UI) error {
 		u.Infof("Generated deployment ID: %s", id)
 	} else {
 		u.Infof("Using deployment ID: %s", id)
+	}
+
+	// id becomes a DNS label (hostname, namespace) below, so it must be
+	// restricted to a safe charset — an unsanitized id (e.g. containing a
+	// newline) could otherwise inject arbitrary /etc/hosts entries.
+	if err := validate.Name(id); err != nil {
+		return fmt.Errorf("invalid agent id: %w", err)
 	}
 
 	deploymentDir := DeploymentPath(cfg, id)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -18,8 +18,10 @@ func TestName(t *testing.T) {
 		"-leading-hyphen", // starts with hyphen
 		"has spaces",
 		"has_underscore",
-		"../etc/passwd", // path traversal
+		"../etc/passwd",                // path traversal
 		"a" + string(make([]byte, 63)), // too long (64 chars)
+		"has\nnewline",                 // /etc/hosts injection (Canary402 agent --id finding)
+		"has/slash",
 	}
 	for _, s := range invalid {
 		if err := Name(s); err == nil {


### PR DESCRIPTION
## Full-surface audit finding (HIGH): agent `--id` injects lines into root-owned `/etc/hosts`

Found by the 2026-07-16 whole-product-surface audit (PR #770), adversarially confirmed. `obol agent new --id <value>` passed the raw `--id` (only `TrimSpace`d) into a hostname string that is written to `/etc/hosts` via `sudo tee` (`internal/dns/resolver.go`) with no character filtering. An `--id` containing a newline injects arbitrary `/etc/hosts` entries (e.g. redirect a domain to an attacker IP). The same unvalidated `--id` also flowed into filesystem paths and a recursive-delete target (the sibling MEDIUM finding) — both closed here.

### Fix (defense in depth)
1. **Primary:** `--id` is validated as a strict DNS label (`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, bounded length) at the `Onboard` boundary (shared `validate` helper, used by both hermes and openclaw paths) — it *becomes* a hostname, so this is correct regardless of the injection.
2. **Belt-and-suspenders:** the `/etc/hosts` writer skips any hostname containing a non-DNS character, so no malformed value can reach the file even from another caller.

Test: validator rejects newline/space/slash/leading-dash/empty ids, accepts normal ones; resolver skips a malformed hostname. Tests green.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk
