### PR TITLE
fix(ui): honor OBOL_NONINTERACTIVE on a real TTY

### DIFF
--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -11,9 +11,9 @@ import (
 )
 
 // isInteractive returns true if prompts should be shown.
-// Returns false in JSON mode or when stdin is not a terminal.
+// Returns false in JSON mode, when not a TTY, or when OBOL_NONINTERACTIVE=true.
 func (u *UI) isInteractive() bool {
-	return !u.IsJSON() && u.IsTTY()
+	return !u.IsJSON() && u.IsTTY() && os.Getenv("OBOL_NONINTERACTIVE") != "true"
 }
 
 // Confirm asks a yes/no question, returns true for "y"/"yes".

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIsInteractive_OBOLNonInteractive(t *testing.T) {
+	u := NewForTest(&bytes.Buffer{}, &bytes.Buffer{})
+	u.isTTY = true // force TTY so only the env guard can suppress interactivity
+
+	if !u.isInteractive() {
+		t.Fatal("isInteractive() = false with TTY, human output, and OBOL_NONINTERACTIVE unset; want true")
+	}
+
+	t.Setenv("OBOL_NONINTERACTIVE", "true")
+	if u.isInteractive() {
+		t.Fatal("isInteractive() = true with OBOL_NONINTERACTIVE=true; want false")
+	}
+}
+
+func TestConfirm_OBOLNonInteractiveReturnsDefault(t *testing.T) {
+	u := NewForTest(&bytes.Buffer{}, &bytes.Buffer{})
+	u.isTTY = true
+	t.Setenv("OBOL_NONINTERACTIVE", "true")
+
+	if got := u.Confirm("proceed?", true); !got {
+		t.Fatalf("Confirm(defaultYes=true) = %v; want true without reading stdin", got)
+	}
+	if got := u.Confirm("proceed?", false); got {
+		t.Fatalf("Confirm(defaultYes=false) = %v; want false without reading stdin", got)
+	}
+}


### PR DESCRIPTION
## Problem

`OBOL_NONINTERACTIVE=true` had no effect on a real TTY. `internal/ui/prompt.go`'s
`isInteractive()` gated prompting on JSON-output mode and TTY detection only:

```go
func (u *UI) isInteractive() bool {
	return !u.IsJSON() && u.IsTTY()
}
```

It never consulted the env var, so scripted/automated runs launched from a real
terminal (e.g. CI runners with a pty, installer wrappers) still hit every
`Confirm`/`Select`/`Input` call and blocked waiting on stdin — including the
"start cluster now?" and Ollama-model prompts during `obol stack up`.

Audited every `Confirm`/`Select` call site in the codebase (`internal/app`,
`internal/openclaw`, `internal/network`, `internal/tunnel`, `internal/stackbackup`,
`internal/hermes`, `internal/stack/safety.go`, `cmd/obol/*.go`): all of them
already route through `UI.Confirm`/`UI.Select`, and there is no raw
survey/promptui prompt anywhere in `internal/`. The Ollama-detection logic in
`internal/stack/stack.go` only warns/logs when no models are pulled — it
never calls `Confirm`. So the single `isInteractive()` guard is the one and
only chokepoint; no other call site needed touching.

## Fix

`isInteractive()` now also requires `OBOL_NONINTERACTIVE` is not `"true"`:

```go
func (u *UI) isInteractive() bool {
	return !u.IsJSON() && u.IsTTY() && os.Getenv("OBOL_NONINTERACTIVE") != "true"
}
```

Every prompt (`Confirm`, `Select`, `Input`, `InputWithSuffix`, `SecretInput`)
already short-circuits through `isInteractive()` and falls back to its
default/error path, so this one guard covers all of them.

## Diagram

```mermaid
flowchart LR
    A[OBOL_NONINTERACTIVE env var] --> D{isInteractive guard}
    B[IsJSON] --> D
    C[IsTTY] --> D
    D -- "any condition false" --> E["Confirm/Select/Input\nreturn default (no prompt)"]
    D -- "all true" --> F["Confirm/Select/Input\nprompt on stdin"]
```

## Validation

```
$ gofmt -l internal/ui/prompt.go internal/ui/prompt_test.go
(no output)

$ go build ./...
(exit 0)

$ go test ./internal/ui/... -count=1 -v
=== RUN   TestIsInteractive_OBOLNonInteractive
--- PASS: TestIsInteractive_OBOLNonInteractive (0.00s)
=== RUN   TestConfirm_OBOLNonInteractiveReturnsDefault
--- PASS: TestConfirm_OBOLNonInteractiveReturnsDefault (0.00s)
PASS
ok  	github.com/ObolNetwork/obol-stack/internal/ui	0.533s
```

---
https://claude.ai/code/session_01PnhCQLz7CHuDBUhWd5xF8v
