### PR TITLE
feat(helm): template authCaptureUnlock so the paid unlock gate survives a sync

### DIFF
--- a/internal/embed/infrastructure/base/templates/x402.yaml
+++ b/internal/embed/infrastructure/base/templates/x402.yaml
@@ -20,6 +20,11 @@ metadata:
 ---
 # Static gateway settings plus optional manual routes. In cluster mode the
 # gateway merges these with dynamic routes derived from ready ServiceOffers.
+#
+# authCaptureUnlock is rendered from values so it SURVIVES `obol stack up`.
+# Hand-patching this ConfigMap works until the next sync, which restores the
+# chart default and silently disables the fee split — that has already
+# happened once on a live stack.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,10 +34,34 @@ data:
   pricing.yaml: |
     wallet: ""
     chain: "base"
-    facilitatorURL: "https://x402.gcp.obol.tech"
+    facilitatorURL: "{{ .Values.x402.facilitatorURL | default "https://x402.gcp.obol.tech" }}"
     # verifyOnly applies to the legacy /verify endpoint only. The shared seller
     # gateway path always settles after upstream success.
     verifyOnly: true
+    {{- with .Values.x402.authCaptureUnlock }}
+    {{- if .enabled }}
+    # Paid unlock gate. The offer named by offerPrefix must already expose a
+    # `gate: auth` route (its free SIWX sign-in is suppressed); buyers mint a
+    # session by paying once instead. minFeeBps/maxFeeBps bound the cut the
+    # buyer signs; the remainder goes to payTo.
+    authCaptureUnlock:
+      enabled: true
+      offerPrefix: {{ .offerPrefix | quote }}
+      price: {{ .price | quote }}
+      network: {{ .network | quote }}
+      payTo: {{ .payTo | quote }}
+      feeRecipient: {{ .feeRecipient | quote }}
+      minFeeBps: {{ .minFeeBps }}
+      maxFeeBps: {{ .maxFeeBps }}
+      captureAuthorizer: {{ .captureAuthorizer | quote }}
+      {{- with .captureDeadlineSecs }}
+      captureDeadlineSecs: {{ . }}
+      {{- end }}
+      {{- with .refundDeadlineSecs }}
+      refundDeadlineSecs: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
     routes: []
 
 ---

--- a/internal/embed/infrastructure/base/values.yaml
+++ b/internal/embed/infrastructure/base/values.yaml
@@ -1,0 +1,40 @@
+# Defaults for the base chart. The helmfile passes dataDir and network
+# explicitly; everything below is what a stack gets when it says nothing.
+
+x402:
+  # Facilitator the verifier settles against.
+  #
+  # The hosted facilitator supports the `auth-capture` scheme on Base Sepolia
+  # ONLY (eip155:84532). To run the paid unlock gate on Base MAINNET, point
+  # this at the in-cluster facilitator sidecar instead:
+  #   facilitatorURL: "http://localhost:8090"
+  facilitatorURL: "https://x402.gcp.obol.tech"
+
+  # Paid unlock gate (opt-in, off by default — no fee is taken unless you
+  # configure this). Turns ONE `gate: auth` offer from free wallet sign-in
+  # into pay-once-to-mint-a-session, and splits that single payment on-chain
+  # between payTo and feeRecipient via AuthCaptureEscrow.
+  #
+  # Only one unlock offer per stack today; per-offer configuration via the
+  # ServiceOffer CRD is the follow-up. Set offerPrefix to the offer's public
+  # path — it must match the route's stripPrefix exactly.
+  authCaptureUnlock:
+    enabled: false
+    offerPrefix: ""
+    price: ""
+    network: ""
+    # Seller leg. Falls back to the verifier's own wallet when empty.
+    payTo: ""
+    # Fee leg. Required when enabled, and must be a non-zero address
+    # whenever maxFeeBps > 0.
+    feeRecipient: ""
+    # Bounds on the cut, in basis points, that the buyer signs.
+    # 50 = 0.5%. maxFeeBps must be <= 10000 and >= minFeeBps.
+    minFeeBps: 0
+    maxFeeBps: 0
+    # Address permitted to capture the escrowed authorization. Required
+    # when enabled.
+    captureAuthorizer: ""
+    # Optional; the verifier applies its own defaults when these are unset.
+    captureDeadlineSecs: null
+    refundDeadlineSecs: null

