### PR TITLE
fix(discovery): full upstream OpenAPI + per-origin agent-registration

### DIFF
--- a/internal/serviceoffercontroller/hostoffer_test.go
+++ b/internal/serviceoffercontroller/hostoffer_test.go
@@ -35,8 +35,8 @@ func TestBuildHostHTTPRoute(t *testing.T) {
 	}
 
 	rules, _, _ := unstructured.NestedSlice(route.Object, "spec", "rules")
-	if len(rules) != 4 {
-		t.Fatalf("rules = %d, want 4 (/, /openapi.json, /.well-known/x402, catch-all)", len(rules))
+	if len(rules) != 5 {
+		t.Fatalf("rules = %d, want 5 (/, openapi, x402, agent-registration, catch-all)", len(rules))
 	}
 
 	// Rule shapes: first three Exact → catalog httpd with full-path
@@ -45,8 +45,9 @@ func TestBuildHostHTTPRoute(t *testing.T) {
 		"/":                 "/offers/sec/audit/index.html",
 		"/openapi.json":     "/offers/sec/audit/openapi.json",
 		"/.well-known/x402": "/offers/sec/audit/x402.json",
+		"/.well-known/agent-registration.json": "/offers/sec/audit/agent-registration.json",
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		rule := rules[i].(map[string]any)
 		match := rule["matches"].([]any)[0].(map[string]any)["path"].(map[string]any)
 		if match["type"] != "Exact" {
@@ -64,7 +65,7 @@ func TestBuildHostHTTPRoute(t *testing.T) {
 		}
 	}
 
-	catchall := rules[3].(map[string]any)
+	catchall := rules[4].(map[string]any)
 	match := catchall["matches"].([]any)[0].(map[string]any)["path"].(map[string]any)
 	if match["type"] != "PathPrefix" || match["value"] != "/" {
 		t.Fatalf("catch-all match = %v", match)
@@ -104,14 +105,17 @@ func TestBuildHostHTTPRoute(t *testing.T) {
 func TestBuildOfferBundles(t *testing.T) {
 	profile := schemas.StorefrontProfile{DisplayName: "Acme", ContactEmail: "ops@acme.example"}
 	offer := hostnameOffer()
+	prev := tryUpstreamOpenAPI
+	tryUpstreamOpenAPI = func(*monetizeapi.ServiceOffer) map[string]any { return nil }
+	defer func() { tryUpstreamOpenAPI = prev }()
 
 	if got := buildOfferBundles([]*monetizeapi.ServiceOffer{routeTableOffer()}, profile); len(got) != 0 {
 		t.Fatalf("path-only offer produced bundles: %v", got)
 	}
 
 	bundles := buildOfferBundles([]*monetizeapi.ServiceOffer{offer}, profile)
-	if len(bundles) != 3 {
-		t.Fatalf("len(bundles) = %d, want 3", len(bundles))
+	if len(bundles) != 4 {
+		t.Fatalf("len(bundles) = %d, want 4", len(bundles))
 	}
 	byPath := map[string]string{}
 	for _, f := range bundles {
@@ -182,6 +186,9 @@ func TestBuildOfferBundles(t *testing.T) {
 // spec.branding fields override the storefront profile on the dedicated
 // origin's surfaces, empty fields inherit.
 func TestBuildOfferBundles_BrandingOverride(t *testing.T) {
+	prev := tryUpstreamOpenAPI
+	tryUpstreamOpenAPI = func(*monetizeapi.ServiceOffer) map[string]any { return nil }
+	defer func() { tryUpstreamOpenAPI = prev }()
 	profile := storefront.ResolvePublished(&schemas.StorefrontProfile{
 		DisplayName:  "Acme",
 		ContactEmail: "ops@acme.example",
@@ -265,5 +272,64 @@ func TestCatalogAdvertisesDedicatedOrigin(t *testing.T) {
 	skill := buildSkillCatalogMarkdown([]*monetizeapi.ServiceOffer{offer}, "https://shared.example", nil)
 	if !strings.Contains(skill, "`POST https://audit.v1337.example/submit`") {
 		t.Errorf("skill.md routes not rooted at dedicated origin:\n%.400s", skill)
+	}
+}
+
+
+func TestBuildOfferBundles_UpstreamOpenAPI(t *testing.T) {
+	profile := schemas.StorefrontProfile{DisplayName: "Acme", ContactEmail: "ops@acme.example"}
+	offer := hostnameOffer()
+	offer.Spec.Registration.Name = "Hyperliquid Trading Intelligence"
+	offer.Spec.Registration.Description = "Full first-party catalog."
+	prev := tryUpstreamOpenAPI
+	tryUpstreamOpenAPI = func(*monetizeapi.ServiceOffer) map[string]any {
+		return map[string]any{
+			"openapi": "3.1.0",
+			"info":    map[string]any{"title": "upstream-title", "version": "1.1.0"},
+			"paths": map[string]any{
+				"/v1/leaderboard": map[string]any{
+					"get": map[string]any{
+						"summary": "Leaderboard", "security": []any{map[string]any{"x402": []any{}}},
+						"x-payment-info": map[string]any{"price": map[string]any{"amount": "0.001"}},
+						"responses": map[string]any{"200": map[string]any{}, "402": map[string]any{}},
+					},
+				},
+				"/v1/markets/overview": map[string]any{
+					"get": map[string]any{"summary": "Free overview", "security": []any{}, "responses": map[string]any{"200": map[string]any{}}},
+				},
+			},
+		}
+	}
+	defer func() { tryUpstreamOpenAPI = prev }()
+	bundles := buildOfferBundles([]*monetizeapi.ServiceOffer{offer}, profile)
+	byPath := map[string]string{}
+	for _, f := range bundles {
+		byPath[f.Path] = f.Content
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(byPath["offers/sec/audit/openapi.json"]), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc["info"].(map[string]any)["title"] != "Hyperliquid Trading Intelligence" {
+		t.Errorf("title = %v", doc["info"])
+	}
+	if _, ok := doc["paths"].(map[string]any)["/v1/leaderboard"]; !ok {
+		t.Fatalf("missing leaderboard in paths: %v", doc["paths"])
+	}
+	var wk struct {
+		Resources []struct{ Resource string `json:"resource"` } `json:"resources"`
+	}
+	if err := json.Unmarshal([]byte(byPath["offers/sec/audit/x402.json"]), &wk); err != nil {
+		t.Fatal(err)
+	}
+	if len(wk.Resources) != 1 || !strings.Contains(wk.Resources[0].Resource, "/v1/leaderboard") {
+		t.Fatalf("x402 resources = %+v", wk.Resources)
+	}
+	var reg map[string]any
+	if err := json.Unmarshal([]byte(byPath["offers/sec/audit/agent-registration.json"]), &reg); err != nil {
+		t.Fatal(err)
+	}
+	if reg["name"] != "Hyperliquid Trading Intelligence" {
+		t.Errorf("reg name = %v", reg["name"])
 	}
 }

--- a/internal/serviceoffercontroller/offerbundle.go
+++ b/internal/serviceoffercontroller/offerbundle.go
@@ -52,16 +52,32 @@ func buildOfferBundles(offers []*monetizeapi.ServiceOffer, profile schemas.Store
 		// branding block overrides the storefront profile field-wise
 		// (empty fields inherit).
 		originProfile := storefront.MergeProfile(profile, offer.Spec.Branding.ProfilePatch())
+		upstreamDoc := tryUpstreamOpenAPI(offer)
+		openapiContent := buildOfferScopedOpenAPI(offer, originProfile)
+		x402Content := buildOfferWellKnownX402(offer)
+		if upstreamDoc != nil {
+			if rewritten, ok := rewriteUpstreamOpenAPI(upstreamDoc, offer, originProfile); ok {
+				openapiContent = rewritten
+			}
+			if expanded := buildOfferWellKnownX402FromOpenAPI(offer, upstreamDoc); expanded != "" {
+				x402Content = expanded
+			}
+		}
 		bundles = append(bundles,
 			offerBundleFile{
 				Key:     offerBundleKey(offer, "openapi.json"),
 				Path:    offerBundleDir(offer) + "/openapi.json",
-				Content: buildOfferScopedOpenAPI(offer, originProfile),
+				Content: openapiContent,
 			},
 			offerBundleFile{
 				Key:     offerBundleKey(offer, "x402.json"),
 				Path:    offerBundleDir(offer) + "/x402.json",
-				Content: buildOfferWellKnownX402(offer),
+				Content: x402Content,
+			},
+			offerBundleFile{
+				Key:     offerBundleKey(offer, "agent-registration.json"),
+				Path:    offerBundleDir(offer) + "/agent-registration.json",
+				Content: buildOfferAgentRegistration(offer, originProfile),
 			},
 			offerBundleFile{
 				Key:     offerBundleKey(offer, "index.html"),
@@ -74,8 +90,6 @@ func buildOfferBundles(offers []*monetizeapi.ServiceOffer, profile schemas.Store
 	return bundles
 }
 
-// bundleDigestInput folds bundle contents into the catalog content hash so
-// bundle-only changes (e.g. a hostname added to one offer) roll the httpd.
 func bundleDigestInput(bundles []offerBundleFile) string {
 	var b strings.Builder
 	for _, f := range bundles {

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -815,6 +815,7 @@ func buildHostHTTPRoute(offer *monetizeapi.ServiceOffer) *unstructured.Unstructu
 					exactTo("/", "index.html"),
 					exactTo("/openapi.json", "openapi.json"),
 					exactTo("/.well-known/x402", "x402.json"),
+					exactTo("/.well-known/agent-registration.json", "agent-registration.json"),
 					map[string]any{
 						"matches": []any{
 							map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/"}},

--- a/internal/serviceoffercontroller/upstream_openapi.go
+++ b/internal/serviceoffercontroller/upstream_openapi.go
@@ -1,0 +1,269 @@
+package serviceoffercontroller
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ObolNetwork/obol-stack/internal/erc8004"
+	"github.com/ObolNetwork/obol-stack/internal/monetizeapi"
+	"github.com/ObolNetwork/obol-stack/internal/schemas"
+)
+
+var upstreamOpenAPIClient = &http.Client{Timeout: 3 * time.Second}
+
+// tryUpstreamOpenAPI is the seam tests replace.
+var tryUpstreamOpenAPI = fetchUpstreamOpenAPI
+
+func fetchUpstreamOpenAPI(offer *monetizeapi.ServiceOffer) map[string]any {
+	if offer == nil || offer.IsAgent() || offer.IsInference() {
+		return nil
+	}
+	if strings.TrimSpace(offer.Spec.Upstream.Service) == "" {
+		return nil
+	}
+	base := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+		offer.Spec.Upstream.Service,
+		offer.EffectiveNamespace(),
+		offer.EffectivePort(),
+	)
+	for _, path := range upstreamOpenAPIPathCandidates(offer) {
+		doc, err := getJSONMap(base + path)
+		if err != nil || doc == nil {
+			continue
+		}
+		paths, _ := doc["paths"].(map[string]any)
+		if len(paths) == 0 {
+			continue
+		}
+		return doc
+	}
+	return nil
+}
+
+func upstreamOpenAPIPathCandidates(offer *monetizeapi.ServiceOffer) []string {
+	var out []string
+	if offer.Spec.Registration.Metadata != nil {
+		if p := strings.TrimSpace(offer.Spec.Registration.Metadata["openapiPath"]); p != "" {
+			if !strings.HasPrefix(p, "/") {
+				p = "/" + p
+			}
+			out = append(out, p)
+		}
+	}
+	out = append(out, "/v1/openapi.json", "/openapi.json")
+	return out
+}
+
+func getJSONMap(url string) (map[string]any, error) {
+	resp, err := upstreamOpenAPIClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func rewriteUpstreamOpenAPI(doc map[string]any, offer *monetizeapi.ServiceOffer, profile schemas.StorefrontProfile) (string, bool) {
+	if doc == nil {
+		return "", false
+	}
+	out := map[string]any{}
+	for k, v := range doc {
+		out[k] = v
+	}
+	origin := offer.EffectiveOrigin()
+	out["servers"] = []any{map[string]any{"url": origin}}
+	info, _ := out["info"].(map[string]any)
+	if info == nil {
+		info = map[string]any{}
+	} else {
+		copied := map[string]any{}
+		for k, v := range info {
+			copied[k] = v
+		}
+		info = copied
+	}
+	if title := strings.TrimSpace(offer.Spec.Registration.Name); title != "" {
+		info["title"] = title
+	}
+	if desc := strings.TrimSpace(offer.Spec.Registration.Description); desc != "" {
+		info["description"] = desc
+	}
+	if email := strings.TrimSpace(profile.ContactEmail); email != "" {
+		info["contact"] = map[string]any{"name": strings.TrimSpace(profile.DisplayName), "email": email}
+	}
+	out["info"] = info
+	if _, has := out["x-discovery"]; !has {
+		out["x-discovery"] = map[string]any{
+			"source": "upstream-openapi",
+			"note":   "Full first-party API surface; paid ops carry x-payment-info + 402 responses (x402scan OpenAPI-first).",
+		}
+	}
+	encoded, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", false
+	}
+	return string(encoded), true
+}
+
+func buildOfferWellKnownX402FromOpenAPI(offer *monetizeapi.ServiceOffer, doc map[string]any) string {
+	if doc == nil {
+		return ""
+	}
+	origin := strings.TrimRight(offer.EffectiveOrigin(), "/")
+	paths, _ := doc["paths"].(map[string]any)
+	if len(paths) == 0 {
+		return ""
+	}
+	pathKeys := make([]string, 0, len(paths))
+	for p := range paths {
+		pathKeys = append(pathKeys, p)
+	}
+	sort.Strings(pathKeys)
+	defaultAccepts := []any{}
+	for _, p := range offer.EffectivePayments() {
+		defaultAccepts = append(defaultAccepts, wellKnownAccept(p))
+	}
+	if len(defaultAccepts) == 0 {
+		return ""
+	}
+	var resources []any
+	for _, p := range pathKeys {
+		item, _ := paths[p].(map[string]any)
+		if item == nil {
+			continue
+		}
+		for _, m := range []string{"get", "post", "put", "patch", "delete", "head", "options"} {
+			op, _ := item[m].(map[string]any)
+			if op == nil || !openAPIOpIsPaid(op) {
+				continue
+			}
+			desc, _ := op["summary"].(string)
+			if desc == "" {
+				desc, _ = op["description"].(string)
+			}
+			if desc == "" {
+				desc = offerDescription(offer, "x402 payment-gated service.")
+			}
+			resources = append(resources, map[string]any{
+				"resource":    origin + joinOpenAPIPath("/", p),
+				"type":        "http",
+				"method":      strings.ToUpper(m),
+				"description": desc,
+				"x402Version": 2,
+				"accepts":     defaultAccepts,
+			})
+		}
+	}
+	if len(resources) == 0 {
+		return ""
+	}
+	if len(resources) > 200 {
+		resources = resources[:200]
+	}
+	encoded, err := json.MarshalIndent(map[string]any{"x402Version": 2, "resources": resources}, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func openAPIOpIsPaid(op map[string]any) bool {
+	if op == nil {
+		return false
+	}
+	if gate, _ := op["x-gate"].(string); gate == "free" {
+		return false
+	}
+	if _, hasPay := op["x-payment-info"]; hasPay {
+		return true
+	}
+	if sec, ok := op["security"].([]any); ok && len(sec) == 0 {
+		return false
+	}
+	if responses, ok := op["responses"].(map[string]any); ok {
+		if _, has402 := responses["402"]; has402 {
+			if sec, ok := op["security"].([]any); ok && len(sec) == 0 {
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func buildOfferAgentRegistration(offer *monetizeapi.ServiceOffer, profile schemas.StorefrontProfile) string {
+	origin := strings.TrimRight(offer.EffectiveOrigin(), "/")
+	name := strings.TrimSpace(offer.Spec.Registration.Name)
+	if name == "" {
+		name = offer.Name
+	}
+	desc := strings.TrimSpace(offer.Spec.Registration.Description)
+	if desc == "" {
+		desc = offerDescription(offer, "x402 payment-gated service.")
+	}
+	image := strings.TrimSpace(offer.Spec.Registration.Image)
+	if image == "" {
+		if logo := strings.TrimSpace(profile.LogoURL); logo != "" && (strings.HasPrefix(logo, "http://") || strings.HasPrefix(logo, "https://")) {
+			image = logo
+		} else {
+			image = origin + "/agent-icon.png"
+		}
+	}
+	services := []erc8004.ServiceDef{{Name: "web", Endpoint: origin, Version: "1.0.0"}}
+	if len(offer.Spec.Registration.Services) > 0 {
+		var scoped []erc8004.ServiceDef
+		for _, s := range offer.Spec.Registration.Services {
+			ep := strings.TrimSpace(s.Endpoint)
+			if ep == "" {
+				continue
+			}
+			if strings.Contains(ep, "://") && !strings.HasPrefix(ep, origin) {
+				continue
+			}
+			scoped = append(scoped, erc8004.ServiceDef{
+				Name:     defaultString(s.Name, "web"),
+				Endpoint: ep,
+				Version:  defaultString(s.Version, "1.0.0"),
+			})
+		}
+		if len(scoped) > 0 {
+			services = scoped
+		}
+	}
+	if len(offer.Spec.Registration.Skills) > 0 || len(offer.Spec.Registration.Domains) > 0 {
+		services = append(services, erc8004.ServiceDef{
+			Name: "OASF", Version: "0.8",
+			Skills: offer.Spec.Registration.Skills, Domains: offer.Spec.Registration.Domains,
+		})
+	}
+	doc := erc8004.AgentRegistration{
+		Type: erc8004.RegistrationType, Name: name, Description: desc, Image: image,
+		Active: offer.Spec.Registration.Enabled, X402Support: true, Services: services,
+		SupportedTrust: offer.Spec.Registration.SupportedTrust,
+	}
+	if meta := nonEmptyStringMap(offer.Spec.Registration.Metadata); len(meta) > 0 {
+		doc.Metadata = meta
+	}
+	encoded, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return `{"type":"` + erc8004.RegistrationType + `","name":"` + name + `","active":false,"services":[]}`
+	}
+	return string(encoded)
+}


### PR DESCRIPTION
## Summary

Fixes two related production issues on dedicated offer origins (validated against [x402scan DISCOVERY.md](https://github.com/Merit-Systems/x402scan/blob/main/docs/DISCOVERY.md)):

1. **Discovery incompleteness** — hostname `/openapi.json` was a thin route-table doc (often ~8 free paths). x402scan is **OpenAPI-first** at `/openapi.json`, so multi-route products (e.g. hl-intel, 95+ paths) were under-indexed.
2. **Registration bleed** — `/.well-known/agent-registration.json` had no host-scoped route, so every origin returned the cluster-global AgentIdentity mega-doc (Hyperliquid-data + solar + predictfun + …).

## Changes

| Surface | Before | After |
|---|---|---|
| `GET /openapi.json` (hostname) | Route-table only | **Upstream full OAS** when available (`/v1/openapi.json` or metadata `openapiPath`) |
| `GET /.well-known/x402` | One catch-all resource | **Expanded paid resources** from OAS `x-payment-info` / 402 ops |
| `GET /.well-known/agent-registration.json` | Global mega-doc | **Single-offer ERC-8004 doc** for that origin |

## Implementation

- `upstream_openapi.go` — fetch + rewrite servers + x402 fan-out + per-offer registration
- `buildOfferBundles` — prefer upstream OAS; always emit `agent-registration.json`
- `buildHostHTTPRoute` — Exact match for `/.well-known/agent-registration.json` (wins over global AgentIdentity route)
- Tests for host route rule count, upstream OAS injection, registration isolation

## Live verification (silvernuc3)

| Origin | openapi paths | x402 resources | registration |
|---|---|---|---|
| hyperliquid-data.v1337.org | **96** | **88** | Hyperliquid-data only (no bleed) |
| hyperliquid-analyst.v1337.org | 1 | 1 | **HyperAnalyst** only (no bleed) |

Free samples still 200; paid leaderboard still 402.

## Test plan

- [x] `go test ./internal/serviceoffercontroller/`
- [x] Live hyperliquid-data/analyst discovery + registration
- [ ] Rebuild/redeploy controller on other stacks
- [ ] Spot-check another multi-route http offer (e.g. marketkit) after rollout

Related: discovery completeness + registration bleed from Hyperliquid health review.