### PR TITLE
fix(chat-widget): clickjacking, stale-bundle, and withdraw-race hardening

### DIFF
--- a/internal/serviceoffercontroller/assets/chat.html
+++ b/internal/serviceoffercontroller/assets/chat.html
@@ -311,7 +311,9 @@ const TWA_ABI = [{
   ],
 }];
 async function withdraw() {
-  if (!burner || !wallet || balance <= 0n || withdrawing) return;
+  // busy = a paid message is mid-flight and may be about to spend this same
+  // balance via payFetch; withdrawing itself blocks a send below.
+  if (!burner || !wallet || balance <= 0n || withdrawing || busy) return;
   withdrawing = true;
   const amt = balance;
   try {
@@ -339,11 +341,13 @@ async function withdraw() {
     const r = sig.slice(0, 66);
     const s = "0x" + sig.slice(66, 130);
     const v = parseInt(sig.slice(130, 132), 16);
-    await wallet.writeContract({
+    const hash = await wallet.writeContract({
       account: mainAddr, chain, address: asset, abi: TWA_ABI,
       functionName: "transferWithAuthorization",
       args: [burner.address, mainAddr, amt, 0n, validBefore, nonce, v, r, s],
     });
+    status("withdrawal sent, waiting for confirmation…", true);
+    await pub.waitForTransactionReceipt({ hash });
     say("sys", "Withdrew $" + formatUnits(amt, 6) + " to " + short(mainAddr));
     await refreshBalance();
     status("");
@@ -372,7 +376,7 @@ $("composer").onsubmit = async (ev) => {
   ev.preventDefault();
   const ta = $("input");
   const text = ta?.value.trim();
-  if (!text || !payFetch || busy) return;
+  if (!text || !payFetch || busy || withdrawing) return;
   busy = true; ta.value = ""; ta.disabled = true;
   say("user", text);
   messages.push({ role: "user", content: text });

--- a/internal/serviceoffercontroller/hostoffer_test.go
+++ b/internal/serviceoffercontroller/hostoffer_test.go
@@ -1,7 +1,9 @@
 package serviceoffercontroller
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -317,6 +319,27 @@ func TestBuildHostHTTPRoute_AgentChatWidget(t *testing.T) {
 		}
 	}
 
+	// /chat holds a hot session key and signs USDC transfers — it must carry
+	// frame-ancestors 'self' so it can't be clickjacked into a cross-origin
+	// iframe (the offer's own landing page still embeds it same-origin).
+	chatRule := rules[4].(map[string]any)
+	var sawCSP bool
+	for _, rawFilter := range chatRule["filters"].([]any) {
+		filter := rawFilter.(map[string]any)
+		if filter["type"] != "ResponseHeaderModifier" {
+			continue
+		}
+		for _, s := range filter["responseHeaderModifier"].(map[string]any)["set"].([]any) {
+			h := s.(map[string]any)
+			if h["name"] == "Content-Security-Policy" && h["value"] == "frame-ancestors 'self'" {
+				sawCSP = true
+			}
+		}
+	}
+	if !sawCSP {
+		t.Errorf("/chat rule missing Content-Security-Policy: frame-ancestors 'self'")
+	}
+
 	// Catch-all must still be last.
 	last := rules[6].(map[string]any)
 	match := last["matches"].([]any)[0].(map[string]any)["path"].(map[string]any)
@@ -398,6 +421,20 @@ func TestStaticSiteServesChatWidget(t *testing.T) {
 	}
 	if !strings.Contains(chat, "chat-vendor.js?v=") {
 		t.Errorf("chat page missing cache-busted vendor import")
+	}
+}
+
+// TestChatVendorVersionMatchesBundle guards the ?v= cache-buster on
+// chat.html's chat-vendor.js import against a forgotten bump: the bundle is
+// served 1-year immutable (buildHostHTTPRoute's exactToShared), so a rebuild
+// that forgets to bump ?v= would silently serve returning visitors the OLD
+// payment-signing bundle for up to a year. This must fail CI whenever
+// assets/chat-vendor.js and assets/chat.html's ?v= go out of sync.
+func TestChatVendorVersionMatchesBundle(t *testing.T) {
+	sum := sha256.Sum256([]byte(chatWidgetVendorJS))
+	want := "chat-vendor.js?v=" + fmt.Sprintf("%x", sum)[:8]
+	if !strings.Contains(chatWidgetTmplSrc, want) {
+		t.Fatalf("chat.html's chat-vendor.js ?v= does not match sha256(assets/chat-vendor.js); want %q (see assets/README.md rebuild steps)", want)
 	}
 }
 

--- a/internal/serviceoffercontroller/render.go
+++ b/internal/serviceoffercontroller/render.go
@@ -940,8 +940,15 @@ func hostRouteRules(offer *monetizeapi.ServiceOffer, exactTo, exactToShared func
 		exactTo("/.well-known/agent-registration.json", "agent-registration.json"),
 	}
 	if offer.IsAgent() {
+		// The chat page holds a hot session key and signs USDC transfers —
+		// frame-ancestors 'self' stops it being clickjacked into a
+		// cross-origin iframe (Connect/Fund/Withdraw/Send). The offer's own
+		// landing page embeds it same-origin (TestOfferLandingChatEmbed), so
+		// that legitimate embed still works.
+		chatRule := exactTo("/chat", "chat.html")
+		addResponseHeader(chatRule, "Content-Security-Policy", "frame-ancestors 'self'")
 		rules = append(rules,
-			exactTo("/chat", "chat.html"),
+			chatRule,
 			exactToShared("/chat-vendor.js", "chat-vendor.js"),
 		)
 	}
@@ -954,6 +961,23 @@ func hostRouteRules(offer *monetizeapi.ServiceOffer, exactTo, exactToShared func
 			map[string]any{"name": "x402-verifier", "namespace": "x402", "port": int64(8080)},
 		},
 	})
+}
+
+// addResponseHeader appends a Set entry to a rule's existing
+// ResponseHeaderModifier filter (every exactTo rule has exactly one, from
+// cacheFilter) — Gateway API's core filters are unspecified/implementation
+// -defined if repeated within one rule, so extra headers merge into the
+// existing filter instead of adding a second one.
+func addResponseHeader(rule map[string]any, name, value string) {
+	for _, f := range rule["filters"].([]any) {
+		fm := f.(map[string]any)
+		if fm["type"] != "ResponseHeaderModifier" {
+			continue
+		}
+		mod := fm["responseHeaderModifier"].(map[string]any)
+		mod["set"] = append(mod["set"].([]any), map[string]any{"name": name, "value": value})
+		return
+	}
 }
 
 // sharedOriginRule is the /services/<name> PathPrefix rule → verifier,


### PR DESCRIPTION
Chat-widget findings from the PR #756 review. Adds a test enforcing chat.html's ?v= matches the embedded chat-vendor.js sha256 (a forgotten bump otherwise serves returning visitors the old payment-signing bundle for up to a year); serves /chat with frame-ancestors 'self' so the hot-session-key payment UI can't be clickjacked; makes withdraw() await the receipt like fund() and guards the in-flight-payment race.

https://claude.ai/code/session_014YjPMViNrZ7zBVgUQzwEKk