--- a/internal/embed/infrastructure/helmfile.yaml
+++ b/internal/embed/infrastructure/helmfile.yaml
@@ -23,6 +23,26 @@ values:
   # quick tunnel that should be preserved across the sync.
   - cloudflared:
       enabled: true
+  # x402 gateway settings. authCaptureUnlock is the opt-in paid unlock gate;
+  # off by default, so no fee is taken and the verifier's pricing config is
+  # byte-identical to before unless a stack configures it. Override with a
+  # state-values file or e.g.
+  #   --state-values-set x402.authCaptureUnlock.enabled=true
+  # NOTE: the hosted facilitator only supports auth-capture on Base Sepolia.
+  # For Base mainnet set x402.facilitatorURL to the in-cluster sidecar
+  # (http://localhost:8090).
+  - x402:
+      facilitatorURL: "https://x402.gcp.obol.tech"
+      authCaptureUnlock:
+        enabled: false
+        offerPrefix: ""
+        price: ""
+        network: ""
+        payTo: ""
+        feeRecipient: ""
+        minFeeBps: 0
+        maxFeeBps: 0
+        captureAuthorizer: ""
 
 releases:
   # Monitoring stack (Prometheus operator + Prometheus). Must run before
@@ -130,6 +150,10 @@ releases:
     values:
       - dataDir: /data
       - network: "{{ .Values.network }}"
+      # Passed through so the paid unlock gate is declarative and survives a
+      # re-sync. Off unless the stack sets it — see base/values.yaml.
+      - x402:
+          {{- toYaml .Values.x402 | nindent 10 }}
 
   # Cloudflare Tunnel (dormant until configured via obol tunnel login/provision).
   # `condition: cloudflared.enabled` lets `obol stack up` flip this off when an

--- a/internal/embed/skills/sell/references/x402-pricing.md
+++ b/internal/embed/skills/sell/references/x402-pricing.md
@@ -100,3 +100,38 @@ Client
 ## Important
 
 This Traefik `ForwardAuth` flow is a gating step, not the final settlement point for the supported production path. Final settlement belongs in a component that can observe the upstream result, such as `x402-buyer` or the standalone `obol sell inference` gateway.
+
+## Paid unlock gate (`authCaptureUnlock`)
+
+Opt-in, and **off by default** — no fee is taken unless you configure it.
+
+It changes **one** offer from *free wallet sign-in* to *pay once to sign in*. Normally a `gate: auth` route lets a buyer sign in with SIWX for free and then use the route on a session. With the unlock enabled, those free sign-in endpoints are suppressed and the only way to mint a session is a single inline payment on the first request. Everything after that is session-authenticated, not paid again.
+
+That one payment is split on-chain via `AuthCaptureEscrow`: a buyer-signed, bounded percentage (`minFeeBps`–`maxFeeBps`) goes to `feeRecipient`, the remainder to `payTo`.
+
+It is **not** a percentage cut of every payment your stack takes, and it cannot route a share to an upstream provider — the split has exactly two legs and fires only on the unlock.
+
+Configure it through chart values so it survives `obol stack up`. Hand-patching the `x402-pricing` ConfigMap works until the next sync, which restores the chart default and silently disables the fee:
+
+```yaml
+x402:
+  facilitatorURL: "http://localhost:8090"
+  authCaptureUnlock:
+    enabled: true
+    offerPrefix: "/services/my-offer"   # must equal the route's stripPrefix
+    price: "0.01"
+    network: "base"
+    payTo: "0x..."                      # seller; defaults to the verifier wallet
+    feeRecipient: "0x..."               # required when enabled
+    minFeeBps: 50                       # 50 = 0.5%; min <= max, max <= 10000
+    maxFeeBps: 50
+    captureAuthorizer: "0x..."          # required when enabled
+```
+
+> **Base mainnet needs the in-cluster facilitator.** The hosted facilitator at
+> `https://x402.gcp.obol.tech` advertises `auth-capture` on **Base Sepolia only**
+> (`eip155:84532`) — check `/supported` before assuming otherwise. For mainnet,
+> point `facilitatorURL` at the facilitator sidecar (`http://localhost:8090`),
+> which carries the `v2-eip155-auth-capture` scheme for `eip155:8453`.
+
+Two current limits: only **one** unlock offer per stack (`offerPrefix` is global, matched by exact string comparison), and a `ServiceOffer` cannot declare `scheme: auth-capture` — its CRD enum permits `exact` only. Per-offer configuration is the intended follow-up.


