### PR TITLE
fix(agentcrd): strip server-managed metadata before ResumeAll re-apply

### DIFF
--- a/internal/agentcrd/manifest.go
+++ b/internal/agentcrd/manifest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/kubectl"
+	"github.com/ObolNetwork/obol-stack/internal/stackbackup"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"gopkg.in/yaml.v3"
 )
@@ -89,6 +90,20 @@ func ResumeAll(cfg *config.Config, u *ui.UI) {
 			u.Warnf("Could not read recorded agent %s: %v", name, err)
 			continue
 		}
+		// Persisted manifests may include server-managed metadata (resourceVersion,
+		// uid, managedFields, ...) captured after apply. Strip them so kubectl
+		// apply does not fail with "resourceVersion: Invalid value: 0".
+		var doc map[string]any
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			u.Warnf("Could not parse recorded agent %s: %v", name, err)
+			continue
+		}
+		stackbackup.StripServerManagedMetadata(doc)
+		stripped, err := yaml.Marshal(doc)
+		if err != nil {
+			u.Warnf("Could not re-marshal recorded agent %s: %v", name, err)
+			continue
+		}
 		warnIfWalletWouldRegenerate(cfg, name, data, u)
 		nsErr := kubectl.PipeCommands(bin, kubeconfig,
 			[]string{"create", "namespace", Namespace(name), "--dry-run=client", "-o", "yaml"},
@@ -96,7 +111,7 @@ func ResumeAll(cfg *config.Config, u *ui.UI) {
 		if nsErr != nil {
 			u.Warnf("Could not ensure namespace for agent %s: %v", name, nsErr)
 		}
-		if err := kubectl.Apply(bin, kubeconfig, data); err != nil {
+		if err := kubectl.Apply(bin, kubeconfig, stripped); err != nil {
 			u.Warnf("Could not re-apply agent %s (run 'obol agent new %s' to recreate): %v", name, name, err)
 			continue
 		}

--- a/internal/agentcrd/manifest_test.go
+++ b/internal/agentcrd/manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ObolNetwork/obol-stack/internal/config"
+	"github.com/ObolNetwork/obol-stack/internal/stackbackup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -62,5 +63,57 @@ func TestManifestStoreRoundTrip(t *testing.T) {
 	}
 	if names := ListPersistedManifests(cfg); len(names) != 1 || names[0] != "scout" {
 		t.Fatalf("after remove: %v", names)
+	}
+}
+
+// TestStripServerManagedMetadataOnAgentManifest pins the ResumeAll strip path:
+// persisted Agent YAML may carry server-managed metadata; stripping must drop
+// those fields while keeping name/namespace and spec intact.
+func TestStripServerManagedMetadataOnAgentManifest(t *testing.T) {
+	manifest := map[string]any{
+		"apiVersion": "obol.org/v1alpha1",
+		"kind":       "Agent",
+		"metadata": map[string]any{
+			"name":              "quant",
+			"namespace":         "agent-quant",
+			"resourceVersion":   "12345",
+			"uid":               "abc-123",
+			"creationTimestamp": "2024-01-01T00:00:00Z",
+			"managedFields":     []any{map[string]any{"manager": "kubectl"}},
+		},
+		"spec": map[string]any{
+			"model":  "qwen3.5:9b",
+			"skills": []any{"gas"},
+			"wallet": map[string]any{"create": true},
+		},
+	}
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	stackbackup.StripServerManagedMetadata(doc)
+
+	meta, ok := doc["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata missing or wrong type: %T", doc["metadata"])
+	}
+	for _, k := range []string{"resourceVersion", "uid", "creationTimestamp", "managedFields"} {
+		if _, present := meta[k]; present {
+			t.Errorf("server-managed field %q still present after strip", k)
+		}
+	}
+	if meta["name"] != "quant" || meta["namespace"] != "agent-quant" {
+		t.Fatalf("identity fields altered: %v", meta)
+	}
+	spec, ok := doc["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec missing or wrong type: %T", doc["spec"])
+	}
+	if spec["model"] != "qwen3.5:9b" {
+		t.Fatalf("spec.model altered: %v", spec["model"])
 	}
 }

