### PR TITLE
fix(tunnel): make hostname add idempotent for already-bound hosts

### DIFF
--- a/internal/tunnel/hostnames.go
+++ b/internal/tunnel/hostnames.go
@@ -43,7 +43,7 @@ type HostnameListResult struct {
 // HostnameMutationResult is the JSON-serialisable result of Add/RemoveHostname.
 type HostnameMutationResult struct {
 	Hostname       string         `json:"hostname"`
-	Action         string         `json:"action"` // "added" | "removed"
+	Action         string         `json:"action"` // "added" | "removed" | "unchanged"
 	ManagementMode string         `json:"management_mode"`
 	Hostnames      []HostnameInfo `json:"hostnames"`
 }
@@ -98,7 +98,28 @@ func AddHostname(cfg *config.Config, u *ui.UI, opts AddHostnameOptions) (*Hostna
 	existing := st.HostnameSet()
 	for _, h := range existing {
 		if h == hostname {
-			return nil, fmt.Errorf("%s is already a tunnel hostname; nothing to do", hostname)
+			// Idempotent: this hostname is already bound. Still re-render
+			// the storefront catch-all over the current set — a caller may
+			// be retrying `tunnel hostname add <host> --offer ns/name`
+			// after the offer bind, and the catch-all must be swept to
+			// skip a hostname that has since become offer-bound, or a
+			// stale catch-all route keeps shadowing the offer's
+			// dedicated-origin route (Gateway API breaks the PathPrefix-/
+			// tie by route age).
+			if err := CreateStorefront(cfg, existing...); err != nil {
+				u.Warnf("could not refresh storefront: %v", err)
+			}
+
+			u.Blank()
+			u.Successf("Hostname already present: https://%s", hostname)
+			u.Dim("  No changes needed — this is a no-op.")
+
+			return &HostnameMutationResult{
+				Hostname:       hostname,
+				Action:         "unchanged",
+				ManagementMode: st.Management(),
+				Hostnames:      hostnameInfos(existing),
+			}, nil
 		}
 	}
 

--- a/internal/tunnel/hostnames_test.go
+++ b/internal/tunnel/hostnames_test.go
@@ -182,6 +182,8 @@ func TestHostnameInfos_PrimaryAndURL(t *testing.T) {
 }
 
 // --- AddHostname guards (all error before any cluster call) ----------------
+// Exception: TestAddHostname_DuplicateIsIdempotent succeeds as a no-op and
+// fail-opens through CreateStorefront (no real cluster required).
 
 func TestAddHostname_RejectsEmptyHostname(t *testing.T) {
 	cfg := newHostnameTestConfig(t)
@@ -211,16 +213,29 @@ func TestAddHostname_RejectsWithoutPersistentTunnel(t *testing.T) {
 	}
 }
 
-func TestAddHostname_RejectsDuplicate(t *testing.T) {
+func TestAddHostname_DuplicateIsIdempotent(t *testing.T) {
 	cfg := newHostnameTestConfig(t)
 	writeFakeKubeconfig(t, cfg)
 	if err := saveTunnelState(cfg, persistentLocalState("a.example.com")); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	// Mixed-case duplicate must still be rejected (normalized match).
-	_, err := AddHostname(cfg, ui.New(false), AddHostnameOptions{Hostname: "A.Example.com"})
-	if err == nil || !strings.Contains(err.Error(), "already a tunnel hostname") {
-		t.Fatalf("expected duplicate rejection, got %v", err)
+	// Mixed-case duplicate must still resolve to the same tracked hostname
+	// (normalized match) and succeed as a no-op instead of erroring. This
+	// exercises the storefront re-render path too (CreateStorefront fails
+	// open when kubectl/cluster access isn't available, so it does not
+	// turn this into an error in a unit-test environment).
+	result, err := AddHostname(cfg, ui.New(false), AddHostnameOptions{Hostname: "A.Example.com"})
+	if err != nil {
+		t.Fatalf("expected idempotent success for already-bound hostname, got error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a non-nil result")
+	}
+	if result.Action != "unchanged" {
+		t.Fatalf("Action = %q, want %q", result.Action, "unchanged")
+	}
+	if len(result.Hostnames) != 1 || result.Hostnames[0].Hostname != "a.example.com" {
+		t.Fatalf("expected result to report the existing hostname set, got %+v", result.Hostnames)
 	}
 }
 


### PR DESCRIPTION
## Problem

`obol tunnel hostname add <existing-host>` was not idempotent. When the hostname was already tracked on the tunnel, `AddHostname` returned an error (`%s is already a tunnel hostname; nothing to do`) and exited 1 before reaching the storefront catch-all re-render.

That short-circuit is especially harmful for the retry path used by `obol tunnel hostname add <host> --offer <ns>/<name>`: the CLI binds `ServiceOffer.spec.hostname` first so that `CreateStorefront` can skip offer-bound hosts from the storefront catch-all. If `AddHostname` is re-run for a hostname that is already bound (idempotent retry), the early error means the catch-all is never re-swept. A stale catch-all route can keep shadowing the offer's dedicated-origin route — Gateway API breaks the `PathPrefix=/` tie by route age.

## Fix

Treat "already present" as an idempotent success:

1. Detect the hostname is already in `st.HostnameSet()` (normalized match, including mixed-case input).
2. Still call `CreateStorefront(cfg, existing...)` over the current set so the catch-all is re-rendered and skips any hostnames that have since become offer-bound.
3. Print a no-op success message and return `HostnameMutationResult{Action: "unchanged", ...}` with exit 0.

No new sweep function: the duplicate path reuses the same `CreateStorefront` call the normal success path already uses. `CreateStorefront` continues to fail open (warn only) when kubectl/cluster access is unavailable.

## Diagram

```mermaid
flowchart TD
  A["tunnel hostname add host"] --> B{"already bound?"}
  B -->|yes| C["CreateStorefront over current set<br/>skips offer-bound hosts"]
  C --> D["idempotent success<br/>Action=unchanged, exit 0"]
  B -->|no| E["normal add path"]
  E --> F["route DNS / render ingress"]
  F --> G["CreateStorefront over updated set"]
  G --> H["persist state"]
  H --> I["success<br/>Action=added"]
```

## Validation

```
gofmt -l internal/tunnel/hostnames.go internal/tunnel/hostnames_test.go
go build ./...
go test ./internal/tunnel/... -count=1
```

Actual output:

```
ok  	github.com/ObolNetwork/obol-stack/internal/tunnel	1.306s
```

- `gofmt -l` printed nothing (both files already formatted).
- `go build ./...` succeeded with no output.
- `go test ./internal/tunnel/... -count=1` passed.

---
https://claude.ai/code/session_01PnhCQLz7CHuDBUhWd5xF8v
