### PR TITLE
fix(flows): let the smoke test the k3s backend, and stop one dead probe killing a flow

### DIFF
--- a/flows/flow-04-agent.sh
+++ b/flows/flow-04-agent.sh
@@ -236,11 +236,17 @@ fi
 # dashboard host. Obol edge-redirects "/" → /auth/password-login so operators
 # can open the pretty host; Hermes's own /auth/login?provider=basic still 500s.
 # See docs/guides/hermes-dashboard-login.md.
-dash_code() { curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
-    -s -o /dev/null -w "%{http_code}" --max-time 10 "$@" 2>/dev/null; }
+# Both helpers swallow curl's exit status and emit "000" on a connection
+# failure. lib.sh runs under `set -euo pipefail`, and these are called inside
+# command substitutions, so an unguarded curl exit 7 (CURLE_COULDNT_CONNECT)
+# aborts the ENTIRE flow at whichever probe hit it first — you lose every
+# remaining step and the report shows a truncated log rather than a failed
+# assertion. A dead ingress must fail these steps, not kill the run.
+dash_code() { local out; out=$(curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
+    -s -o /dev/null -w "%{http_code}" --max-time 10 "$@" 2>/dev/null) || true; printf '%s' "${out:-000}"; }
 # -L follows redirect once so we can assert the pretty root lands on a non-500 page.
-dash_code_follow() { curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
-    -s -o /dev/null -w "%{http_code}" --max-time 10 -L --max-redirs 3 "$@" 2>/dev/null; }
+dash_code_follow() { local out; out=$(curl --resolve "${HERMES_DASHBOARD_HOST}:${ingress_port}:127.0.0.1" \
+    -s -o /dev/null -w "%{http_code}" --max-time 10 -L --max-redirs 3 "$@" 2>/dev/null) || true; printf '%s' "${out:-000}"; }
 dash_status="" dash_protected="" dash_login="" dash_root="" dash_root_final=""
 for i in $(seq 1 15); do
     dash_status=$(dash_code "$HERMES_DASHBOARD_URL/api/status")

--- a/flows/lib.sh
+++ b/flows/lib.sh
@@ -565,7 +565,12 @@ bootstrap_flow_workspace() {
     reset_flow_workspace "$dir"
     cp "$picked" "$dir/bin/obol"
     chmod +x "$dir/bin/obol"
-    for tool in kubectl helm helmfile k3d k9s openclaw; do
+    # k3s belongs in this list: internal/stack/backend_k3s.go resolves it at
+    # cfg.BinDir/k3s with NO PATH fallback, so omitting it made OBOL_BACKEND=k3s
+    # impossible to exercise from the flows at all — every run died on
+    # "prerequisites check failed: k3s not found at <workspace>/bin/k3s".
+    # It is linked only when present, so k3d-only hosts are unaffected.
+    for tool in kubectl helm helmfile k3d k3s k9s openclaw; do
         src=$(command -v "$tool" 2>/dev/null || printf '%s\n' "$OBOL_ROOT/.workspace/bin/$tool")
         [ -f "$src" ] && ln -sf "$src" "$dir/bin/$tool" 2>/dev/null
     done

--- a/flows/release-smoke.sh
+++ b/flows/release-smoke.sh
@@ -77,7 +77,11 @@ prepare_workspace() {
     mv "$tmp_obol" "$OBOL"
 
     local tool src
-    for tool in kubectl helm helmfile k3d k9s openclaw; do
+    # k3s is linked here too: internal/stack/backend_k3s.go resolves it at
+    # cfg.BinDir/k3s with NO PATH fallback, so without this OBOL_BACKEND=k3s
+    # could never be exercised by the smoke — every run died on
+    # "prerequisites check failed: k3s not found at <workspace>/bin/k3s".
+    for tool in kubectl helm helmfile k3d k3s k9s openclaw; do
         src=$(command -v "$tool" 2>/dev/null || true)
         [ -n "$src" ] && ln -sf "$src" "$OBOL_BIN_DIR/$tool"
     done
@@ -87,6 +91,13 @@ prepare_workspace() {
             return 1
         fi
     done
+    # k3s stays optional so k3d-only hosts are unaffected — but if the run
+    # actually asks for the k3s backend, fail here with an actionable message
+    # rather than inside the first flow's prerequisites check.
+    if [ "${OBOL_BACKEND:-}" = "k3s" ] && [ ! -x "$OBOL_BIN_DIR/k3s" ]; then
+        echo "OBOL_BACKEND=k3s but k3s is not on PATH — install it or unset OBOL_BACKEND" >&2
+        return 1
+    fi
 
     echo "==> Ensuring Python payment dependencies"
     ensure_payment_python_deps


### PR DESCRIPTION
Two harness defects found while validating `v0.14.0-rc3` — a release whose entire content was two k3s blockers.

## 1. The smoke could never exercise `OBOL_BACKEND=k3s`

`flows/lib.sh` and `flows/release-smoke.sh` relink tools into the flow workspace with a hard-coded list that omitted `k3s`:

```bash
for tool in kubectl helm helmfile k3d k9s openclaw; do
```

and `internal/stack/backend_k3s.go` resolves k3s at `cfg.BinDir/k3s` with **no PATH fallback**. The failure was deterministic and immediate:

```
✗ prerequisites check failed: k3s not found at
  /home/claude/obol-stack-rc3/.workspace/bin/k3s
```

which cascade-failed every flow in the run. So the one backend rc3 existed to fix was the one backend the release smoke could not touch — the k3s fixes had to be verified by hand instead.

`k3s` now joins the relink loop. It is linked **only when present**, so k3d-only hosts are unaffected, and it is deliberately **not** added to the required-tools list. Instead `release-smoke.sh` fails fast with an actionable message when `OBOL_BACKEND=k3s` is requested and k3s is genuinely absent, rather than letting the first flow discover it 20 minutes in.

## 2. flow-04 aborted the whole flow when loopback ingress was down

`lib.sh` runs under `set -euo pipefail`. `dash_code()` and `dash_code_follow()` are called inside command substitutions with no guard, so a curl exit 7 (`CURLE_COULDNT_CONNECT`) killed the script at whichever probe hit it first — losing every remaining step and leaving a truncated log instead of a failed assertion.

Observed on a real host: `flow-04-agent.log` simply stops mid-step at `STEP: [17] Hermes native dash…`. One dead endpoint, and the rest of the flow's coverage silently vanishes.

Both helpers now swallow curl's status and emit `000` — which is what curl's own `-w "%{http_code}"` already writes on a connection failure — so a dead ingress **fails the step** instead of ending the run.

I checked the other curl-in-substitution sites rather than assuming: `flow-04-agent.sh:130` is already guarded with `|| true`, and `lib-dual-stack.sh:466` captures with `|| rc=$?`. These two were the only unguarded ones, so this is the whole blast radius.

## Verification

- `bash -n` clean on all three files.
- The **old** `dash_code` form, against an unreachable host under `set -euo pipefail`, aborts the script — no line after it executes.
- The **new** form returns `000` and execution continues, so the assertion can fail normally.
- A healthy endpoint still returns its real status code (`200`), so the guard does not mask genuine results.

## Scope

Flow-harness only; no production code touched. Targets `integration/v0.14.0-rc3` for the next RC.