--- a/internal/stackbackup/cluster.go
+++ b/internal/stackbackup/cluster.go
@@ -211,16 +211,20 @@ func StripK8sJSON(data []byte) ([]byte, error) {
 		}
 		for _, it := range items {
 			if obj, ok := it.(map[string]any); ok {
-				stripObject(obj)
+				StripServerManagedMetadata(obj)
 			}
 		}
 	} else {
-		stripObject(doc)
+		StripServerManagedMetadata(doc)
 	}
 	return json.MarshalIndent(doc, "", "  ")
 }
 
-func stripObject(obj map[string]any) {
+// StripServerManagedMetadata strips server-managed fields from one decoded
+// Kubernetes object (map from json.Unmarshal or yaml.Unmarshal) so it can be
+// re-applied. Used by StripK8sJSON (export/import dumps) and by
+// internal/agentcrd.ResumeAll (persisted Agent manifests on stack up).
+func StripServerManagedMetadata(obj map[string]any) {
 	delete(obj, "status")
 	meta, ok := obj["metadata"].(map[string]any)
 	if !ok {


### PR DESCRIPTION
## Problem

`obol stack up` replays persisted Agent CR manifests via `internal/agentcrd.ResumeAll`. Those manifests are written by `PersistManifest` as a full `yaml.Marshal` of the applied object, which can already include server-managed metadata (`resourceVersion`, `uid`, `creationTimestamp`, `managedFields`, …).

On cluster recreate / re-apply, `ResumeAll` previously passed those bytes straight to `kubectl.Apply`. Kubernetes rejects the update with:

```text
metadata.resourceVersion: Invalid value: 0: must be specified for an update
```

Root cause: replaying a client-side record that still carries server-managed identity fields.

## Fix

1. **`internal/stackbackup/cluster.go`** — export the existing unexported `stripObject` helper as `StripServerManagedMetadata(obj map[string]any)` (same body). `StripK8sJSON` continues to call it for JSON dumps; no behavior change for export/import.

2. **`internal/agentcrd/manifest.go`** — in `ResumeAll`, after reading each persisted YAML file:
   - `yaml.Unmarshal` into `map[string]any`
   - call `stackbackup.StripServerManagedMetadata`
   - `yaml.Marshal` back to bytes
   - pass the stripped bytes only to `kubectl.Apply`

Parse/marshal failures warn and `continue` (best-effort per agent). `warnIfWalletWouldRegenerate` still receives the original unstripped bytes (it only reads `spec.wallet.create`).

## Diagram

```mermaid
flowchart LR
  A["Persisted Agent YAML<br/>(resourceVersion, uid,<br/>managedFields, …)"] --> B["yaml.Unmarshal"]
  B --> C["StripServerManagedMetadata<br/>(shared stackbackup helper)"]
  C --> D["yaml.Marshal"]
  D --> E["kubectl apply"]
  E --> F["Apply succeeds<br/>(no resourceVersion:0 error)"]
```

## Validation

```bash
gofmt -l internal/stackbackup/cluster.go internal/agentcrd/manifest.go internal/agentcrd/manifest_test.go internal/stackbackup/stackbackup_test.go
# (no output — all files formatted)

go build ./...
# exit 0

go test ./internal/agentcrd/... ./internal/stackbackup/... -count=1 -v
```

```
=== RUN   TestValidateName
...
=== RUN   TestManifestStoreRoundTrip
--- PASS: TestManifestStoreRoundTrip (0.00s)
=== RUN   TestStripServerManagedMetadataOnAgentManifest
--- PASS: TestStripServerManagedMetadataOnAgentManifest (0.00s)
PASS
ok  	github.com/ObolNetwork/obol-stack/internal/agentcrd	1.474s
=== RUN   TestSelectDataNamespaces
...
=== RUN   TestStripK8sJSON
--- PASS: TestStripK8sJSON (0.00s)
=== RUN   TestStripK8sJSONEmptyList
--- PASS: TestStripK8sJSONEmptyList (0.00s)
...
PASS
ok  	github.com/ObolNetwork/obol-stack/internal/stackbackup	2.046s
```

---
https://claude.ai/code/session_01PnhCQLz7CHuDBUhWd5xF8v
