### PR TITLE
feat: publish Obol CLI version for the frontend footer

### DIFF
--- a/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
+++ b/internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl
@@ -23,6 +23,12 @@ image:
     - name: OBOL_AUTH_DB_PATH
       value: "/data/auth.sqlite"
 
+    # Running Obol CLI version — shown in the local frontend footer.
+    # Injected by `obol stack up` via OBOL_STACK_VERSION; the frontend also
+    # reads obolVersion from the obol-stack-config ConfigMap.
+    - name: OBOL_STACK_VERSION
+      value: {{ env "OBOL_STACK_VERSION" | default "" | quote }}
+
     # Obol Agent (ADK) in-cluster URL for CopilotKit runtime
     - name: ADK_AGENT_URL
       value: "http://obol-agent.agent.svc.cluster.local:8000/"

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/tunnel"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
 	"github.com/ObolNetwork/obol-stack/internal/update"
+	"github.com/ObolNetwork/obol-stack/internal/version"
 	x402verifier "github.com/ObolNetwork/obol-stack/internal/x402"
 	petname "github.com/dustinkirkland/golang-petname"
 	"gopkg.in/yaml.v3"
@@ -488,6 +489,7 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	helmfileCmd.Env = append(os.Environ(),
 		"KUBECONFIG="+kubeconfigPath,
 		"STACK_DATA_DIR="+dataDir,
+		"OBOL_STACK_VERSION="+version.Version,
 	)
 
 	// In development mode, build and import local repo images that aren't on a
@@ -521,6 +523,11 @@ func syncDefaults(cfg *config.Config, u *ui.UI, kubeconfigPath string, dataDir s
 	}
 
 	u.Success("Default infrastructure deployed")