### PR DESCRIPTION
## Problem

`x402-pricing` is a Helm-managed static ConfigMap (`internal/embed/infrastructure/base/templates/x402.yaml`) shipping `routes: []` and no `authCaptureUnlock`. The only way to turn the paid unlock gate on was to patch the live ConfigMap by hand — which the next `obol stack up` reverts to the chart default, **silently disabling the fee split**.

This is not hypothetical. On a live stack the ConfigMap's `last-applied-configuration` still carries a fully configured canary:

```yaml
authCaptureUnlock:
  enabled: true
  offerPrefix: "/services/authcap-canary"
  price: "0.01"
  minFeeBps: 50
  maxFeeBps: 50
```

…while the live `data` is the untouched chart default. The configured fee address holds exactly **0.000050 USDC** — precisely 50 bps of one `0.01` unlock — and nothing since. The mechanism worked; a reconcile turned it off and nobody noticed.

## Change

`authCaptureUnlock` and `facilitatorURL` now render from values, defaulted **off** in both `base/values.yaml` and the helmfile's state values, and passed through to the `base` release.

With the defaults the rendered `pricing.yaml` is **byte-identical** to what ships today, so no existing stack changes behaviour.

`facilitatorURL` is templated in the same change because it is load-bearing for this feature — see below.

## The mainnet trap

The hosted facilitator advertises `auth-capture` on **Base Sepolia only**. Straight from its `/supported`:

```
auth-capture       @ eip155:84532     ← testnet only
batch-settlement   @ eip155:8453
exact              @ eip155:8453
```

So enabling the unlock on `network: base` while pointed at `https://x402.gcp.obol.tech` lands on a facilitator that cannot settle the scheme. Mainnet needs the in-cluster sidecar (`http://localhost:8090`), whose config declares `v2-eip155-auth-capture` for `eip155:8453` — which is exactly how the canary worked.

Worth flagging: the rc2 notes said the hosted facilitator made the gate "usable on this release". True for testnet, not mainnet. The docs added here state the constraint explicitly.

## Docs

The seller-facing `x402-pricing.md` reference had **no mention of this feature at all**, which is why it has been read as *"an opt-in platform fee on everything the seller receives"*.

It isn't. It turns **one** `gate: auth` offer from free wallet sign-in into **pay-once-to-mint-a-session**, and splits that single payment two ways. It does not apply to normal paid requests, and it cannot route a share to an upstream provider — the split has exactly two legs (`payTo`, `feeRecipient`) and fires only on the unlock.

The doc also records both current ceilings, so they stop being rediscovered:
- **One unlock offer per stack** — `offerPrefix` is global, matched by exact string comparison (`unlockgate.go:23`).
- **Per-offer config is impossible today** — `ServiceOfferPayment.Scheme` is `+kubebuilder:validation:Enum=exact`, with `TODO(auth-capture)` above it (`monetizeapi/types.go:307`).

## Verification

- `helm template` with defaults reproduces the current `pricing.yaml` byte-for-byte.
- With the canary values it reproduces the exact config that produced the real on-chain fee.
- The CI `helm-template-smoke` command (placeholder substitution + full chart render) exits 0 at 3407 lines.
- `go build ./...` and `go test ./internal/embed/... ./internal/x402/...` pass.

## Not in scope

Per-offer `authCaptureUnlock` via the CRD, which the `TODO(auth-capture)` names as the follow-up.
