### PR TITLE
fix(flows): flow-16 asserts the agent model-strip instead of contradicting it

### DIFF
--- a/flows/flow-16-sell-agent.sh
+++ b/flows/flow-16-sell-agent.sh
@@ -7,7 +7,9 @@
 #      remote-signer in the agent's namespace)
 #   2. Gate it with `obol sell agent <name>` (creates a ServiceOffer of
 #      type=agent referencing the Agent)
-#   3. Probe → expect 402 with extra.agentModel + extra.agentSkills
+#   3. Probe → expect 402 with extra.agentSkills + extra.agentRuntime, and
+#      NO extra.agentModel (the model id is stripped on purpose — see
+#      mergeAgentExtras and TestMergeAgentExtras_AddsAgentFieldsButNotModel)
 #   4. Leave paid-call/settlement coverage to flow-08 until this scenario's
 #      commerce path is promoted into CI as a first-class smoke.
 #
@@ -231,7 +233,14 @@ else
     CURL_BASE="curl"
 fi
 
-step "402 response carries agentModel + agentSkills"
+# The 402 must surface what a buyer needs to choose the offer — the runtime
+# and the skill list — and must NOT leak the underlying model id. Stripping
+# agentModel is deliberate: mergeAgentExtras (internal/x402/verifier.go)
+# writes only agentSkills and agentRuntime, and
+# TestMergeAgentExtras_AddsAgentFieldsButNotModel asserts that agentModel is
+# never surfaced, because the buyer does not select one and it is an internal
+# detail. This step asserts that contract in both directions.
+step "402 response carries agentSkills + agentRuntime, and strips agentModel"
 body_402=$($CURL_BASE -s --max-time 10 -X POST \
     "$BASE_URL/services/$OFFER_NAME/v1/chat/completions" \
     -H "Content-Type: application/json" \
@@ -240,13 +249,14 @@ if echo "$body_402" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 extra = d['accepts'][0].get('extra') or {}
-assert extra.get('agentModel'), 'agentModel missing'
 assert extra.get('agentSkills'), 'agentSkills missing'
-print(f\"OK: model={extra['agentModel']} skills={','.join(extra['agentSkills'])}\")
+assert extra.get('agentRuntime'), 'agentRuntime missing'
+assert 'agentModel' not in extra, f\"agentModel leaked: {extra.get('agentModel')!r}\"
+print(f\"OK: runtime={extra['agentRuntime']} skills={','.join(extra['agentSkills'])}\")
 " 2>&1 | grep -q "^OK:"; then
-    pass "402 extra surfaces agent metadata"
+    pass "402 extra surfaces agent metadata without leaking the model id"
 else
-    fail "402 missing agent metadata — ${body_402:0:300}"
+    fail "402 agent metadata contract violated — ${body_402:0:300}"
 fi
 
 # §4: Paid path intentionally deferred.


### PR DESCRIPTION
## Problem

`flow-16-sell-agent` step 13 is titled *"402 response carries agentModel + agentSkills"* and asserts:

```python
assert extra.get('agentModel'), 'agentModel missing'
```

The verifier deliberately does **not** surface `agentModel`. `mergeAgentExtras` (`internal/x402/verifier.go`) writes only `agentSkills` and `agentRuntime`, and there is a unit test pinning exactly that:

```go
// TestMergeAgentExtras_AddsAgentFieldsButNotModel
t.Error("agentModel must not be surfaced — the underlying model is an internal detail, not buyer-facing")
```

That is the **rc1 agent model-strip**. So this step has been asserting the inverse of a shipped, unit-tested contract, and failing ever since.

## Evidence it's the flow, not the code

During `v0.14.0-rc3` pre-publish validation this step failed **identically on two independent hosts**, with everything around it green. Step 12 immediately before it logged:

```
ServiceOffer serving (ModelReady=True UpstreamHealthy=True PaymentGateReady=True RoutePublished=True)
```

and the 402 body was well-formed:

```json
{"accepts":[{...,"extra":{"agentRuntime":"hermes","agentSkills":["ethereum-networks","ethereum-local-wallet","addresses"]}}]}
```

A real regression would not reproduce identically on two hosts while every payment path around it passes. It also means this step's failure has been masking the flow's actual signal in every release smoke since rc1.

## Fix

The step now asserts the contract in **both** directions:

- `agentSkills` and `agentRuntime` must be **present** — a buyer needs them to choose the offer
- `agentModel` must be **absent** — surfacing it would be a regression against the model-strip

Retitled to *"402 response carries agentSkills + agentRuntime, and strips agentModel"*, with a comment pointing at `mergeAgentExtras` and its unit test so the next reader doesn't re-litigate this.

Verified against the literal `extra{}` block both hosts produced: passes as shipped, and fails with `agentModel leaked: 'qwen3.5:9b'` if the id is ever surfaced. `bash -n` clean.

## Scope

Flow-only; no production code touched. Targets `integration/v0.14.0-rc3` for the next RC — `v0.14.0-rc3` is already published without it.