+
+	// Publish the running CLI version for the local frontend footer.
+	if err := tunnel.SyncStackConfigVersion(cfg); err != nil {
+		u.Warnf("Could not publish Obol version to frontend config: %v", err)
+	}
 
 	restoredLiteLLMConfig := false
 	if previousLiteLLMConfig != "" {

--- a/internal/tunnel/stackconfig_test.go
+++ b/internal/tunnel/stackconfig_test.go
@@ -1,0 +1,44 @@
+package tunnel
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The obolVersion-only apply MUST NOT share kubectl's default server-side-apply
+// field manager with SyncTunnelConfigMap. Server-side apply prunes fields a
+// manager previously owned but no longer sends, so a shared manager would make
+// every SyncStackConfigVersion call delete tunnelURL from obol-stack-config.
+func TestStackConfigVersionApplyArgs_UsesDedicatedFieldManager(t *testing.T) {
+	args := stackConfigVersionApplyArgs("/tmp/kubeconfig.yaml")
+
+	var fieldManager string
+	for _, arg := range args {
+		if after, ok := strings.CutPrefix(arg, "--field-manager="); ok {
+			fieldManager = after
+		}
+	}
+
+	if fieldManager == "" {
+		t.Fatalf("no --field-manager in %v: the apply would inherit kubectl's default manager and prune tunnelURL", args)
+	}
+
+	if fieldManager == "kubectl" || fieldManager == "kubectl-client-side-apply" {
+		t.Fatalf("--field-manager=%q collides with kubectl's default manager, which owns tunnelURL", fieldManager)
+	}
+
+	if fieldManager != stackConfigVersionFieldManager {
+		t.Errorf("--field-manager: got %q, want %q", fieldManager, stackConfigVersionFieldManager)
+	}
+}
+
+func TestStackConfigVersionApplyArgs_ServerSideApply(t *testing.T) {
+	args := stackConfigVersionApplyArgs("/tmp/kubeconfig.yaml")
+
+	for _, want := range []string{"apply", "--server-side", "--force-conflicts", "--kubeconfig", "/tmp/kubeconfig.yaml"} {
+		if !slices.Contains(args, want) {
+			t.Errorf("missing %q in %v", want, args)
+		}
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1020,6 +1020,31 @@ data:
 	return nil
 }
 
+// stackConfigVersionFieldManager scopes the obolVersion-only apply to its own
+// server-side-apply field manager.
+//
+// This is load-bearing, not cosmetic. Server-side apply deletes fields a
+// manager previously owned but no longer sends. SyncTunnelConfigMap applies
+// {tunnelURL, obolVersion} under kubectl's default manager; if this
+// obolVersion-only apply reused that manager, every call would prune
+// tunnelURL — which serviceoffer-controller reads for the ERC-8004
+// registration doc and the OpenAPI `servers` block, and the frontend reads for
+// the agent registration and marketplace URLs. Quick-tunnel stacks would never
+// get it back on `obol stack up`, because the tunnel stays dormant there and
+// SyncTunnelConfigMap is not called again.
+const stackConfigVersionFieldManager = "obol-stack-version"
+
+// stackConfigVersionApplyArgs builds the kubectl argv for the obolVersion-only
+// apply. Split out so the field-manager invariant above is unit-testable.
+func stackConfigVersionApplyArgs(kubeconfigPath string) []string {
+	return []string{
+		"--kubeconfig", kubeconfigPath,
+		"apply", "--server-side", "--force-conflicts",
+		"--field-manager=" + stackConfigVersionFieldManager,
+		"-f", "-",
+	}
+}
+
 // SyncStackConfigVersion SSA-merges only obolVersion into
 // obol-frontend/obol-stack-config, leaving tunnelURL untouched. Used on stack
 // up when no tunnel sync runs yet (after infra deploy creates the namespace).
@@ -1036,10 +1061,7 @@ data:
   obolVersion: %q
 `, version.Version)
 
-	cmd := exec.Command(kubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"apply", "--server-side", "--force-conflicts", "-f", "-",
-	)
+	cmd := exec.Command(kubectlPath, stackConfigVersionApplyArgs(kubeconfigPath)...)
 	cmd.Stdin = strings.NewReader(manifest)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl apply obol-stack-config failed: %w: %s", err, strings.TrimSpace(string(out)))

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ObolNetwork/obol-stack/internal/config"
 	"github.com/ObolNetwork/obol-stack/internal/images"
 	"github.com/ObolNetwork/obol-stack/internal/ui"
+	"github.com/ObolNetwork/obol-stack/internal/version"
 )
 
 const (
@@ -987,8 +988,9 @@ func freeLocalPort() (int, error) {
 }
 
 // SyncTunnelConfigMap creates or patches the obol-stack-config ConfigMap in the
-// obol-frontend namespace with the current tunnel URL. The frontend reads this
-// ConfigMap to construct the correct dashboard URL.
+// obol-frontend namespace with the current tunnel URL and the running Obol CLI
+// version. The frontend reads this ConfigMap for the public tunnel URL and the
+// footer version display.
 func SyncTunnelConfigMap(cfg *config.Config, tunnelURL string) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
@@ -1007,7 +1009,8 @@ metadata:
   namespace: obol-frontend
 data:
   tunnelURL: %s
-`, strings.TrimRight(tunnelURL, "/"))
+  obolVersion: %s
+`, strings.TrimRight(tunnelURL, "/"), version.Version)
 
 	// Server-side apply avoids the flaky client-side /openapi/v2 download on k3d.
 	cmd := exec.Command(kubectlPath,
@@ -1020,6 +1023,52 @@ data:
 		return fmt.Errorf("kubectl apply failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 
+	return nil
+}
+
+// SyncStackConfigVersion patches obolVersion into obol-frontend/obol-stack-config
+// without touching tunnelURL. Used on stack up when no tunnel sync runs yet.
+func SyncStackConfigVersion(cfg *config.Config) error {
+	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
+	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
+
+	_ = exec.Command(kubectlPath,
+		"--kubeconfig", kubeconfigPath,
+		"create", "namespace", "obol-frontend",
+		"--dry-run=client", "-o", "yaml",
+	).Run()
+
+	patch := fmt.Sprintf(`{"data":{"obolVersion":%q}}`, version.Version)
+	cmd := exec.Command(kubectlPath,
+		"--kubeconfig", kubeconfigPath,
+		"patch", "configmap", "obol-stack-config",
+		"-n", "obol-frontend",
+		"--type", "merge",
+		"-p", patch,
+	)
+	if out, err := cmd.CombinedOutput(); err == nil {
+		return nil
+	} else if !strings.Contains(string(out), "NotFound") && !strings.Contains(string(out), "not found") {
+		return fmt.Errorf("kubectl patch obol-stack-config failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	// ConfigMap does not exist yet (no tunnel ever synced) — create with version only.
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: obol-stack-config
+  namespace: obol-frontend
+data:
+  obolVersion: %s
+`, version.Version)
+	create := exec.Command(kubectlPath,
+		"--kubeconfig", kubeconfigPath,
+		"apply", "--server-side", "--force-conflicts", "-f", "-",
+	)
+	create.Stdin = strings.NewReader(manifest)
+	if out, err := create.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply obol-stack-config failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
 	return nil
 }
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -990,17 +990,11 @@ func freeLocalPort() (int, error) {
 // SyncTunnelConfigMap creates or patches the obol-stack-config ConfigMap in the
 // obol-frontend namespace with the current tunnel URL and the running Obol CLI
 // version. The frontend reads this ConfigMap for the public tunnel URL and the
-// footer version display.
+// footer version display. Server-side apply merges fields; call after
+// obol-frontend exists (helmfile).
 func SyncTunnelConfigMap(cfg *config.Config, tunnelURL string) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
-
-	// Ensure the namespace exists (non-fatal if it doesn't).
-	_ = exec.Command(kubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"create", "namespace", "obol-frontend",
-		"--dry-run=client", "-o", "yaml",
-	).Run()
 
 	manifest := fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap
@@ -1008,8 +1002,8 @@ metadata:
   name: obol-stack-config
   namespace: obol-frontend
 data:
-  tunnelURL: %s
-  obolVersion: %s
+  tunnelURL: %q
+  obolVersion: %q
 `, strings.TrimRight(tunnelURL, "/"), version.Version)
 
 	// Server-side apply avoids the flaky client-side /openapi/v2 download on k3d.
@@ -1026,47 +1020,28 @@ data:
 	return nil
 }
 
-// SyncStackConfigVersion patches obolVersion into obol-frontend/obol-stack-config
-// without touching tunnelURL. Used on stack up when no tunnel sync runs yet.
+// SyncStackConfigVersion SSA-merges only obolVersion into
+// obol-frontend/obol-stack-config, leaving tunnelURL untouched. Used on stack
+// up when no tunnel sync runs yet (after infra deploy creates the namespace).
 func SyncStackConfigVersion(cfg *config.Config) error {
 	kubectlPath := filepath.Join(cfg.BinDir, "kubectl")
 	kubeconfigPath := filepath.Join(cfg.ConfigDir, "kubeconfig.yaml")
 
-	_ = exec.Command(kubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"create", "namespace", "obol-frontend",
-		"--dry-run=client", "-o", "yaml",
-	).Run()
-
-	patch := fmt.Sprintf(`{"data":{"obolVersion":%q}}`, version.Version)
-	cmd := exec.Command(kubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"patch", "configmap", "obol-stack-config",
-		"-n", "obol-frontend",
-		"--type", "merge",
-		"-p", patch,
-	)
-	if out, err := cmd.CombinedOutput(); err == nil {
-		return nil
-	} else if !strings.Contains(string(out), "NotFound") && !strings.Contains(string(out), "not found") {
-		return fmt.Errorf("kubectl patch obol-stack-config failed: %w: %s", err, strings.TrimSpace(string(out)))
-	}
-
-	// ConfigMap does not exist yet (no tunnel ever synced) — create with version only.
 	manifest := fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap
 metadata:
   name: obol-stack-config
   namespace: obol-frontend
 data:
-  obolVersion: %s
+  obolVersion: %q
 `, version.Version)
-	create := exec.Command(kubectlPath,
+
+	cmd := exec.Command(kubectlPath,
 		"--kubeconfig", kubeconfigPath,
 		"apply", "--server-side", "--force-conflicts", "-f", "-",
 	)
-	create.Stdin = strings.NewReader(manifest)
-	if out, err := create.CombinedOutput(); err != nil {
+	cmd.Stdin = strings.NewReader(manifest)
+	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl apply obol-stack-config failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -196,7 +196,13 @@ func ApplyUpgrades(cfg *config.Config, u *ui.UI, opts UpgradeOptions) error {
 		helmfileArgs...,
 	)
 
-	helmfileCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+	// OBOL_STACK_VERSION must match what `obol stack up` renders, or the
+	// obol-frontend podspec env flips to "" here and the deployment rolls for
+	// no reason on every upgrade.
+	helmfileCmd.Env = append(os.Environ(),
+		"KUBECONFIG="+kubeconfigPath,
+		"OBOL_STACK_VERSION="+version.Version,
+	)
 
 	label := "Upgrading default infrastructure"
 	if opts.ChartFilter != "" {


### PR DESCRIPTION
Write `obolVersion` into `obol-stack-config` on stack up / tunnel sync and inject `OBOL_STACK_VERSION` into the frontend pod so the UI can show the running CLI release.

Pairs with ObolNetwork/obol-stack-front-end#460, which renders the value.

## Summary

What changed:

- `internal/tunnel/tunnel.go` — `SyncTunnelConfigMap` now publishes `obolVersion` alongside `tunnelURL`, and quotes both values.
- `internal/tunnel/tunnel.go` — new `SyncStackConfigVersion` writes `obolVersion` alone, for the stack-up path where no tunnel sync runs. It applies under its **own** server-side-apply field manager (`obol-stack-version`).
- `internal/stack/stack.go` — `syncDefaults` exports `OBOL_STACK_VERSION` to helmfile and calls `SyncStackConfigVersion` after the infra deploy.
- `internal/update/update.go` — `obol upgrade` exports the same variable, so the rendered podspec matches what stack up produces.
- `internal/embed/infrastructure/values/obol-frontend.yaml.gotmpl` — new `OBOL_STACK_VERSION` env on the frontend container.

Why it matters:

The frontend footer currently shows only the front-end image tag. Users debugging a stack have no in-UI answer to "which obol CLI built this?". Two delivery paths are wired on purpose: the pod env is the fast path and the only one that works for a local `pnpm dev` frontend outside the cluster; the ConfigMap is the authoritative in-cluster path and is the one that survives `obol upgrade`.

Risk level: medium — touches `obol stack up`'s ConfigMap publishing, which `serviceoffer-controller` and the frontend both read.

Commit under test: `7a0f31a9`

Base branch: `main`

## Scope

- [x] Code
- [x] Charts / manifests
- [ ] Flows / QA scripts
- [ ] Docs / skills
- [ ] Images / dependencies
- [ ] Other:

## Review Notes

### Field manager is load-bearing (fixed in `a6058c91`)

The first cut of `SyncStackConfigVersion` applied `{obolVersion}` under kubectl's default SSA field manager — the same manager `SyncTunnelConfigMap` uses for `{tunnelURL, obolVersion}`. Server-side apply **deletes** fields a manager previously owned but no longer sends, so every call silently pruned `tunnelURL`. Reproduced against a live k3d cluster in a scratch namespace:

```text
apply {tunnelURL, obolVersion} -> {"obolVersion":"0.14.0","tunnelURL":"https://x.example.com"}
apply {obolVersion}            -> {"obolVersion":"0.15.0"}          # tunnelURL gone
```

Blast radius, had it shipped: `SyncStackConfigVersion` runs on every `obol stack up`, immediately after the block in `syncDefaults` that skips the cloudflared chart specifically to preserve a healthy quick tunnel's URL. Quick-tunnel stacks never recover it in that run, because the tunnel stays dormant and `SyncTunnelConfigMap` is not called again (`stack.go` only reaches it under `st.IsPersistent()`). Downstream:

- `serviceoffercontroller.registrationBaseURL` falls back to `defaultBaseURL` → ERC-8004 registration doc and the OpenAPI `servers` block lose the public origin.
- Frontend `getTunnelURL()` → agent registration card and marketplace service URLs lose it too.
- `enqueueDiscoveryRefresh` watches this exact ConfigMap, so even persistent-tunnel stacks (where it is restored later in the same run) re-render every offer and registration twice per stack up.

Fixed by applying under `--field-manager=obol-stack-version`. `tunnelURL` stays owned by kubectl and untouched; a later `SyncTunnelConfigMap` still overwrites both via `--force-conflicts`. Locked in by `TestStackConfigVersionApplyArgs_UsesDedicatedFieldManager`.

### Reviewer focus

- `stackConfigVersionApplyArgs` — the dedicated field manager is not cosmetic; see above.
- `internal/update/update.go` — without the env line, `obol upgrade` renders `OBOL_STACK_VERSION=""`, the podspec differs from stack up's, and the frontend deployment rolls for nothing.
- Removing the `kubectl create namespace --dry-run=client -o yaml` call is safe: it never created anything (dry-run + `-o yaml` to a discarded stdout), and `base/templates/obol-frontend.yaml` pre-creates the namespace.

### Known gaps

- **The feature is not user-visible until the frontend image pin is bumped.** `obol-frontend.yaml.gotmpl` digest-pins `v0.1.28-rc3`; the footer that reads this data ships in obol-stack-front-end#460. That bump is not in this PR.
- **Dev builds show `obol-dev`.** `justfile` passes ldflags for `github.com/obol/obol-stack/internal/version`, but the module is `github.com/ObolNetwork/obol-stack` — Go silently ignores the unknown symbol, so `just build` leaves `Version = "dev"`. Verified locally (`obol version` → `Version: dev`). `.goreleaser.yaml` uses the correct path, so released binaries report a real version. Pre-existing; worth a separate one-line fix, noting that the `VERSION` file also still reads `0.0.0`.
- Two write paths and two read paths is more surface than the minimum. The ConfigMap alone would suffice in-cluster and updates without rolling the pod; the env var earns its place only as the outside-the-cluster escape hatch for `pnpm dev`. Kept deliberately, documented in the front-end `.env.example`.

### Follow-ups

- Bump the frontend image pin once #460 is released.
- Fix the `justfile` ldflags module path (and decide what `VERSION` should contain for dev builds).

## Validation

CI checks:

| Check | Status | Link |
|-------|--------|------|
| Go build, vet, and unit tests | pass | run 30127068462 (re-running on `7a0f31a9`) |
| helm template embedded chart | pass | run 30127068532 |
| CRD generation up-to-date | pass | run 30127068462 |
| goreleaser config valid | pass | run 30127068462 |
| lint-test / gitleaks / CodeQL | pass | runs 30127068462, 30127068738, 30127064575 |

Unit tests:

```text
go build ./...                                              ok
go vet ./internal/tunnel ./internal/update ./internal/stack  ok
go test ./internal/tunnel ./internal/update ./internal/stack ./cmd/obol -count=1
  ok  internal/tunnel  2.771s
  ok  internal/update  1.862s
  ok  internal/stack   6.611s
  ok  cmd/obol         3.206s
commit 7a0f31a9
```

Cluster behaviour check (live k3d, throwaway namespace) — the SSA prune above, and the fix:

```text
# shared field manager (pre-fix shape)
apply {tunnelURL, obolVersion} -> {"obolVersion":"0.14.0","tunnelURL":"https://x.example.com"}
apply {obolVersion}            -> {"obolVersion":"0.15.0"}

# dedicated field manager (shipped shape)
apply {tunnelURL, obolVersion}                              -> {"obolVersion":"0.14.0","tunnelURL":"https://x.example.com"}
apply {obolVersion} --field-manager=obol-stack-version      -> {"obolVersion":"0.15.0","tunnelURL":"https://x.example.com"}
apply {tunnelURL, obolVersion} --force-conflicts            -> {"obolVersion":"0.15.0","tunnelURL":"https://y.example.com"}
```

Integration tests:

```text
not run
```

Flow tests:

| Flow | Network | QA machine label | Worktree | Result | Artifacts |
|------|---------|------------------|----------|--------|-----------|
| — | — | — | — | not run | — |

Release smoke:

```text
not run
```

Recommended before merge: one `obol stack up` on a stack with a live quick tunnel, asserting `obol kubectl get cm obol-stack-config -n obol-frontend -o jsonpath='{.data}'` still carries both `tunnelURL` and `obolVersion` afterwards.

## Live Chain Evidence

Not applicable — no on-chain surface in this change.
